### PR TITLE
NAR RACE -502エラー時にoption=2フォールバック + スペック順序変更

### DIFF
--- a/scripts/quickstart.py
+++ b/scripts/quickstart.py
@@ -2446,6 +2446,16 @@ class QuickstartRunner:
         ("DIFN", "蓄積系ソフト用蓄積情報", 1),
     ]
 
+    # NAR用簡易モード: DIFNを先に取得してからRACE
+    # NV-LinkサーバーはUmaConnでデータダウンロード未完了のスペックに対して
+    # option=1（セットアップ）で-502を返すことがある。
+    # DIFNは蓄積系で別メカニズムのため成功しやすい。
+    # RACEはoption=2（差分モード）を使用して-502を回避する。
+    NAR_SIMPLE_SPECS = [
+        ("DIFN", "蓄積系ソフト用蓄積情報", 1),
+        ("RACE", "レース情報", 2),
+    ]
+
     # 標準モード: 簡易 + 付加情報 (option=1)
     STANDARD_SPECS = [
         ("TOKU", "特別登録馬", 1),
@@ -2690,10 +2700,18 @@ class QuickstartRunner:
         return not has_error
 
     def _get_specs_for_mode(self) -> list:
-        """モードに応じたスペックリストを取得（蓄積系のみ）"""
+        """モードに応じたスペックリストを取得（蓄積系のみ）
+
+        NARデータソースの場合、簡易モードではNAR_SIMPLE_SPECSを使用する。
+        これによりDIFNを先に取得し、RACEはoption=2（差分モード）で取得する。
+        """
         mode = self.settings.get('mode', 'simple')
+        data_source = self.settings.get('data_source', 'jra')
         if mode == 'simple':
-            specs = self.SIMPLE_SPECS.copy()
+            if data_source == 'nar':
+                specs = self.NAR_SIMPLE_SPECS.copy()
+            else:
+                specs = self.SIMPLE_SPECS.copy()
         elif mode == 'standard':
             specs = self.STANDARD_SPECS.copy()
         elif mode == 'update':

--- a/tests/e2e/e2e_download_test.py
+++ b/tests/e2e/e2e_download_test.py
@@ -1,0 +1,254 @@
+"""E2E Download Test - JRA + NAR actual data download via COM API.
+
+Tests:
+1. JRA: 1 day of RACE data download
+2. NAR: 1 day of RACE data download
+3. JRA quickstart mini: download -> parse -> DB store -> verify
+"""
+import os
+import sys
+import sqlite3
+import time
+from datetime import datetime, timedelta
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(PROJECT_ROOT / "src"))
+
+
+def log(msg):
+    print(f"[{datetime.now().strftime('%H:%M:%S')}] {msg}", flush=True)
+
+
+def test_jra_download():
+    """Test JRA (JV-Link) actual data download - 1 day."""
+    log("=" * 60)
+    log("TEST 1: JRA 1-day download")
+    log("=" * 60)
+
+    from jvlink.wrapper import JVLinkWrapper
+
+    wrapper = JVLinkWrapper()
+    try:
+        wrapper.jv_init()
+        log("JV-Link initialized OK")
+
+        target_date = (datetime.now() - timedelta(days=7)).strftime("%Y%m%d")
+        log(f"Target date: {target_date}")
+
+        ret = wrapper.jv_open("RACE", f"{target_date}000000", option=2)
+        log(f"JV_Open returned: {ret}")
+
+        if ret < 0:
+            log(f"WARN: JV_Open returned {ret} (may be no data)")
+            wrapper.jv_close()
+            return "SKIP"
+
+        record_count = 0
+        while True:
+            status, filename, data = wrapper.jv_read(100000)
+            if status == 0:
+                break
+            elif status in (-1, -3):
+                log("Data downloading, waiting...")
+                time.sleep(2)
+                continue
+            elif status < -1:
+                log(f"Error: {status}")
+                break
+            else:
+                record_count += 1
+                if record_count <= 3:
+                    log(f"  Record #{record_count}: {len(data)}B from {filename}")
+
+        wrapper.jv_close()
+        log(f"JRA download complete: {record_count} records")
+
+        if record_count > 0:
+            log("PASS: JRA download OK")
+            return "PASS"
+        else:
+            log("WARN: No records (may be no races on this date)")
+            return "SKIP"
+
+    except Exception as e:
+        log(f"FAIL: {e}")
+        return "FAIL"
+    finally:
+        try:
+            wrapper.jv_close()
+        except Exception:
+            pass
+
+
+def test_nar_download():
+    """Test NAR (NV-Link) actual data download - 1 day."""
+    log("=" * 60)
+    log("TEST 2: NAR 1-day download")
+    log("=" * 60)
+
+    from nvlink.wrapper import NVLinkWrapper
+
+    wrapper = NVLinkWrapper()
+    try:
+        wrapper.nv_init()
+        log("NV-Link initialized OK")
+
+        target_date = (datetime.now() - timedelta(days=7)).strftime("%Y%m%d")
+        log(f"Target date: {target_date}")
+
+        ret = wrapper.nv_open("RACE", f"{target_date}000000", option=1)
+        log(f"NV_Open returned: {ret}")
+
+        if ret < 0:
+            log(f"WARN: NV_Open returned {ret}")
+            wrapper.nv_close()
+            return "SKIP"
+
+        record_count = 0
+        while True:
+            status, filename, data = wrapper.nv_read(110000)
+            if status == 0:
+                break
+            elif status == -1:
+                log("No more data")
+                break
+            elif status == -3:
+                log("Data downloading (-3), waiting...")
+                time.sleep(2)
+                continue
+            elif status < -1:
+                log(f"Error: {status}")
+                break
+            else:
+                record_count += 1
+                if record_count <= 3:
+                    log(f"  Record #{record_count}: {len(data)}B from {filename}")
+
+        wrapper.nv_close()
+        log(f"NAR download complete: {record_count} records")
+
+        if record_count > 0:
+            log("PASS: NAR download OK")
+            return "PASS"
+        else:
+            log("WARN: No records")
+            return "SKIP"
+
+    except Exception as e:
+        log(f"FAIL: {e}")
+        return "FAIL"
+    finally:
+        try:
+            wrapper.nv_close()
+        except Exception:
+            pass
+
+
+def test_jra_quickstart_mini():
+    """Test quickstart flow: download -> parse -> DB store (JRA, 1 day)."""
+    log("=" * 60)
+    log("TEST 3: JRA quickstart mini (download -> parse -> DB)")
+    log("=" * 60)
+
+    db_path = PROJECT_ROOT / "tests" / "e2e" / "e2e_test.db"
+    if db_path.exists():
+        db_path.unlink()
+
+    try:
+        from jvlink.wrapper import JVLinkWrapper
+        from parsers import get_parser
+        from db.sqlite_writer import SQLiteWriter
+
+        wrapper = JVLinkWrapper()
+        wrapper.jv_init()
+
+        target_date = (datetime.now() - timedelta(days=7)).strftime("%Y%m%d")
+
+        writer = SQLiteWriter(str(db_path))
+        total_records = 0
+
+        ret = wrapper.jv_open("RACE", f"{target_date}000000", option=2)
+        log(f"JV_Open(RACE): {ret}")
+        if ret < 0:
+            log("No data available")
+            writer.close()
+            return "SKIP"
+
+        while True:
+            status, filename, data = wrapper.jv_read(100000)
+            if status == 0:
+                break
+            elif status < 0:
+                if status in (-1, -3):
+                    time.sleep(1)
+                    continue
+                break
+
+            record_id = data[:2] if len(data) >= 2 else ""
+            parser = get_parser(record_id)
+            if parser:
+                try:
+                    rows = parser.parse(data)
+                    if rows:
+                        for row in (rows if isinstance(rows, list) else [rows]):
+                            writer.write(parser.table_name, row)
+                            total_records += 1
+                except Exception as e:
+                    log(f"  Parse error for {record_id}: {e}")
+
+        wrapper.jv_close()
+        writer.close()
+        log(f"DB stored: {total_records} records -> {db_path}")
+
+        # Verify DB
+        conn = sqlite3.connect(str(db_path))
+        tables = [r[0] for r in conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table'"
+        ).fetchall()]
+        log(f"Tables created: {tables}")
+        for t in tables:
+            count = conn.execute(f"SELECT COUNT(*) FROM [{t}]").fetchone()[0]
+            log(f"  {t}: {count} rows")
+        conn.close()
+
+        if total_records > 0:
+            log("PASS: Quickstart mini OK")
+            return "PASS"
+        else:
+            log("SKIP: No data available")
+            return "SKIP"
+
+    except Exception as e:
+        log(f"FAIL: {e}")
+        import traceback
+        traceback.print_exc()
+        return "FAIL"
+    finally:
+        try:
+            if db_path.exists():
+                db_path.unlink()
+        except Exception:
+            pass
+
+
+if __name__ == "__main__":
+    log("E2E Download Test Started")
+    log(f"Project: {PROJECT_ROOT}")
+
+    results = {}
+    results["JRA Download"] = test_jra_download()
+    results["NAR Download"] = test_nar_download()
+    results["JRA Quickstart Mini"] = test_jra_quickstart_mini()
+
+    log("")
+    log("=" * 60)
+    log("RESULTS")
+    log("=" * 60)
+    for name, result in results.items():
+        icon = {"PASS": "\u2705", "FAIL": "\u274c", "SKIP": "\u26a0\ufe0f"}.get(result, "?")
+        log(f"  {icon} {name}: {result}")
+
+    fails = sum(1 for r in results.values() if r == "FAIL")
+    log(f"\nTotal: {len(results)} tests, {fails} failures")
+    sys.exit(1 if fails > 0 else 0)

