### PR TITLE
利用者向けマニュアルを整理

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,12 @@
 ### Added
 
 - JVOpen/JVRTOpen の対応データ種別、レコード種別、保存先テーブル、運用コマンドをまとめた `docs/data_support.md` を追加
+- 初回ユーザー向けの実行順序をまとめた `docs/getting_started.md` を追加
 
 ### Changed
 
 - 公開ドキュメントを日本語表記へ統一
+- README と MkDocs ホームを、初回導線・目的別コマンド・重要なデータ区分が一目で分かる構成へ整理
 - `quickstart.bat` は SQLite 既定の通常セットアップに戻し、PostgreSQL 専用の `quickstart_postgres_timeseries.bat` 呼び出しを削除
 - SQLite でも `quickstart.bat --yes --include-timeseries` または `jltsql realtime odds-timeseries --db sqlite` で公式 `TS_O1/TS_O2` を保存できることを明記
 - `quickstart.bat` 完了時に SQLite 用 `daily_sync.bat` の Windows タスクスケジューラ登録を確認するよう変更

--- a/README.md
+++ b/README.md
@@ -1,101 +1,26 @@
 # JRVLTSQL
 
-JRA-VAN DataLab データを SQLite/PostgreSQL に取り込む Windows 専用パイプライン。
+JRVLTSQL は、JRA-VAN DataLab の JRA データを SQLite または PostgreSQL に保存する
+Windows 向けツールです。NAR / 地方競馬は対象外です。
 
-JRA（中央競馬）専用です。
+公開ドキュメント: https://miyamamoto.github.io/jrvltsql/
 
-ドキュメント: https://miyamamoto.github.io/jrvltsql/
-
----
-
-## まず何をすればよいか
-
-| 目的 | まず実行 | 到達点 |
-|------|----------|--------|
-| SQLite で試す | `quickstart.bat` | JRA の主要データがローカル DB に入ります。 |
-| SQLite に公式時系列オッズも入れる | `quickstart.bat` で時系列オッズ取得を選択、または `quickstart.bat --yes --include-timeseries` | SQLite の `TS_O1` / `TS_O2` に公式1年保持の単複枠・馬連時系列オッズが入ります。 |
-| PostgreSQL 運用を始める | `quickstart_postgres_timeseries.bat 20250426 20260412` | `RACE` 系データと公式 `TS_O1` / `TS_O2` が入り、日次同期タスク登録まで進めます。 |
-| 公式時系列オッズだけ足す | `fetch_timeseries_postgres.bat 20250426 20260412` | 既存 PostgreSQL に `TS_O1` / `TS_O2` だけ追加します。 |
-| 三連複・三連単の締切前オッズを残す | `jltsql realtime odds-sokuho-timeseries --from 20260418 --to 20260419 --db postgresql` | 開催週の全賭式オッズが `TS_O1`〜`TS_O6` に入ります。 |
-| 日次同期を自動化する | `quickstart.bat` / `quickstart_postgres_timeseries.bat` の最後で登録、または `install_tasks.ps1` | `daily_sync.bat` が Windows タスクとして登録されます。SQLite / PostgreSQL のどちらにも対応します。 |
-
-`daily_sync.bat` は通常データ更新用です。`--db sqlite` / `--db postgresql`
-の両方に対応します。公式時系列オッズや全賭式速報オッズを継続蓄積したい場合は、
-上のオッズ取得コマンドを別途実行してください。
-
-## どこまで対応しているか
-
-| データ | 対応 | 保存先 | 注意 |
-|--------|------|--------|------|
-| JRA の出馬表・成績・払戻 | 対応済み | `NL_RA`, `NL_SE`, `NL_HR` など | `quickstart.bat` / `quickstart_postgres_timeseries.bat` で取得します。 |
-| 確定オッズ 全賭式 | 対応済み | `NL_O1`〜`NL_O6` | レース後の確定オッズです。投資判断時点のオッズではありません。 |
-| 単複枠・馬連の公式時系列オッズ | 対応済み | `TS_O1`, `TS_O2` | `0B41` / `0B42`。JRA-VAN 側の保持は約1年です。 |
-| ワイド・馬単・三連複・三連単の締切前オッズ | 開催週の蓄積で対応 | `TS_O3`〜`TS_O6` | `0B30` または `0B33`〜`0B36`。SQLite / PostgreSQL どちらにも保存できます。JRA-VAN 側の保持は約1週間です。 |
-| NAR / 地方競馬 | 非対応 | - | このリポジトリは JRA 専用です。 |
-
----
-
-## 必要要件
+## まず準備
 
 | 項目 | 要件 |
-|------|------|
+| --- | --- |
 | OS | Windows 10 / 11 |
-| Python | **3.12 (32-bit)** — JV-Link COM DLL が 32-bit のため必須 |
-| JRA-VAN | DataLab 会員登録 + サービスキー |
+| Python | Python 3.10 以上。JV-Link COM を直接使う環境では 32-bit Python を推奨します。 |
+| 契約 | JRA-VAN DataLab + サービスキー |
+| PostgreSQL | PostgreSQL 運用時のみ必要 |
 
