### PR TITLE
Wire quickstart into PostgreSQL time-series setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- `quickstart.bat` から PostgreSQL time-series quickstart を続けて実行できる導線を追加
+- `quickstart_postgres_timeseries.bat` 完了時に Windows Task Scheduler 登録を確認するよう変更
+- `install_tasks.ps1` で `daily_sync.bat` の DB 種別・日付窓・PostgreSQL 環境変数永続化を指定可能に変更
+
 ## [1.4.0] - 2026-05-03
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ quickstart.bat
 4. JRA-VAN からのデータ取得・DB 格納
 5. S3 キャッシュのアップロード（オプション）
 6. DB 検証 (`raceday_verify --phase pre`)
+7. PostgreSQL + 公式時系列オッズ投入の実行確認（オプション）
 
 PostgreSQL + 時系列オッズ:
 
@@ -46,7 +47,10 @@ quickstart_postgres_timeseries.bat 20250426 20260412
 ```
 
 `quickstart_postgres_timeseries.bat` は、`RACE` データと公式1年保持の
-`TS_O1/TS_O2` 時系列オッズを PostgreSQL に投入します。
+`TS_O1/TS_O2` 時系列オッズを PostgreSQL に投入します。完了時に
+Windows Task Scheduler へ `daily_sync.bat` を登録するか確認します。
+タスクから PostgreSQL に接続する場合は、現在の `POSTGRES_*` 接続情報を
+Windows ユーザー環境変数へ保存するかも確認されます。
 
 ---
 
@@ -89,6 +93,9 @@ jltsql cache sync --upload             # ローカル → S3 同期
 quickstart_postgres_timeseries.bat 20250426 20260412
 ```
 
+通常の `quickstart.bat` からも、セットアップ完了後にこの PostgreSQL +
+時系列オッズ投入を続けて実行できます。
+
 既に `NL_RA` が入っていて時系列オッズだけを追加する場合:
 
 ```bat
@@ -108,6 +115,20 @@ jltsql realtime odds-timeseries --from <FROM> --to <TO> --db postgresql
 ```
 
 `odds-timeseries` は `0B41/0B42` で公式1年保持の単複枠・馬連時系列を取得し、`TS_O1/TS_O2` に保存します。`0B30` の全賭式速報オッズは1週間保持なので、開催週に蓄積する場合だけ `realtime odds-sokuho-timeseries` を使います。
+
+### Windows タスク登録
+
+PostgreSQL 運用では、`quickstart_postgres_timeseries.bat` の最後に
+`daily_sync.bat` を Windows Task Scheduler に登録するか確認されます。
+手動で登録する場合は以下を実行します。
+
+```powershell
+powershell -NoProfile -ExecutionPolicy Bypass -File install_tasks.ps1 -DbType postgresql -Time 06:30
+```
+
+`POSTGRES_PASSWORD` などを現在の CMD セッションだけで設定している場合、
+タスク実行時には見えません。登録時の確認で `POSTGRES_*` を Windows
+ユーザー環境変数へ保存するか、あらかじめ永続的な環境変数として設定してください。
 
 ### fetch オプション
 

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -88,6 +88,10 @@ PostgreSQL に RACE と公式1年保持の TS_O1/TS_O2 を投入します。
 quickstart_postgres_timeseries.bat 20250426 20260412
 ```
 
+`quickstart.bat` からも通常セットアップ完了後にこの処理を続けて実行できます。
+`quickstart_postgres_timeseries.bat` の最後では、`daily_sync.bat` を
+Windows Task Scheduler に登録するか確認します。
+
 既に RACE / NL_RA がある場合は、時系列オッズだけ追加します。
 
 ```bat

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -23,9 +23,10 @@ NAR data is outside this repository.
 | `src/database/` | SQLite/PostgreSQL handlers and schemas. |
 | `src/realtime/` | Realtime data collection. |
 | `scripts/quickstart.py` | Non-interactive and interactive setup/update orchestration. |
-| `quickstart.bat` | General SQLite-first quickstart. |
-| `quickstart_postgres_timeseries.bat` | PostgreSQL + official time-series odds setup. |
+| `quickstart.bat` | General SQLite-first quickstart with optional PostgreSQL time-series follow-up. |
+| `quickstart_postgres_timeseries.bat` | PostgreSQL + official time-series odds setup, followed by optional task registration. |
 | `daily_sync.bat` | Recent race-card/result sync for scheduled Windows tasks. |
+| `install_tasks.ps1` | Windows Task Scheduler registration for `daily_sync.bat`. |
 
 ## Data Stores
 
