### PR TITLE
Stabilize Windows daily sync workflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.3.0] - 2026-04-22
+
+### Added
+
+- **Dual-write mode** を追加
+  - SQLite を primary としつつ PostgreSQL へ同時書き込み
+  - `src/database/dual_handler.py` を新設
+- **PostgreSQL migration support** を追加
+  - 既存 SQLite スキーマの PostgreSQL 側反映と移行経路を整備
+- migration / dual-write 向けテストを追加
+  - `tests/test_migration.py`
+
+### Fixed
+
+- DDL が dual-write 時に mirror 側へ確実に反映されない問題を修正
+- realtime / verify 周辺の false positive とメッセージ不整合を修正
+- batch importer / realtime updater の PostgreSQL 併用時の整合性を改善
+
+### Changed
+
+- CLI と database 初期化フローを dual-write / PostgreSQL mirror 前提で整理
+- realtime monitor の DB 書き込み経路を見直し
+- config example を PostgreSQL 併用前提に更新
+
 ## [1.2.0] - 2026-04-17
 
 ### ⚠️ Breaking Changes
@@ -75,6 +99,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - CLI コマンド（fetch, status, monitor, init）
 
 [Unreleased]: https://github.com/miyamamoto/jrvltsql/compare/v1.2.0...HEAD
+[1.3.0]: https://github.com/miyamamoto/jrvltsql/compare/v1.2.0...v1.3.0
 [1.2.0]: https://github.com/miyamamoto/jrvltsql/compare/v1.1.0...v1.2.0
 [1.1.0]: https://github.com/miyamamoto/jrvltsql/compare/v1.0.0...v1.1.0
 [1.0.0]: https://github.com/miyamamoto/jrvltsql/releases/tag/v1.0.0

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,38 +1,46 @@
-# jrvltsql v1.1.0 リリースノート
+# jrvltsql v1.3.0 リリースノート
 
-## 主要な新機能
+## 主要な変更
 
-### 🔧 H1/H6パーサーのフルストラクト対応
-- H1（票数1）: 28,955バイトのフルストラクトを正しくパース
-- H6（3連単票数）: 102,900バイトのフルストラクトを正しくパース
-- 賭式×組番に展開してDBに格納
+### 🗄️ Dual-write mode
+- SQLite を primary にしつつ PostgreSQL へ同時書き込み
+- DDL / migration も mirror 側へ反映
+- PostgreSQL 併用時の移行パスを標準化
 
-### 📦 ワンコマンドインストーラー
-```powershell
-irm https://raw.githubusercontent.com/miyamamoto/jrvltsql/master/install.ps1 | iex
-```
+### 🔄 PostgreSQL migration 整備
+- schema migration の PostgreSQL 対応を追加
+- migration テストを拡充
+- batch / realtime の書き込み経路を調整
 
-### 🔄 自動アップデート
-- `jltsql update` — ワンコマンドでアップデート
-- `jltsql version --check` — 最新版チェック
-- 起動時の自動チェック（設定可能）
+### 🧪 品質改善
+- DDL mirror の反映漏れを修正
+- realtime / verify 周辺の false positive を解消
+- dual-write / migration まわりのテストを追加
 
-### 📚 ドキュメント整備
-- Getting Started, Reference, UserGuide を最新仕様に更新
+## 対象ユーザー
 
-### 🧹 リポジトリ整理
-- 不要ファイル10個削除（7,178行削減）
-- .gitignore整備
+- Windows 上で JV-Link から JRA データを取り込みたい運用者
+- SQLite から PostgreSQL mirror / 移行へ進めたい運用者
+- race day の realtime 監視を安定化したい利用者
 
 ## システム要件
 - Windows 10/11
 - Python 3.12（32-bit）
 - JV-Link（中央競馬）
 
-## インストール
+## インストール / アップデート
 ```powershell
 irm https://raw.githubusercontent.com/miyamamoto/jrvltsql/master/install.ps1 | iex
 ```
 
-## テスト
-- 1,247 テストケース（1,239 pass, 8 skip）
+## 主な差分
+
+- `src/database/dual_handler.py`
+- `src/database/migration.py`
+- `src/services/realtime_monitor.py`
+- `src/cli/main.py`
+
+## 補足
+
+- 本リリースは **JRA 専用** です
+- NAR 取り込みは `jrvltsql-nar` 側で分離管理します

