### PR TITLE
Fix performance benchmark CI dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ s3 = ["boto3>=1.26", "cryptography>=41.0"]
 dev = [
     "pytest>=7.4",
     "pytest-cov>=4.1",
+    "pytest-benchmark>=4.0",
     "black>=23.0",
     "ruff>=0.1",
     "mypy>=1.5",


### PR DESCRIPTION
## Summary
- Add pytest-benchmark to dev dependencies so the master-only performance-test job recognizes --benchmark-only.

## Verification
- pytest tests/test_performance_benchmarks.py -q --benchmark-only
- git diff --check