@@ -54,5 +55,8 @@ decision-time odds, keep collecting these specs during the racing week.
 ## Scheduling
 
 Use Windows Task Scheduler to run `daily_sync.bat` for ordinary race data.
+`quickstart_postgres_timeseries.bat` prompts for this registration at the end
+of the PostgreSQL time-series setup. The scheduled task needs persistent
+`POSTGRES_*` environment variables when PostgreSQL is used.
 Use a separate realtime task or service for race-day `0B30` to `0B36`
 collection when full-ticket decision odds are required.

--- a/docs/index.md
+++ b/docs/index.md
@@ -29,7 +29,9 @@ jltsql realtime odds-timeseries --from 20250425 --to 20260425 --db postgresql
 - JRA-VAN の実データ取得は Windows + JV-Link 環境が必要です。
 - `0B41/0B42` は公式1年保持の時系列オッズで、`TS_O1/TS_O2` に保存します。
 - 0B30〜0B36 は速報オッズで、公式仕様上の保存期間は 1週間です。
+- `quickstart.bat` は通常セットアップ完了後に PostgreSQL + 時系列オッズ投入を続けるか確認します。
 - PostgreSQL へ `RACE` と `TS_O1/TS_O2` をまとめて投入する場合は `quickstart_postgres_timeseries.bat` を使います。
+- `quickstart_postgres_timeseries.bat` の最後で、`daily_sync.bat` を Windows Task Scheduler に登録するか確認します。
 - ワイド・馬単・三連複・三連単の締切前オッズは、開催週に `odds-sokuho-timeseries` で継続蓄積してください。
 - 古い設計メモや未実装機能のドキュメントは削除しています。
 

--- a/docs/postgresql.md
+++ b/docs/postgresql.md
@@ -22,6 +22,14 @@ quickstart_postgres_timeseries.bat 20250426 20260412
 ```
 
 This loads race data and official one-year `TS_O1/TS_O2` odds into PostgreSQL.
+`quickstart.bat` also offers this PostgreSQL time-series step after the normal
+setup completes.
+
+At the end of `quickstart_postgres_timeseries.bat`, the script asks whether to
+register `daily_sync.bat` in Windows Task Scheduler. If PostgreSQL connection
+values are only set in the current shell, choose the prompt that persists the
+current `POSTGRES_*` values to the Windows user environment, or configure those
+environment variables manually before relying on the scheduled task.
 
 ## Daily Sync
 
@@ -30,6 +38,12 @@ daily_sync.bat --db postgresql --days-back 7 --days-forward 3
 ```
 
 This keeps recent race cards, results, and related ordinary data current.
+
+Register or update the daily task manually:
+
+```powershell
+powershell -NoProfile -ExecutionPolicy Bypass -File install_tasks.ps1 -DbType postgresql -Time 06:30
+```
 
 ## SQLite Fallback
 

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -9,9 +9,15 @@ removed because they described non-current options.
 | `quickstart_postgres_timeseries.bat` | PostgreSQL setup/update plus official `TS_O1/TS_O2` odds. |
 | `fetch_timeseries_postgres.bat` | Add official `TS_O1/TS_O2` odds to an existing PostgreSQL installation. |
 | `daily_sync.bat` | Scheduled recent data sync. |
+| `install_tasks.ps1` | Register or update the Windows Task Scheduler entry for `daily_sync.bat`. |
 | `scripts/quickstart.py` | Python orchestration used by the batch wrappers. |
 | `scripts/raceday_verify.py` | Race-day data health checks. |
 | `tools/export_timeseries_csv.py` | Export stored time-series odds for inspection. |
 
 For exact CLI options, run each script with `--help` where supported or use
 `jltsql --help`.
+
+`quickstart.bat` asks whether to continue into
+`quickstart_postgres_timeseries.bat` after the ordinary setup. The PostgreSQL
+time-series quickstart then asks whether to register `daily_sync.bat` as a
+daily Windows scheduled task.