--- a/daily_sync.bat
+++ b/daily_sync.bat
@@ -1,0 +1,24 @@
+@echo off
+setlocal enabledelayedexpansion
+chcp 65001 >nul 2>&1
+set PYTHONIOENCODING=utf-8
+title JLTSQL Daily Sync
+
+cd /d "%~dp0"
+
+if exist "%~dp0venv32\Scripts\python.exe" (
+    set "PYTHON=%~dp0venv32\Scripts\python.exe"
+) else if exist "%~dp0.venv\Scripts\python.exe" (
+    set "PYTHON=%~dp0.venv\Scripts\python.exe"
+) else (
+    set "PYTHON=python"
+)
+
+echo ============================================================
+echo   JLTSQL Daily Sync
+echo ============================================================
+echo Using Python: %PYTHON%
+echo.
+
+"%PYTHON%" scripts\daily_update.py %*
+exit /b %errorlevel%

--- a/install_tasks.ps1
+++ b/install_tasks.ps1
@@ -1,0 +1,30 @@
+param(
+    [string]$TaskName = "JRVLTSQL_DailySync",
+    [string]$Time = "06:30",
+    [switch]$Force
+)
+
+$ErrorActionPreference = "Stop"
+
+$root = Split-Path -Parent $MyInvocation.MyCommand.Path
+$bat = Join-Path $root "daily_sync.bat"
+
+if (-not (Test-Path $bat)) {
+    throw "daily_sync.bat not found: $bat"
+}
+
+if ($Force -and (Get-ScheduledTask -TaskName $TaskName -ErrorAction SilentlyContinue)) {
+    Unregister-ScheduledTask -TaskName $TaskName -Confirm:$false
+}
+
+$action = New-ScheduledTaskAction -Execute "cmd.exe" -Argument "/c `"$bat`"" -WorkingDirectory $root
+$trigger = New-ScheduledTaskTrigger -Daily -At $Time
+$settings = New-ScheduledTaskSettingsSet -StartWhenAvailable -AllowStartIfOnBatteries -DontStopIfGoingOnBatteries
+
+if (Get-ScheduledTask -TaskName $TaskName -ErrorAction SilentlyContinue) {
+    Set-ScheduledTask -TaskName $TaskName -Trigger $trigger -Action $action -Settings $settings | Out-Null
+} else {
+    Register-ScheduledTask -TaskName $TaskName -Action $action -Trigger $trigger -Settings $settings -Description "JRA daily sync for jrvltsql" | Out-Null
+}
+
+Write-Host "Scheduled task ready: $TaskName at $Time"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "jltsql"
-version = "1.2.0"
+version = "1.3.0"
 description = "JRA-VAN DataLab の競馬データをSQLite・PostgreSQLにインポートするツール"
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/quickstart.bat
+++ b/quickstart.bat
@@ -2,7 +2,7 @@
 setlocal enabledelayedexpansion
 chcp 65001 >nul 2>&1
 set PYTHONIOENCODING=utf-8
-title JLTSQL Setup
+title JLTSQL Quickstart
 
 REM Move to batch file directory
 cd /d "%~dp0"
@@ -15,62 +15,50 @@ echo.
 REM Store exit code for later
 set SCRIPT_EXIT_CODE=0
 
-REM ============================================================
-REM   Python Detection (32-bit required for JV-Link COM API)
-REM ============================================================
+REM Prefer repo-local interpreters first so Windows collectors can run
+REM without relying on global PATH state.
+if exist "%~dp0venv32\Scripts\python.exe" (
+    set "PYTHON=%~dp0venv32\Scripts\python.exe"
+    goto :run
+)
+
+if exist "%~dp0.venv\Scripts\python.exe" (
+    set "PYTHON=%~dp0.venv\Scripts\python.exe"
+    goto :run
+)
 
 REM First try: explicit PYTHON environment variable
 if defined PYTHON (
-    echo Using PYTHON environment variable: %PYTHON%
-    "%PYTHON%" scripts/quickstart.py %*
-    set SCRIPT_EXIT_CODE=!errorlevel!
-    goto :check_result
+    goto :run
 )
 
-REM Second try: py launcher with 32-bit Python 3.12
-py -3.12-32 --version >nul 2>&1
-if !errorlevel!==0 (
-    echo Using: Python 3.12 ^(32-bit^)
-    py -3.12-32 scripts/quickstart.py %*
-    set SCRIPT_EXIT_CODE=!errorlevel!
-    goto :check_result
-)
-
-REM Third try: py launcher with any 32-bit Python
-py -32 --version >nul 2>&1
-if !errorlevel!==0 (
-    echo Using: Python ^(32-bit^)
-    py -32 scripts/quickstart.py %*
-    set SCRIPT_EXIT_CODE=!errorlevel!
-    goto :check_result
-)
-
-REM Fourth try: py launcher (any version)
+REM Prefer regular py launcher; JLTSQL now supports bridge-based JRA access
+REM and no longer requires a global 32-bit Python install.
 py --version >nul 2>&1
 if !errorlevel!==0 (
-    echo Using: Python ^(py launcher^)
-    echo [WARNING] 64-bit Python may not support JV-Link COM API
-    py scripts/quickstart.py %*
-    set SCRIPT_EXIT_CODE=!errorlevel!
-    goto :check_result
+    set "PYTHON=py"
+    goto :run
 )
 
-REM Fifth try: python in PATH
+REM Fallback: python in PATH
 python --version >nul 2>&1
 if !errorlevel!==0 (
-    echo Using: Python ^(PATH^)
-    echo [WARNING] 64-bit Python may not support JV-Link COM API
-    python scripts/quickstart.py %*
-    set SCRIPT_EXIT_CODE=!errorlevel!
-    goto :check_result
+    set "PYTHON=python"
+    goto :run
 )
 
 REM No Python found
 echo ERROR: Python not found
-echo Please install Python 3.12 (32-bit) for JV-Link COM API support
+echo Please install Python 3.10+ or create venv32/.venv in this repository.
 echo Download: https://www.python.org/downloads/
 pause
 exit /b 1
+
+:run
+echo Using Python: %PYTHON%
+"%PYTHON%" scripts/quickstart.py %*
+set SCRIPT_EXIT_CODE=!errorlevel!
+goto :check_result
 
 :check_result
 echo.

--- a/scripts/daily_update.py
+++ b/scripts/daily_update.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python
+"""Non-interactive daily JRA sync for Windows task scheduling."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from datetime import datetime, timedelta
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(PROJECT_ROOT))
+
+from src.database import create_database_from_config
+from src.importer.batch import BatchProcessor
+from src.utils.config import load_config
+
+UPDATE_SPECS = [
+    ("TOKU", 2),
+    ("RACE", 2),
+    ("TCVN", 2),
+    ("RCVN", 2),
+]
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Run daily JRA incremental sync")
+    parser.add_argument("--config", default=None, help="Path to config.yaml")
+    parser.add_argument("--days-back", type=int, default=7, help="Fetch window size in days")
+    parser.add_argument("--db", default=None, choices=["sqlite", "postgresql"], help="Override database type")
+    parser.add_argument("--ensure-tables", action="store_true", help="Create/migrate tables before sync")
+    args = parser.parse_args()
+
+    config_path = args.config or str(PROJECT_ROOT / "config" / "config.yaml")
+    config = load_config(config_path)
+    database = create_database_from_config(config, db_type_override=args.db)
+
+    to_date = datetime.now().strftime("%Y%m%d")
+    from_date = (datetime.now() - timedelta(days=max(args.days_back, 1))).strftime("%Y%m%d")
+
+    with database:
+        for spec, option in UPDATE_SPECS:
+            processor = BatchProcessor(
+                database=database,
+                sid=config.get("jvlink.sid", "JLTSQL"),
+                batch_size=1000,
+                service_key=config.get("jvlink.service_key"),
+                show_progress=False,
+            )
+            print(f"[daily-sync] {spec} {from_date}..{to_date} option={option}")
+            stats = processor.process_date_range(
+                data_spec=spec,
+                from_date=from_date,
+                to_date=to_date,
+                option=option,
+                ensure_tables=args.ensure_tables,
+            )
+            print(
+                f"[daily-sync] {spec} fetched={stats.get('records_fetched', 0)} "
+                f"parsed={stats.get('records_parsed', 0)} imported={stats.get('records_imported', 0)} "
+                f"failed={stats.get('records_failed', 0)}"
+            )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/importer/batch.py
+++ b/src/importer/batch.py
@@ -118,6 +118,16 @@ class BatchProcessor:
             option=option,
         )
 
+        if self._should_split_setup_range(from_date, to_date, option):
+            return self._process_split_setup_range(
+                data_spec=data_spec,
+                from_date=from_date,
+                to_date=to_date,
+                option=option,
+                auto_commit=auto_commit,
+                ensure_tables=ensure_tables,
+            )
+
         # Ensure tables exist
         if ensure_tables:
             logger.info("Ensuring all tables exist")
@@ -150,6 +160,64 @@ class BatchProcessor:
         except Exception as e:
             logger.error("Batch processing failed", error=str(e))
             raise
+
+    @staticmethod
+    def _should_split_setup_range(from_date: str, to_date: str, option: int) -> bool:
+        if option not in (3, 4):
+            return False
+        start = datetime.strptime(from_date, "%Y%m%d")
+        end = datetime.strptime(to_date, "%Y%m%d")
+        return (end - start).days > 370
+
+    def _iter_year_chunks(self, from_date: str, to_date: str) -> Iterator[Tuple[str, str]]:
+        start = datetime.strptime(from_date, "%Y%m%d")
+        end = datetime.strptime(to_date, "%Y%m%d")
+        year = start.year
+        while year <= end.year:
+            chunk_start = max(start, datetime(year, 1, 1))
+            chunk_end = min(end, datetime(year, 12, 31))
+            yield chunk_start.strftime("%Y%m%d"), chunk_end.strftime("%Y%m%d")
+            year += 1
+
+    def _process_split_setup_range(
+        self,
+        data_spec: str,
+        from_date: str,
+        to_date: str,
+        option: int,
+        auto_commit: bool,
+        ensure_tables: bool,
+    ) -> dict:
+        logger.info(
+            "Splitting setup range into yearly chunks to avoid JVOpen memory pressure",
+            data_spec=data_spec,
+            from_date=from_date,
+            to_date=to_date,
+            option=option,
+        )
+        combined_stats: dict = {}
+        for idx, (chunk_from, chunk_to) in enumerate(self._iter_year_chunks(from_date, to_date), start=1):
+            logger.info(
+                "Processing setup chunk",
+                chunk_index=idx,
+                chunk_from=chunk_from,
+                chunk_to=chunk_to,
+                data_spec=data_spec,
+            )
+            chunk_stats = self.process_date_range(
+                data_spec=data_spec,
+                from_date=chunk_from,
+                to_date=chunk_to,
+                option=option,
+                auto_commit=auto_commit,
+                ensure_tables=ensure_tables and idx == 1,
+            )
+            for key, value in chunk_stats.items():
+                if isinstance(value, (int, float)):
+                    combined_stats[key] = combined_stats.get(key, 0) + value
+                else:
+                    combined_stats[key] = value
+        return combined_stats
 
     def process_month(
         self,


### PR DESCRIPTION
## Summary
- add a self-contained Windows daily sync entrypoint for JRA
- prefer repo-local Python interpreters in quickstart and task scripts
- split long setup imports into yearly chunks to avoid JVOpen memory failures
- add a Scheduled Task installer for Windows collectors

## Validation
- python3 -m py_compile src/importer/batch.py scripts/daily_update.py
- confirmed on Windows host that daily_sync.bat initializes JV-Link and imports records

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Dual-write mode enabling simultaneous SQLite and PostgreSQL writes with SQLite as primary.
  * PostgreSQL migration support with schema mapping for existing SQLite data.
  * Windows scheduled task automation for daily data synchronization.

* **Bug Fixes**
  * Fixed DDL mirroring inconsistencies between databases.
  * Resolved false positives in realtime verification.
  * Improved data integrity when batch importing and realtime updates use PostgreSQL together.

* **Documentation**
  * Updated release notes and changelog for v1.3.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->