### PR TITLE
fix(tests): ignore WAL cleanup errors in benchmark TemporaryDirectory

### DIFF
--- a/tests/test_performance_benchmarks.py
+++ b/tests/test_performance_benchmarks.py
@@ -62,7 +62,7 @@ class TestImportPerformance(PerformanceTestBase):
 
     def setUp(self):
         """Set up test fixtures."""
-        self.temp_dir = tempfile.TemporaryDirectory()
+        self.temp_dir = tempfile.TemporaryDirectory(ignore_cleanup_errors=True)
         self.db_path = Path(self.temp_dir.name) / 'perf.db'
 
         self.database = SQLiteDatabase({'path': str(self.db_path)})
@@ -146,7 +146,7 @@ class TestQueryPerformance(PerformanceTestBase):
 
     def setUp(self):
         """Set up test fixtures."""
-        self.temp_dir = tempfile.TemporaryDirectory()
+        self.temp_dir = tempfile.TemporaryDirectory(ignore_cleanup_errors=True)
         self.db_path = Path(self.temp_dir.name) / 'query_perf.db'
 
         self.database = SQLiteDatabase({'path': str(self.db_path)})
@@ -215,7 +215,7 @@ class TestDatabaseComparison(PerformanceTestBase):
 
     def setUp(self):
         """Set up test database."""
-        self.temp_dir = tempfile.TemporaryDirectory()
+        self.temp_dir = tempfile.TemporaryDirectory(ignore_cleanup_errors=True)
 
         # SQLite only (DuckDB not supported on 32-bit Python)
         sqlite_path = Path(self.temp_dir.name) / 'sqlite.db'
@@ -265,7 +265,7 @@ class TestMemoryUsage(PerformanceTestBase):
 
     def setUp(self):
         """Set up test fixtures."""
-        self.temp_dir = tempfile.TemporaryDirectory()
+        self.temp_dir = tempfile.TemporaryDirectory(ignore_cleanup_errors=True)
         self.db_path = Path(self.temp_dir.name) / 'memory.db'
 
         self.database = SQLiteDatabase({'path': str(self.db_path)})
@@ -314,7 +314,7 @@ class TestScalability(PerformanceTestBase):
 
     def setUp(self):
         """Set up test fixtures."""
-        self.temp_dir = tempfile.TemporaryDirectory()
+        self.temp_dir = tempfile.TemporaryDirectory(ignore_cleanup_errors=True)
 
     def tearDown(self):
         """Clean up."""


### PR DESCRIPTION
## Summary
SQLite WAL mode (enabled via `PRAGMA journal_mode = WAL` for performance) creates `.db-wal`/`.db-shm` files alongside the main database. On Windows, `TemporaryDirectory.cleanup()` → `shutil.rmtree()` intermittently fails with `PermissionError` if these files linger after `connection.close()`.

Using `ignore_cleanup_errors=True` (available since Python 3.10, we're on 3.13) prevents tearDown from raising, eliminating the flaky `ERROR` that caused `raceday_verify` unit test checks to report failures.

This is the root cause of the recurring `Unit tests failed (exit 1)` seen in monitoring runs even though all test assertions passed.

## Test plan
- [x] `pytest tests/test_performance_benchmarks.py` — 14 passed
- [x] Full suite: 1236 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved robustness of performance benchmark test fixtures by suppressing cleanup errors during test teardown, ensuring tests complete reliably even with temporary file system issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->