--- a/tests/test_nar_race_fallback.py
+++ b/tests/test_nar_race_fallback.py
@@ -1,0 +1,206 @@
+"""Tests for NAR RACE -502 fallback to option=2.
+
+NV-LinkサーバーはUmaConnでデータダウンロード未完了のスペックに対して
+option=1で-502を返すことがある。この場合、option=2（差分モード）で
+自動的に再試行する機能のテスト。
+"""
+
+import pytest
+from unittest.mock import MagicMock, patch, PropertyMock
+from datetime import datetime
+
+from src.fetcher.historical import HistoricalFetcher
+from src.fetcher.base import FetcherError
+from src.utils.data_source import DataSource
+
+
+@pytest.fixture
+def nar_fetcher():
+    """NAR用HistoricalFetcherのモックを作成"""
+    with patch.object(HistoricalFetcher, '__init__', lambda self, **kw: None):
+        fetcher = HistoricalFetcher()
+        fetcher.data_source = DataSource.NAR
+        fetcher.show_progress = False
+        fetcher.progress_display = None
+        fetcher._skip_cleanup = False
+        fetcher._nar_skipped_dates = []
+        fetcher.jvlink = MagicMock()
+        return fetcher
+
+
+def _make_mock_fetch(behavior):
+    """Create a mock fetch method based on behavior dict.
+
+    behavior: dict mapping (date, option) -> "success" | "fail_502" | list of records
+    Default: "fail_502"
+    """
+    def mock_fetch(data_spec, from_date, to_date, option=1):
+        key = (from_date, option)
+        action = behavior.get(key, "fail_502")
+        if action == "fail_502":
+            raise FetcherError("Download failed with status code: -502")
+        elif action == "success":
+            yield {"record": "data", "date": from_date}
+        elif isinstance(action, list):
+            yield from action
+        else:
+            yield action
+    return mock_fetch
+
+
+class TestNarOption2Fallback:
+    """option=1で-502時にoption=2へフォールバックするテスト"""
+
+    def test_fallback_to_option2_on_502(self, nar_fetcher):
+        """option=1で-502 → option=2で成功するケース"""
+        nar_fetcher.fetch = _make_mock_fetch({
+            ("20250101", 1): "fail_502",
+            ("20250101", 2): "success",
+        })
+        results = list(nar_fetcher._fetch_nar_daily("RACE", "20250101", "20250101", 1))
+        assert len(results) == 1
+        assert results[0]["record"] == "data"
+        assert nar_fetcher._nar_skipped_dates == []
+
+    def test_fallback_option2_also_fails(self, nar_fetcher):
+        """option=1もoption=2も-502で失敗するケース"""
+        nar_fetcher.fetch = _make_mock_fetch({
+            ("20250101", 1): "fail_502",
+            ("20250101", 2): "fail_502",
+        })
+        results = list(nar_fetcher._fetch_nar_daily("RACE", "20250101", "20250101", 1))
+        assert len(results) == 0
+        assert nar_fetcher._nar_skipped_dates == ["20250101"]
+
+    def test_no_fallback_when_already_option2(self, nar_fetcher):
+        """option=2で-502の場合、さらにフォールバックしない"""
+        call_log = []
+
+        def mock_fetch(data_spec, from_date, to_date, option=1):
+            call_log.append((from_date, option))
+            raise FetcherError("Download failed with status code: -502")
+            yield  # noqa: make generator
+
+        nar_fetcher.fetch = mock_fetch
+        results = list(nar_fetcher._fetch_nar_daily("RACE", "20250101", "20250101", 2))
+        assert len(results) == 0
+        assert nar_fetcher._nar_skipped_dates == ["20250101"]
+        # Should only try option=2 once, no further fallback
+        assert call_log == [("20250101", 2)]
+
+    def test_consecutive_502_skip_remaining(self, nar_fetcher):
+        """3日連続-502で残りをスキップ（option=2フォールバック後も失敗）"""
+        nar_fetcher.fetch = _make_mock_fetch({})  # All fail with -502
+        results = list(nar_fetcher._fetch_nar_daily("RACE", "20250101", "20250105", 1))
+        assert len(results) == 0
+        # 3日連続失敗後、残り2日もスキップ
+        assert len(nar_fetcher._nar_skipped_dates) == 5
+
+    def test_successful_day_resets_consecutive_count(self, nar_fetcher):
+        """成功した日で連続カウントがリセットされる"""
+        nar_fetcher.fetch = _make_mock_fetch({
+            ("20250101", 1): "fail_502",
+            ("20250101", 2): "fail_502",
+            ("20250102", 1): "success",
+            ("20250103", 1): "fail_502",
+            ("20250103", 2): "fail_502",
+        })
+        results = list(nar_fetcher._fetch_nar_daily("RACE", "20250101", "20250103", 1))
+        assert len(results) == 1
+        assert "20250101" in nar_fetcher._nar_skipped_dates
+        assert "20250102" not in nar_fetcher._nar_skipped_dates
+        assert "20250103" in nar_fetcher._nar_skipped_dates
+
+    def test_non_502_error_propagated(self, nar_fetcher):
+        """-502以外のエラーはそのまま再送出される"""
+        def mock_fetch(data_spec, from_date, to_date, option=1):
+            raise FetcherError("Authentication failed: -100")
+            yield
+
+        nar_fetcher.fetch = mock_fetch
+        with pytest.raises(FetcherError, match="-100"):
+            list(nar_fetcher._fetch_nar_daily("RACE", "20250101", "20250101", 1))
+
+    def test_non_502_error_in_option2_fallback_propagated(self, nar_fetcher):
+        """-502フォールバック中に-502以外のエラーが出たら再送出"""
+        call_count = 0
+
+        def mock_fetch(data_spec, from_date, to_date, option=1):
+            nonlocal call_count
+            call_count += 1
+            if option == 1:
+                raise FetcherError("Download failed with status code: -502")
+            else:
+                raise FetcherError("Authentication failed: -100")
+            yield
+
+        nar_fetcher.fetch = mock_fetch
+        with pytest.raises(FetcherError, match="-100"):
+            list(nar_fetcher._fetch_nar_daily("RACE", "20250101", "20250101", 1))
+
+
+class TestNarSimpleSpecs:
+    """NAR用SIMPLE_SPECSの順序テスト"""
+
+    def test_nar_simple_specs_difn_first(self):
+        """NAR_SIMPLE_SPECSでDIFNがRACEより前にある"""
+        import pathlib
+        quickstart_path = pathlib.Path(__file__).parent.parent / 'scripts' / 'quickstart.py'
+        content = quickstart_path.read_text(encoding='utf-8')
+
+        assert 'NAR_SIMPLE_SPECS' in content
+
+        lines = content.split('\n')
+        in_nar_specs = False
+        difn_line = -1
+        race_line = -1
+        for i, line in enumerate(lines):
+            if 'NAR_SIMPLE_SPECS' in line and '=' in line:
+                in_nar_specs = True
+                continue
+            if in_nar_specs:
+                if ']' in line and '(' not in line:
+                    break
+                if '"DIFN"' in line:
+                    difn_line = i
+                if '"RACE"' in line:
+                    race_line = i
+
+        assert difn_line > 0, "DIFN not found in NAR_SIMPLE_SPECS"
+        assert race_line > 0, "RACE not found in NAR_SIMPLE_SPECS"
+        assert difn_line < race_line, "DIFN should come before RACE in NAR_SIMPLE_SPECS"
+
+    def test_nar_simple_specs_race_option2(self):
+        """NAR_SIMPLE_SPECSでRACEがoption=2を使用する"""
+        import pathlib
+        quickstart_path = pathlib.Path(__file__).parent.parent / 'scripts' / 'quickstart.py'
+        content = quickstart_path.read_text(encoding='utf-8')
+
+        lines = content.split('\n')
+        in_nar_specs = False
+        for line in lines:
+            if 'NAR_SIMPLE_SPECS' in line and '=' in line:
+                in_nar_specs = True
+                continue
+            if in_nar_specs:
+                if ']' in line and '(' not in line:
+                    break
+                if '"RACE"' in line:
+                    assert ', 2)' in line or ', 2,' in line, \
+                        f"RACE in NAR_SIMPLE_SPECS should use option=2, got: {line.strip()}"
+                    break
+
+
+class TestGetSpecsForMode:
+    """_get_specs_for_modeのデータソース分岐テスト"""
+
+    def test_get_specs_contains_nar_branch(self):
+        """_get_specs_for_modeがNARデータソースを判別する"""
+        import pathlib
+        quickstart_path = pathlib.Path(__file__).parent.parent / 'scripts' / 'quickstart.py'
+        content = quickstart_path.read_text(encoding='utf-8')
+
+        # _get_specs_for_mode内でdata_sourceを確認してNAR_SIMPLE_SPECSを使用
+        assert "data_source" in content
+        assert "NAR_SIMPLE_SPECS" in content
+        assert "'nar'" in content or '"nar"' in content


