### PR TITLE
Publish full documentation navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ JRA-VAN DataLab データを SQLite/PostgreSQL に取り込む Windows 専用パ
 
 JRA（中央競馬）専用です。
 
+Documentation: https://miyamamoto.github.io/jrvltsql/
+
 ---
 
 ## 必要要件

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -21,6 +21,10 @@ markdown_extensions:
 
 nav:
   - Home: index.md
+  - Architecture: architecture.md
   - CLI: CLI.md
+  - PostgreSQL: postgresql.md
+  - Time-series odds: timeseries_odds.md
+  - Scripts: scripts.md
 
 copyright: Copyright &copy; 2024 JRVLTSQL Contributors


### PR DESCRIPTION
## Summary
- Add the GitHub Pages documentation URL to README.
- Expose architecture, PostgreSQL, time-series odds, and scripts docs in mkdocs navigation.

## Verification
- Markdown link check for README.md and docs/**/*.md
- Parsed mkdocs nav
- git diff --check