### PR TITLE
PostgreSQL quickstart の説明を整理

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,6 @@ Windows タスクスケジューラへ登録するか確認されます。
 | SQLite で範囲指定して公式時系列オッズも入れる | `quickstart_timeseries.bat --db sqlite --from 20250426 --to 20260412` | 指定範囲の通常データ + `TS_O1` / `TS_O2` を取得し、日次同期タスク登録を確認します。 |
 | PostgreSQL で範囲指定して公式時系列オッズも入れる | `quickstart_timeseries.bat --db postgresql --from 20250426 --to 20260412` | 指定範囲の通常データ + `TS_O1` / `TS_O2` を取得し、日次同期タスク登録を確認します。 |
 | SQLite で非対話実行する | `quickstart.bat --yes --include-timeseries` | 通常データは `19860101`〜今日、公式時系列オッズは今日から過去12か月を取得します。タスク登録確認は出しません。 |
-| PostgreSQL 旧導線で運用を始める | `quickstart_postgres_timeseries.bat 20250426 20260412` | PostgreSQL に指定範囲の通常データと公式 `TS_O1` / `TS_O2` が入ります。 |
 | 既存 PostgreSQL に公式時系列だけ足す | `fetch_timeseries_postgres.bat 20250426 20260412` | `TS_O1` / `TS_O2` だけを追加します。 |
 | 三連複・三連単を含む締切前オッズを残す | `jltsql realtime odds-sokuho-timeseries --from 20260418 --to 20260419 --db postgresql` | 開催週の全賭式速報オッズを `TS_O1`〜`TS_O6` に保存します。 |
 | 日次同期を手動登録する | `powershell -NoProfile -ExecutionPolicy Bypass -File install_tasks.ps1 -DbType sqlite -Time 06:30` | `daily_sync.bat` を Windows タスクとして登録します。 |
@@ -86,7 +85,7 @@ quickstart_timeseries.bat --db postgresql --from 20250426 --to 20260412
 
 SQLite と PostgreSQL の範囲指定は `quickstart_timeseries.bat --db <sqlite|postgresql> --from <FROM> --to <TO>` に統一しています。
 `quickstart_timeseries.bat` で `--from` / `--to` を省略した場合は、通常データも公式時系列オッズも今日から過去365日分を対象にします。
-`quickstart_postgres_timeseries.bat <FROM> <TO>` も後方互換の旧導線として残しています。
+PostgreSQL 専用バッチ `quickstart_postgres_timeseries.bat <FROM> <TO>` もありますが、新規利用では上の共通コマンドを使ってください。
 
 ## 日次同期
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -25,7 +25,7 @@ NAR / 地方競馬はこのリポジトリの対象外です。
 | `scripts/quickstart.py` | 対話・非対話の初期セットアップと更新処理をまとめます。 |
 | `quickstart.bat` | Windows 向けの通常 quickstart です。既定は SQLite で、対話形式または `--yes --include-timeseries` により SQLite に公式時系列オッズも保存できます。最後に SQLite 用の日次同期タスク登録を確認します。 |
 | `quickstart_timeseries.bat` | SQLite / PostgreSQL 共通の範囲指定つき時系列 quickstart です。指定範囲の通常データと公式時系列オッズを投入し、最後にタスク登録を確認します。 |
-| `quickstart_postgres_timeseries.bat` | PostgreSQL 専用の後方互換 quickstart です。 |
+| `quickstart_postgres_timeseries.bat` | PostgreSQL 専用 quickstart です。 |
 | `daily_sync.bat` | Windows タスクスケジューラから実行する日次同期です。 |
 | `install_tasks.ps1` | `daily_sync.bat` の Windows タスク登録・更新を行います。 |
 

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -124,7 +124,7 @@ quickstart_timeseries.bat --db postgresql --from 20250426 --to 20260412
 
 - `quickstart_timeseries.bat --db sqlite|postgresql --from <FROM> --to <TO>` が、範囲指定つき時系列 quickstart の推奨導線です。
 - `--from` / `--to` を省略した場合は、通常データも公式時系列オッズも今日から過去365日分を対象にします。