--- a/docs/timeseries_odds.md
+++ b/docs/timeseries_odds.md
@@ -29,6 +29,10 @@ PostgreSQL quickstart for race data plus official `TS_O1/TS_O2`:
 quickstart_postgres_timeseries.bat 20250426 20260412
 ```
 
+`quickstart.bat` can run this PostgreSQL time-series quickstart as an optional
+follow-up after the ordinary setup. The PostgreSQL time-series quickstart also
+asks whether to register `daily_sync.bat` in Windows Task Scheduler.
+
 ## Important Constraints
 
 - JRA-VAN does not provide long-retention historical time-series odds for every

--- a/install_tasks.ps1
+++ b/install_tasks.ps1
@@ -1,6 +1,11 @@
 param(
     [string]$TaskName = "JRVLTSQL_DailySync",
     [string]$Time = "06:30",
+    [ValidateSet("sqlite", "postgresql")]
+    [string]$DbType = "postgresql",
+    [int]$DaysBack = 7,
+    [int]$DaysForward = 3,
+    [switch]$PersistPostgresEnvironment,
     [switch]$Force
 )
 
@@ -13,11 +18,48 @@ if (-not (Test-Path $bat)) {
     throw "daily_sync.bat not found: $bat"
 }
 
+if ($Time -notmatch '^\d{1,2}:\d{2}$') {
+    throw "Time must use HH:mm format, for example 06:30"
+}
+
+if ($PersistPostgresEnvironment) {
+    if ($DbType -ne "postgresql") {
+        throw "-PersistPostgresEnvironment can only be used with -DbType postgresql"
+    }
+
+    $defaults = @{
+        POSTGRES_HOST = "127.0.0.1"
+        POSTGRES_PORT = "5432"
+        POSTGRES_DATABASE = "keiba_dev"
+        POSTGRES_USER = "ingestion_writer"
+    }
+
+    foreach ($name in @("POSTGRES_HOST", "POSTGRES_PORT", "POSTGRES_DATABASE", "POSTGRES_USER", "POSTGRES_PASSWORD")) {
+        $value = [Environment]::GetEnvironmentVariable($name, "Process")
+        if ([string]::IsNullOrWhiteSpace($value) -and $defaults.ContainsKey($name)) {
+            $value = $defaults[$name]
+        }
+        if ([string]::IsNullOrWhiteSpace($value)) {
+            throw "$name is required to persist PostgreSQL environment for the scheduled task"
+        }
+        [Environment]::SetEnvironmentVariable($name, $value, "User")
+    }
+
+    $postgresDatabase = [Environment]::GetEnvironmentVariable("POSTGRES_DATABASE", "Process")
+    if ([string]::IsNullOrWhiteSpace($postgresDatabase)) {
+        $postgresDatabase = $defaults["POSTGRES_DATABASE"]
+    }
+    [Environment]::SetEnvironmentVariable("POSTGRES_DB", $postgresDatabase, "User")
+    Write-Host "Persisted POSTGRES_* values to the Windows user environment"
+}
+
 if ($Force -and (Get-ScheduledTask -TaskName $TaskName -ErrorAction SilentlyContinue)) {
     Unregister-ScheduledTask -TaskName $TaskName -Confirm:$false
 }
 
-$action = New-ScheduledTaskAction -Execute "cmd.exe" -Argument "/c `"$bat`"" -WorkingDirectory $root
+$dailySyncArgs = "--db $DbType --days-back $DaysBack --days-forward $DaysForward"
+$cmdArgument = "/c `"`"$bat`" $dailySyncArgs`""
+$action = New-ScheduledTaskAction -Execute "cmd.exe" -Argument $cmdArgument -WorkingDirectory $root
 $trigger = New-ScheduledTaskTrigger -Daily -At $Time
 $settings = New-ScheduledTaskSettingsSet -StartWhenAvailable -AllowStartIfOnBatteries -DontStopIfGoingOnBatteries
 
@@ -27,4 +69,4 @@ if (Get-ScheduledTask -TaskName $TaskName -ErrorAction SilentlyContinue) {
     Register-ScheduledTask -TaskName $TaskName -Action $action -Trigger $trigger -Settings $settings -Description "JRA daily sync for jrvltsql" | Out-Null
 }
 
-Write-Host "Scheduled task ready: $TaskName at $Time"
+Write-Host "Scheduled task ready: $TaskName at $Time ($bat $dailySyncArgs)"

--- a/quickstart.bat
+++ b/quickstart.bat
@@ -88,6 +88,22 @@ echo   To view data:
 echo     - Use DB Browser for SQLite
 echo     - Python: sqlite3.connect('data/keiba.db')
 echo.
+call :prompt_postgres_timeseries
+if !errorlevel! neq 0 (
+    set "SCRIPT_EXIT_CODE=!errorlevel!"
+    echo.
+    echo ============================================================
+    echo   PostgreSQL Time-Series Setup Failed
+    echo ============================================================
+    echo.
+    echo   Exit Code: !SCRIPT_EXIT_CODE!
+    echo.
+    echo   Press Enter to close...
+    set /p dummy=
+    endlocal & exit /b !SCRIPT_EXIT_CODE!
+)
+
+echo.
 echo   CLI commands:
 echo     jltsql status   - Check database status
 echo     jltsql fetch    - Fetch additional data
