### PR TITLE
公開ドキュメントを日本語化

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,20 +1,21 @@
-# Changelog
+# 変更履歴
 
-All notable changes to this project will be documented in this file.
+このプロジェクトの主な変更点をこのファイルに記録します。
 
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
-and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+形式は [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) を参考にし、
+バージョン番号は [Semantic Versioning](https://semver.org/spec/v2.0.0.html) に従います。
 
 ## [Unreleased]
 
 ### Added
 
-- JVOpen/JVRTOpen の対応 data spec、レコード種別、保存先テーブル、運用コマンドをまとめた `docs/data_support.md` を追加
+- JVOpen/JVRTOpen の対応データ種別、レコード種別、保存先テーブル、運用コマンドをまとめた `docs/data_support.md` を追加
 
 ### Changed
 
-- `quickstart.bat` から PostgreSQL time-series quickstart を続けて実行できる導線を追加
-- `quickstart_postgres_timeseries.bat` 完了時に Windows Task Scheduler 登録を確認するよう変更
+- 公開ドキュメントを日本語表記へ統一
+- `quickstart.bat` から PostgreSQL 時系列オッズのクイックスタートを続けて実行できる導線を追加
+- `quickstart_postgres_timeseries.bat` 完了時に Windows タスクスケジューラ登録を確認するよう変更
 - `install_tasks.ps1` で `daily_sync.bat` の DB 種別・日付窓・PostgreSQL 環境変数永続化を指定可能に変更
 
 ## [1.4.0] - 2026-05-03
@@ -27,31 +28,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `daily_sync.bat`
 - 公式1年保持の `0B41/0B42` を `TS_O1/TS_O2` に保存する導線を整理
 - 開催週の速報オッズ `0B30` 系から `TS_O1`〜`TS_O6` を蓄積する導線を追加
-- expanded odds rows の直接保存と multi-row PostgreSQL insert を追加
-- JRA collector 単体の architecture / PostgreSQL / time-series odds / scripts docs を追加
+- 展開済みオッズ行の直接保存と PostgreSQL 複数行 INSERT を追加
+- JRA データコレクタ単体のアーキテクチャ / PostgreSQL / 時系列オッズ / スクリプトのドキュメントを追加
 
 ### Fixed
 
-- JRA-VAN time-series odds key の生成を修正
+- JRA-VAN 時系列オッズキーの生成を修正
 - 空欄・未発売系オッズ値を PostgreSQL 保存前に正規化
-- O1〜O6 の expanded parser output をテスト側でも正しく扱うよう修正
-- PostgreSQL multi-row placeholder generation を修正
+- O1〜O6 の展開済みパーサー出力をテスト側でも正しく扱うよう修正
+- PostgreSQL 複数行 INSERT のプレースホルダ生成を修正
 
 ### Changed
 
-- PostgreSQL time-series quickstart 名を collector 汎用名へ変更
-  - new name: `quickstart_postgres_timeseries.bat`
-- 古い script README を削除し、現行 docs へ集約
-- 公開 docs から downstream system 固有の表現と内部パス例を削除
+- PostgreSQL 時系列オッズのクイックスタート名をデータコレクタ汎用名へ変更
+  - 新しい名前: `quickstart_postgres_timeseries.bat`
+- 古いスクリプト README を削除し、現行ドキュメントへ集約
+- 公開ドキュメントから下流システム固有の表現と内部パス例を削除
 
 ## [1.3.0] - 2026-04-22
 
 ### Added
 
-- **Dual-write mode** を追加
+- **二重書き込みモード** を追加
   - SQLite を primary としつつ PostgreSQL へ同時書き込み
   - `src/database/dual_handler.py` を新設
-- **PostgreSQL migration support** を追加
+- **PostgreSQL 移行支援** を追加
   - 既存 SQLite スキーマの PostgreSQL 側反映と移行経路を整備
 - migration / dual-write 向けテストを追加
   - `tests/test_migration.py`
@@ -123,7 +124,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Windows専用であることを明確化
 - ワンコマンドインストーラーをREADMEに追加
 - クロスプラットフォーム検証の注記追加
-- Getting Started / Reference / UserGuide を最新仕様に更新
+- 入門 / リファレンス / ユーザーガイドを最新仕様に更新
 
 ## [1.0.0] - 2025-02-07
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ JRA-VAN DataLab データを SQLite/PostgreSQL に取り込む Windows 専用パ
 
 JRA（中央競馬）専用です。
 
-Documentation: https://miyamamoto.github.io/jrvltsql/
+ドキュメント: https://miyamamoto.github.io/jrvltsql/
 
 ---
 
@@ -48,7 +48,7 @@ quickstart_postgres_timeseries.bat 20250426 20260412
 
 `quickstart_postgres_timeseries.bat` は、`RACE` データと公式1年保持の
 `TS_O1/TS_O2` 時系列オッズを PostgreSQL に投入します。完了時に
-Windows Task Scheduler へ `daily_sync.bat` を登録するか確認します。
+Windows タスクスケジューラへ `daily_sync.bat` を登録するか確認します。
 タスクから PostgreSQL に接続する場合は、現在の `POSTGRES_*` 接続情報を
 Windows ユーザー環境変数へ保存するかも確認されます。
 
@@ -119,7 +119,7 @@ jltsql realtime odds-timeseries --from <FROM> --to <TO> --db postgresql
 ### Windows タスク登録
 
 PostgreSQL 運用では、`quickstart_postgres_timeseries.bat` の最後に
-`daily_sync.bat` を Windows Task Scheduler に登録するか確認されます。
+`daily_sync.bat` を Windows タスクスケジューラに登録するか確認されます。
 手動で登録する場合は以下を実行します。
 
 ```powershell
@@ -143,12 +143,12 @@ powershell -NoProfile -ExecutionPolicy Bypass -File install_tasks.ps1 -DbType po
 
 ## ドキュメント
 
-- [Architecture](docs/architecture.md)
+- [アーキテクチャ](docs/architecture.md)
 - [CLI](docs/CLI.md)
-- [Supported data](docs/data_support.md)
+- [対応データ種別一覧](docs/data_support.md)
 - [PostgreSQL](docs/postgresql.md)
-- [Time-series odds](docs/timeseries_odds.md)
-- [Scripts](docs/scripts.md)
+- [時系列オッズ](docs/timeseries_odds.md)
+- [スクリプト一覧](docs/scripts.md)
 
 ---
 

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -1,4 +1,4 @@
-# CLI Reference
+# CLI リファレンス
 
 現在使うコマンドだけを記載します。正確なオプション一覧は、実行環境で `jltsql --help` または各サブコマンドの `--help` を確認してください。
 
@@ -17,7 +17,7 @@ jltsql fetch --from 20260101 --to 20260417 --spec RACE --option 1
 ```
 
 対応済みの `JVOpen` / `JVRTOpen` spec、保存先テーブル、運用コマンドは
-[Supported data](data_support.md) を参照してください。
+[対応データ種別一覧](data_support.md) を参照してください。
 
 主な `option`:
 
@@ -83,7 +83,7 @@ jltsql realtime timeseries --spec 0B41,0B42 --from 20250425 --to 20260425 --db-p
 jltsql realtime odds-sokuho-timeseries --from 20260418 --to 20260419 --db postgresql
 ```
 
-## PostgreSQL time-series quickstart
+## PostgreSQL 時系列オッズ quickstart
 
 PostgreSQL に RACE と公式1年保持の TS_O1/TS_O2 を投入します。
 
@@ -93,7 +93,7 @@ quickstart_postgres_timeseries.bat 20250426 20260412
 
 `quickstart.bat` からも通常セットアップ完了後にこの処理を続けて実行できます。
 `quickstart_postgres_timeseries.bat` の最後では、`daily_sync.bat` を
-Windows Task Scheduler に登録するか確認します。
+ Windows タスクスケジューラに登録するか確認します。
 
 既に RACE / NL_RA がある場合は、時系列オッズだけ追加します。
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,65 +1,68 @@
-# Architecture
+# アーキテクチャ
 
-jrvltsql is a Windows collector for JRA-VAN DataLab. It stores JRA data in
-SQLite or PostgreSQL and can optionally mirror data into a shared PostgreSQL
-database for downstream analytics.
+jrvltsql は、JRA-VAN DataLab のデータを SQLite または PostgreSQL に保存する
+Windows 向け JRA データコレクタです。共有分析基盤向けに PostgreSQL へ
+直接保存できます。
 
-## Scope
+## 対象範囲
 
-- JRA only.
-- Windows 10/11.
-- JRA-VAN DataLab and JV-Link.
-- 32-bit Python is recommended because JV-Link is a 32-bit COM component.
+- JRA / 中央競馬のみ
+- Windows 10 / 11
+- JRA-VAN DataLab + JV-Link
+- JV-Link COM コンポーネントが 32-bit のため、32-bit Python を推奨
 
-NAR data is outside this repository.
+NAR / 地方競馬はこのリポジトリの対象外です。
 
-## Components
+## 主要コンポーネント
 
-| Component | Responsibility |
+| コンポーネント | 役割 |
 | --- | --- |
-| `src/cli/main.py` | Click CLI entry point (`jltsql`). |
-| `src/jvlink/` | JV-Link COM access and constants. |
-| `src/parser/` | JRA-VAN record parsers. |
-| `src/database/` | SQLite/PostgreSQL handlers and schemas. |
-| `src/realtime/` | Realtime data collection. |
-| `scripts/quickstart.py` | Non-interactive and interactive setup/update orchestration. |
-| `quickstart.bat` | General SQLite-first quickstart with optional PostgreSQL time-series follow-up. |
-| `quickstart_postgres_timeseries.bat` | PostgreSQL + official time-series odds setup, followed by optional task registration. |
-| `daily_sync.bat` | Recent race-card/result sync for scheduled Windows tasks. |
-| `install_tasks.ps1` | Windows Task Scheduler registration for `daily_sync.bat`. |
+| `src/cli/main.py` | Click ベースの CLI エントリポイントです。コマンド名は `jltsql` です。 |
+| `src/jvlink/` | JV-Link COM へのアクセス、データ種別定数、キー生成を担当します。 |
+| `src/parser/` | JRA-VAN レコードのパーサー群です。 |
+| `src/database/` | SQLite / PostgreSQL ハンドラ、スキーマ、テーブル対応を管理します。 |
+| `src/realtime/` | JVRTOpen 速報・時系列データの保存処理を担当します。 |
+| `scripts/quickstart.py` | 対話・非対話の初期セットアップと更新処理をまとめます。 |
+| `quickstart.bat` | Windows 向けの通常 quickstart です。必要に応じて PostgreSQL 時系列オッズ導線へ進めます。 |
+| `quickstart_postgres_timeseries.bat` | PostgreSQL へ RACE と公式時系列オッズを投入し、最後にタスク登録を確認します。 |
+| `daily_sync.bat` | Windows タスクスケジューラから実行する日次同期です。 |
+| `install_tasks.ps1` | `daily_sync.bat` の Windows タスク登録・更新を行います。 |
 
-The supported `JVOpen` / `JVRTOpen` spec matrix is documented in
-[Supported data](data_support.md).
+対応している `JVOpen` / `JVRTOpen` spec、保存先テーブル、運用コマンドは
+[対応データ種別一覧](data_support.md) にまとめています。
 
-## Data Stores
+## データ保存先
 
-| Store | Use |
+| 保存先 | 用途 |
 | --- | --- |
-| SQLite | Local single-user storage and fallback. |
-| PostgreSQL | Shared storage for multi-host analytics and downstream systems. |
-| Binary cache | Local cache to avoid unnecessary JV-Link reads. |
+| SQLite | 単一ユーザー・ローカル検証・PostgreSQL がない環境でのフォールバック |
+| PostgreSQL | 複数ホストで共有するコレクタ / 分析基盤 |
+| バイナリキャッシュ | JV-Link 読み出しの再実行を減らすためのローカルキャッシュ |
 
-`config/config.yaml.example` defaults to SQLite. PostgreSQL mode is selected
-through CLI options or a local config file.
+`config/config.yaml.example` の既定は SQLite です。PostgreSQL を使う場合は
+CLI 引数またはローカル設定で切り替えます。
 
-## Time-Series Odds
+## 時系列オッズ
 
-JRA-VAN long-retention time-series odds are:
+JRA-VAN の公式長期保持時系列オッズは以下です。
 
-| JVRTOpen spec | Stored tables | Coverage |
+| JVRTOpen spec | 保存先テーブル | 対象 |
 | --- | --- | --- |
-| `0B41` | `TS_O1` | Win/place/bracket, one-year retention. |
-| `0B42` | `TS_O2` | Quinella, one-year retention. |
+| `0B41` | `TS_O1` | 単勝・複勝・枠連。保持は約1年です。 |
+| `0B42` | `TS_O2` | 馬連。保持は約1年です。 |
 
-Full-ticket realtime odds are `0B30` to `0B36`. They cover the race-week
-retention window only. To evaluate wide, exacta, trio, and trifecta with
-decision-time odds, keep collecting these specs during the racing week.
+全賭式の速報オッズは `0B30`〜`0B36` です。こちらは開催週の約1週間保持です。
+ワイド、馬単、三連複、三連単を投資判断時点オッズで評価するには、
+開催週に継続蓄積してください。
 
-## Scheduling
+## スケジューリング
 
-Use Windows Task Scheduler to run `daily_sync.bat` for ordinary race data.
-`quickstart_postgres_timeseries.bat` prompts for this registration at the end
-of the PostgreSQL time-series setup. The scheduled task needs persistent
-`POSTGRES_*` environment variables when PostgreSQL is used.
-Use a separate realtime task or service for race-day `0B30` to `0B36`
-collection when full-ticket decision odds are required.
+通常データの同期は、Windows タスクスケジューラで `daily_sync.bat` を
+日次実行します。`quickstart_postgres_timeseries.bat` は、PostgreSQL
+時系列オッズ投入完了後にこのタスク登録を確認します。
+
+PostgreSQL 接続をタスクから行う場合、`POSTGRES_*` 環境変数は Windows
+ユーザー環境変数など永続的に参照できる場所へ設定してください。
+
+開催週の `0B30`〜`0B36` 継続蓄積は、通常の日次同期とは別に race-day 用の
+リアルタイムタスクまたはサービスとして運用します。

--- a/docs/data_support.md
+++ b/docs/data_support.md
@@ -1,21 +1,20 @@
-# Supported Data Matrix
+# 対応データ種別一覧
 
-This page lists the JRA-VAN data families that jrvltsql currently supports.
-It is intended to make the collection scope explicit in the same operational
-style as update-data matrices in tools such as EveryDB2.
+このページでは、jrvltsql が対応している JRA-VAN DataLab / JV-Link の
+データ種別、レコード種別、保存先テーブル、運用コマンドをまとめます。
 
-jrvltsql is JRA-only. NAR data is outside this repository.
+jrvltsql は JRA / 中央競馬専用です。NAR / 地方競馬はこのリポジトリの対象外です。
 
-## Reading This Page
+## 表の見方
 
-| Mark | Meaning |
+| 表記 | 意味 |
 | --- | --- |
-| Supported | Parser, schema, and importer/updater path exist. |
-| Operational | A maintained command or batch file is provided. |
-| Parser/schema only | Record parser and table exist, but no recommended operational flow is documented. |
-| Not supported | Outside the current jrvltsql scope. |
+| 対応済み | パーサー、スキーマ、importer / updater の保存経路があります。 |
+| 運用導線あり | 保守している CLI コマンドまたは batch ファイルがあります。 |
+| パーサー・スキーマのみ | レコードのパーサーとテーブルはありますが、推奨運用フローは未整備です。 |
+| 非対応 | 現在の jrvltsql の対象外です。 |
 
-The implementation source of truth is:
+実装上の正本は以下です。
 
 - `src/jvlink/constants.py`
 - `src/parser/factory.py`
@@ -23,82 +22,81 @@ The implementation source of truth is:
 - `src/database/schema.py`
 - `src/cli/main.py`
 
-## Acquisition Families
+## 取得系統
 
-| Family | JV-Link API | Option/spec | Operational command | Key/range | Status |
+| 系統 | JV-Link API | option / データ種別 | 運用コマンド | キー / 範囲 | 対応状況 |
 | --- | --- | --- | --- | --- | --- |
-| Normal accumulated data | `JVOpen` | option `1` | `jltsql fetch --spec <SPEC> --option 1` | `FromTime` style date range | Supported |
-| This-week data | `JVOpen` | option `2` | `quickstart.bat`, `daily_sync.bat`, `jltsql fetch --option 2` | Current race week | Supported for `TOKU`, `RACE`, `TCVN`, `RCVN` |
-| Setup data | `JVOpen` | option `3` / `4` | `quickstart.bat`, `jltsql fetch --option 3/4` | Initial historical setup | Supported for the accumulated specs listed below |
-| Realtime race/event data | `JVRTOpen` | `0B11` to `0B17` | `jltsql realtime start --specs <SPEC>` | `YYYYMMDD` | Supported for listed record types |
-| Realtime odds/votes | `JVRTOpen` | `0B20`, `0B30` to `0B36` | `jltsql realtime timeseries --spec <SPEC>` | `YYYYMMDDJJRR` | Supported, one-week JRA-VAN retention |
-| Official historical odds time-series | `JVRTOpen` | `0B41`, `0B42` | `quickstart_postgres_timeseries.bat`, `fetch_timeseries_postgres.bat`, `jltsql realtime odds-timeseries` | `YYYYMMDDJJRR` | Supported, about one-year JRA-VAN retention |
+| 蓄積系 通常データ | `JVOpen` | option `1` | `jltsql fetch --spec <SPEC> --option 1` | FromTime 形式の日付範囲 | 対応済み |
+| 今週データ | `JVOpen` | option `2` | `quickstart.bat`, `daily_sync.bat`, `jltsql fetch --option 2` | 今週開催分 | `TOKU`, `RACE`, `TCVN`, `RCVN` に対応 |
+| セットアップデータ | `JVOpen` | option `3` / `4` | `quickstart.bat`, `jltsql fetch --option 3/4` | 初期構築用の過去範囲 | 下記の蓄積系 spec に対応 |
+| 速報レース・開催情報 | `JVRTOpen` | `0B11`〜`0B17` | `jltsql realtime start --specs <SPEC>` | `YYYYMMDD` | 下記レコードに対応 |
+| 速報オッズ・票数 | `JVRTOpen` | `0B20`, `0B30`〜`0B36` | `jltsql realtime timeseries --spec <SPEC>` | `YYYYMMDDJJRR` | 対応済み。JRA-VAN 側の保持は約1週間 |
+| 公式時系列オッズ | `JVRTOpen` | `0B41`, `0B42` | `quickstart_postgres_timeseries.bat`, `fetch_timeseries_postgres.bat`, `jltsql realtime odds-timeseries` | `YYYYMMDDJJRR` | 対応済み。JRA-VAN 側の保持は約1年 |
 
-## JVOpen Accumulated Data
+## JVOpen 蓄積系データ
 
-| Data spec | Alias | Description | Main record types | Stored tables | Option 1 | Option 2 | Option 3/4 | Notes |
+| データ種別 | 別名 | 内容 | 主なレコード種別 | 保存先テーブル | option 1 | option 2 | option 3/4 | 備考 |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| `TOKU` | - | Special registration | `TK` | `NL_TK` | Yes | Yes | Yes | Included in standard/full quickstart. |
-| `RACE` | - | Race card, results, payouts, final odds, votes, WIN5, exclusions | `RA`, `SE`, `HR`, `H1`, `H6`, `O1`-`O6`, `WF`, `JG` | `NL_RA`, `NL_SE`, `NL_HR`, `NL_H1`, `NL_H6`, `NL_O1`-`NL_O6`, `NL_WF`, `NL_JG` | Yes | Yes | Yes | Core race data. Final odds are stored here, not decision-time odds. |
-| `DIFF` | `DIFN` | Accumulated master diffs | `UM`, `KS`, `CH`, `BR`, `BN`, `RC` | `NL_UM`, `NL_KS`, `NL_CH`, `NL_BR`, `NL_BN`, `NL_RC` | Yes | No | Yes | `DIFN` is accepted as the current alias. |
-| `BLOD` | `BLDN` | Bloodline data | `HN`, `SK`, `BT` | `NL_HN`, `NL_SK`, `NL_BT` | Yes | No | Yes | `BLDN` is accepted as the current alias. |
-| `MING` | - | Data-mining predictions | `DM`, `TM` | `NL_DM`, `NL_TM` | Yes | No | Yes | Included in full quickstart. |
-| `SLOP` | - | Hill-training related data | `HC` | `NL_HC` | Yes | No | Yes | Included in standard/full quickstart. |
-| `WOOD` | - | Woodchip-training related data | `WC` | `NL_WC` | Yes | No | Yes | Included in standard/full quickstart. |
-| `YSCH` | - | Race schedule | `YS` | `NL_YS` | Yes | No | Yes | Used for race calendar maintenance. |
-| `HOSE` | `HOSN` | Sales price data | `HS` | `NL_HS` | Yes | No | Yes | `HOSN` is accepted as the current alias. |
-| `HOYU` | - | Horse-name meaning/origin | `HY` | `NL_HY` | Yes | No | Yes | Included in standard/full quickstart. |
-| `COMM` | - | Course/commentary information | `CS` | `NL_CS` | Yes | No | Yes | Included in full quickstart. |
-| `SNAP` | - | Race-card snapshot data | Returned record types vary | Existing `NL_*` tables by record type | Yes | No | Yes | Accepted by validation; not used by default quickstart. |
-| `O1`-`O6` | - | Final odds by bet type | `O1`-`O6` | `NL_O1`-`NL_O6` | Yes | No | Yes | Usually obtained through `RACE`; use time-series commands for decision-time odds. |
-| `TCVN` | - | Special-registration supplementation | Multiple master/race records | Existing `NL_*` tables by record type | No | Yes | No | Used by this-week update mode. |
-| `RCVN` | - | Race-info supplementation | Multiple master/race records | Existing `NL_*` tables by record type | No | Yes | No | Used by this-week update mode. |
+| `TOKU` | - | 特別登録馬 | `TK` | `NL_TK` | はい | はい | はい | standard / full quickstart に含めています。 |
+| `RACE` | - | レース、出走馬、払戻、確定オッズ、票数、WIN5、除外情報 | `RA`, `SE`, `HR`, `H1`, `H6`, `O1`〜`O6`, `WF`, `JG` | `NL_RA`, `NL_SE`, `NL_HR`, `NL_H1`, `NL_H6`, `NL_O1`〜`NL_O6`, `NL_WF`, `NL_JG` | はい | はい | はい | 中核データです。`NL_O*` は確定オッズで、投資判断時点のオッズではありません。 |
+| `DIFF` | `DIFN` | 蓄積系マスタ差分 | `UM`, `KS`, `CH`, `BR`, `BN`, `RC` | `NL_UM`, `NL_KS`, `NL_CH`, `NL_BR`, `NL_BN`, `NL_RC` | はい | いいえ | はい | 現在は `DIFN` も受け付けます。 |
+| `BLOD` | `BLDN` | 血統情報 | `HN`, `SK`, `BT` | `NL_HN`, `NL_SK`, `NL_BT` | はい | いいえ | はい | 現在は `BLDN` も受け付けます。 |
+| `MING` | - | データマイニング予想 | `DM`, `TM` | `NL_DM`, `NL_TM` | はい | いいえ | はい | full quickstart に含めています。 |
+| `SLOP` | - | 坂路調教関連 | `HC` | `NL_HC` | はい | いいえ | はい | standard / full quickstart に含めています。 |
+| `WOOD` | - | ウッドチップ調教関連 | `WC` | `NL_WC` | はい | いいえ | はい | standard / full quickstart に含めています。 |
+| `YSCH` | - | 開催スケジュール | `YS` | `NL_YS` | はい | いいえ | はい | 開催カレンダー保守に使います。 |
+| `HOSE` | `HOSN` | 競走馬市場取引価格 | `HS` | `NL_HS` | はい | いいえ | はい | 現在は `HOSN` も受け付けます。 |
+| `HOYU` | - | 馬名の意味由来 | `HY` | `NL_HY` | はい | いいえ | はい | standard / full quickstart に含めています。 |
+| `COMM` | - | 各種解説・コース情報 | `CS` | `NL_CS` | はい | いいえ | はい | full quickstart に含めています。 |
+| `SNAP` | - | 出馬表スナップショット | 返却レコードは状況依存 | レコード種別に応じた既存 `NL_*` テーブル | はい | いいえ | はい | validation 上は対応。既定 quickstart では使っていません。 |
+| `O1`〜`O6` | - | 賭式別の確定オッズ | `O1`〜`O6` | `NL_O1`〜`NL_O6` | はい | いいえ | はい | 通常は `RACE` 経由で取得します。投資判断時点のオッズは時系列コマンドを使います。 |
+| `TCVN` | - | 特別登録馬情報補填 | 複数のマスタ・レース系レコード | レコード種別に応じた既存 `NL_*` テーブル | いいえ | はい | いいえ | 今週データ更新で使います。 |
+| `RCVN` | - | レース情報補填 | 複数のマスタ・レース系レコード | レコード種別に応じた既存 `NL_*` テーブル | いいえ | はい | いいえ | 今週データ更新で使います。 |
 
-## JVRTOpen Realtime Race/Event Data
+## JVRTOpen 速報レース・開催情報
 
-| Data spec | Description | Expected record types | Stored tables | Key format | Status |
+| データ種別 | 内容 | 想定レコード種別 | 保存先テーブル | キー形式 | 対応状況 |
 | --- | --- | --- | --- | --- | --- |
-| `0B11` | Realtime horse weight | `WH` | `RT_WH` | `YYYYMMDD` | Supported |
-| `0B12` | Realtime race result / payout updates after result confirmation | `RA`, `SE`, `HR` | `RT_RA`, `RT_SE`, `RT_HR` | `YYYYMMDD` | Supported |
-| `0B13` | Realtime time-type data-mining prediction | `DM` | `RT_DM` | `YYYYMMDD` | Supported |
-| `0B14` | Realtime event/weather/track-change bundle | `WE`, `AV`, `JC`, `TC`, `CC` | `RT_WE`, `RT_AV`, `RT_JC`, `RT_TC`, `RT_CC` | `YYYYMMDD` | Supported |
-| `0B15` | Realtime race-card/race updates from entry-list stage onward | `RA`, `SE`, `HR` | `RT_RA`, `RT_SE`, `RT_HR` | `YYYYMMDD` | Supported |
-| `0B16` | Realtime event-change stream | `WE`, `AV`, `JC`, `TC`, `CC` | `RT_WE`, `RT_AV`, `RT_JC`, `RT_TC`, `RT_CC` | `YYYYMMDD` | Supported if provided by JV-Link for the event |
-| `0B17` | Realtime match-type data-mining prediction | `TM` | `RT_TM` | `YYYYMMDD` | Supported |
-| `0B51` | Realtime WIN5 | `WF` | `NL_WF` parser/schema exists; no `RT_WF` operational table | `YYYYMMDD` or WIN5 event key | Parser/schema only |
+| `0B11` | 速報馬体重 | `WH` | `RT_WH` | `YYYYMMDD` | 対応済み |
+| `0B12` | 成績確定後の速報レース・払戻 | `RA`, `SE`, `HR` | `RT_RA`, `RT_SE`, `RT_HR` | `YYYYMMDD` | 対応済み |
+| `0B13` | 速報タイム型データマイニング予想 | `DM` | `RT_DM` | `YYYYMMDD` | 対応済み |
+| `0B14` | 速報開催情報一括 | `WE`, `AV`, `JC`, `TC`, `CC` | `RT_WE`, `RT_AV`, `RT_JC`, `RT_TC`, `RT_CC` | `YYYYMMDD` | 対応済み |
+| `0B15` | 出走馬名表以降の速報レース情報 | `RA`, `SE`, `HR` | `RT_RA`, `RT_SE`, `RT_HR` | `YYYYMMDD` | 対応済み |
+| `0B16` | 速報開催情報変更 | `WE`, `AV`, `JC`, `TC`, `CC` | `RT_WE`, `RT_AV`, `RT_JC`, `RT_TC`, `RT_CC` | `YYYYMMDD` | JV-Link から提供される場合に対応 |
+| `0B17` | 速報対戦型データマイニング予想 | `TM` | `RT_TM` | `YYYYMMDD` | 対応済み |
+| `0B51` | 速報重勝式 WIN5 | `WF` | `NL_WF` のパーサー・スキーマは存在。`RT_WF` 運用テーブルは未整備 | `YYYYMMDD` または WIN5 開催キー | パーサー・スキーマのみ |
 
-## JVRTOpen Odds And Votes
+## JVRTOpen オッズ・票数
 
-| Data spec | Description | Expected record types | Stored tables in normal realtime mode | Stored tables in time-series mode | Key format | JRA-VAN retention | Operational command |
+| データ種別 | 内容 | 想定レコード種別 | 通常速報モードの保存先 | 時系列モードの保存先 | キー形式 | JRA-VAN 側の保持 | 運用コマンド |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| `0B20` | Realtime vote counts | `H1`, `H6` | `RT_H1`, `RT_H6` | Not applicable | `YYYYMMDDJJRR` | About one week | Parser/schema supported; no recommended batch helper |
-| `0B30` | Realtime odds, all bet types | `O1`-`O6` | `RT_O1`-`RT_O6` | `TS_O1`-`TS_O6` | `YYYYMMDDJJRR` | About one week | `jltsql realtime odds-sokuho-timeseries` |
-| `0B31` | Realtime odds, win/place/bracket | `O1` | `RT_O1` | `TS_O1` | `YYYYMMDDJJRR` | About one week | `jltsql realtime timeseries --spec 0B31` |
-| `0B32` | Realtime odds, quinella | `O2` | `RT_O2` | `TS_O2` | `YYYYMMDDJJRR` | About one week | `jltsql realtime timeseries --spec 0B32` |
-| `0B33` | Realtime odds, wide | `O3` | `RT_O3` | `TS_O3` | `YYYYMMDDJJRR` | About one week | `jltsql realtime timeseries --spec 0B33` |
-| `0B34` | Realtime odds, exacta | `O4` | `RT_O4` | `TS_O4` | `YYYYMMDDJJRR` | About one week | `jltsql realtime timeseries --spec 0B34` |
-| `0B35` | Realtime odds, trio | `O5` | `RT_O5` | `TS_O5` | `YYYYMMDDJJRR` | About one week | `jltsql realtime timeseries --spec 0B35` |
-| `0B36` | Realtime odds, trifecta | `O6` | `RT_O6` | `TS_O6` | `YYYYMMDDJJRR` | About one week | `jltsql realtime timeseries --spec 0B36` |
-| `0B41` | Official historical odds time-series, win/place/bracket | `O1` | Not recommended | `TS_O1` | `YYYYMMDDJJRR` | About one year | `jltsql realtime odds-timeseries` |
-| `0B42` | Official historical odds time-series, quinella | `O2` | Not recommended | `TS_O2` | `YYYYMMDDJJRR` | About one year | `jltsql realtime odds-timeseries` |
+| `0B20` | 速報票数 | `H1`, `H6` | `RT_H1`, `RT_H6` | 対象外 | `YYYYMMDDJJRR` | 約1週間 | パーサー・スキーマ対応。推奨 batch helper は未整備 |
+| `0B30` | 全賭式の速報オッズ | `O1`〜`O6` | `RT_O1`〜`RT_O6` | `TS_O1`〜`TS_O6` | `YYYYMMDDJJRR` | 約1週間 | `jltsql realtime odds-sokuho-timeseries` |
+| `0B31` | 単勝・複勝・枠連の速報オッズ | `O1` | `RT_O1` | `TS_O1` | `YYYYMMDDJJRR` | 約1週間 | `jltsql realtime timeseries --spec 0B31` |
+| `0B32` | 馬連の速報オッズ | `O2` | `RT_O2` | `TS_O2` | `YYYYMMDDJJRR` | 約1週間 | `jltsql realtime timeseries --spec 0B32` |
+| `0B33` | ワイドの速報オッズ | `O3` | `RT_O3` | `TS_O3` | `YYYYMMDDJJRR` | 約1週間 | `jltsql realtime timeseries --spec 0B33` |
+| `0B34` | 馬単の速報オッズ | `O4` | `RT_O4` | `TS_O4` | `YYYYMMDDJJRR` | 約1週間 | `jltsql realtime timeseries --spec 0B34` |
+| `0B35` | 三連複の速報オッズ | `O5` | `RT_O5` | `TS_O5` | `YYYYMMDDJJRR` | 約1週間 | `jltsql realtime timeseries --spec 0B35` |
+| `0B36` | 三連単の速報オッズ | `O6` | `RT_O6` | `TS_O6` | `YYYYMMDDJJRR` | 約1週間 | `jltsql realtime timeseries --spec 0B36` |
+| `0B41` | 単勝・複勝・枠連の公式時系列オッズ | `O1` | 非推奨 | `TS_O1` | `YYYYMMDDJJRR` | 約1年 | `jltsql realtime odds-timeseries` |
+| `0B42` | 馬連の公式時系列オッズ | `O2` | 非推奨 | `TS_O2` | `YYYYMMDDJJRR` | 約1年 | `jltsql realtime odds-timeseries` |
 
-Important operational constraints:
+運用上の重要事項:
 
-- `0B41` and `0B42` are the only official long-retention historical
-  time-series odds feeds.
-- Wide, exacta, trio, and trifecta decision-time odds require race-week
-  accumulation through `0B30` or `0B33` to `0B36`.
-- Time-series odds commands save expanded one-row-per-combination rows in
-  `TS_O*` tables and preserve `HassoTime`.
-- `NL_O*` tables contain final odds. They are useful for historical reference
-  but must not be treated as decision-time odds.
+- 公式に長期保持される時系列オッズは `0B41` と `0B42` です。
+- ワイド、馬単、三連複、三連単の投資判断時点オッズは、開催週に
+  `0B30` または `0B33`〜`0B36` を継続蓄積する必要があります。
+- 時系列オッズコマンドは、組み合わせ単位に展開した行を `TS_O*` に保存し、
+  `HassoTime` を保持します。
+- `NL_O*` は確定オッズです。過去参照には使えますが、投資判断時点の
+  オッズとして扱ってはいけません。
 
-## Parser And Table Coverage
+## パーサー・テーブル対応
 
-jrvltsql currently has parser and schema coverage for these 38 JRA record
-types:
+jrvltsql は現在、以下 38 種類の JRA レコード種別に対してパーサーと
+スキーマを持っています。
 
-| Record types | Stored tables |
+| レコード種別 | 保存先テーブル |
 | --- | --- |
 | `RA`, `SE`, `HR` | `NL_RA`, `NL_SE`, `NL_HR` |
 | `UM`, `KS`, `CH`, `BR`, `BN` | `NL_UM`, `NL_KS`, `NL_CH`, `NL_BR`, `NL_BN` |
@@ -110,17 +108,13 @@ types:
 | `DM`, `TM`, `WF`, `JG` | `NL_DM`, `NL_TM`, `NL_WF`, `NL_JG` |
 | `HC`, `HS`, `HY`, `WC`, `CK` | `NL_HC`, `NL_HS`, `NL_HY`, `NL_WC`, `NL_CK` |
 
-Realtime mirrors exist for the supported realtime record families as `RT_*`.
-Odds time-series mirrors exist as `TS_O1` to `TS_O6`.
+対応済みの速報系レコードは `RT_*` にも保存できます。オッズ時系列は
+`TS_O1`〜`TS_O6` に保存します。
 
-## Out Of Scope
+## 対象外
 
-| Item | Status | Reason |
+| 項目 | 状況 | 理由 |
 | --- | --- | --- |
-| NAR / local racing | Not supported | This repository is JRA-only. Use a separate NAR collector/repository. |
-| Long-retention historical time-series for wide/exacta/trio/trifecta | Not available from JRA-VAN official long-history specs | Must be accumulated during the current race week via `0B30` or `0B33`-`0B36`. |
-| Investment decision snapshots | Downstream concern | jrvltsql stores raw/final/time-series records; strategy systems choose decision timing from stored data. |
-
-## Reference
-
-- [EveryDB2 manual: update data type settings](https://everydb.iwinz.net/edb2_manual/05-UpdateData.html)
+| NAR / 地方競馬 | 非対応 | このリポジトリは JRA 専用です。地方競馬は別コレクタ / 別リポジトリの対象です。 |
+| ワイド・馬単・三連複・三連単の長期公式時系列 | JRA-VAN の長期公式 spec では取得不可 | 開催週に `0B30` または `0B33`〜`0B36` で蓄積する必要があります。 |
+| 投資判断スナップショット | 下流システム側の責務 | jrvltsql は raw / 確定 / 時系列データを保存します。投資判断時刻は保存済みデータから利用側が選びます。 |

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,4 +1,4 @@
-# JRVLTSQL Docs
+# JRVLTSQL ドキュメント
 
 JRVLTSQL は JRA-VAN DataLab のデータを SQLite / PostgreSQL に取り込む Windows 向けツールです。
 
@@ -12,7 +12,7 @@ JRVLTSQL は JRA-VAN DataLab のデータを SQLite / PostgreSQL に取り込む
 - SQLite / PostgreSQL
 
 対応済みの JVOpen / JVRTOpen データ種別、保存先テーブル、運用コマンドは
-[Supported data](data_support.md) に集約しています。
+[対応データ種別一覧](data_support.md) に集約しています。
 
 ## 基本コマンド
 
@@ -34,15 +34,15 @@ jltsql realtime odds-timeseries --from 20250425 --to 20260425 --db postgresql
 - 0B30〜0B36 は速報オッズで、公式仕様上の保存期間は 1週間です。
 - `quickstart.bat` は通常セットアップ完了後に PostgreSQL + 時系列オッズ投入を続けるか確認します。
 - PostgreSQL へ `RACE` と `TS_O1/TS_O2` をまとめて投入する場合は `quickstart_postgres_timeseries.bat` を使います。
-- `quickstart_postgres_timeseries.bat` の最後で、`daily_sync.bat` を Windows Task Scheduler に登録するか確認します。
+- `quickstart_postgres_timeseries.bat` の最後で、`daily_sync.bat` を Windows タスクスケジューラに登録するか確認します。
 - ワイド・馬単・三連複・三連単の締切前オッズは、開催週に `odds-sokuho-timeseries` で継続蓄積してください。
 - 古い設計メモや未実装機能のドキュメントは削除しています。
 
-## Documents
+## ドキュメント
 
-- [Architecture](architecture.md)
+- [アーキテクチャ](architecture.md)
 - [CLI](CLI.md)
-- [Supported data](data_support.md)
+- [対応データ種別一覧](data_support.md)
 - [PostgreSQL](postgresql.md)
-- [Time-series odds](timeseries_odds.md)
-- [Scripts](scripts.md)
+- [時系列オッズ](timeseries_odds.md)
+- [スクリプト一覧](scripts.md)

--- a/docs/postgresql.md
+++ b/docs/postgresql.md
@@ -1,8 +1,10 @@
 # PostgreSQL
 
-jrvltsql can write directly to PostgreSQL for shared collection.
+jrvltsql は SQLite だけでなく PostgreSQL へ直接保存できます。複数マシンで
+コレクタのデータを共有する場合や、下流の分析基盤へ渡す場合は PostgreSQL
+運用を推奨します。
 
-## Required Environment
+## 必要な環境変数
 
 ```bat
 set POSTGRES_HOST=<host>
@@ -12,40 +14,39 @@ set POSTGRES_USER=<user>
 set POSTGRES_PASSWORD=<password>
 ```
 
-`POSTGRES_DB` is also accepted by some scripts as an alias for
-`POSTGRES_DATABASE`.
+一部の script では `POSTGRES_DATABASE` の別名として `POSTGRES_DB` も使えます。
 
-## Quickstart
+## クイックスタート
 
 ```bat
 quickstart_postgres_timeseries.bat 20250426 20260412
 ```
 
-This loads race data and official one-year `TS_O1/TS_O2` odds into PostgreSQL.
-`quickstart.bat` also offers this PostgreSQL time-series step after the normal
-setup completes.
+このコマンドは、RACE データと公式1年保持の `TS_O1/TS_O2` 時系列オッズを
+PostgreSQL に投入します。通常の `quickstart.bat` からも、セットアップ完了後に
+この PostgreSQL 時系列オッズ投入へ進めます。
 
-At the end of `quickstart_postgres_timeseries.bat`, the script asks whether to
-register `daily_sync.bat` in Windows Task Scheduler. If PostgreSQL connection
-values are only set in the current shell, choose the prompt that persists the
-current `POSTGRES_*` values to the Windows user environment, or configure those
-environment variables manually before relying on the scheduled task.
+`quickstart_postgres_timeseries.bat` の最後では、`daily_sync.bat` を
+Windows タスクスケジューラへ登録するか確認します。PostgreSQL 接続情報を
+現在の CMD セッションだけに設定している場合、タスク実行時には見えません。
+登録時の確認で現在の `POSTGRES_*` を Windows ユーザー環境変数へ保存するか、
+事前に永続的な環境変数として設定してください。
 
-## Daily Sync
+## 日次同期
 
 ```bat
 daily_sync.bat --db postgresql --days-back 7 --days-forward 3
 ```
 
-This keeps recent race cards, results, and related ordinary data current.
+このコマンドは、直近のレース番組、結果、関連する通常データを更新します。
 
-Register or update the daily task manually:
+手動で Windows タスクを登録・更新する場合:
 
 ```powershell
 powershell -NoProfile -ExecutionPolicy Bypass -File install_tasks.ps1 -DbType postgresql -Time 06:30
 ```
 
-## SQLite Fallback
+## SQLite フォールバック
 
-The example config defaults to SQLite. Use SQLite for local single-user work or
-when PostgreSQL is not available.
+`config/config.yaml.example` の既定は SQLite です。PostgreSQL を使えない
+ローカル検証や単一ユーザー運用では SQLite を使えます。

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -1,23 +1,23 @@
-# Scripts
+# スクリプト一覧
 
-This page lists the current operational scripts. Older script catalogues were
-removed because they described non-current options.
+現在の運用で使うスクリプトだけを記載します。古い設計や現在使っていない導線の
+スクリプト一覧は削除しています。
 
-| Script | Use |
+| スクリプト | 用途 |
 | --- | --- |
-| `quickstart.bat` | General Windows quickstart, SQLite-first. |
-| `quickstart_postgres_timeseries.bat` | PostgreSQL setup/update plus official `TS_O1/TS_O2` odds. |
-| `fetch_timeseries_postgres.bat` | Add official `TS_O1/TS_O2` odds to an existing PostgreSQL installation. |
-| `daily_sync.bat` | Scheduled recent data sync. |
-| `install_tasks.ps1` | Register or update the Windows Task Scheduler entry for `daily_sync.bat`. |
-| `scripts/quickstart.py` | Python orchestration used by the batch wrappers. |
-| `scripts/raceday_verify.py` | Race-day data health checks. |
-| `tools/export_timeseries_csv.py` | Export stored time-series odds for inspection. |
+| `quickstart.bat` | Windows 向けの通常 quickstart です。既定は SQLite です。 |
+| `quickstart_postgres_timeseries.bat` | PostgreSQL へ RACE と公式 `TS_O1/TS_O2` 時系列オッズを投入します。 |
+| `fetch_timeseries_postgres.bat` | 既存 PostgreSQL 環境へ公式 `TS_O1/TS_O2` 時系列オッズだけを追加します。 |
+| `daily_sync.bat` | Windows タスクスケジューラから実行する日次同期です。 |
+| `install_tasks.ps1` | `daily_sync.bat` の Windows タスク登録・更新を行います。 |
+| `scripts/quickstart.py` | バッチファイルから呼ばれる Python 側のセットアップ・更新処理です。 |
+| `scripts/raceday_verify.py` | レース開催日のデータ健全性チェックです。 |
+| `tools/export_timeseries_csv.py` | 保存済み時系列オッズを確認用 CSV として出力します。 |
 
-For exact CLI options, run each script with `--help` where supported or use
-`jltsql --help`.
+正確な CLI 引数は、実行環境で `--help` が使えるスクリプトでは `--help` を確認し、
+それ以外は `jltsql --help` を参照してください。
 
-`quickstart.bat` asks whether to continue into
-`quickstart_postgres_timeseries.bat` after the ordinary setup. The PostgreSQL
-time-series quickstart then asks whether to register `daily_sync.bat` as a
-daily Windows scheduled task.
+`quickstart.bat` は通常セットアップ完了後に
+`quickstart_postgres_timeseries.bat` を続けて実行するか確認します。
+PostgreSQL 時系列オッズ投入が終わると、`daily_sync.bat` を日次 Windows
+タスクとして登録するか確認します。

--- a/docs/timeseries_odds.md
+++ b/docs/timeseries_odds.md
@@ -1,44 +1,45 @@
-# Time-Series Odds
+# 時系列オッズ
 
-This repository supports two different JRA-VAN realtime odds paths.
-For the full supported-data matrix, including non-odds data specs, see
-[Supported data](data_support.md).
+jrvltsql では、JRA-VAN のリアルタイムオッズ系データを次の2系統として扱います。
+オッズ以外を含む全データ種別の対応状況は
+[対応データ種別一覧](data_support.md) を参照してください。
 
-| Purpose | JVRTOpen spec | Stored tables | Retention | Notes |
+| 用途 | JVRTOpen spec | 保存先テーブル | 保持期間 | 備考 |
 | --- | --- | --- | --- | --- |
-| Official long history | `0B41` | `TS_O1` | About one year | Win/place/bracket time-series odds. |
-| Official long history | `0B42` | `TS_O2` | About one year | Quinella time-series odds. |
-| Race-week sokuho | `0B30` | `TS_O1` to `TS_O6` | About one week | All ticket types in one stream. |
-| Race-week sokuho | `0B31` to `0B36` | `TS_O1` to `TS_O6` | About one week | Ticket-specific realtime odds streams. |
+| 公式長期時系列 | `0B41` | `TS_O1` | 約1年 | 単勝・複勝・枠連の時系列オッズです。 |
+| 公式長期時系列 | `0B42` | `TS_O2` | 約1年 | 馬連の時系列オッズです。 |
+| 開催週の速報蓄積 | `0B30` | `TS_O1`〜`TS_O6` | 約1週間 | 全賭式を1つのストリームから取得します。 |
+| 開催週の速報蓄積 | `0B31`〜`0B36` | `TS_O1`〜`TS_O6` | 約1週間 | 賭式別の速報オッズストリームです。 |
 
-## Commands
+## コマンド
 
-Official long-history time-series odds:
+公式1年保持の時系列オッズ:
 
 ```bat
 jltsql realtime odds-timeseries --from 20250426 --to 20260412 --db postgresql
 ```
 
-Race-week all-ticket sokuho accumulation:
+開催週の全賭式速報オッズ蓄積:
 
 ```bat
 jltsql realtime odds-sokuho-timeseries --from 20260418 --to 20260419 --db postgresql
 ```
 
-PostgreSQL quickstart for race data plus official `TS_O1/TS_O2`:
+PostgreSQL へ RACE と公式 `TS_O1/TS_O2` をまとめて投入:
 
 ```bat
 quickstart_postgres_timeseries.bat 20250426 20260412
 ```
 
-`quickstart.bat` can run this PostgreSQL time-series quickstart as an optional
-follow-up after the ordinary setup. The PostgreSQL time-series quickstart also
-asks whether to register `daily_sync.bat` in Windows Task Scheduler.
+`quickstart.bat` からも、通常セットアップ完了後に PostgreSQL 時系列オッズ投入を
+続けて実行できます。`quickstart_postgres_timeseries.bat` の最後では、
+`daily_sync.bat` を Windows タスクスケジューラへ登録するか確認します。
 
-## Important Constraints
+## 重要な制約
 
-- JRA-VAN does not provide long-retention historical time-series odds for every
-  ticket type.
-- The collector stores raw time-series odds. Downstream consumers should choose
-  their own decision snapshot timing from `HassoTime`.
-- `HassoTime` is an announced timestamp, not necessarily equal to post time.
+- JRA-VAN はすべての賭式について長期保持の時系列オッズを提供しているわけではありません。
+- ワイド、馬単、三連複、三連単の投資判断時点オッズは、開催週に
+  `0B30` または `0B33`〜`0B36` を継続蓄積する必要があります。
+- jrvltsql は raw の時系列オッズを保存します。投資判断時刻は、利用側が
+  `HassoTime` から選択してください。
+- `HassoTime` は発表時刻であり、必ずしも発走時刻と一致しません。

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,6 @@
-site_name: JRVLTSQL Documentation
-site_description: JRA-VAN DataLab data import tool for SQLite/PostgreSQL
-site_author: JRVLTSQL Contributors
+site_name: JRVLTSQL ドキュメント
+site_description: JRA-VAN DataLab データを SQLite/PostgreSQL に取り込む Windows 向けツール
+site_author: JRVLTSQL コントリビューター
 site_url: https://miyamamoto.github.io/jrvltsql/
 
 repo_name: miyamamoto/jrvltsql
@@ -20,12 +20,12 @@ markdown_extensions:
       permalink: true
 
 nav:
-  - Home: index.md
-  - Architecture: architecture.md
+  - ホーム: index.md
+  - アーキテクチャ: architecture.md
   - CLI: CLI.md
-  - Supported data: data_support.md
+  - 対応データ種別一覧: data_support.md
   - PostgreSQL: postgresql.md
-  - Time-series odds: timeseries_odds.md
-  - Scripts: scripts.md
+  - 時系列オッズ: timeseries_odds.md
+  - スクリプト一覧: scripts.md
 
-copyright: Copyright &copy; 2024 JRVLTSQL Contributors
+copyright: Copyright &copy; 2024 JRVLTSQL コントリビューター

--- a/src/jvlink/constants.py
+++ b/src/jvlink/constants.py
@@ -71,12 +71,12 @@ DATA_SPEC_O4 = "O4"  # 馬単オッズ
 DATA_SPEC_O5 = "O5"  # 3連複オッズ
 DATA_SPEC_O6 = "O6"  # 3連単オッズ
 
-# Real-time Data Specifications (JVRTOpen用)
+# リアルタイムデータ種別 (JVRTOpen用)
 # 速報系データ: レース確定情報（結果が確定したら更新）
 # オッズ系データ: レース単位キーで取得する速報オッズ/時系列オッズ
 
 # 速報系データ (0B1x系) - JRA-VAN公式仕様に基づく
-# 参照: JV-Data仕様書、EveryDB2マニュアル表5.1-1
+# 参照: JV-Data仕様書
 # 注意: 速報系はYYYYMMDD形式のkeyを使用（日付単位）
 JVRTOPEN_SPEED_REPORT_SPECS = {
     "0B11": "速報馬体重",              # WH: 馬体重情報


### PR DESCRIPTION
## 概要
- README / MkDocs / 各公開ドキュメントを日本語表記へ統一
- 対応データ種別一覧から EveryDB2 への言及を削除
- constants の参照コメントから EveryDB2 表記を削除

## 確認
- `rg -n "EveryDB|EveryDB2" -S` で該当なし
- `mkdocs build --strict`
- `pytest tests/test_quickstart_cli.py -q`