### PR TITLE
feat(database): dual-write mode (SQLite primary + PostgreSQL mirror)

### DIFF
--- a/config/config.yaml.example
+++ b/config/config.yaml.example
@@ -19,7 +19,13 @@ nvlink:
 
 # Database Settings
 database:
-  # Default database type (sqlite, postgresql)
+  # Database mode: sqlite, postgresql, or dual
+  #   sqlite     - local SQLite file only (original behavior, single-user)
+  #   postgresql - remote PostgreSQL only (multi-user / server deployment)
+  #   dual       - write to both SQLite (primary) AND PostgreSQL (secondary).
+  #                SQLite stays authoritative; PG is a best-effort mirror.
+  #                Recommended while migrating an existing SQLite installation
+  #                to a shared PG without cutting over the source of truth.
   type: "sqlite"
 
 databases:
@@ -33,7 +39,7 @@ databases:
       cache_size: -64000  # 64MB
       temp_store: "MEMORY"
 
-  # PostgreSQL Database (for multi-user/server deployment)
+  # PostgreSQL Database (used when type=postgresql or type=dual)
   postgresql:
     enabled: false
     host: "${POSTGRES_HOST:localhost}"

--- a/src/cli/main.py
+++ b/src/cli/main.py
@@ -328,8 +328,7 @@ def fetch(ctx, date_from, date_to, data_spec, jv_option, db, batch_size, progres
       jltsql fetch --from 20240101 --to 20241231 --spec RACE
       jltsql fetch --from 20240101 --to 20241231 --spec DIFF --option 3
     """
-    from src.database.sqlite_handler import SQLiteDatabase
-    from src.database.postgresql_handler import PostgreSQLDatabase
+    from src.database import create_database_from_config, DatabaseError
     from src.database.schema import create_all_tables
     from src.importer.batch import BatchProcessor
 
@@ -370,17 +369,10 @@ def fetch(ctx, date_from, date_to, data_spec, jv_option, db, batch_size, progres
 
     try:
         # Initialize database
-        if db_type == "sqlite":
-            db_config = config.get("databases.sqlite") if config else {"path": "data/keiba.db"}
-            database = SQLiteDatabase(db_config)
-        elif db_type == "postgresql":
-            if not config:
-                console.print("[red]Error:[/red] PostgreSQL requires configuration file.")
-                sys.exit(1)
-            database = PostgreSQLDatabase(config.get("databases.postgresql"))
-        else:
-            console.print(f"[red]Error:[/red] Unsupported database type: {db_type}")
-            console.print("[yellow]Note:[/yellow] Supported types: sqlite, postgresql")
+        try:
+            database = create_database_from_config(config, db_type_override=db_type)
+        except (ValueError, DatabaseError) as exc:
+            console.print(f"[red]Error:[/red] {exc}")
             sys.exit(1)
 
         # Connect to database
@@ -536,24 +528,17 @@ def cache_build(ctx, data_spec, date_from, date_to, jv_option, also_import, db, 
     if also_import:
         # Use BatchProcessor with cache
         from src.importer.batch import BatchProcessor
-        from src.database.sqlite_handler import SQLiteDatabase
-        from src.database.postgresql_handler import PostgreSQLDatabase
+        from src.database import create_database_from_config, DatabaseError
 
         if db:
             db_type = db
         else:
             db_type = config.get("database.type", "sqlite") if config else "sqlite"
 
-        if db_type == "sqlite":
-            db_config = config.get("databases.sqlite") if config else {"path": "data/keiba.db"}
-            database = SQLiteDatabase(db_config)
-        elif db_type == "postgresql":
-            if not config:
-                click.echo("Error: PostgreSQL requires configuration file.")
-                sys.exit(1)
-            database = PostgreSQLDatabase(config.get("databases.postgresql"))
-        else:
-            click.echo(f"Error: Unsupported database type: {db_type}")
+        try:
+            database = create_database_from_config(config, db_type_override=db_type)
+        except (ValueError, DatabaseError) as exc:
+            click.echo(f"Error: {exc}")
             sys.exit(1)
 
         with database:
@@ -802,8 +787,7 @@ def monitor(ctx, daemon, data_spec, interval, db):
       jltsql monitor                        # 中央競馬監視
       jltsql monitor --daemon               # バックグラウンド実行
     """
-    from src.database.sqlite_handler import SQLiteDatabase
-    from src.database.postgresql_handler import PostgreSQLDatabase
+    from src.database import create_database_from_config, DatabaseError
     from src.database.schema import create_all_tables
     from src.realtime.monitor import RealtimeMonitor
 
@@ -828,17 +812,10 @@ def monitor(ctx, daemon, data_spec, interval, db):
 
     try:
         # Initialize database
-        if db_type == "sqlite":
-            db_config = config.get("databases.sqlite") if config else {"path": "data/keiba.db"}
-            database = SQLiteDatabase(db_config)
-        elif db_type == "postgresql":
-            if not config:
-                console.print("[red]Error:[/red] PostgreSQL requires configuration file.")
-                sys.exit(1)
-            database = PostgreSQLDatabase(config.get("databases.postgresql"))
-        else:
-            console.print(f"[red]Error:[/red] Unsupported database type: {db_type}")
-            console.print("[yellow]Note:[/yellow] Supported types: sqlite, postgresql")
+        try:
+            database = create_database_from_config(config, db_type_override=db_type)
+        except (ValueError, DatabaseError) as exc:
+            console.print(f"[red]Error:[/red] {exc}")
             sys.exit(1)
 
         # Connect to database
@@ -913,9 +890,8 @@ def create_tables(ctx, db, create_all, nl_only, rt_only):
       jltsql create-tables --rt-only      # Create only RT_* tables
     """
     from rich.progress import Progress, TextColumn
+    from src.database import create_database_from_config, DatabaseError
     from src.database.schema import SCHEMAS, create_all_tables
-    from src.database.sqlite_handler import SQLiteDatabase
-    from src.database.postgresql_handler import PostgreSQLDatabase
 
     config = ctx.obj.get("config")
     if not config and not db:
@@ -932,17 +908,10 @@ def create_tables(ctx, db, create_all, nl_only, rt_only):
 
     try:
         # Initialize database
-        if db_type == "sqlite":
-            db_config = config.get("databases.sqlite") if config else {"path": "data/keiba.db"}
-            database = SQLiteDatabase(db_config)
-        elif db_type == "postgresql":
-            if not config:
-                console.print("[red]Error:[/red] PostgreSQL requires configuration file.")
-                sys.exit(1)
-            database = PostgreSQLDatabase(config.get("databases.postgresql"))
-        else:
-            console.print(f"[red]Error:[/red] Unsupported database type: {db_type}")
-            console.print("[yellow]Note:[/yellow] Supported types: sqlite, postgresql")
+        try:
+            database = create_database_from_config(config, db_type_override=db_type)
+        except (ValueError, DatabaseError) as exc:
+            console.print(f"[red]Error:[/red] {exc}")
             sys.exit(1)
 
         # Connect to database
@@ -1019,9 +988,8 @@ def create_indexes(ctx, db, table):
       jltsql create-indexes --db sqlite        # Create indexes in SQLite
       jltsql create-indexes --table NL_RA      # Create indexes for NL_RA only
     """
+    from src.database import create_database_from_config, DatabaseError
     from src.database.indexes import IndexManager
-    from src.database.sqlite_handler import SQLiteDatabase
-    from src.database.postgresql_handler import PostgreSQLDatabase
 
     config = ctx.obj.get("config")
     if not config and not db:
@@ -1038,17 +1006,10 @@ def create_indexes(ctx, db, table):
 
     try:
         # Initialize database
-        if db_type == "sqlite":
-            db_config = config.get("databases.sqlite") if config else {"path": "data/keiba.db"}
-            database = SQLiteDatabase(db_config)
-        elif db_type == "postgresql":
-            if not config:
-                console.print("[red]Error:[/red] PostgreSQL requires configuration file.")
-                sys.exit(1)
-            database = PostgreSQLDatabase(config.get("databases.postgresql"))
-        else:
-            console.print(f"[red]Error:[/red] Unsupported database type: {db_type}")
-            console.print("[yellow]Note:[/yellow] Supported types: sqlite, postgresql")
+        try:
+            database = create_database_from_config(config, db_type_override=db_type)
+        except (ValueError, DatabaseError) as exc:
+            console.print(f"[red]Error:[/red] {exc}")
             sys.exit(1)
 
         # Connect to database
@@ -1125,8 +1086,7 @@ def export(ctx, table, output_format, output, where, db):
       jltsql export --table NL_HR --format parquet --output payouts.parquet
     """
     from pathlib import Path
-    from src.database.sqlite_handler import SQLiteDatabase
-    from src.database.postgresql_handler import PostgreSQLDatabase
+    from src.database import create_database_from_config, DatabaseError
 
     config = ctx.obj.get("config")
     if not config and not db:
@@ -1149,17 +1109,10 @@ def export(ctx, table, output_format, output, where, db):
 
     try:
         # Initialize database
-        if db_type == "sqlite":
-            db_config = config.get("databases.sqlite") if config else {"path": "data/keiba.db"}
-            database = SQLiteDatabase(db_config)
-        elif db_type == "postgresql":
-            if not config:
-                console.print("[red]Error:[/red] PostgreSQL requires configuration file.")
-                sys.exit(1)
-            database = PostgreSQLDatabase(config.get("databases.postgresql"))
-        else:
-            console.print(f"[red]Error:[/red] Unsupported database type: {db_type}")
-            console.print("[yellow]Note:[/yellow] Supported types: sqlite, postgresql")
+        try:
+            database = create_database_from_config(config, db_type_override=db_type)
+        except (ValueError, DatabaseError) as exc:
+            console.print(f"[red]Error:[/red] {exc}")
             sys.exit(1)
 
         # Connect and export
@@ -1395,8 +1348,7 @@ def start(ctx, specs, db, batch_size, no_create_tables):
       jltsql realtime start --specs 0B12,0B15   # 複数データ種別
       jltsql realtime start --db sqlite         # データベース指定
     """
-    from src.database.sqlite_handler import SQLiteDatabase
-    from src.database.postgresql_handler import PostgreSQLDatabase
+    from src.database import create_database_from_config, DatabaseError
     from src.services.realtime_monitor import RealtimeMonitor
 
     config = ctx.obj.get("config")
@@ -1425,17 +1377,10 @@ def start(ctx, specs, db, batch_size, no_create_tables):
 
     try:
         # Initialize database
-        if db_type == "sqlite":
-            db_config = config.get("databases.sqlite") if config else {"path": "data/keiba.db"}
-            database = SQLiteDatabase(db_config)
-        elif db_type == "postgresql":
-            if not config:
-                console.print("[red]Error:[/red] PostgreSQL requires configuration file.")
-                sys.exit(1)
-            database = PostgreSQLDatabase(config.get("databases.postgresql"))
-        else:
-            console.print(f"[red]Error:[/red] Unsupported database type: {db_type}")
-            console.print("[yellow]Note:[/yellow] Supported types: sqlite, postgresql")
+        try:
+            database = create_database_from_config(config, db_type_override=db_type)
+        except (ValueError, DatabaseError) as exc:
+            console.print(f"[red]Error:[/red] {exc}")
             sys.exit(1)
 
         # Create monitor
@@ -1594,6 +1539,7 @@ def timeseries(ctx, spec, from_date, to_date, db, db_path):
       jltsql realtime timeseries --spec 0B31,0B32 --db-path data/keiba.db
     """
     from datetime import datetime, timedelta
+    from src.database import create_database_from_config, DatabaseError
     from src.database.sqlite_handler import SQLiteDatabase
     from src.fetcher.realtime import RealtimeFetcher
     from src.realtime.updater import RealtimeUpdater
@@ -1634,11 +1580,18 @@ def timeseries(ctx, spec, from_date, to_date, db, db_path):
     console.print()
 
     try:
-        # Initialize database for saving
-        if db_type == "postgresql":
-            from src.database.postgresql_handler import PostgreSQLDatabase
-            database = PostgreSQLDatabase(config.get("databases.postgresql"))
+        # Initialize database for saving. For 'dual' mode we also want the
+        # timeseries writes to be mirrored, so defer to the shared factory.
+        if db_type in ("postgresql", "dual"):
+            try:
+                database = create_database_from_config(
+                    config, db_type_override=db_type
+                )
+            except (ValueError, DatabaseError) as exc:
+                console.print(f"[red]Error:[/red] {exc}")
+                sys.exit(1)
         else:
+            # Legacy SQLite path with explicit per-command db_path override.
             db_config = {"path": database_path}
             database = SQLiteDatabase(db_config)
 

--- a/src/database/__init__.py
+++ b/src/database/__init__.py
@@ -1,0 +1,96 @@
+"""Database handlers for JLTSQL.
+
+Exposes :func:`create_database_from_config` as the canonical way to build a
+:class:`BaseDatabase` from the user's config. Supported ``database.type``
+values:
+
+- ``sqlite``      → :class:`SQLiteDatabase`
+- ``postgresql``  → :class:`PostgreSQLDatabase`
+- ``dual``        → :class:`DualDatabase` wrapping SQLite (primary) + PostgreSQL (secondary)
+
+The ``dual`` mode lets ingestion keep writing to SQLite (historical
+behavior) while also mirroring every write into PostgreSQL, which is the
+recommended migration path when standing up a remote analytics PG alongside
+an existing SQLite installation.
+"""
+
+from typing import Any, Optional
+
+from .base import BaseDatabase, DatabaseError  # re-export for external callers
+
+SUPPORTED_DB_TYPES = ("sqlite", "postgresql", "dual")
+
+
+def create_database_from_config(
+    config: Any,
+    db_type_override: Optional[str] = None,
+) -> BaseDatabase:
+    """Build a :class:`BaseDatabase` from config.
+
+    Args:
+        config: Loaded configuration object exposing a ``get(key, default)``
+            method (see :mod:`src.utils.config`).
+        db_type_override: Optional explicit type (``sqlite`` / ``postgresql``
+            / ``dual``). If ``None``, uses ``database.type`` from the config.
+
+    Returns:
+        Concrete BaseDatabase instance (not yet connected).
+
+    Raises:
+        ValueError: If the resolved db_type is not supported.
+        DatabaseError: If PostgreSQL is requested without matching config.
+    """
+    # Local imports to avoid circular-import friction with base.py.
+    from .sqlite_handler import SQLiteDatabase
+    from .postgresql_handler import PostgreSQLDatabase
+    from .dual_handler import DualDatabase
+
+    if db_type_override:
+        db_type = db_type_override
+    elif config is not None:
+        db_type = config.get("database.type", "sqlite")
+    else:
+        db_type = "sqlite"
+
+    if db_type == "sqlite":
+        sqlite_config = (
+            config.get("databases.sqlite") if config else {"path": "data/keiba.db"}
+        )
+        return SQLiteDatabase(sqlite_config)
+
+    if db_type == "postgresql":
+        if not config:
+            raise DatabaseError(
+                "PostgreSQL requires a configuration file with "
+                "databases.postgresql settings"
+            )
+        return PostgreSQLDatabase(config.get("databases.postgresql"))
+
+    if db_type == "dual":
+        if not config:
+            raise DatabaseError(
+                "Dual-write requires a configuration file with both "
+                "databases.sqlite and databases.postgresql settings"
+            )
+        sqlite_config = config.get("databases.sqlite") or {"path": "data/keiba.db"}
+        pg_config = config.get("databases.postgresql")
+        if not pg_config:
+            raise DatabaseError(
+                "Dual-write requires databases.postgresql to be configured"
+            )
+        primary = SQLiteDatabase(sqlite_config)
+        secondary = PostgreSQLDatabase(pg_config)
+        return DualDatabase(primary=primary, secondary=secondary)
+
+    raise ValueError(
+        f"Unsupported database type: {db_type!r}. "
+        f"Supported: {', '.join(SUPPORTED_DB_TYPES)}"
+    )
+
+
+__all__ = [
+    "BaseDatabase",
+    "DatabaseError",
+    "create_database_from_config",
+    "SUPPORTED_DB_TYPES",
+]

--- a/src/database/dual_handler.py
+++ b/src/database/dual_handler.py
@@ -1,0 +1,215 @@
+"""Dual-write database handler.
+
+Wraps a primary and a secondary BaseDatabase so every DDL / INSERT / COMMIT
+is issued against both. Reads are served by the primary only.
+
+Typical use: primary=SQLiteDatabase (authoritative, fast local ingestion),
+secondary=PostgreSQLDatabase (mirror for analytics / cross-host consumers).
+
+Failure policy
+--------------
+The primary is the source of truth. Secondary failures (connect, create_table,
+insert, insert_many, commit) are logged as warnings and tracked via
+``self._secondary_errors`` but **do NOT raise**, preserving ingestion
+throughput if the secondary is unavailable.
+"""
+
+from typing import Any, Dict, List, Optional
+
+from src.utils.logger import get_logger
+
+from .base import BaseDatabase, DatabaseError
+
+logger = get_logger(__name__)
+
+
+class DualDatabase(BaseDatabase):
+    """BaseDatabase implementation that forwards writes to two backends.
+
+    The primary is treated as the source of truth; secondary failures are
+    logged but do not propagate. This mirrors the ``PgWriter`` dual-write
+    pattern used by the sibling ``jrvltsql-nar`` project, but here the
+    BaseDatabase interface itself is the abstraction boundary.
+    """
+
+    def __init__(self, primary: BaseDatabase, secondary: BaseDatabase):
+        # NOTE: we intentionally skip ``super().__init__`` because our
+        # configuration is the pair of backends themselves. The ABC requires
+        # the abstract methods to be implemented (they are, below).
+        self.config = {
+            "primary_type": primary.get_db_type(),
+            "secondary_type": secondary.get_db_type(),
+        }
+        self._connection = None  # BaseDatabase.is_connected() reads this
+        self._cursor = None
+        self._primary = primary
+        self._secondary = secondary
+        self._secondary_errors = 0
+        logger.info(
+            f"DualDatabase initialized: primary={primary.get_db_type()}, "
+            f"secondary={secondary.get_db_type()}"
+        )
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    def connect(self) -> None:
+        """Connect both backends. Secondary failure is logged, not raised."""
+        self._primary.connect()
+        # Surface primary's connection so BaseDatabase.is_connected() works.
+        self._connection = getattr(self._primary, "_connection", None)
+        try:
+            self._secondary.connect()
+        except Exception as e:
+            logger.warning(
+                f"DualDatabase: secondary connect failed ({self._secondary.get_db_type()}): {e}"
+            )
+            self._secondary_errors += 1
+
+    def disconnect(self) -> None:
+        """Disconnect both backends."""
+        try:
+            self._primary.disconnect()
+        finally:
+            try:
+                self._secondary.disconnect()
+            except Exception as e:
+                logger.warning(
+                    f"DualDatabase: secondary disconnect failed: {e}"
+                )
+        self._connection = None
+
+    def is_connected(self) -> bool:
+        """Report connection status of the primary backend."""
+        return self._primary.is_connected()
+
+    def get_db_type(self) -> str:
+        """Report the primary's type.
+
+        The caller side uses ``get_db_type()`` to decide behavior such as
+        whether to attempt rollback. Preserving the primary's semantics keeps
+        the rest of the codebase unchanged.
+        """
+        return self._primary.get_db_type()
+
+    # ------------------------------------------------------------------
+    # Reads: primary only
+    # ------------------------------------------------------------------
+
+    def execute(self, sql: str, parameters: Optional[tuple] = None) -> Any:
+        """Execute SQL on primary (reads + non-idempotent writes).
+
+        NOTE: arbitrary ``execute()`` calls are NOT mirrored to secondary
+        because the SQL may be reads or primary-specific statements
+        (PRAGMA, VACUUM, etc.). Use ``insert`` / ``insert_many`` /
+        ``create_table`` / ``commit`` for dual-write paths.
+        """
+        return self._primary.execute(sql, parameters)
+
+    def executemany(self, sql: str, parameters_list: List[tuple]) -> Any:
+        return self._primary.executemany(sql, parameters_list)
+
+    def fetch_one(
+        self, sql: str, parameters: Optional[tuple] = None
+    ) -> Optional[Dict[str, Any]]:
+        return self._primary.fetch_one(sql, parameters)
+
+    def fetch_all(
+        self, sql: str, parameters: Optional[tuple] = None
+    ) -> List[Dict[str, Any]]:
+        return self._primary.fetch_all(sql, parameters)
+
+    def table_exists(self, table_name: str) -> bool:
+        return self._primary.table_exists(table_name)
+
+    # ------------------------------------------------------------------
+    # Writes: dual
+    # ------------------------------------------------------------------
+
+    def create_table(self, table_name: str, schema: str) -> None:
+        """Create table in both backends.
+
+        The shared DDL in :mod:`src.database.schema` is deliberately written
+        in a subset of SQL compatible with both SQLite and PostgreSQL, so
+        the same schema string works on each side.
+        """
+        self._primary.create_table(table_name, schema)
+        try:
+            self._secondary.create_table(table_name, schema)
+        except Exception as e:
+            logger.warning(
+                f"DualDatabase: secondary create_table failed for {table_name}: {e}"
+            )
+            self._secondary_errors += 1
+
+    def insert(
+        self,
+        table_name: str,
+        data: Dict[str, Any],
+        use_replace: bool = True,
+    ) -> int:
+        rows = self._primary.insert(table_name, data, use_replace)
+        try:
+            self._secondary.insert(table_name, data, use_replace)
+        except Exception as e:
+            logger.warning(
+                f"DualDatabase: secondary insert failed for {table_name}: {e}"
+            )
+            self._secondary_errors += 1
+        return rows
+
+    def insert_many(
+        self,
+        table_name: str,
+        data_list: List[Dict[str, Any]],
+        use_replace: bool = True,
+    ) -> int:
+        rows = self._primary.insert_many(table_name, data_list, use_replace)
+        try:
+            self._secondary.insert_many(table_name, data_list, use_replace)
+        except Exception as e:
+            logger.warning(
+                f"DualDatabase: secondary insert_many failed for {table_name} "
+                f"({len(data_list)} rows): {e}"
+            )
+            self._secondary_errors += 1
+        return rows
+
+    def commit(self) -> None:
+        self._primary.commit()
+        try:
+            self._secondary.commit()
+        except Exception as e:
+            logger.warning(f"DualDatabase: secondary commit failed: {e}")
+            self._secondary_errors += 1
+
+    def rollback(self) -> None:
+        """Rollback primary only.
+
+        The secondary (typically PostgreSQL) may run in autocommit mode and
+        not support rollback. Callers that care about atomicity across both
+        stores must manage at a higher level; dual-write is a best-effort
+        mirror, not a distributed transaction.
+        """
+        try:
+            self._primary.rollback()
+        except DatabaseError:
+            # Primary already raised; don't double-report.
+            raise
+
+    # ------------------------------------------------------------------
+    # Diagnostics
+    # ------------------------------------------------------------------
+
+    @property
+    def secondary_error_count(self) -> int:
+        """Number of secondary-side failures since startup (read-only)."""
+        return self._secondary_errors
+
+    def __repr__(self) -> str:
+        return (
+            f"DualDatabase(primary={self._primary!r}, "
+            f"secondary={self._secondary!r}, "
+            f"secondary_errors={self._secondary_errors})"
+        )


### PR DESCRIPTION
## Summary

Adds a new \`database.type=\"dual\"\` option that writes every DDL / INSERT / COMMIT to **both** SQLite (primary, source of truth) and PostgreSQL (secondary, best-effort mirror). Reads go to the primary only. Secondary failures are logged via structlog but do **not** fail the primary write path, preserving ingestion throughput.

This mirrors the dual-write pattern already used by the sibling [jrvltsql-nar](https://github.com/miyamamoto/jrvltsql-nar) project (\`NAR_PG_URL\` / \`--pg-url\` → \`PgWriter\`) but implemented one layer higher at the \`BaseDatabase\` interface so all existing importer / fetcher code works unchanged.

## Motivation

Stand up a shared PostgreSQL alongside an existing SQLite installation without cutting over the source of truth. Once PG has been validated (row counts match, queries return identical results), the deployment can flip \`database.type\` to \`\"postgresql\"\` and retire SQLite.

## Changes

- **\`src/database/dual_handler.py\`** (new, 215 LOC): \`DualDatabase(BaseDatabase)\` wrapper
  - \`connect\` / \`disconnect\` / \`create_table\` / \`insert\` / \`insert_many\` / \`commit\` → both backends
  - Reads (\`execute\` / \`fetch_one\` / \`fetch_all\` / \`table_exists\`) → primary only
  - \`get_db_type()\` returns primary's type so existing rollback logic (see \`importer/importer.py:460\`) works unchanged
  - \`secondary_error_count\` property for ops monitoring
- **\`src/database/__init__.py\`**: new \`create_database_from_config()\` factory
  - Resolves \`sqlite\` / \`postgresql\` / \`dual\` from \`config.database.type\`
  - Centralises what was previously a repeated if/elif/else block in CLI
- **\`src/cli/main.py\`**: refactored 8 call sites to use the factory. Reduces ~140 LOC of duplicated instantiation into 3 LOC per site.
- **\`config/config.yaml.example\`**: documents the new \`dual\` mode

## How to enable

\`\`\`yaml
# config/config.yaml
database:
  type: \"dual\"

databases:
  sqlite:
    enabled: true
    path: \"./data/keiba.db\"
  postgresql:
    enabled: true
    host: \"192.168.0.223\"
    port: 5432
    database: \"keiba_dev\"
    user: \"ingestion_writer\"
    password: \"\${POSTGRES_PASSWORD}\"
\`\`\`

Then run the existing commands unchanged:

\`\`\`bat
jltsql create-tables
jltsql fetch --from 20240101 --to 20240131 --spec RACE
jltsql realtime start
\`\`\`

Both SQLite and PostgreSQL will receive the same data.

## Backward compat

Default \`database.type\` remains \`\"sqlite\"\`. Existing deployments are unaffected until they explicitly opt in to \`\"postgresql\"\` or \`\"dual\"\`.

## Failure policy

Intentionally non-transactional across the two backends (see \`dual_handler.py\` docstring):

- Primary failure → raises as before
- Secondary failure → logged warning, counter incremented, primary continues

This matches the jrvltsql-nar PgWriter policy.

## Test plan

- [x] \`python -c \"import ast; ast.parse(open('src/cli/main.py').read())\"\` — syntax check
- [x] \`python -c \"import ast; ast.parse(open('src/database/dual_handler.py').read())\"\` — syntax check
- [x] \`python -c \"import ast; ast.parse(open('src/database/__init__.py').read())\"\` — syntax check
- [ ] Smoke test: \`jltsql create-tables\` with \`database.type=dual\` against a live PG
- [ ] Smoke test: \`jltsql fetch --spec RACE\` small date range, verify row counts match between SQLite and PG
- [ ] Run existing pytest suite (\`pytest tests/ -q --ignore=tests/integration/ --ignore=tests/e2e/\`)

## Related

- Consumer project's design doc: https://github.com/miyamamoto/kps/blob/main/docs/DESIGN_V2.md (Option B, §2 — this PR is prerequisite for the JRA ingestion → remote PG migration)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced dual database mode, enabling simultaneous writes to SQLite (authoritative) and PostgreSQL (best-effort mirror) to support migration scenarios.

* **Chores**
  * Updated database configuration documentation to reflect three supported modes.
  * Refactored database initialization logic across CLI commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->