### PR TITLE
chore(release): prepare v1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.3.0] - 2026-04-22
+
+### Added
+
+- **Dual-write mode** を追加
+  - SQLite を primary としつつ PostgreSQL へ同時書き込み
+  - `src/database/dual_handler.py` を新設
+- **PostgreSQL migration support** を追加
+  - 既存 SQLite スキーマの PostgreSQL 側反映と移行経路を整備
+- migration / dual-write 向けテストを追加
+  - `tests/test_migration.py`
+
+### Fixed
+
+- DDL が dual-write 時に mirror 側へ確実に反映されない問題を修正
+- realtime / verify 周辺の false positive とメッセージ不整合を修正
+- batch importer / realtime updater の PostgreSQL 併用時の整合性を改善
+
+### Changed
+
+- CLI と database 初期化フローを dual-write / PostgreSQL mirror 前提で整理
+- realtime monitor の DB 書き込み経路を見直し
+- config example を PostgreSQL 併用前提に更新
+
 ## [1.2.0] - 2026-04-17
 
 ### ⚠️ Breaking Changes
@@ -75,6 +99,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - CLI コマンド（fetch, status, monitor, init）
 
 [Unreleased]: https://github.com/miyamamoto/jrvltsql/compare/v1.2.0...HEAD
+[1.3.0]: https://github.com/miyamamoto/jrvltsql/compare/v1.2.0...v1.3.0
 [1.2.0]: https://github.com/miyamamoto/jrvltsql/compare/v1.1.0...v1.2.0
 [1.1.0]: https://github.com/miyamamoto/jrvltsql/compare/v1.0.0...v1.1.0
 [1.0.0]: https://github.com/miyamamoto/jrvltsql/releases/tag/v1.0.0

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,38 +1,46 @@
-# jrvltsql v1.1.0 リリースノート
+# jrvltsql v1.3.0 リリースノート
 
-## 主要な新機能
+## 主要な変更
 
-### 🔧 H1/H6パーサーのフルストラクト対応
-- H1（票数1）: 28,955バイトのフルストラクトを正しくパース
-- H6（3連単票数）: 102,900バイトのフルストラクトを正しくパース
-- 賭式×組番に展開してDBに格納
+### 🗄️ Dual-write mode
+- SQLite を primary にしつつ PostgreSQL へ同時書き込み
+- DDL / migration も mirror 側へ反映
+- PostgreSQL 併用時の移行パスを標準化
 
-### 📦 ワンコマンドインストーラー
-```powershell
-irm https://raw.githubusercontent.com/miyamamoto/jrvltsql/master/install.ps1 | iex
-```
+### 🔄 PostgreSQL migration 整備
+- schema migration の PostgreSQL 対応を追加
+- migration テストを拡充
+- batch / realtime の書き込み経路を調整
 
-### 🔄 自動アップデート
-- `jltsql update` — ワンコマンドでアップデート
-- `jltsql version --check` — 最新版チェック
-- 起動時の自動チェック（設定可能）
+### 🧪 品質改善
+- DDL mirror の反映漏れを修正
+- realtime / verify 周辺の false positive を解消
+- dual-write / migration まわりのテストを追加
 
-### 📚 ドキュメント整備
-- Getting Started, Reference, UserGuide を最新仕様に更新
+## 対象ユーザー
 
-### 🧹 リポジトリ整理
-- 不要ファイル10個削除（7,178行削減）
-- .gitignore整備
+- Windows 上で JV-Link から JRA データを取り込みたい運用者
+- SQLite から PostgreSQL mirror / 移行へ進めたい運用者
+- race day の realtime 監視を安定化したい利用者
 
 ## システム要件
 - Windows 10/11
 - Python 3.12（32-bit）
 - JV-Link（中央競馬）
 
-## インストール
+## インストール / アップデート
 ```powershell
 irm https://raw.githubusercontent.com/miyamamoto/jrvltsql/master/install.ps1 | iex
 ```
 
-## テスト
-- 1,247 テストケース（1,239 pass, 8 skip）
+## 主な差分
+
+- `src/database/dual_handler.py`
+- `src/database/migration.py`
+- `src/services/realtime_monitor.py`
+- `src/cli/main.py`
+
+## 補足
+
+- 本リリースは **JRA 専用** です
+- NAR 取り込みは `jrvltsql-nar` 側で分離管理します

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "jltsql"
-version = "1.2.0"
+version = "1.3.0"
 description = "JRA-VAN DataLab の競馬データをSQLite・PostgreSQLにインポートするツール"
 readme = "README.md"
 license = {text = "Apache-2.0"}


### PR DESCRIPTION
## 概要
- v1.3.0 の version/changelog/release notes を更新
- dual-write / PostgreSQL migration 系の変更を release ノートへ反映

## 検証
- python3 -m py_compile で v1.2.0 以降の Python 差分を確認
- PYTHONPATH=/home/keiba/work/jrvltsql pytest -q tests/test_migration.py tests/test_realtime.py
  - 45 passed

## 備考
- GitHub Release は tag `v1.3.0` で作成済み


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes - v1.3.0

* **New Features**
  * Dual-write mode: simultaneous writes to SQLite (primary) and PostgreSQL
  * PostgreSQL migration support with schema synchronization capability

* **Bug Fixes**
  * Fixed DDL mirror propagation in dual-write operations
  * Resolved realtime verification false positives
  * Improved consistency between batch importer and realtime updater with PostgreSQL

<!-- end of auto-generated comment: release notes by coderabbit.ai -->