@@ -103,3 +119,26 @@ echo   Press Enter to close...
 set /p dummy=
 endlocal
 exit /b 0
+
+:prompt_postgres_timeseries
+if /I "!JLTSQL_SKIP_POSTGRES_TIMESERIES_PROMPT!"=="1" exit /b 0
+if not exist "%~dp0quickstart_postgres_timeseries.bat" exit /b 0
+
+echo.
+echo ============================================================
+echo   Optional PostgreSQL Time-Series Odds Setup
+echo ============================================================
+echo.
+echo   This runs quickstart_postgres_timeseries.bat to load RACE data
+echo   and official one-year TS_O1/TS_O2 odds into PostgreSQL.
+echo.
+set /p RUN_PG_TS="  Run PostgreSQL time-series quickstart now? [y/N]: "
+if /I not "!RUN_PG_TS!"=="y" exit /b 0
+
+echo.
+set /p PG_TS_FROM_DATE="  From date YYYYMMDD [blank = today-365d]: "
+set /p PG_TS_TO_DATE="  To date YYYYMMDD [blank = today]: "
+echo.
+
+call "%~dp0quickstart_postgres_timeseries.bat" "!PG_TS_FROM_DATE!" "!PG_TS_TO_DATE!"
+exit /b !errorlevel!

--- a/quickstart_postgres_timeseries.bat
+++ b/quickstart_postgres_timeseries.bat
@@ -87,4 +87,50 @@ if not "%SCRIPT_EXIT_CODE%"=="0" (
 )
 
 echo [OK] PostgreSQL time-series quickstart completed.
+call :prompt_scheduler
+if !errorlevel! neq 0 exit /b !errorlevel!
+exit /b 0
+
+:prompt_scheduler
+if /I "!JLTSQL_SKIP_SCHEDULER_PROMPT!"=="1" exit /b 0
+
+echo.
+echo ============================================================
+echo   Optional Windows Task Scheduler Registration
+echo ============================================================
+echo.
+echo   This registers daily_sync.bat as a Windows scheduled task.
+echo   Default task: JRVLTSQL_DailySync, daily at 06:30.
+echo.
+set /p REGISTER_TASK="  Register or update the scheduled task now? [y/N]: "
+if /I not "!REGISTER_TASK!"=="y" (
+    echo [INFO] Scheduled task registration skipped.
+    exit /b 0
+)
+
+set "TASK_TIME=06:30"
+set /p TASK_TIME_INPUT="  Daily run time HH:mm [06:30]: "
+if not "!TASK_TIME_INPUT!"=="" set "TASK_TIME=!TASK_TIME_INPUT!"
+
+set "PERSIST_ENV_ARG="
+echo.
+echo   PostgreSQL scheduled tasks need persistent POSTGRES_* environment variables.
+echo   Saving them stores the current connection values in your Windows user environment.
+echo.
+set /p SAVE_PG_ENV="  Save current POSTGRES_* values for the scheduled task? [y/N]: "
+if /I "!SAVE_PG_ENV!"=="y" set "PERSIST_ENV_ARG=-PersistPostgresEnvironment"
+
+if not exist "%~dp0install_tasks.ps1" (
+    echo [ERROR] install_tasks.ps1 not found.
+    exit /b 1
+)
+
+powershell -NoProfile -ExecutionPolicy Bypass -File "%~dp0install_tasks.ps1" -Time "!TASK_TIME!" -DbType postgresql !PERSIST_ENV_ARG!
+set "TASK_EXIT_CODE=!errorlevel!"
+if not "!TASK_EXIT_CODE!"=="0" (
+    echo [ERROR] Scheduled task registration failed. Exit code: !TASK_EXIT_CODE!
+    exit /b !TASK_EXIT_CODE!
+)
+
+echo [OK] Scheduled task registration completed.
 exit /b 0


### PR DESCRIPTION
## Summary
- Add an optional PostgreSQL time-series quickstart prompt after the regular quickstart completes
- Prompt for Windows Task Scheduler registration after PostgreSQL time-series setup
- Extend install_tasks.ps1 with DB type, date window, and POSTGRES_* persistence options
- Update README, MkDocs docs, and changelog

## Verification
- git diff --check
- pytest tests/test_quickstart_cli.py -q
- mkdocs build --strict