### PR TITLE
fix(scheduler): UTF-8 stdout reconfigure for Windows CP932 consoles

### DIFF
--- a/scripts/raceday_scheduler.py
+++ b/scripts/raceday_scheduler.py
@@ -36,6 +36,11 @@ import time
 from datetime import datetime, date
 from pathlib import Path
 
+# Windows CP932 console can't encode Unicode characters like em dashes
+if sys.stdout.encoding and sys.stdout.encoding.lower() in ("cp932", "cp936", "cp950"):
+    sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+    sys.stderr.reconfigure(encoding="utf-8", errors="replace")
+
 PROJECT_ROOT = Path(__file__).parent.parent
 
 # (verify_time, phase, description)


### PR DESCRIPTION
## Summary

`raceday_scheduler.py` crashed on Windows with:
```
UnicodeEncodeError: 'cp932' codec can't encode character '\u2014' in position 22: illegal multibyte sequence
```

The em dash `—` in the schedule header header can't be encoded by CP932 (Shift-JIS), which is the default console encoding on Japanese Windows.

Fix: reconfigure `sys.stdout`/`sys.stderr` to UTF-8 when a CJK code page is detected.

## Test plan

- [x] `python scripts/raceday_scheduler.py --dry-run` — prints full 16-checkpoint schedule without errors
- [x] `pytest tests/ -q` — 1255 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)