### PR TITLE
fix(raceday_verify): remove duplicate NL_H1 issue in final phase

### DIFF
--- a/scripts/raceday_verify.py
+++ b/scripts/raceday_verify.py
@@ -842,8 +842,7 @@ def run_phase_final(con, args, year, monthday, issues, nl_checks, rt_checks):
     # Hard requirements for final phase
     if (nl_checks.get("NL_RA  (race header) ") or 0) == 0:
         issues.append("FINAL: NL_RA has no data for today")
-    if (nl_checks.get("NL_H1  (payouts)     ") or 0) == 0:
-        issues.append("FINAL: NL_H1 (payouts) empty -- run: fetch --spec DIFF --option 1")
+    # NL_H1 absence already reported by check_payout_completeness above
     # RT_H1 is never populated by realtime monitoring; JRA only publishes
     # payout records via DIFF batch (NL_H1), not through 0B15 realtime stream.
     if (rt_checks.get("RT_H1  (払戻 速報)   ") or 0) == 0:


### PR DESCRIPTION
## Summary
- `run_phase_final()` was appending `"FINAL: NL_H1 (payouts) empty"` as a second issue, but `check_payout_completeness()` (called just above it) already appends `"No payout data (H1) after 17:00"` for the same condition
- Removed the redundant check; NL_H1 absence is now reported exactly once

## Test plan
- [ ] Run `raceday_verify.py --phase final` when NL_H1=0 → confirms only 1 issue in report
- [ ] Run when NL_H1>0 → confirms no false positive

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated payout verification checks by removing a redundant validation step from the final verification phase. Payout completeness is now verified once during the earlier verification stage, reducing code redundancy and streamlining the verification workflow without affecting validation results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->