-> **なぜ 32-bit Python?**  
-> JV-Link (`JVDTLab.JVLink`) は 32-bit COM DLL として提供されています。64-bit + DllSurrogate は
-> セットアップモード (option=3/4) でハング等の不安定な動作が確認されているため、32-bit Python を推奨します。
-
----
-
-## クイックスタート詳細
-
-一般利用（SQLite 既定）:
-
-```bat
-quickstart.bat
-```
-
-`quickstart.bat` をダブルクリック（または CMD から実行）するだけで以下を自動処理します：
-
-1. Python (32-bit) の検出
-2. S3 キャッシュの事前ダウンロード（オプション）
-3. データ取得モードの選択（今週 / 差分 / フルセットアップ）
-4. JRA-VAN からのデータ取得・DB 格納
-5. S3 キャッシュのアップロード（オプション）
-6. DB 検証 (`raceday_verify --phase pre`)
-7. SQLite 日次同期タスク登録の実行確認（オプション）
-
-対話形式では、公式1年保持の時系列オッズを取得するか確認されます。
-非対話で SQLite に `TS_O1/TS_O2` を入れる場合は以下です。
-
-```bat
-quickstart.bat --yes --include-timeseries
-```
-
-PostgreSQL + 時系列オッズ:
-
-```bat
-quickstart_postgres_timeseries.bat 20250426 20260412
-```
-
-`quickstart_postgres_timeseries.bat` は、`RACE` データと公式1年保持の
-`TS_O1/TS_O2` 時系列オッズを PostgreSQL に投入します。完了時に
-Windows タスクスケジューラへ `daily_sync.bat` を登録するか確認します。
-タスクから PostgreSQL に接続する場合は、現在の `POSTGRES_*` 接続情報を
-Windows ユーザー環境変数へ保存するかも確認されます。
-
----
-
-## インストール
+PowerShell でインストールします。
 
 ```powershell
-# PowerShell（ワンライナー）
 irm https://raw.githubusercontent.com/miyamamoto/jrvltsql/master/install.ps1 | iex
 ```
 
-または手動：
+手動で入れる場合:
 
 ```bat
 git clone https://github.com/miyamamoto/jrvltsql.git
@@ -103,202 +28,97 @@ cd jrvltsql
 pip install -e .
 ```
 
----
+## 最短手順
 
-## 主な CLI コマンド
+迷ったら、まず SQLite で動かしてください。
 
 ```bat
-jltsql status                          # DB 状態確認
-jltsql create-tables                   # テーブル作成
-jltsql create-indexes                  # インデックス作成
-jltsql fetch --from 20260101 --to 20260417 --spec RACE --option 1
-jltsql realtime start --specs 0B12,0B15,0B30
-jltsql realtime odds-timeseries --from 20250426 --to 20260412 --db postgresql
-jltsql cache info                      # キャッシュ統計
-jltsql cache sync --download           # S3 → ローカル同期
-jltsql cache sync --upload             # ローカル → S3 同期
+quickstart.bat
 ```
 
-### PostgreSQL投入
+これで JRA の出馬表、成績、払戻、確定オッズなどの通常データが
+`data\keiba.db` に入ります。完了時に、通常データの日次同期タスクを
+Windows タスクスケジューラへ登録するか確認されます。
 
-公式1年保持の `TS_O1/TS_O2` を PostgreSQL にまとめて投入する場合:
+## 目的別コマンド
+
+| 目的 | 実行するコマンド | 結果 |
+| --- | --- | --- |
+| SQLite に通常データを入れる | `quickstart.bat` | `NL_RA`, `NL_SE`, `NL_HR`, `NL_O1`〜`NL_O6` などが `data\keiba.db` に入ります。 |
+| SQLite に公式時系列オッズも入れる | `quickstart.bat` で時系列オッズ取得を選ぶ | `TS_O1` / `TS_O2` に単複枠・馬連の公式時系列オッズが入ります。 |
+| SQLite で非対話実行する | `quickstart.bat --yes --include-timeseries` | 通常データ + `TS_O1` / `TS_O2` を取得します。タスク登録確認は出しません。 |
+| PostgreSQL 運用を始める | `quickstart_postgres_timeseries.bat 20250426 20260412` | PostgreSQL に指定範囲の通常データと公式 `TS_O1` / `TS_O2` が入ります。 |
+| 既存 PostgreSQL に公式時系列だけ足す | `fetch_timeseries_postgres.bat 20250426 20260412` | `TS_O1` / `TS_O2` だけを追加します。 |
+| 三連複・三連単を含む締切前オッズを残す | `jltsql realtime odds-sokuho-timeseries --from 20260418 --to 20260419 --db postgresql` | 開催週の全賭式速報オッズを `TS_O1`〜`TS_O6` に保存します。 |
+| 日次同期を手動登録する | `powershell -NoProfile -ExecutionPolicy Bypass -File install_tasks.ps1 -DbType sqlite -Time 06:30` | `daily_sync.bat` を Windows タスクとして登録します。 |
+
+詳細な判断フローは [はじめに](docs/getting_started.md) を参照してください。
+
+## 重要な区別
+
+| データ | 保存先 | 取得方法 | 注意 |
+| --- | --- | --- | --- |
+| 通常データ | `NL_*` | `quickstart.bat`, `daily_sync.bat` | 出馬表、結果、払戻、確定オッズなどです。 |
+| 確定オッズ | `NL_O1`〜`NL_O6` | `RACE` 取得 | レース後の確定オッズです。投資判断時点のオッズではありません。 |
+| 公式時系列オッズ | `TS_O1`, `TS_O2` | `0B41`, `0B42` | 単複枠・馬連のみ。JRA-VAN 側の保持は約1年です。 |
+| 開催週の速報オッズ | `TS_O1`〜`TS_O6` | `0B30` または `0B31`〜`0B36` | 全賭式対応。ただし JRA-VAN 側の保持は約1週間です。 |
+| 日次同期 | `NL_*` | `daily_sync.bat --db sqlite` / `--db postgresql` | 時系列オッズは取得しません。 |
+
+## PostgreSQL を使う場合
+
+先に接続情報を設定します。
+
+```bat
+set POSTGRES_HOST=127.0.0.1
+set POSTGRES_PORT=5432
+set POSTGRES_DATABASE=keiba_dev
+set POSTGRES_USER=ingestion_writer
+set POSTGRES_PASSWORD=<password>
+```
+
+その後、PostgreSQL 用 quickstart を実行します。
 
 ```bat
 quickstart_postgres_timeseries.bat 20250426 20260412
 ```
 
-`quickstart.bat` から PostgreSQL 専用セットアップは呼びません。SQLite と
-PostgreSQL の導線を分けるため、PostgreSQL 運用を始める場合は
-`quickstart_postgres_timeseries.bat` を直接実行してください。
+`quickstart.bat` から PostgreSQL 用 quickstart は呼びません。SQLite と PostgreSQL の導線は分けています。
 