-- `quickstart_postgres_timeseries.bat <FROM> <TO>` は後方互換の旧導線として残しています。
+- PostgreSQL 専用バッチ `quickstart_postgres_timeseries.bat <FROM> <TO>` もありますが、新規利用では共通コマンドを使ってください。
 - タスクから PostgreSQL に接続する場合は、`POSTGRES_*` を Windows ユーザー環境変数として保存する必要があります。
 
 ## 5. ルートD: 三連複・三連単を含む締切前オッズを残す
@@ -186,7 +186,7 @@ powershell -NoProfile -ExecutionPolicy Bypass -File install_tasks.ps1 -DbType po
 | --- | --- |
 | `quickstart.bat` は PostgreSQL も設定するのか | しません。SQLite 既定の通常 quickstart です。 |
 | SQLite と PostgreSQL で時系列 quickstart のコマンド形は違うのか | 推奨導線は同じです。`quickstart_timeseries.bat --db sqlite|postgresql --from <FROM> --to <TO>` を使います。 |
-| `quickstart_postgres_timeseries.bat` は SQLite にも使うのか | 使いません。PostgreSQL 専用の後方互換 batch です。 |
+| `quickstart_postgres_timeseries.bat` は SQLite にも使うのか | 使いません。PostgreSQL 専用 batch です。 |
 | `daily_sync.bat` は SQLite / PostgreSQL の両方で使えるのか | 使えます。`--db sqlite` または `--db postgresql` を指定します。 |
 | `daily_sync.bat` で時系列オッズも入るのか | 入りません。通常データ更新だけです。 |
 | 確定オッズ `NL_O*` は投資判断時点のオッズか | 違います。レース後の確定オッズです。 |

--- a/docs/postgresql.md
+++ b/docs/postgresql.md
@@ -9,7 +9,7 @@ jrvltsql は SQLite だけでなく PostgreSQL へ直接保存できます。複
 | 操作 | 入るデータ | 入らないデータ |
 | --- | --- | --- |
 | `quickstart_timeseries.bat --db postgresql --from <FROM> --to <TO>` | 指定範囲の通常データ、公式1年保持の `TS_O1` / `TS_O2` | `TS_O3`〜`TS_O6` の長期蓄積 |
-| `quickstart_postgres_timeseries.bat <FROM> <TO>` | 同上。PostgreSQL 専用の後方互換 batch | SQLite 保存 |
+| `quickstart_postgres_timeseries.bat <FROM> <TO>` | 同上。PostgreSQL 専用 batch | SQLite 保存 |
 | `fetch_timeseries_postgres.bat <FROM> <TO>` | 公式1年保持の `TS_O1` / `TS_O2` | `RACE` 系データ、`TS_O3`〜`TS_O6` |
 | `daily_sync.bat --db postgresql` | 直近の通常データ | 時系列オッズ |
 | `jltsql realtime odds-sokuho-timeseries --db postgresql` | 開催週の `TS_O1`〜`TS_O6` | JRA-VAN 側の保持期間を過ぎた速報オッズ |
@@ -37,7 +37,7 @@ PostgreSQL に投入します。通常の `quickstart.bat` からは呼びませ
 SQLite と PostgreSQL の範囲指定つき時系列 quickstart は、同じ
 `quickstart_timeseries.bat --db <sqlite|postgresql> --from <FROM> --to <TO>` に統一しています。
 `--from` / `--to` を省略した場合は、通常データも公式時系列オッズも今日から過去365日分を対象にします。
