### PR TITLE
fix(dual-write): prevent NL_H1 Total row + pg8000 session poisoning cascade

### DIFF
--- a/src/database/postgresql_handler.py
+++ b/src/database/postgresql_handler.py
@@ -531,27 +531,55 @@ class PostgreSQLDatabase(BaseDatabase):
             raise DatabaseError(f"Failed to commit transaction: {e}")
 
     def rollback(self) -> None:
-        """Rollback current transaction.
+        """Rollback the current transaction.
 
-        pg8000.native is always in autocommit mode and doesn't support rollback.
-        psycopg supports rollback.
+        pg8000.native maintains per-connection transaction state; after a
+        server error (e.g. NOT NULL violation) the connection stays in a
+        poisoned "in failed transaction" state until an explicit ROLLBACK.
+        We send ROLLBACK ourselves; if even that fails we close and rebuild
+        the connection so subsequent operations succeed.
 
         Raises:
-            DatabaseError: If rollback fails
+            DatabaseError: if rollback AND reconnect both fail
         """
         if not self._connection:
             raise DatabaseError("Database not connected")
 
         try:
             if DRIVER == "pg8000":
-                # pg8000.native is in autocommit mode, no rollback possible
-                logger.warning("pg8000.native doesn't support rollback (autocommit mode)")
+                try:
+                    self._connection.run("ROLLBACK")
+                    logger.debug("pg8000 ROLLBACK sent")
+                except Exception as e:
+                    logger.warning(
+                        f"pg8000 ROLLBACK failed ({e}); reconnecting"
+                    )
+                    self._reconnect()
             else:  # psycopg
                 self._connection.rollback()
                 logger.debug("Transaction rolled back")
 
+        except DatabaseError:
+            raise
         except Exception as e:
             raise DatabaseError(f"Failed to rollback transaction: {e}")
+
+    def _reconnect(self) -> None:
+        """Close and re-open the PG connection after a broken session."""
+        try:
+            if self._connection is not None:
+                try:
+                    self._connection.close()
+                except Exception:
+                    pass
+            self._connection = None
+            self._cursor = None
+            self.connect()
+            logger.info("PostgreSQL connection re-established")
+        except Exception as e:
+            self._connection = None
+            logger.error(f"PostgreSQL reconnect failed: {e}")
+            raise DatabaseError(f"PostgreSQL reconnect failed: {e}")
 
     def insert(self, table_name: str, data: Dict[str, Any], use_replace: bool = True) -> int:
         """Insert single row into table.

--- a/src/parser/h1_parser.py
+++ b/src/parser/h1_parser.py
@@ -158,7 +158,7 @@ class H1Parser:
         if totals:
             total_row = dict(header)
             total_row["BetType"] = "Total"
-            total_row["Kumi"] = ""
+            total_row["Kumi"] = "TOTAL"
             total_row["Hyo"] = ""
             total_row["Ninki"] = ""
             total_row.update(totals)


### PR DESCRIPTION
## Summary

Two coupled bugs caused PostgreSQL dual-write to stop after the first H1 payout file, despite the SQLite primary continuing cleanly. Fetches appeared healthy on SQLite but PG ended up with only the records that arrived before the first Total summary row.

## Root cause

1. **`parser/h1_parser.py`** emits a Total summary row with `Kumi=""` (empty string). The importer's generic "convert empty string to `None`" logic then converts that to NULL. PostgreSQL rejects it because `nl_h1.kumi` is `NOT NULL` + part of the primary key. SQLite is weakly typed and accepted empty strings, so the bug only surfaced on the PG side.

2. **`database/postgresql_handler.py:rollback()`** was effectively a no-op on pg8000. The comment asserted that "autocommit means no rollback is possible" — but that's misleading: after a server error pg8000 keeps the connection in an *aborted-transaction* state until an explicit `ROLLBACK` is issued. Every subsequent `INSERT`/`SELECT` on that connection then failed with a generic "network error", which looks like a transport issue but was actually client-side session state.

Because (2) meant we never recovered from (1), a single bad Total row from H1 poisoned the whole run — all later NL_RA / NL_SE / NL_HR / NL_JG inserts on the same connection got dropped with noisy "network error" warnings.

## Changes

### `src/parser/h1_parser.py`
- Total summary row now uses `Kumi="TOTAL"` instead of `""`. The sentinel is unique per (race, bettype), survives the importer's empty-to-None coercion, and satisfies the `nl_h1.kumi NOT NULL` constraint.

### `src/database/postgresql_handler.py`
- `rollback()` on pg8000 now sends an explicit `ROLLBACK` via `connection.run("ROLLBACK")`, matching the psycopg path.
- If `ROLLBACK` itself fails (e.g. the connection is genuinely broken), we escalate to a new `_reconnect()` helper that `close()`s and re-opens the connection, breaking any cascade.
- `_reconnect()` is also reusable for future "connection died mid-fetch" scenarios.

## Verification

**Before** (sid=JLTSQL_FULL10Y, RACE option=4, 10y fetch): after the first Total row, pg_stat_user_tables showed `nl_h1 = 34,623` frozen for the rest of the run; every subsequent batch logged `secondary insert_many failed: ... network error`. PG ended up with ~0.1% of the records SQLite had.

**After** (small RACE option=1 dual-write smoke test):
```
Statistics:
  Fetched:  2,216
  Parsed:   58,969
  Imported: 58,969
  Failed:   0
```
PG side:
```
nl_h1 rows : 37,661
  of which kumi='TOTAL' : 46
```
No "network error" warnings. Cascade eliminated.

Running the full existing test suite (`tests/test_parsers.py tests/test_converters.py`) → **451 tests passed**.

## Test plan

- [x] Existing `tests/test_parsers.py` + `tests/test_converters.py` → pass (451 tests)
- [x] Small RACE option=1 dual-write smoke test → PG rows match SQLite; Total rows land with `kumi='TOTAL'`
- [x] No references to `Kumi=""` elsewhere in tests (checked: zero hits)
- [ ] Full RACE 10y dual-write (deferred — covered by follow-up bulk-sync path for now)

## Follow-ups (not in this PR)

- Consider auditing `h6_parser.py` / `hr_parser.py` for the same "empty-string primary key column" pattern (manual spot-check found no obvious hits, but a grep-based audit would be cheap).
- A mocked unit test for `PostgreSQLDatabase.rollback()` using a stub pg8000 connection would lock in the behaviour; holding off here because the existing test file doesn't mock pg8000 and would need a new fixture.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Enhanced database transaction rollback handling with automatic session reconnection on rollback failures.
* Updated H1 parser summary rows to display "TOTAL" label for clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->