-既に `NL_RA` が入っていて時系列オッズだけを追加する場合:
+## 日次同期
 
-```bat
-fetch_timeseries_postgres.bat 20250426 20260412
-```
-
-日付を省略した場合は今日から過去365日分を取得します。
+`daily_sync.bat` は SQLite / PostgreSQL の両方に対応します。
 
 ```bat
-fetch_timeseries_postgres.bat
+daily_sync.bat --db sqlite --days-back 7 --days-forward 3
+daily_sync.bat --db postgresql --days-back 7 --days-forward 3
 ```
 
-直接 CLI を使う場合:
-
-```bat
-jltsql realtime odds-timeseries --from <FROM> --to <TO> --db postgresql
-```
-
-SQLite に保存する場合:
-
-```bat
-jltsql realtime odds-timeseries --from <FROM> --to <TO> --db sqlite --db-path data/keiba.db
-```
-
-`odds-timeseries` は `0B41/0B42` で公式1年保持の単複枠・馬連時系列を取得し、`TS_O1/TS_O2` に保存します。`0B30` の全賭式速報オッズは1週間保持なので、開催週に蓄積する場合だけ `realtime odds-sokuho-timeseries` を使います。
-
-### Windows タスク登録
-
-`daily_sync.bat` は SQLite / PostgreSQL の両方に対応しています。
-`quickstart.bat` の最後では SQLite 用、`quickstart_postgres_timeseries.bat`
-の最後では PostgreSQL 用として Windows タスクスケジューラに登録するか確認されます。
-手動で登録する場合は以下を実行します。
+手動で Windows タスクへ登録する場合:
 
 ```powershell
 powershell -NoProfile -ExecutionPolicy Bypass -File install_tasks.ps1 -DbType sqlite -Time 06:30
 powershell -NoProfile -ExecutionPolicy Bypass -File install_tasks.ps1 -DbType postgresql -Time 06:30
 ```
 
-`POSTGRES_PASSWORD` などを現在の CMD セッションだけで設定している場合、
-タスク実行時には見えません。登録時の確認で `POSTGRES_*` を Windows
-ユーザー環境変数へ保存するか、あらかじめ永続的な環境変数として設定してください。
+`daily_sync.bat` は通常データ更新用です。公式時系列オッズや全賭式速報オッズを継続蓄積する場合は、別途オッズ取得コマンドを実行してください。
 
-### fetch オプション
+## 詳細ドキュメント
 
-| option | 内容 |
-|--------|------|
-| 1 | 通常取得（差分） |
-| 2 | 今週データ |
-| 3 | セットアップ |
-| 4 | 分割セットアップ |
-
----
-
-## ドキュメント
-
-- [アーキテクチャ](docs/architecture.md)
-- [CLI](docs/CLI.md)
-- [対応データ種別一覧](docs/data_support.md)
-- [PostgreSQL](docs/postgresql.md)
-- [時系列オッズ](docs/timeseries_odds.md)
-- [スクリプト一覧](docs/scripts.md)
-
----
-
-## レースデー監視
-
-### tmux セッション起動
-
-```bash
-# WSL または Git Bash から
-bash scripts/raceday_tmux.sh           # 起動 + アタッチ
-bash scripts/raceday_tmux.sh --detach  # バックグラウンド起動
-bash scripts/raceday_tmux.sh --from 12:00  # 午後から開始
-```
-
-tmux セッション `jrvltsql-raceday` を 3 ウィンドウで起動します：
-
-| ウィンドウ | 内容 |
-|-----------|------|
-| `[0] monitor` | `jltsql realtime start` — RT_ ライブストリーム |
-| `[1] scheduler` | `raceday_scheduler.py` — レースごとの自動検証（12R + 事後） |
-| `[2] status` | `jltsql status` + `cache info` (watch) |
-
-### Claude Code /loop で自動修正
-
-Claude Code 内で以下を実行すると、検証レポートを読んで問題があれば自動でコードを修正・PR を作成します：
-
-```
-/loop 35m
-Run python scripts/raceday_verify.py --phase auto, read the JSON report in
-data/raceday_report_*.json, and if there are issues: diagnose the root cause,
-fix the code, create a branch and PR with gh pr create. Report what you found.
-```
-
-### 検証フェーズ
-
-```bat
-python scripts/raceday_verify.py --phase pre        # 開催前 (〜10:05)
-python scripts/raceday_verify.py --phase rt-check   # レース中 RT_ 確認
-python scripts/raceday_verify.py --phase nl-mid     # 後半 NL_+RT_ 確認
-python scripts/raceday_verify.py --phase post       # 最終レース後
-python scripts/raceday_verify.py --phase final      # 払戻確定後
-python scripts/raceday_verify.py --phase quickstart # smoke test
-python scripts/raceday_verify.py --phase auto       # 時刻から自動判定
-```
-
----
-
-## キャッシュ
-
-取得したレコードをバイナリ形式でローカルキャッシュします。  
-2 回目以降の取得は JV-Link を経由せずキャッシュから読み込むため高速です。
-
-```
-data/cache/nl/{SPEC}/{YYYYMMDD}.bin   # NL_ 蓄積系
-data/cache/rt/{SPEC}/{YYYYMMDD}.bin   # RT_ リアルタイム系
-```
-
-S3 バックアップ設定：
-
-```bat
-jltsql cache s3-setup    # S3 認証情報の設定
-jltsql cache sync        # 双方向同期
-```
-
----
-
-## ディレクトリ構成
-
-```
-jrvltsql/
-├── src/
-│   ├── cli/main.py          # CLI エントリポイント (jltsql コマンド)
-│   ├── fetcher/             # JV-Link データ取得
-│   ├── importer/            # DB インポート
-│   ├── parser/              # JV-Link レコードパーサー (38種)
-│   ├── realtime/            # リアルタイム監視
-│   ├── cache/               # バイナリキャッシュ管理
-│   └── database/            # SQLite / PostgreSQL ハンドラ
-├── scripts/
-│   ├── quickstart.py        # 対話型セットアップウィザード
-│   ├── raceday_verify.py    # 競馬開催日検証スクリプト
-│   ├── raceday_scheduler.py # レース時刻連動スケジューラ
-│   └── raceday_tmux.sh      # tmux レースデーセッション
-├── tests/                   # pytest (1,178 テスト)
-├── quickstart.bat           # Windows ワンクリック起動
-└── config/config.yaml       # 設定ファイル
-```
-
----
+| ドキュメント | 内容 |
+| --- | --- |
+| [はじめに](docs/getting_started.md) | 目的別の実行順序 |
+| [対応データ種別一覧](docs/data_support.md) | JVOpen / JVRTOpen spec と保存先 |
+| [時系列オッズ](docs/timeseries_odds.md) | `0B41/0B42` と `0B30` 系の違い |
+| [PostgreSQL](docs/postgresql.md) | PostgreSQL 保存と日次同期 |
+| [CLI](docs/CLI.md) | CLI リファレンス |
+| [スクリプト一覧](docs/scripts.md) | batch / script の役割 |
+| [アーキテクチャ](docs/architecture.md) | 実装構成 |
 
 ## テスト
 
 ```bat
 pytest tests/ -q --ignore=tests/integration/ --ignore=tests/e2e/
 ```
