### PR TITLE
fix(verify): use RT_SE for result completion during live racing

### DIFF
--- a/scripts/raceday_verify.py
+++ b/scripts/raceday_verify.py
@@ -514,9 +514,13 @@ def check_se_results(con, year, monthday, issues):
     print(f"  [INFO] RT_SE confirmed winners:    {rt_winner}")
 
     if nl_ra_count > 0:
-        completion = nl_winner / nl_ra_count * 100
+        # During live racing NL_SE winners stay 0 until DIFFU fetch (~17:30).
+        # Use RT_SE as the authoritative source while racing is ongoing.
+        effective_winner = rt_winner if rt_winner > nl_winner else nl_winner
+        source = "RT_SE" if rt_winner > nl_winner else "NL_SE"
+        completion = effective_winner / nl_ra_count * 100
         marker = "[OK] " if completion >= 80 else "[!]  "
-        print(f"  {marker} Result completion: {nl_winner}/{nl_ra_count} races ({completion:.0f}%)")
+        print(f"  {marker} Result completion: {effective_winner}/{nl_ra_count} races ({completion:.0f}%)  [{source}]")
         if completion < 50 and datetime.now().hour >= 17:
             issues.append(f"Race results only {completion:.0f}% complete after 17:00 — fetch DIFFU")
 


### PR DESCRIPTION
## Summary

- `check_se_results()` was computing race completion from `NL_SE.KakuteiJyuni`, which stays 0 all day until DIFFU is fetched after ~17:30
- During live racing this showed `0/36 races (0%) [!]` even with 20+ confirmed finishers in RT_SE
- Fix: use `max(rt_winner, nl_winner)` with a `[RT_SE]` / `[NL_SE]` source label — RT_SE drives the number intraday, NL_SE takes over after DIFFU lands

## Test plan

- [x] `--phase nl-mid` at 14:00 now shows `23/36 races (64%) [RT_SE]` instead of `0/36 (0%)`
- [x] Post-17:00 logic unchanged — still adds to issues if < 50% after 17:00

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved result completion percentage calculations for live-racing scenarios by implementing smart data source selection to ensure accurate metrics even when traditional data sources aren't fully populated.
  * Added source attribution tags to completion output for transparency about which dataset is driving the reported completion percentage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->