### PR DESCRIPTION
## 問題
NAR quickstart（簡易モード+1週間）でRACEスペックがoption=1で-502エラーになり、NL_RA/NL_SE/NL_HRテーブルが空になる。DIFNスペックは蓄積系メカニズムのため正常取得できる。

## 根本原因
NV-LinkサーバーはUmaConnでデータダウンロード完了していないスペックに対してRACEのoption=1（セットアップ）で-502を返す。

## 修正内容

### 1. NAR用SIMPLE_SPECS追加 (`quickstart.py`)
- `NAR_SIMPLE_SPECS`を追加: DIFNを先に取得してからRACE
- RACEはoption=2（差分モード）をデフォルトで使用
- `_get_specs_for_mode`で`data_source='nar'`の場合に`NAR_SIMPLE_SPECS`を使用

### 2. option=2フォールバック (`historical.py`)
- `_fetch_nar_daily`でoption=1が-502で失敗した場合、自動的にoption=2（差分モード）で再試行
- option=2でも失敗した場合はスキップ（既存の動作を維持）
- 3日連続-502で残りをスキップする既存ロジックはそのまま

### 3. テスト追加
- `tests/test_nar_race_fallback.py`: 10テストケース
  - option=2フォールバック成功/失敗
  - 連続-502スキップ
  - 非-502エラー伝播
  - NAR_SIMPLE_SPECSの順序・option検証

Closes #54

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * NAR data source now supported in simple mode with optimized data ordering.
  * Enhanced error handling for NAR data downloads with automatic fallback retry mechanism on failures, reducing unnecessary data skips.

* **Tests**
  * Added end-to-end download workflow tests for JRA and NAR data sources.
  * Added fallback error-handling validation tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->