-
----
-
-## ドキュメント
-
-| ドキュメント | 内容 |
-|------------|------|
-| [docs/index.md](docs/index.md) | 最小ドキュメント |
-| [docs/CLI.md](docs/CLI.md) | CLI 最小リファレンス |
-| [CHANGELOG.md](CHANGELOG.md) | 変更履歴 |
-
----
 
 ## ライセンス
 

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -86,7 +86,7 @@ jltsql realtime odds-sokuho-timeseries --from 20260418 --to 20260419 --db sqlite
 
 ## PostgreSQL 時系列オッズ quickstart
 
-PostgreSQL に RACE と公式1年保持の TS_O1/TS_O2 を投入します。
+PostgreSQL に指定範囲の通常データと公式1年保持の TS_O1/TS_O2 を投入します。
 
 ```bat
 quickstart_postgres_timeseries.bat 20250426 20260412

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -24,7 +24,7 @@ NAR / 地方競馬はこのリポジトリの対象外です。
 | `src/realtime/` | JVRTOpen 速報・時系列データの保存処理を担当します。 |
 | `scripts/quickstart.py` | 対話・非対話の初期セットアップと更新処理をまとめます。 |
 | `quickstart.bat` | Windows 向けの通常 quickstart です。既定は SQLite で、対話形式または `--yes --include-timeseries` により SQLite に公式時系列オッズも保存できます。最後に SQLite 用の日次同期タスク登録を確認します。 |
-| `quickstart_postgres_timeseries.bat` | PostgreSQL へ RACE と公式時系列オッズを投入し、最後にタスク登録を確認します。 |
+| `quickstart_postgres_timeseries.bat` | PostgreSQL へ指定範囲の通常データと公式時系列オッズを投入し、最後にタスク登録を確認します。 |
 | `daily_sync.bat` | Windows タスクスケジューラから実行する日次同期です。 |
 | `install_tasks.ps1` | `daily_sync.bat` の Windows タスク登録・更新を行います。 |
 

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -1,0 +1,196 @@
+# はじめに
+
+このページは、JRVLTSQL を初めて使うときの実行順序だけをまとめた手順書です。
+細かい spec やテーブル定義は、あとで [対応データ種別一覧](data_support.md) を見てください。
+
+## 0. 準備
+
+JRVLTSQL は Windows + JRA-VAN DataLab / JV-Link を前提にした JRA 用ツールです。
+地方競馬は対象外です。
+
+Python は 3.10 以上で動作します。JV-Link COM を直接使う環境では 32-bit Python を推奨します。
+
+インストール:
+
+```powershell
+irm https://raw.githubusercontent.com/miyamamoto/jrvltsql/master/install.ps1 | iex
+```
+
+手動で入れる場合:
+
+```bat
+git clone https://github.com/miyamamoto/jrvltsql.git
+cd jrvltsql
+pip install -e .
+```
+
+## 1. まず決めること
+
+決めることは2つだけです。
+
+| 質問 | 迷ったときの選択 |
+| --- | --- |
+| 保存先は SQLite か PostgreSQL か | まずは SQLite。共有・本番運用なら PostgreSQL。 |
+| 必要なオッズはどれか | 通常データだけなら `quickstart.bat`。投資判断時点のオッズ評価をするなら時系列オッズも取得。 |
+
+## 2. ルートA: SQLiteでまず動かす
+
+一番簡単な導線です。
+
+```bat
+quickstart.bat
+```
+
+実行後にできること:
+
+- `data\keiba.db` が作られます。
+- 出馬表、成績、払戻、確定オッズなどの通常データが `NL_*` に入ります。
+- 完了時に、SQLite 用の日次同期タスクを登録するか確認されます。
+
+このコマンドだけではできないこと:
+
+- PostgreSQL への保存
+- 三連複・三連単を含む締切前オッズの長期蓄積
+
+## 3. ルートB: SQLiteに公式時系列オッズも入れる
+
+単複枠・馬連の過去時系列オッズも保存したい場合です。
+
+対話形式では、`quickstart.bat` の途中で時系列オッズ取得を選びます。
+
+非対話で実行する場合:
+
+```bat
+quickstart.bat --yes --include-timeseries
+```
+
+実行後に入るデータ:
+
+| データ | 保存先 |
+| --- | --- |
+| 通常データ | `NL_*` |
+| 単複枠の公式時系列オッズ | `TS_O1` |
+| 馬連の公式時系列オッズ | `TS_O2` |
+
+注意:
+
+- `--yes` を付けると確認プロンプトを出しません。
+- そのため、日次同期タスク登録もスキップします。必要なら後で `install_tasks.ps1` を実行してください。
+- `TS_O1` / `TS_O2` は JRA-VAN 側で約1年保持される公式時系列です。
+
+## 4. ルートC: PostgreSQLで運用する
+
+共有DBや本番運用では PostgreSQL を使います。
+
+先に接続情報を設定します。
+
+```bat
+set POSTGRES_HOST=127.0.0.1
+set POSTGRES_PORT=5432
+set POSTGRES_DATABASE=keiba_dev
+set POSTGRES_USER=ingestion_writer
+set POSTGRES_PASSWORD=<password>
+```
+
+次に PostgreSQL 用 quickstart を実行します。
+
+```bat
+quickstart_postgres_timeseries.bat 20250426 20260412
+```
+
+実行後にできること:
+
+- PostgreSQL に指定範囲の通常データが入ります。
+- 公式時系列オッズ `TS_O1` / `TS_O2` が入ります。
+- 完了時に、PostgreSQL 用の日次同期タスクを登録するか確認されます。
+
+注意:
+
+- `quickstart.bat` から PostgreSQL 用 quickstart は呼びません。
+- SQLite と PostgreSQL は導線を分けています。
+- タスクから PostgreSQL に接続する場合は、`POSTGRES_*` を Windows ユーザー環境変数として保存する必要があります。
+
+## 5. ルートD: 三連複・三連単を含む締切前オッズを残す
+
+全賭式の投資判断時点オッズを評価したい場合は、開催週に速報オッズを蓄積します。
+
+PostgreSQL に保存する場合:
+
+```bat
+jltsql realtime odds-sokuho-timeseries --from 20260418 --to 20260419 --db postgresql
+```
+
+SQLite に保存する場合:
+
+```bat
+jltsql realtime odds-sokuho-timeseries --from 20260418 --to 20260419 --db sqlite --db-path data/keiba.db
+```
+
+入るデータ:
+
+| 賭式 | 保存先 |
+| --- | --- |
+| 単勝・複勝・枠連 | `TS_O1` |
+| 馬連 | `TS_O2` |
+| ワイド | `TS_O3` |
+| 馬単 | `TS_O4` |
+| 三連複 | `TS_O5` |
+| 三連単 | `TS_O6` |
+
+注意:
+
+- `0B30` 系の速報オッズは JRA-VAN 側の保持が約1週間です。
+- 1か月後にまとめて取りに行く運用はできません。
+- 長期評価したい場合は、開催週から継続蓄積してください。
+- `jltsql realtime odds-timeseries` / `odds-sokuho-timeseries` は、既存 DB のレース情報を使って取得キーを作ります。先に通常データを入れてください。
+
+## 日次同期
+
+通常データの更新だけを毎日行う場合は `daily_sync.bat` を使います。
+直接実行時の既定は PostgreSQL です。SQLite では必ず `--db sqlite` を指定してください。
+
+```bat
+daily_sync.bat --db sqlite --days-back 7 --days-forward 3
+daily_sync.bat --db postgresql --days-back 7 --days-forward 3
+```
+
+Windows タスクスケジューラへ手動登録する場合:
+
+```powershell
+powershell -NoProfile -ExecutionPolicy Bypass -File install_tasks.ps1 -DbType sqlite -Time 06:30
+powershell -NoProfile -ExecutionPolicy Bypass -File install_tasks.ps1 -DbType postgresql -Time 06:30
+```
+
+`daily_sync.bat` が更新するのは通常データです。時系列オッズは取得しません。
+
+## よくある混同
+
+| 混同しやすい点 | 正しい理解 |
+| --- | --- |
+| `quickstart.bat` は PostgreSQL も設定するのか | しません。SQLite 既定の通常 quickstart です。 |
+| `quickstart_postgres_timeseries.bat` は SQLite にも使うのか | 使いません。PostgreSQL 専用です。 |
+| `daily_sync.bat` は SQLite / PostgreSQL の両方で使えるのか | 使えます。`--db sqlite` または `--db postgresql` を指定します。 |
+| `daily_sync.bat` で時系列オッズも入るのか | 入りません。通常データ更新だけです。 |
+| 確定オッズ `NL_O*` は投資判断時点のオッズか | 違います。レース後の確定オッズです。 |
+| 三連複・三連単の過去時系列を1年分まとめて取れるか | 取れません。開催週の継続蓄積が必要です。 |
+
+## 動作確認
+
+DB の状態確認:
+
+```bat
+jltsql status
+```
+
+保存済み時系列オッズを CSV で見る場合:
+
+```bat
+python tools/export_timeseries_csv.py --help
+```
+
+CLI の詳細:
+
+```bat
+jltsql --help
+jltsql realtime --help
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,73 +1,38 @@
 # JRVLTSQL ドキュメント
 
