### PR TITLE
feat(migration): add PostgreSQL support to schema migration

### DIFF
--- a/src/database/migration.py
+++ b/src/database/migration.py
@@ -76,8 +76,15 @@ def migrate_table_if_needed(db: BaseDatabase, table_name: str, schema_sql: str) 
         logger.warning(f"Could not parse schema SQL for {table_name}, skipping migration check")
         return False
 
-    # Get existing columns via PRAGMA
-    existing_info = db.fetch_all(f'PRAGMA table_info("{table_name}")')
+    # Get existing columns — PRAGMA for SQLite, information_schema for PostgreSQL
+    if db.get_db_type() == "postgresql":
+        existing_info = db.fetch_all(
+            "SELECT column_name AS name FROM information_schema.columns "
+            "WHERE table_name = ? AND table_schema = 'public'",
+            (table_name,),
+        )
+    else:
+        existing_info = db.fetch_all(f'PRAGMA table_info("{table_name}")')
     existing_columns = {row['name'] for row in existing_info}
 
     if existing_columns == expected_columns:

--- a/tests/test_migration.py
+++ b/tests/test_migration.py
@@ -3,15 +3,72 @@
 import sqlite3
 import tempfile
 import os
+from typing import Any, Dict, List, Optional
 
 import pytest
 
+from src.database.base import BaseDatabase
 from src.database.sqlite_handler import SQLiteDatabase
 from src.database.migration import (
     _extract_columns_from_sql,
     migrate_table_if_needed,
     migrate_all_tables,
 )
+
+
+class MockPostgreSQLDatabase(BaseDatabase):
+    """Minimal in-memory mock that behaves like PostgreSQLDatabase for migration tests."""
+
+    def __init__(self):
+        super().__init__({})
+        self._tables: Dict[str, List[str]] = {}  # table_name -> [col_name, ...]
+        self._executed: List[str] = []
+
+    def get_db_type(self) -> str:
+        return "postgresql"
+
+    def connect(self): pass
+    def disconnect(self): pass
+    def commit(self): pass
+    def rollback(self): pass
+
+    def table_exists(self, table_name: str) -> bool:
+        return table_name in self._tables
+
+    def execute(self, sql: str, parameters=None):
+        self._executed.append(sql.strip())
+        upper = sql.strip().upper()
+        if upper.startswith("DROP TABLE"):
+            # Extract table name: DROP TABLE "NL_H1" or DROP TABLE NL_H1
+            import re
+            m = re.search(r'DROP\s+TABLE\s+"?(\w+)"?', sql, re.IGNORECASE)
+            if m:
+                self._tables.pop(m.group(1), None)
+        elif upper.startswith("CREATE TABLE"):
+            from src.database.migration import _extract_columns_from_sql
+            import re
+            m = re.search(r'CREATE\s+TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?"?(\w+)"?', sql, re.IGNORECASE)
+            if m:
+                cols = _extract_columns_from_sql(sql)
+                self._tables[m.group(1)] = list(cols or [])
+
+    def executemany(self, sql: str, parameters): pass
+
+    def fetch_one(self, sql: str, parameters=None) -> Optional[Dict[str, Any]]:
+        rows = self.fetch_all(sql, parameters)
+        return rows[0] if rows else None
+
+    def fetch_all(self, sql: str, parameters=None) -> List[Dict[str, Any]]:
+        # Respond to information_schema.columns query used in migration
+        if "information_schema.columns" in sql.lower():
+            table_name = parameters[0] if parameters else None
+            cols = self._tables.get(table_name, [])
+            return [{"name": c} for c in cols]
+        return []
+
+    def create_table(self, table_name: str, schema: str): pass
+
+    def _execute_raw(self, sql: str, parameters=None): pass
 
 
 @pytest.fixture
@@ -145,3 +202,47 @@ def test_migrate_all_tables_multiple(db):
     assert "BetType" in h1_cols
     h6_cols = {r['name'] for r in db.fetch_all("PRAGMA table_info(NL_H6)")}
     assert "SanrentanKumi" in h6_cols
+
+
+# --- PostgreSQL path tests (mock DB, no server required) ---
+
+@pytest.fixture
+def pg_db():
+    return MockPostgreSQLDatabase()
+
+
+def test_pg_migrate_drops_and_recreates_on_mismatch(pg_db):
+    """PostgreSQL path: mismatch triggers DROP + CREATE via information_schema."""
+    pg_db.execute(OLD_SCHEMA)  # seeds _tables["NL_H1"] with old columns
+
+    result = migrate_table_if_needed(pg_db, "NL_H1", NEW_SCHEMA)
+    assert result is True
+
+    # Table should now have new columns
+    assert "BetType" in pg_db._tables["NL_H1"]
+    assert "TanUma" not in pg_db._tables["NL_H1"]
+
+
+def test_pg_migrate_no_op_when_schema_matches(pg_db):
+    """PostgreSQL path: no migration when columns already match."""
+    pg_db.execute(NEW_SCHEMA)
+
+    result = migrate_table_if_needed(pg_db, "NL_H1", NEW_SCHEMA)
+    assert result is False
+
+
+def test_pg_migrate_no_op_when_table_missing(pg_db):
+    """PostgreSQL path: no migration when table doesn't exist."""
+    result = migrate_table_if_needed(pg_db, "NL_H1", NEW_SCHEMA)
+    assert result is False
+
+
+def test_pg_migrate_all_tables(pg_db):
+    """PostgreSQL path: migrate_all_tables handles multiple tables."""
+    pg_db.execute(OLD_SCHEMA)
+    pg_db.execute(OLD_H6)
+
+    count = migrate_all_tables(pg_db, {"NL_H1": NEW_SCHEMA, "NL_H6": NEW_H6})
+    assert count == 2
+    assert "BetType" in pg_db._tables["NL_H1"]
+    assert "SanrentanKumi" in pg_db._tables["NL_H6"]


### PR DESCRIPTION
## Summary
- `migrate_table_if_needed()` was using `PRAGMA table_info()` (SQLite-only) to inspect existing columns
- Now branches on `db.get_db_type()`: SQLite keeps PRAGMA, PostgreSQL uses `information_schema.columns`
- Added `MockPostgreSQLDatabase` test fixture (no live server needed) + 4 new test cases covering the PostgreSQL migration path

## Test plan
- [x] All 10 migration tests pass (`pytest tests/test_migration.py`)
- [x] SQLite path unchanged
- [x] PostgreSQL path: mismatch triggers DROP+recreate, match is no-op, missing table is no-op

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced database migration system to properly support PostgreSQL databases alongside existing SQLite support.
* **Tests**
  * Added comprehensive test coverage for PostgreSQL database migrations, including validation of schema changes and multi-table migration operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->