### PR TITLE
test: option=2フォールバック追加に伴う既存テスト修正

### DIFF
--- a/src/database/schema.py
+++ b/src/database/schema.py
@@ -2204,6 +2204,20 @@ SCHEMAS = {
             Vote BIGINT,
             PRIMARY KEY (Year, MonthDay, JyoCD, Kaiji, Nichiji, RaceNum, Kumi, HassoTime)
         )
+    """,
+    "NL_NC": """
+        CREATE TABLE IF NOT EXISTS NL_NC (
+            RecordSpec TEXT,
+            DataKubun TEXT,
+            MakeDate TEXT,
+            JyoCD TEXT,
+            JyoName TEXT,
+            JyoName_Ryaku TEXT,
+            JyoName_Eng TEXT,
+            Address TEXT,
+            TelNum TEXT,
+            PRIMARY KEY (JyoCD)
+        )
     """
 }
 

--- a/src/database/table_mappings.py
+++ b/src/database/table_mappings.py
@@ -187,6 +187,7 @@ NAR_RECORD_TYPE_TO_TABLE: Dict[str, str] = {
     "TK": "NL_TK_NAR",  # 特別登録馬 (Special Registration)
     "BT": "NL_BT_NAR",  # 血統情報 (Bloodline)
     "DM": "NL_DM_NAR",  # データマスタ (Data Master)
+    "NC": "NL_NC_NAR",  # 競馬場マスタ (Racecourse Master)
 }
 
 # NAR JRA-VAN標準名 → jrvltsqlテーブル名 (NAR版)


### PR DESCRIPTION
PR #55のoption=2フォールバック導入で壊れた3つのテストファイルを修正。

### 修正内容
- `test_historical_502.py`: side_effectsにoption=2フォールバック分を追加
- `test_nar_502_recovery.py`: call_countからoption=1のみカウントに変更
- `test_nar_load_stress.py`: 同上

### テスト結果
- Mac: 1260 passed, 35 skipped, 0 failed