-JRVLTSQL は JRA-VAN DataLab のデータを SQLite / PostgreSQL に取り込む Windows 向けツールです。
+JRVLTSQL は、JRA-VAN DataLab の JRA データを SQLite または PostgreSQL に保存する
+Windows 向けツールです。NAR / 地方競馬は対象外です。
 
-この `docs/` は、現在の運用に必要な最小限の情報だけを残しています。詳細な運用手順は `README.md`、CLI の引数確認は `jltsql --help` と [CLI.md](CLI.md) を参照してください。
+初めて使う場合は、まず [はじめに](getting_started.md) を読んでください。
 
-## 最初に見る表
+## 最初に見る順序
 
-| 目的 | 実行するもの | 結果 |
+1. [はじめに](getting_started.md): 目的別の実行順序
+2. [時系列オッズ](timeseries_odds.md): 公式時系列と開催週速報オッズの違い
+3. [PostgreSQL](postgresql.md): PostgreSQL 運用と日次同期
+4. [対応データ種別一覧](data_support.md): JVOpen / JVRTOpen spec と保存先
+5. [CLI](CLI.md): `jltsql` の主要コマンド
+6. [スクリプト一覧](scripts.md): batch / PowerShell の役割
+7. [アーキテクチャ](architecture.md): 実装構成
+
+## まず使うコマンド
+
+| 目的 | コマンド |
+| --- | --- |
+| SQLite でまず作る | `quickstart.bat` |
+| SQLite に公式時系列オッズも入れる | `quickstart.bat --yes --include-timeseries` |
+| PostgreSQL で始める | `quickstart_postgres_timeseries.bat <FROM> <TO>` |
+| 既存 PostgreSQL に公式時系列だけ足す | `fetch_timeseries_postgres.bat <FROM> <TO>` |
+| 開催週の全賭式速報オッズを蓄積する | `jltsql realtime odds-sokuho-timeseries --from <FROM> --to <TO> --db postgresql` |
+| DB 状態を確認する | `jltsql status` |
+| 日次同期を手動実行する | `daily_sync.bat --db sqlite` / `daily_sync.bat --db postgresql` |
+
+## 重要な区別
+
+| データ | 保存先 | 注意 |
 | --- | --- | --- |
