### PR TITLE
fix(tests): ensure disconnect() in test_database_growth to prevent Windows PermissionError

### DIFF
--- a/tests/test_performance_benchmarks.py
+++ b/tests/test_performance_benchmarks.py
@@ -355,32 +355,33 @@ class TestScalability(PerformanceTestBase):
         database = SQLiteDatabase({'path': str(db_path)})
         database.connect()
 
-        schema_mgr = SchemaManager(database)
-        schema_mgr.create_table('NL_RA')
+        try:
+            schema_mgr = SchemaManager(database)
+            schema_mgr.create_table('NL_RA')
 
-        importer = DataImporter(database, batch_size=100)
+            importer = DataImporter(database, batch_size=100)
 
-        # Import in stages, measure time each stage
-        stages = [500, 1000, 1500, 2000]
-        times = []
+            # Import in stages, measure time each stage
+            stages = [500, 1000, 1500, 2000]
+            times = []
 
-        for stage_size in stages:
-            records = self.generate_sample_records(stage_size)
-            _, elapsed = self.measure_time(importer.import_records, records)
-            times.append(elapsed)
+            for stage_size in stages:
+                records = self.generate_sample_records(stage_size)
+                _, elapsed = self.measure_time(importer.import_records, records)
+                times.append(elapsed)
 
-            print(f"Stage {stage_size} records: {elapsed:.3f}s")
+                print(f"Stage {stage_size} records: {elapsed:.3f}s")
 
-            # Clear for next stage
-            database.execute("DELETE FROM NL_RA")
+                # Clear for next stage
+                database.execute("DELETE FROM NL_RA")
 
-        # Performance shouldn't degrade significantly
-        # (Last stage should be within 3x of first)
-        if len(times) > 1:
-            ratio = times[-1] / times[0]
-            self.assertLess(ratio, 5.0, "Performance degradation too high")
-
-        database.disconnect()
+            # Performance shouldn't degrade significantly
+            # (Last stage should be within 3x of first)
+            if len(times) > 1 and times[0] > 0:
+                ratio = times[-1] / times[0]
+                self.assertLess(ratio, 5.0, "Performance degradation too high")
+        finally:
+            database.disconnect()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
- Wrap database operations in `try/finally` so `database.disconnect()` is always called, even when assertions fail
- On Windows, `TemporaryDirectory.cleanup()` in `tearDown` raises `PermissionError` if the SQLite file is still open — this caused intermittent `ERROR` in the full test suite
- Guard ratio calculation against `times[0] == 0` (avoids `ZeroDivisionError` on very fast machines)

This fixes the occasional `test_database_growth` flaky failure seen in CI and in `raceday_verify --phase auto` unit test checks.

## Test plan
- [x] `pytest tests/test_performance_benchmarks.py::TestScalability::test_database_growth` — passes
- [x] Full suite: 1236 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)