### PR TITLE
fix: wrong DIFFU spec name + remove RT_H1 false positive in final phase

### DIFF
--- a/scripts/raceday_verify.py
+++ b/scripts/raceday_verify.py
@@ -815,8 +815,8 @@ def run_phase_post(con, args, year, monthday, issues, nl_checks, rt_checks):
     race_date = args.date or date.today().strftime("%Y%m%d")
     if args.fetch:
         if (nl_checks.get("NL_H1  (payouts)     ") or 0) == 0:
-            print(f"\n[AUTO-FETCH] Fetching DIFFU (payouts/results)...")
-            run_fetch("DIFFU", race_date, race_date, 1, args.db)
+            print(f"\n[AUTO-FETCH] Fetching DIFF (payouts/results)...")
+            run_fetch("DIFF", race_date, race_date, 1, args.db)
         if (nl_checks.get("NL_RA  (race header) ") or 0) == 0:
             print(f"\n[AUTO-FETCH] Fetching RACE data...")
             run_fetch("RACE", race_date, race_date, 1, args.db)
@@ -842,9 +842,11 @@ def run_phase_final(con, args, year, monthday, issues, nl_checks, rt_checks):
     if (nl_checks.get("NL_RA  (race header) ") or 0) == 0:
         issues.append("FINAL: NL_RA has no data for today")
     if (nl_checks.get("NL_H1  (payouts)     ") or 0) == 0:
-        issues.append("FINAL: NL_H1 (payouts) empty -- run fetch DIFFU")
+        issues.append("FINAL: NL_H1 (payouts) empty -- run: fetch --spec DIFF --option 1")
+    # RT_H1 is never populated by realtime monitoring; JRA only publishes
+    # payout records via DIFF batch (NL_H1), not through 0B15 realtime stream.
     if (rt_checks.get("RT_H1  (払戻 速報)   ") or 0) == 0:
-        issues.append("FINAL: RT_H1 empty -- realtime payout data missing")
+        print("  [INFO] RT_H1=0 (expected -- payout speed-reports only arrive via DIFF batch)")
 
     run_unit_tests(issues)
     test_quickstart(args.db, issues)


### PR DESCRIPTION
## Summary
Two bugs found during 2026-04-18 race day monitoring:

1. **Wrong spec name in auto-fetch**: `run_fetch("DIFFU", ...)` used `DIFFU` but the CLI only accepts `DIFF`. The auto-fetch silently failed on every `post` phase run when `--fetch` was passed. Changed to `"DIFF"`.

2. **RT_H1=0 false positive in final phase**: `run_phase_final` flagged `RT_H1=0` as a hard issue, but a full day of realtime monitoring (0B12 + 0B15 running 09:03-16:36) confirmed RT_H1 is structurally never populated via realtime stream. JRA only publishes payout records through the DIFF batch → NL_H1. Changed to `[INFO]` print.

## Test plan
- [x] `python scripts/raceday_verify.py --phase final --date 20260418` shows RT_H1=0 as [INFO] (not an issue) — issue count drops from 3 to 2
- [x] Auto-fetch path now uses correct `"DIFF"` spec

🤖 Generated with [Claude Code](https://claude.com/claude-code)