-| まず SQLite で JRA データを作る | `quickstart.bat` | 主要な蓄積系データを SQLite に取り込みます。 |
-| SQLite に公式時系列オッズも入れる | `quickstart.bat` で時系列オッズ取得を選択、または `quickstart.bat --yes --include-timeseries` | `TS_O1` / `TS_O2` を SQLite に保存します。 |
-| PostgreSQL で運用を始める | `quickstart_postgres_timeseries.bat <FROM> <TO>` | `RACE` 系データと公式1年保持の `TS_O1` / `TS_O2` を PostgreSQL に投入します。 |
-| 公式時系列オッズだけ追加する | `fetch_timeseries_postgres.bat <FROM> <TO>` | 既存 PostgreSQL に `TS_O1` / `TS_O2` を追加します。 |
-| 三連複・三連単を含む全賭式の締切前オッズを蓄積する | `jltsql realtime odds-sokuho-timeseries --from <FROM> --to <TO> --db postgresql` | 開催週の速報オッズを `TS_O1`〜`TS_O6` に保存します。`--db sqlite` も指定できます。 |
-| 日次同期を自動化する | `quickstart.bat` / `quickstart_postgres_timeseries.bat` の最後で登録、または `install_tasks.ps1` | SQLite / PostgreSQL 用の `daily_sync.bat` を Windows タスクスケジューラへ登録します。 |
-
-## どこまでできるか
-
-| データ | 対応状況 | 注意 |
-| --- | --- | --- |
-| JRA 出馬表・成績・払戻 | 対応済み | `NL_RA`, `NL_SE`, `NL_HR` などに保存します。 |
-| 確定オッズ 全賭式 | 対応済み | `NL_O1`〜`NL_O6`。レース後の確定オッズです。 |
-| 単複枠・馬連の公式時系列オッズ | 対応済み | `TS_O1` / `TS_O2`。JRA-VAN 側の保持は約1年です。 |
-| ワイド・馬単・三連複・三連単の締切前オッズ | 開催週の蓄積で対応 | `TS_O3`〜`TS_O6`。JRA-VAN 側の保持は約1週間です。 |
-| NAR / 地方競馬 | 非対応 | 別コレクタ / 別リポジトリの対象です。 |
-
-## 対象
-
-- JRA / 中央競馬のみ
-- Windows 10 / 11
-- JRA-VAN DataLab + JV-Link
-- SQLite / PostgreSQL
-
-対応済みの JVOpen / JVRTOpen データ種別、保存先テーブル、運用コマンドは
-[対応データ種別一覧](data_support.md) に集約しています。
-
-## 基本コマンド例
-
-```bat
-quickstart.bat
-quickstart_postgres_timeseries.bat 20250426 20260412
-jltsql status
-jltsql create-tables
-jltsql create-indexes
-jltsql fetch --from 20260101 --to 20260417 --spec RACE --option 1
-jltsql realtime start --specs 0B12,0B15,0B30
-jltsql realtime odds-timeseries --from 20250425 --to 20260425 --db postgresql
-```
-
-## 重要な注意
-
-- JRA-VAN の実データ取得は Windows + JV-Link 環境が必要です。
-- `0B41/0B42` は公式1年保持の時系列オッズで、`TS_O1/TS_O2` に保存します。
-- 0B30〜0B36 は速報オッズで、公式仕様上の保存期間は 1週間です。
-- `quickstart.bat` は通常セットアップ用です。PostgreSQL 専用セットアップは呼びません。
-- SQLite に公式時系列オッズを入れる場合は、対話形式で時系列オッズ取得を選ぶか、非対話では `quickstart.bat --yes --include-timeseries` を使います。
-- PostgreSQL へ `RACE` と `TS_O1/TS_O2` をまとめて投入する場合は `quickstart_postgres_timeseries.bat` を使います。
-- `daily_sync.bat` は `--db sqlite` / `--db postgresql` の両方に対応します。
-- `quickstart.bat` の最後では SQLite 用の日次同期タスク登録を確認します。
-- `quickstart_postgres_timeseries.bat` の最後で、`daily_sync.bat` を Windows タスクスケジューラに登録するか確認します。
-- `daily_sync.bat` は通常データの更新用です。公式時系列オッズや全賭式速報オッズの蓄積は別コマンドで行います。
-- ワイド・馬単・三連複・三連単の締切前オッズは、開催週に `odds-sokuho-timeseries` で継続蓄積してください。
-- 古い設計メモや未実装機能のドキュメントは削除しています。
-
-## ドキュメント
-
-- [アーキテクチャ](architecture.md)
-- [CLI](CLI.md)
-- [対応データ種別一覧](data_support.md)
-- [PostgreSQL](postgresql.md)
-- [時系列オッズ](timeseries_odds.md)
-- [スクリプト一覧](scripts.md)
+| 通常データ | `NL_*` | 出馬表、成績、払戻、確定オッズなどです。 |
+| 確定オッズ | `NL_O1`〜`NL_O6` | レース後の確定オッズです。投資判断時点のオッズではありません。 |
+| 公式時系列オッズ | `TS_O1`, `TS_O2` | 単複枠・馬連のみ。JRA-VAN 側の保持は約1年です。 |
+| 開催週の速報オッズ | `TS_O1`〜`TS_O6` | 全賭式対応。ただし JRA-VAN 側の保持は約1週間です。 |
+| 日次同期 | `daily_sync.bat` | 通常データだけを更新します。時系列オッズは取得しません。 |

