### PR TITLE
fix: batch option param + migration quoting + updater list return

### DIFF
--- a/src/database/migration.py
+++ b/src/database/migration.py
@@ -77,7 +77,7 @@ def migrate_table_if_needed(db: BaseDatabase, table_name: str, schema_sql: str) 
         return False
 
     # Get existing columns via PRAGMA
-    existing_info = db.fetch_all(f"PRAGMA table_info({table_name})")
+    existing_info = db.fetch_all(f'PRAGMA table_info("{table_name}")')
     existing_columns = {row['name'] for row in existing_info}
 
     if existing_columns == expected_columns:
@@ -90,7 +90,7 @@ def migrate_table_if_needed(db: BaseDatabase, table_name: str, schema_sql: str) 
         f"expected={sorted(expected_columns)}. "
         f"Dropping and recreating table."
     )
-    db.execute(f"DROP TABLE {table_name}")
+    db.execute(f'DROP TABLE "{table_name}"')
     db.execute(schema_sql)
     db.commit()
     return True

--- a/src/importer/batch.py
+++ b/src/importer/batch.py
@@ -156,6 +156,7 @@ class BatchProcessor:
         year: int,
         month: int,
         data_spec: str = "RACE",
+        option: int = 1,
         auto_commit: bool = True,
     ) -> dict:
         """Process data for a specific month.
@@ -187,12 +188,13 @@ class BatchProcessor:
 
         logger.info(f"Processing month: {year}/{month:02d}")
 
-        return self.process_date_range(data_spec, from_date, to_date, auto_commit)
+        return self.process_date_range(data_spec, from_date, to_date, option=option, auto_commit=auto_commit)
 
     def process_year(
         self,
         year: int,
         data_spec: str = "RACE",
+        option: int = 1,
         auto_commit: bool = True,
     ) -> dict:
         """Process data for a specific year.
@@ -214,7 +216,7 @@ class BatchProcessor:
 
         logger.info(f"Processing year: {year}")
 
-        return self.process_date_range(data_spec, from_date, to_date, auto_commit)
+        return self.process_date_range(data_spec, from_date, to_date, option=option, auto_commit=auto_commit)
 
     def process_multiple_specs(
         self,

--- a/src/realtime/updater.py
+++ b/src/realtime/updater.py
@@ -159,7 +159,7 @@ class RealtimeUpdater:
                     result = self._process_single_record(item, timeseries=timeseries)
                     if result:
                         results.append(result)
-                return results[-1] if results else None
+                return results if results else None
 
             return self._process_single_record(parsed_data, timeseries=timeseries)
 


### PR DESCRIPTION
## Summary

- **batch.py**: `process_month()` / `process_year()` に `option` パラメータが欠けていた。呼び出し側が `option=4`（フルセットアップ）を指定しても無視されて常に `option=1` になっていた
- **migration.py**: PRAGMA table_info / DROP TABLE のテーブル名をクォートしていなかった（SQL インジェクションリスク）
- **updater.py**: H1/H6 のリスト処理で最後の1件しか返さず、他のレコード処理結果を破棄していた

## Test plan

- [x] `pytest tests/` → 1256 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added customizable option parameter to batch month and year processing methods.

* **Bug Fixes**
  * Fixed database operations to properly handle table names with special characters.
  * Improved realtime data processor to return complete batch results instead of partial results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->