### PR TITLE
chore(config): remove NAR leftover nvlink block + default to postgresql

### DIFF
--- a/config/config.yaml.example
+++ b/config/config.yaml.example
@@ -7,26 +7,18 @@ jvlink:
   # Get from https://jra-van.jp/dlb/
   service_key: "${JVLINK_SERVICE_KEY}"
 
-# NV-Link (地方競馬DATA/UmaConn) Settings
-nvlink:
-  # Optional service key (if you want to set it programmatically)
-  # Format: XXXX-XXXX-XXXX-XXXX-X
-  service_key: "${NVLINK_SERVICE_KEY}"
-  # Initialization key (software ID) used by NVInit
-  # Example: "SA000000/SD000004" (your vendor-provided key)
-    # Must be "UNKNOWN" - other values cause -301 auth error
-  initialization_key: "UNKNOWN"
 
 # Database Settings
 database:
-  # Database mode: sqlite, postgresql, or dual
-  #   sqlite     - local SQLite file only (original behavior, single-user)
-  #   postgresql - remote PostgreSQL only (multi-user / server deployment)
+  # Database mode: postgresql, sqlite, or dual
+  #   postgresql - remote PostgreSQL only (default, single source of truth
+  #                for multi-user / analytics / production).
+  #   sqlite     - local SQLite file only (offline / single-user / dev).
   #   dual       - write to both SQLite (primary) AND PostgreSQL (secondary).
   #                SQLite stays authoritative; PG is a best-effort mirror.
-  #                Recommended while migrating an existing SQLite installation
-  #                to a shared PG without cutting over the source of truth.
-  type: "sqlite"
+  #                Useful while migrating an existing SQLite installation to
+  #                a shared PG without cutting over the source of truth.
+  type: "postgresql"
 
 databases:
   # SQLite Database (Default - recommended for single-user)


### PR DESCRIPTION
## Summary

Two tiny cleanups to `config/config.yaml.example`, aimed at new installations:

1. **Drop the `nvlink:` block.** jrvltsql is strictly for JRA; NV-Link (地方競馬 / NAR) belongs in the sibling `jrvltsql-nar` repo. `grep -rn "nvlink\|NVLINK\|NVDT" src/` returns **zero matches**, confirming this has been pure template drift / dead config.

2. **Flip the default `database.type` from `sqlite` to `postgresql`.** Since #100 landed, PG dual-write is no longer a foot-gun, and new installs should go straight to PG as the single source of truth for multi-user / analytics / production. `sqlite` and `dual` remain selectable via explicit config; the inline comment documents both options.

## Diff

- `-15 / +7` lines, comments/config-only
- No code changes, no test changes

## Test plan

- [x] `grep -rn "nvlink\|NVLINK" src/` → 0 hits (nvlink has no consumers in this repo)
- [x] `config/config.yaml.example` still parses as valid YAML
- [x] Existing installs are unaffected (we only change the *example* default; live `config.yaml` is gitignored and preserved per-machine)

## Why now

Follow-up to #100. That PR fixed the dual-write cascade; this one makes `postgresql` the documented default so new users don't inherit a SQLite-first default that then needs migration.