--- a/docs/postgresql.md
+++ b/docs/postgresql.md
@@ -8,7 +8,7 @@ jrvltsql は SQLite だけでなく PostgreSQL へ直接保存できます。複
 
 | 操作 | 入るデータ | 入らないデータ |
 | --- | --- | --- |
-| `quickstart_postgres_timeseries.bat <FROM> <TO>` | `RACE` 系データ、公式1年保持の `TS_O1` / `TS_O2` | `TS_O3`〜`TS_O6` の長期蓄積 |
+| `quickstart_postgres_timeseries.bat <FROM> <TO>` | 指定範囲の通常データ、公式1年保持の `TS_O1` / `TS_O2` | `TS_O3`〜`TS_O6` の長期蓄積 |
 | `fetch_timeseries_postgres.bat <FROM> <TO>` | 公式1年保持の `TS_O1` / `TS_O2` | `RACE` 系データ、`TS_O3`〜`TS_O6` |
 | `daily_sync.bat --db postgresql` | 直近の通常データ | 時系列オッズ |
 | `jltsql realtime odds-sokuho-timeseries --db postgresql` | 開催週の `TS_O1`〜`TS_O6` | JRA-VAN 側の保持期間を過ぎた速報オッズ |
@@ -31,7 +31,7 @@ set POSTGRES_PASSWORD=<password>
 quickstart_postgres_timeseries.bat 20250426 20260412
 ```
 
-このコマンドは、RACE データと公式1年保持の `TS_O1/TS_O2` 時系列オッズを
+このコマンドは、指定範囲の通常データと公式1年保持の `TS_O1/TS_O2` 時系列オッズを
 PostgreSQL に投入します。通常の `quickstart.bat` からは呼びません。
 SQLite と PostgreSQL の導線を分けるため、PostgreSQL 運用を始める場合は
 この batch を直接実行してください。

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -5,10 +5,10 @@
 
 | スクリプト | 最初に使う場面 | できること | できないこと |
 | --- | --- | --- | --- |
-| `quickstart.bat` | まず手元で SQLite DB を作るとき | 通常セットアップ、データ取得、DB 検証を行います。対話形式で時系列オッズ取得を選ぶか、`--yes --include-timeseries` で SQLite に公式 `TS_O1` / `TS_O2` も保存できます。最後に SQLite 用の日次同期タスク登録を確認します。 | PostgreSQL 専用セットアップは呼びません。`--yes` 実行時は日次同期タスク登録確認もスキップします。 |
-| `quickstart_postgres_timeseries.bat` | PostgreSQL 運用を始めるとき | `RACE` 系データと公式 `TS_O1` / `TS_O2` 時系列オッズを投入します。最後に日次タスク登録を確認します。 | 三連複・三連単など `TS_O3`〜`TS_O6` の長期蓄積は行いません。 |
+| `quickstart.bat` | まず手元で SQLite DB を作るとき | 通常セットアップとデータ取得を行います。対話形式で時系列オッズ取得を選ぶか、`--yes --include-timeseries` で SQLite に公式 `TS_O1` / `TS_O2` も保存できます。最後に SQLite 用の日次同期タスク登録を確認します。 | PostgreSQL 専用セットアップは呼びません。`--yes` 実行時は日次同期タスク登録確認もスキップします。 |
+| `quickstart_postgres_timeseries.bat` | PostgreSQL 運用を始めるとき | 指定範囲の通常データと公式 `TS_O1` / `TS_O2` 時系列オッズを投入します。最後に日次タスク登録を確認します。 | 三連複・三連単など `TS_O3`〜`TS_O6` の長期蓄積は行いません。 |
 | `fetch_timeseries_postgres.bat` | 既存 PostgreSQL に公式時系列だけ追加するとき | `0B41` / `0B42` から `TS_O1` / `TS_O2` を追加します。 | `RACE` 系データは追加しません。 |
-| `daily_sync.bat` | 日次で通常データを更新するとき | 直近の通常データを更新します。`--db sqlite` / `--db postgresql` に対応します。既定は過去7日・未来3日です。 | 公式時系列オッズや全賭式速報オッズの蓄積は行いません。 |
+| `daily_sync.bat` | 日次で通常データを更新するとき | 直近の通常データを更新します。`--db sqlite` / `--db postgresql` に対応します。既定は PostgreSQL、過去7日・未来3日です。 | 公式時系列オッズや全賭式速報オッズの蓄積は行いません。SQLite では `--db sqlite` を指定してください。 |
 | `install_tasks.ps1` | 日次同期を Windows タスク化するとき | `daily_sync.bat` の Windows タスク登録・更新を行います。`-DbType sqlite` / `-DbType postgresql` に対応します。 | オッズ取得処理そのものは実行しません。 |
 | `scripts/quickstart.py` | バッチの内部処理 | セットアップ・更新処理の本体です。 | 通常は直接実行する必要はありません。 |
 | `scripts/raceday_verify.py` | 開催日の健全性確認 | レース前後の DB 状態を検証します。 | データ取得の代替ではありません。 |

--- a/docs/timeseries_odds.md
+++ b/docs/timeseries_odds.md
@@ -37,7 +37,7 @@ jltsql realtime odds-sokuho-timeseries --from 20260418 --to 20260419 --db postgr
 jltsql realtime odds-sokuho-timeseries --from 20260418 --to 20260419 --db sqlite --db-path data/keiba.db
 ```
 