-`quickstart_postgres_timeseries.bat <FROM> <TO>` は後方互換の旧導線として残しています。
+PostgreSQL 専用バッチ `quickstart_postgres_timeseries.bat <FROM> <TO>` もありますが、新規利用では共通コマンドを使ってください。
 
 `quickstart_timeseries.bat` と `quickstart_postgres_timeseries.bat` の最後では、`daily_sync.bat` を
 Windows タスクスケジューラへ登録するか確認します。PostgreSQL 接続情報を

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -7,7 +7,7 @@
 | --- | --- | --- | --- |
 | `quickstart.bat` | まず手元で SQLite DB を作るとき | 通常セットアップとデータ取得を行います。対話形式で時系列オッズ取得を選ぶか、`--yes --include-timeseries` で SQLite に公式 `TS_O1` / `TS_O2` も保存できます。最後に SQLite 用の日次同期タスク登録を確認します。 | PostgreSQL 専用セットアップは呼びません。`--yes` 実行時は日次同期タスク登録確認もスキップします。 |
 | `quickstart_timeseries.bat` | SQLite / PostgreSQL で範囲指定して公式時系列オッズも入れるとき | `--db sqlite` / `--db postgresql` を同じ形で指定し、指定範囲の通常データと公式 `TS_O1` / `TS_O2` を投入します。最後に指定 DB 用の日次タスク登録を確認します。 | 三連複・三連単など `TS_O3`〜`TS_O6` の長期蓄積は行いません。 |
-| `quickstart_postgres_timeseries.bat` | PostgreSQL 旧導線を使うとき | 指定範囲の通常データと公式 `TS_O1` / `TS_O2` 時系列オッズを投入します。最後に日次タスク登録を確認します。 | SQLite には使いません。新規手順では `quickstart_timeseries.bat --db postgresql` を推奨します。 |
+| `quickstart_postgres_timeseries.bat` | PostgreSQL 専用バッチを直接使うとき | 指定範囲の通常データと公式 `TS_O1` / `TS_O2` 時系列オッズを投入します。最後に日次タスク登録を確認します。 | SQLite には使いません。新規手順では `quickstart_timeseries.bat --db postgresql` を推奨します。 |
 | `fetch_timeseries_postgres.bat` | 既存 PostgreSQL に公式時系列だけ追加するとき | `0B41` / `0B42` から `TS_O1` / `TS_O2` を追加します。 | `RACE` 系データは追加しません。 |
 | `daily_sync.bat` | 日次で通常データを更新するとき | 直近の通常データを更新します。`--db sqlite` / `--db postgresql` に対応します。既定は PostgreSQL、過去7日・未来3日です。 | 公式時系列オッズや全賭式速報オッズの蓄積は行いません。SQLite では `--db sqlite` を指定してください。 |
 | `install_tasks.ps1` | 日次同期を Windows タスク化するとき | `daily_sync.bat` の Windows タスク登録・更新を行います。`-DbType sqlite` / `-DbType postgresql` に対応します。 | オッズ取得処理そのものは実行しません。 |
@@ -24,7 +24,7 @@
 `quickstart_timeseries.bat --db <sqlite|postgresql> --from <FROM> --to <TO>` を使ってください。
 `--from` / `--to` 省略時は、通常データも公式時系列オッズも今日から過去365日分を対象にします。
 この batch も最後に `daily_sync.bat` の日次 Windows タスク登録を確認します。
-PostgreSQL 旧導線として `quickstart_postgres_timeseries.bat` も残しています。
+PostgreSQL だけを対象にした `quickstart_postgres_timeseries.bat` もありますが、新規手順では共通コマンドを使ってください。
 PostgreSQL 時系列オッズ投入が終わると、`daily_sync.bat` を日次 Windows
 タスクとして登録するか確認します。
 


### PR DESCRIPTION
## Summary
- README の目的別コマンド表から分かりにくい PostgreSQL 専用バッチ行を削除
- 「旧導線」「後方互換」という利用者向けに分かりにくい表現を削除
- 詳細ページでは `quickstart_postgres_timeseries.bat` を PostgreSQL 専用バッチとして説明

## Verification
- git diff --check
- mkdocs build --strict
- pytest tests/test_quickstart_cli.py -q