### PR TITLE
fix: increase bridge timeout to 600s (#68)

### DIFF
--- a/src/nvlink/bridge.py
+++ b/src/nvlink/bridge.py
@@ -288,15 +288,22 @@ class NVLinkBridge:
         Returns:
             Tuple of (result_code, read_count, download_count, last_file_timestamp).
         """
-        response = self._send_command(
-            {
-                "cmd": "open",
-                "dataspec": data_spec,
-                "fromtime": fromtime,
-                "option": option,
-            },
-            timeout=600.0,  # Open can take a while with downloads
-        )
+        try:
+            response = self._send_command(
+                {
+                    "cmd": "open",
+                    "dataspec": data_spec,
+                    "fromtime": fromtime,
+                    "option": option,
+                },
+                timeout=120.0,  # NVOpen can block during download
+            )
+        except NVLinkBridgeError as e:
+            # NVOpen blocked (download or COM hang) — kill bridge and raise -502
+            # so _fetch_nar_daily can retry with option=2 or skip day
+            logger.warning("NVOpen timeout/error, killing bridge", error=str(e), data_spec=data_spec)
+            self._kill_process()
+            raise NVLinkBridgeError("NVOpen timeout", error_code=-502)
 
         code = response.get("code", -1)
         read_count = response.get("readcount", 0)
@@ -315,7 +322,7 @@ class NVLinkBridge:
                     "fromtime": fromtime,
                     "option": option,
                 },
-                timeout=600.0,
+                timeout=120.0,
             )
             code = response.get("code", -1)
             read_count = response.get("readcount", 0)
@@ -506,6 +513,17 @@ class NVLinkBridge:
         """Check if stream is open."""
         return self._is_open
 
+    def _kill_process(self):
+        """Force-kill the bridge subprocess without graceful shutdown."""
+        if self._process is not None:
+            try:
+                self._process.kill()
+                self._process.wait(timeout=5.0)
+            except Exception:
+                pass
+        self._process = None
+        self._is_open = False
+
     def cleanup(self):
         """Stop the bridge subprocess."""
         if self._process is not None and self._process.poll() is None:
@@ -578,7 +596,7 @@ class NVLinkBridge:
     def reinitialize_com(self):
         """Reinitialize by restarting the bridge process."""
         logger.warning("Reinitializing bridge (restart subprocess)")
-        self.cleanup()
+        self._kill_process()
         self._start_process()
         init_key = self.initialization_key or self.sid
         self._send_command({"cmd": "init", "type": "nar", "key": init_key})

--- a/src/nvlink/bridge.py
+++ b/src/nvlink/bridge.py
@@ -102,7 +102,7 @@ class NVLinkBridge:
         sid: str = "UNKNOWN",
         initialization_key: Optional[str] = None,
         bridge_path: Optional[Union[str, Path]] = None,
-        timeout: float = 30.0,
+        timeout: float = 600.0,
     ):
         """Initialize NVLinkBridge.
 
@@ -295,7 +295,7 @@ class NVLinkBridge:
                 "fromtime": fromtime,
                 "option": option,
             },
-            timeout=120.0,  # Open can take a while with downloads
+            timeout=600.0,  # Open can take a while with downloads
         )
 
         code = response.get("code", -1)
@@ -315,7 +315,7 @@ class NVLinkBridge:
                     "fromtime": fromtime,
                     "option": option,
                 },
-                timeout=120.0,
+                timeout=600.0,
             )
             code = response.get("code", -1)
             read_count = response.get("readcount", 0)

--- a/tests/unit/test_nvlink_bridge.py
+++ b/tests/unit/test_nvlink_bridge.py
@@ -320,13 +320,12 @@ class TestNVLinkBridgeAliases:
         assert buff == raw_data
 
     def test_reinitialize_com(self, bridge):
-        """reinitialize_com calls cleanup then restarts."""
-        # Just verify cleanup is called and the method doesn't crash
-        bridge.cleanup = MagicMock()
+        """reinitialize_com calls _kill_process then restarts."""
+        bridge._kill_process = MagicMock()
         bridge._start_process = MagicMock()
         bridge._send_command = MagicMock(return_value={"status": "ok"})
         bridge.reinitialize_com()
-        bridge.cleanup.assert_called_once()
+        bridge._kill_process.assert_called_once()
         bridge._start_process.assert_called_once()
 
 

--- a/tools/nvlink-bridge/Program.cs
+++ b/tools/nvlink-bridge/Program.cs
@@ -2,6 +2,7 @@ using System;
 using System.IO;
 using System.Text;
 using System.Text.Json;
+using System.Threading.Tasks;
 using System.Runtime.InteropServices;
 
 // JV/NV-Link COM Bridge for Python

--- a/tools/nvlink-bridge/Program.cs
+++ b/tools/nvlink-bridge/Program.cs
@@ -140,22 +140,39 @@ class Program
         var dataspec = root.GetProperty("dataspec").GetString() ?? "";
         var fromtime = root.GetProperty("fromtime").GetString() ?? "";
         var option = root.TryGetProperty("option", out var o) ? o.GetInt32() : 1;
+        var timeoutSec = root.TryGetProperty("timeout", out var t) ? t.GetInt32() : 300;
 
         int readcount = 0;
         int downloadcount = 0;
         string lastfiletimestamp = "";
-        int result;
+        int result = -1;
 
-        if (linkType == "jra")
+        // NVOpen/JVOpen can block for minutes during download.
+        // Run in a background thread with timeout to prevent hanging.
+        var openTask = Task.Run(() =>
         {
-            // JVOpen(dataspec, fromtime, option, ref readcount, ref downloadcount, out lastfiletimestamp)
-            // JV-Link passes fromtime as string
-            result = link.JVOpen(dataspec, fromtime, option, ref readcount, ref downloadcount, out lastfiletimestamp);
+            if (linkType == "jra")
+            {
+                result = link.JVOpen(dataspec, fromtime, option, ref readcount, ref downloadcount, out lastfiletimestamp);
+            }
+            else
+            {
+                result = link.NVOpen(dataspec, int.Parse(fromtime), option, ref readcount, ref downloadcount, out lastfiletimestamp);
+            }
+        });
+
+        if (!openTask.Wait(TimeSpan.FromSeconds(timeoutSec)))
+        {
+            // Timeout — try to cancel and return error
+            try { if (linkType == "jra") link.JVCancel(); else link.NVCancel(); } catch { }
+            return new { status = "error", code = -502, error = $"Open timeout ({timeoutSec}s)", readcount = 0, downloadcount = 0, lastfiletimestamp = "" };
         }
-        else
+
+        // Check for task exception
+        if (openTask.IsFaulted)
         {
-            // NVOpen(dataspec, fromtime_as_int, option, ref readcount, ref downloadcount, out lastfiletimestamp)
-            result = link.NVOpen(dataspec, int.Parse(fromtime), option, ref readcount, ref downloadcount, out lastfiletimestamp);
+            var ex = openTask.Exception?.InnerException ?? openTask.Exception;
+            return new { status = "error", code = -1, error = ex?.Message ?? "Unknown error", readcount = 0, downloadcount = 0, lastfiletimestamp = "" };
         }
 
         return new


### PR DESCRIPTION
NV-Link NVOpen はダウンロード中にブロックするため、30秒のデフォルトタイムアウトでは足りない。600秒に引き上げ。