-PostgreSQL へ RACE と公式 `TS_O1/TS_O2` をまとめて投入:
+PostgreSQL へ通常データと公式 `TS_O1/TS_O2` をまとめて投入:
 
 ```bat
 quickstart_postgres_timeseries.bat 20250426 20260412
@@ -49,6 +49,9 @@ quickstart_postgres_timeseries.bat 20250426 20260412
 PostgreSQL にまとめて入れる場合は `quickstart_postgres_timeseries.bat` を
 直接実行してください。`quickstart_postgres_timeseries.bat` の最後では、
 `daily_sync.bat` を Windows タスクスケジューラへ登録するか確認します。
+
+`jltsql realtime odds-timeseries` / `odds-sokuho-timeseries` は、既存 DB の
+レース情報を使って JVRTOpen のキーを作ります。先に通常データを投入してください。
 
 ## 重要な制約
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -21,11 +21,12 @@ markdown_extensions:
 
 nav:
   - ホーム: index.md
-  - アーキテクチャ: architecture.md
-  - CLI: CLI.md
-  - 対応データ種別一覧: data_support.md
-  - PostgreSQL: postgresql.md
+  - はじめに: getting_started.md
   - 時系列オッズ: timeseries_odds.md
+  - PostgreSQL: postgresql.md
+  - 対応データ種別一覧: data_support.md
+  - CLI: CLI.md
   - スクリプト一覧: scripts.md
+  - アーキテクチャ: architecture.md
 
 copyright: Copyright &copy; 2024 JRVLTSQL コントリビューター

--- a/tests/test_quickstart_cli.py
+++ b/tests/test_quickstart_cli.py
@@ -25,6 +25,8 @@ def _build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--mode", choices=["simple", "standard", "full", "update"], default=None)
     parser.add_argument("--include-timeseries", action="store_true")
     parser.add_argument("--timeseries-months", type=int, default=12)
+    parser.add_argument("--timeseries-from-date", type=str, default=None)
+    parser.add_argument("--timeseries-to-date", type=str, default=None)
     parser.add_argument("--include-realtime", action="store_true")
     parser.add_argument("--background", action="store_true")
     parser.add_argument("-y", "--yes", action="store_true")
@@ -42,7 +44,7 @@ def _build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--no-odds", action="store_true")
     parser.add_argument("--no-monitor", action="store_true")
     parser.add_argument("--log-file", type=str, default=None)
-    parser.add_argument("--source", type=str, choices=["jra", "nar", "all"], default="jra")
+    parser.add_argument("--source", type=str, choices=["jra"], default="jra")
     return parser
 
 
@@ -68,13 +70,13 @@ class TestQuickstartArgParsing:
         args = parser.parse_args(["--source", "jra"])
         assert args.source == "jra"
 
-    def test_nar_only(self, parser):
-        args = parser.parse_args(["--source", "nar"])
-        assert args.source == "nar"
+    def test_nar_source_rejected(self, parser):
+        with pytest.raises(SystemExit):
+            parser.parse_args(["--source", "nar"])
 
-    def test_all_sources(self, parser):
-        args = parser.parse_args(["--source", "all"])
-        assert args.source == "all"
+    def test_all_sources_rejected(self, parser):
+        with pytest.raises(SystemExit):
+            parser.parse_args(["--source", "all"])
 
     def test_invalid_source_rejected(self, parser):
         with pytest.raises(SystemExit):
@@ -139,7 +141,7 @@ class TestQuickstartArgParsing:
     def test_combined_flags(self, parser):
         args = parser.parse_args([
             "--mode", "standard",
-            "--source", "nar",
+            "--source", "jra",
             "--from-date", "20230101",
             "-y",
             "--include-timeseries",
@@ -148,7 +150,7 @@ class TestQuickstartArgParsing:
             "--log-file", "/tmp/test.log",
         ])
         assert args.mode == "standard"
-        assert args.source == "nar"
+        assert args.source == "jra"
         assert args.from_date == "20230101"
         assert args.yes is True
         assert args.include_timeseries is True
@@ -214,3 +216,33 @@ class TestQuickstartBatchRoles:
         assert "-DbType sqlite" in text
         assert "SKIP_SCHEDULER_FOR_YES" in text
         assert 'if not "%~1"==""' in text
+
+    def test_postgresql_timeseries_batch_role(self):
+        batch = Path(__file__).resolve().parents[1] / "quickstart_postgres_timeseries.bat"
+        text = batch.read_text(encoding="utf-8")
+
+        assert "POSTGRES_PASSWORD is required" in text
+        assert "--mode update --yes --db-type postgresql" in text
+        assert "--include-timeseries" in text
+        assert "--timeseries-from-date" in text
+        assert "--timeseries-to-date" in text
+        assert "-DbType postgresql" in text
+
+    def test_daily_sync_is_normal_data_only(self):
+        batch = Path(__file__).resolve().parents[1] / "daily_sync.bat"
+        text = batch.read_text(encoding="utf-8")
+
+        assert 'set "DB_TYPE=postgresql"' in text
+        assert "--db-type postgresql" in text
+        assert "--db-type sqlite" in text
+        assert "scripts/quickstart.py --mode update --yes" in text
+        assert "--include-timeseries" not in text
+
+    def test_install_tasks_registers_daily_sync_with_db_type(self):
+        script = Path(__file__).resolve().parents[1] / "install_tasks.ps1"
+        text = script.read_text(encoding="utf-8")
+
+        assert "daily_sync.bat" in text
+        assert "--db" in text
+        assert "$DbType" in text
+        assert "PersistPostgresEnvironment" in text


### PR DESCRIPTION
## Summary
- READMEを初回ユーザー向けの準備、最短手順、目的別コマンド中心に整理
- docs/getting_started.md を追加し、MkDocsホームとナビゲーションを実行順序が分かる導線へ変更
- quickstart/daily sync/PostgreSQL/時系列オッズの説明を実装と整合させ、quickstart引数テストもJRA専用の現状へ更新

## Verification
- git diff --check
- mkdocs build --strict
- pytest tests/test_quickstart_cli.py -q