### PR TITLE
docs: remove jrvltsql-nar references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### ⚠️ Breaking Changes
 
-- **地方競馬（NAR）サポートを廃止** — NAR/NV-Link 関連機能をすべて削除。
-  地方競馬データが必要な場合は [jrvltsql-nar](https://github.com/miyamamoto/jrvltsql-nar) を使用してください。
+- **地方競馬（NAR）サポートを廃止** — NAR/NV-Link 関連機能をすべて削除。本ツールは JRA（中央競馬）専用となります。
 
 ### Added
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 JRA-VAN DataLab データを SQLite/PostgreSQL に取り込む Windows 専用パイプライン。
 
-JRA（中央競馬）専用。地方競馬（NAR）は [jrvltsql-nar](https://github.com/miyamamoto/jrvltsql-nar) を使用してください。
+JRA（中央競馬）専用です。
 
 ---
 


### PR DESCRIPTION
README と CHANGELOG から jrvltsql-nar へのリンク・言及を削除。