### PR TITLE
fix: PostgreSQL初期構築の実バグ修正をpsycopg標準で整理

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-postgres = ["pg8000"]
+postgres = ["psycopg[binary]"]
 s3 = ["boto3>=1.26", "cryptography>=41.0"]
 dev = [
     "pytest>=7.4",
@@ -109,7 +109,7 @@ addopts = [
     "--cov=src",
     "--cov-report=term-missing",
     "--cov-report=html",
-    "--basetemp=C:/tmp/pytest-jrvl",
+    "--basetemp=.pytest-tmp",
 ]
 markers = [
     "slow: marks tests as slow (deselect with '-m \"not slow\"')",

--- a/scripts/quickstart.py
+++ b/scripts/quickstart.py
@@ -444,16 +444,16 @@ def _check_postgresql_database(host: str, port: int, database: str, user: str, p
         ステータス: "exists" (既存), "created" (新規作成), "error" (エラー)
     """
     try:
-        # PostgreSQLドライバのインポート
+        # PostgreSQLドライバのインポート。標準は psycopg[binary]。
         try:
-            import pg8000.native
-            driver = "pg8000"
+            import psycopg
+            driver = "psycopg"
         except ImportError:
             try:
-                import psycopg
-                driver = "psycopg"
+                import pg8000.native
+                driver = "pg8000"
             except ImportError:
-                return "error", "PostgreSQLドライバがインストールされていません。\npip install pg8000 または pip install psycopg を実行してください。"
+                return "error", "PostgreSQLドライバがインストールされていません。\npip install \"psycopg[binary]\" を実行してください。"
 
         # まずpostgresデータベースに接続してターゲットDBの存在確認
         if driver == "pg8000":
@@ -520,11 +520,11 @@ def _drop_postgresql_database(host: str, port: int, database: str, user: str, pa
     """
     try:
         try:
-            import pg8000.native
-            driver = "pg8000"
-        except ImportError:
             import psycopg
             driver = "psycopg"
+        except ImportError:
+            import pg8000.native
+            driver = "pg8000"
 
         if driver == "pg8000":
             conn = pg8000.native.Connection(
@@ -589,16 +589,16 @@ def _test_postgresql_connection(host: str, port: int, database: str, user: str, 
         (成功/失敗, メッセージ)
     """
     try:
-        # PostgreSQLドライバのインポート
+        # PostgreSQLドライバのインポート。標準は psycopg[binary]。
         try:
-            import pg8000.native
-            driver = "pg8000"
+            import psycopg
+            driver = "psycopg"
         except ImportError:
             try:
-                import psycopg
-                driver = "psycopg"
+                import pg8000.native
+                driver = "pg8000"
             except ImportError:
-                return False, "PostgreSQLドライバがインストールされていません。\npip install pg8000 または pip install psycopg を実行してください。"
+                return False, "PostgreSQLドライバがインストールされていません。\npip install \"psycopg[binary]\" を実行してください。"
 
         # 接続テスト
         if driver == "pg8000":
@@ -763,7 +763,7 @@ def _interactive_setup_rich() -> dict:
                     "[cyan]2. サービスの起動確認:[/cyan]\n"
                     "   services.msc → postgresql-x64-XX を開始\n\n"
                     "[cyan]3. Pythonドライバのインストール:[/cyan]\n"
-                    "   pip install pg8000",
+                    "   pip install \"psycopg[binary]\"",
                     border_style="yellow",
                 ))
                 console.print()
@@ -1349,7 +1349,7 @@ def _interactive_setup_simple() -> dict:
                 print("PostgreSQLのインストール・設定方法:")
                 print("  1. https://www.postgresql.org/download/")
                 print("  2. サービス起動: services.msc -> postgresql-x64-XX")
-                print("  3. Pythonドライバ: pip install pg8000")
+                print("  3. Pythonドライバ: pip install \"psycopg[binary]\"")
                 print()
                 retry = input("再試行しますか？ (y/n) [y]: ").strip().lower() or "y"
                 if retry != "y":
@@ -2076,7 +2076,6 @@ class QuickstartRunner:
                 # NL_RAテーブルから開催情報を取得（Kaiji/Nichiji含む）
                 # Year + MonthDay で日付を構成
                 # PostgreSQLでは printf の代わりに lpad を使用
-                # pg8000では :name 形式のプレースホルダーを使用
                 if db.get_db_type() == 'postgresql':
                     query = f"""
                         SELECT DISTINCT
@@ -2086,8 +2085,8 @@ class QuickstartRunner:
                             nichiji,
                             racenum
                         FROM {table_name}
-                        WHERE (year || lpad(monthday::text, 4, '0')) >= :from_date
-                          AND (year || lpad(monthday::text, 4, '0')) <= :to_date
+                        WHERE (year || lpad(monthday::text, 4, '0')) >= ?
+                          AND (year || lpad(monthday::text, 4, '0')) <= ?
                           AND lpad(jyocd::text, 2, '0') IN ('01','02','03','04','05','06','07','08','09','10')
                         ORDER BY race_date, jyocd, racenum
                     """
@@ -2105,11 +2104,7 @@ class QuickstartRunner:
                           AND printf('%02d', CAST(JyoCD AS INTEGER)) IN ('01','02','03','04','05','06','07','08','09','10')
                         ORDER BY race_date, JyoCD, RaceNum
                     """
-                # PostgreSQLでは辞書形式、SQLiteではタプル形式でパラメータを渡す
-                if db.get_db_type() == 'postgresql':
-                    results = db.fetch_all(query, {'from_date': from_date, 'to_date': to_date})
-                else:
-                    results = db.fetch_all(query, (from_date, to_date))
+                results = db.fetch_all(query, (from_date, to_date))
                 # fetch_all returns a list of dictionaries with lowercase keys for PostgreSQL
                 # For consistency, we convert dict rows to tuple rows
                 if db.get_db_type() == 'postgresql':
@@ -2872,7 +2867,7 @@ class QuickstartRunner:
 
         try:
             from src.fetcher.realtime import RealtimeFetcher
-            from src.importer.importer import DataImporter
+            from src.realtime.updater import RealtimeUpdater
 
             # データベース接続
             db = self._create_database()
@@ -2887,7 +2882,10 @@ class QuickstartRunner:
 
             with db:
                 fetcher = RealtimeFetcher(sid="JLTSQL")
-                importer = DataImporter(db, batch_size=1000)
+                # RealtimeUpdater は record_type を RT_*（速報系）/ TS_O*（時系列）に
+                # 正しくルーティングする。DataImporter を使うと NL_* に書き込まれ
+                # 速報系テーブルが空になる。
+                updater = RealtimeUpdater(db)
 
                 for date_str in race_dates:
                     # 時系列データはレース単位のキーが必要
@@ -2897,10 +2895,21 @@ class QuickstartRunner:
                         keys = [date_str]  # 速報系は日付単位
 
                     for key in keys:
-                        records = []
                         try:
                             for record in fetcher.fetch(data_spec=spec, key=key, continuous=False):
-                                records.append(record)
+                                raw_buff = record.get("_raw")
+                                if not raw_buff:
+                                    continue
+                                result = updater.process_record(raw_buff, timeseries=is_time_series)
+                                if result is None:
+                                    continue
+                                # process_record は dict または list[dict] を返す
+                                if isinstance(result, list):
+                                    total_records += sum(
+                                        1 for r in result if r and r.get("success")
+                                    )
+                                elif result.get("success"):
+                                    total_records += 1
                         except Exception as e:
                             error_str = str(e)
                             # 契約外チェック
@@ -2910,11 +2919,6 @@ class QuickstartRunner:
                             if '-1' in error_str or 'no data' in error_str.lower():
                                 continue
                             raise
-
-                        if records:
-                            # インポート
-                            import_stats = importer.import_records(iter(records), auto_commit=True)
-                            total_records += import_stats.get('records_imported', len(records))
 
                 details['records_saved'] = total_records
 
@@ -3154,10 +3158,12 @@ class QuickstartRunner:
         # option=3/4（セットアップモード）は一部のスペックのみ対応
         # RACE, DIFF, BLOD等の主要スペックはoption=2対応
         # COMM, PARA等の補助スペックはoption=1のみ対応
+        # DIFN（マスタデータ: UM, KS, CH）はoption=4が必要（差分では不十分）
         OPTION_4_SUPPORTED_SPECS = {
             "RACE", "DIFF", "BLOD", "SNAP", "SLOP", "WOOD",
             "YSCH", "HOSE", "HOYU", "CHOK", "KISI", "BRDR",
             "TOKU", "MING", "O1", "O2", "O3", "O4", "O5", "O6",
+            "DIFN",  # Master data (horses, jockeys, trainers)
         }
 
         # option=1（差分データ）はJV-Link側の「最終取得時刻」以降のデータのみ返す

--- a/scripts/raceday_verify.py
+++ b/scripts/raceday_verify.py
@@ -663,13 +663,17 @@ def run_unit_tests(issues):
            "--ignore=tests/unit/test_jvlink_bridge.py",
            "--ignore=tests/integration/",
            "--ignore=tests/e2e/",
-           "--basetemp=C:/tmp/pytest-jrvl",
+           "--basetemp=.pytest-tmp",
            "--no-header"]
     r = subprocess.run(cmd, capture_output=True, text=True, timeout=180)
-    lines = (r.stdout + r.stderr).strip().splitlines()
+    output = r.stdout + r.stderr
+    lines = output.strip().splitlines()
     for line in lines[-10:]:
         print(f"  {line}")
     if r.returncode != 0:
+        if "No module named pytest" in output:
+            print("  [SKIP] pytest not installed -- pip install pytest to enable unit tests")
+            return True
         issues.append(f"Unit tests failed (exit {r.returncode})")
         return False
     return True

--- a/scripts/test_postgresql_connection.py
+++ b/scripts/test_postgresql_connection.py
@@ -22,23 +22,22 @@ def test_driver_availability():
     print("=" * 80)
 
     try:
-        import pg8000.native
-        print("✅ pg8000: インストール済み (推奨)")
-        return "pg8000"
-    except ImportError:
-        print("❌ pg8000: 未インストール")
-
-    try:
         import psycopg
-        print("✅ psycopg: インストール済み")
+        print("✅ psycopg: インストール済み (推奨)")
         return "psycopg"
     except ImportError:
         print("❌ psycopg: 未インストール")
 
+    try:
+        import pg8000.native
+        print("✅ pg8000: インストール済み (fallback)")
+        return "pg8000"
+    except ImportError:
+        print("❌ pg8000: 未インストール")
+
     print("\nエラー: PostgreSQLドライバーがインストールされていません")
     print("以下のコマンドでインストールしてください:")
-    print("  pip install pg8000  # 推奨 (純Python)")
-    print("  pip install psycopg # C拡張版")
+    print('  pip install "psycopg[binary]"')
     return None
 
 

--- a/src/database/migration.py
+++ b/src/database/migration.py
@@ -78,16 +78,22 @@ def migrate_table_if_needed(db: BaseDatabase, table_name: str, schema_sql: str) 
 
     # Get existing columns — PRAGMA for SQLite, information_schema for PostgreSQL
     if db.get_db_type() == "postgresql":
+        # PostgreSQL stores unquoted identifiers in lowercase; information_schema
+        # also stores them lowercased, so we must lowercase the lookup key.
         existing_info = db.fetch_all(
             "SELECT column_name AS name FROM information_schema.columns "
             "WHERE table_name = ? AND table_schema = 'public'",
-            (table_name,),
+            (table_name.lower(),),
         )
     else:
         existing_info = db.fetch_all(f'PRAGMA table_info("{table_name}")')
     existing_columns = {row['name'] for row in existing_info}
 
-    if existing_columns == expected_columns:
+    # PostgreSQL lowercases all unquoted identifiers, so compare case-insensitively.
+    # Without this, every PG run sees a "mismatch" between schema.py's CamelCase
+    # column names and information_schema's lowercased names, triggering a DROP+
+    # recreate on every call to create_all_tables() — which silently wipes data.
+    if {c.lower() for c in existing_columns} == {c.lower() for c in expected_columns}:
         return False
 
     # Schema mismatch detected
@@ -97,7 +103,13 @@ def migrate_table_if_needed(db: BaseDatabase, table_name: str, schema_sql: str) 
         f"expected={sorted(expected_columns)}. "
         f"Dropping and recreating table."
     )
-    db.execute(f'DROP TABLE "{table_name}"')
+    # PostgreSQL stores unquoted identifiers in lowercase. Quoting the uppercase
+    # name (e.g. "NL_BN") makes the DROP case-sensitive and fail with
+    # "relation does not exist". Use unquoted/lowercase for PostgreSQL.
+    if db.get_db_type() == "postgresql":
+        db.execute(f'DROP TABLE IF EXISTS {table_name.lower()}')
+    else:
+        db.execute(f'DROP TABLE IF EXISTS "{table_name}"')
     db.execute(schema_sql)
     db.commit()
     return True

--- a/src/database/postgresql_handler.py
+++ b/src/database/postgresql_handler.py
@@ -6,18 +6,18 @@ This module provides PostgreSQL database operations for JLTSQL.
 from typing import Any, Dict, List, Optional
 
 try:
-    import pg8000.native
-    DRIVER = "pg8000"
+    import psycopg
+    from psycopg.rows import dict_row
+    DRIVER = "psycopg"
 except ImportError:
     try:
-        import psycopg
-        from psycopg.rows import dict_row
-        DRIVER = "psycopg"
+        import pg8000.native
+        DRIVER = "pg8000"
     except ImportError:
         raise ImportError(
             "No PostgreSQL driver available. "
-            "Install pg8000 (pure Python, works on Win32): pip install pg8000 "
-            "Or install psycopg (requires libpq): pip install psycopg"
+            "Install psycopg binary: pip install 'psycopg[binary]' "
+            "or the fallback driver: pip install pg8000"
         )
 
 from src.database.base import BaseDatabase, DatabaseError

--- a/src/fetcher/historical.py
+++ b/src/fetcher/historical.py
@@ -225,19 +225,18 @@ class HistoricalFetcher(BaseFetcher):
             raise FetcherError(f"Historical fetch failed: {e}")
 
         finally:
-            # Close stream
+            # Close stream (JVClose) — releases the current open session so
+            # the next jv_init()/jv_open() call in a subsequent chunk works.
             try:
                 self.jvlink.jv_close()
                 logger.info("Data stream closed")
             except Exception as e:
                 logger.warning(f"Failed to close stream: {e}")
 
-            # Explicitly cleanup COM resources
-            if hasattr(self.jvlink, 'cleanup'):
-                try:
-                    self.jvlink.cleanup()
-                except Exception:
-                    pass
+            # Do NOT call cleanup() here: cleanup() destroys the COM object
+            # (self._jvlink = None + CoUninitialize), so subsequent chunks
+            # would hit 'NoneType' object has no attribute 'JVInit'.
+            # cleanup() is called by BatchProcessor.__del__ / explicit close.
 
             # Stop progress display
             if self.progress_display:

--- a/src/fetcher/realtime.py
+++ b/src/fetcher/realtime.py
@@ -632,41 +632,41 @@ class RealtimeFetcher(BaseFetcher):
     ) -> list:
         """Fetch NL_RA race keys from PostgreSQL for time-series odds retrieval."""
         try:
-            import pg8000.dbapi as pgdb
+            import psycopg
 
-            conn = pgdb.connect(
+            conn = psycopg.connect(
                 host=pg_config.get("host", "localhost"),
                 port=int(pg_config.get("port", 5432)),
-                database=pg_config.get("database", "keiba"),
+                dbname=pg_config.get("database", "keiba"),
                 user=pg_config.get("user", "postgres"),
                 password=pg_config.get("password", ""),
             )
             try:
-                cur = conn.cursor()
-                cur.execute(query, params)
-                return cur.fetchall()
+                with conn.cursor() as cur:
+                    cur.execute(query, params)
+                    return cur.fetchall()
             finally:
                 conn.close()
         except ImportError:
             try:
-                import psycopg
+                import pg8000.dbapi as pgdb
 
-                conn = psycopg.connect(
+                conn = pgdb.connect(
                     host=pg_config.get("host", "localhost"),
                     port=int(pg_config.get("port", 5432)),
-                    dbname=pg_config.get("database", "keiba"),
+                    database=pg_config.get("database", "keiba"),
                     user=pg_config.get("user", "postgres"),
                     password=pg_config.get("password", ""),
                 )
                 try:
-                    with conn.cursor() as cur:
-                        cur.execute(query, params)
-                        return cur.fetchall()
+                    cur = conn.cursor()
+                    cur.execute(query, params)
+                    return cur.fetchall()
                 finally:
                     conn.close()
             except ImportError as exc:
                 raise FetcherError(
-                    "PostgreSQL driver not installed. Install pg8000 or psycopg."
+                    "PostgreSQL driver not installed. Install psycopg[binary]."
                 ) from exc
 
     def fetch_time_series_batch(

--- a/src/importer/batch.py
+++ b/src/importer/batch.py
@@ -75,6 +75,14 @@ class BatchProcessor:
             show_progress=show_progress,
         )
 
+    def __del__(self):
+        """Release JV-Link COM/bridge resources when processor is garbage-collected."""
+        try:
+            if hasattr(self.fetcher, 'jvlink') and hasattr(self.fetcher.jvlink, 'cleanup'):
+                self.fetcher.jvlink.cleanup()
+        except Exception:
+            pass
+
     def process_date_range(
         self,
         data_spec: str,
@@ -163,7 +171,10 @@ class BatchProcessor:
 
     @staticmethod
     def _should_split_setup_range(from_date: str, to_date: str, option: int) -> bool:
-        if option not in (3, 4):
+        # option=4 (分割セットアップ) は JVOpen を1回だけ呼び出して全期間を一括取得する。
+        # 年単位に分割すると各チャンクで JV-Link が fromtime 以降の全データを返すため
+        # O(n^2) の処理量になる。option=3 のみ従来の年分割を維持する。
+        if option != 3:
             return False
         start = datetime.strptime(from_date, "%Y%m%d")
         end = datetime.strptime(to_date, "%Y%m%d")

--- a/src/importer/importer.py
+++ b/src/importer/importer.py
@@ -60,6 +60,84 @@ def _should_not_divide(field_name: str) -> bool:
     return False
 
 
+def convert_record_types(record: dict, table_name: str) -> dict:
+    """Convert record field types based on table schema.
+
+    Module-level helper used by DataImporter and RealtimeUpdater so that all
+    write paths (NL_*, RT_*, TS_O*) apply identical numeric/text coercion.
+    Handles JV-Data sentinel values like "***", "----", "0103*****" by
+    mapping them to None for INTEGER/BIGINT/REAL columns. Fields not present
+    in the target schema are dropped so parser metadata never reaches INSERT.
+    """
+    column_types = get_table_column_types(table_name)
+    if not column_types:
+        return record
+
+    converted = {}
+
+    for field_name, value in record.items():
+        if field_name not in column_types:
+            continue
+
+        col_type = column_types[field_name]
+
+        if value is None or (isinstance(value, str) and not value.strip()):
+            converted[field_name] = None
+            continue
+
+        try:
+            if col_type in ("INTEGER", "BIGINT"):
+                str_value = str(value).strip()
+                if str_value:
+                    if (str_value.startswith('***') or
+                        '****' in str_value or
+                        all(c in '-*' for c in str_value) or
+                        '--' in str_value or
+                        '*' in str_value):
+                        converted[field_name] = None
+                    else:
+                        numeric_part = ''.join(c for c in str_value if c.isdigit() or c == '-')
+                        if numeric_part and numeric_part != '-':
+                            converted[field_name] = int(numeric_part)
+                        else:
+                            converted[field_name] = None
+                else:
+                    converted[field_name] = None
+
+            elif col_type == "REAL":
+                str_value = str(value).strip()
+                if str_value:
+                    if (str_value.startswith('***') or
+                        '****' in str_value or
+                        all(c in '-*' for c in str_value) or
+                        '--' in str_value or
+                        '*' in str_value):
+                        converted[field_name] = None
+                    else:
+                        numeric_part = ''.join(c for c in str_value if c.isdigit() or c in '.-')
+                        if numeric_part and numeric_part not in ('-', '.', '-.'):
+                            float_value = float(numeric_part)
+                            if _should_divide_by_10(field_name):
+                                converted[field_name] = float_value / 10.0
+                            else:
+                                converted[field_name] = float_value
+                        else:
+                            converted[field_name] = None
+                else:
+                    converted[field_name] = None
+
+            else:
+                if isinstance(value, str):
+                    converted[field_name] = value.strip() if value.strip() else None
+                else:
+                    converted[field_name] = str(value) if value is not None else None
+
+        except (ValueError, TypeError):
+            converted[field_name] = None
+
+    return converted
+
+
 class ImporterError(Exception):
     """Data importer error."""
 
@@ -226,102 +304,10 @@ class DataImporter:
     def _convert_record(self, record: dict, table_name: str) -> dict:
         """Convert record field types based on table schema.
 
-        Converts string values from parsers to appropriate types (INTEGER, REAL)
-        based on the schema definition. Also handles special JV-Data formatting
-        where some REAL values are stored as 10x their actual value.
-
-        Args:
-            record: Cleaned record dictionary (without metadata)
-            table_name: Target table name for type mapping
-
-        Returns:
-            Record with converted field types
+        Delegates to the module-level convert_record_types() so that
+        DataImporter and RealtimeUpdater share identical coercion rules.
         """
-        # Get column types for this table
-        column_types = get_table_column_types(table_name)
-        if not column_types:
-            # No schema found, return as-is
-            return record
-
-        converted = {}
-
-        for field_name, value in record.items():
-            col_type = column_types.get(field_name, "TEXT")
-
-            # Handle empty/whitespace values
-            if value is None or (isinstance(value, str) and not value.strip()):
-                converted[field_name] = None
-                continue
-
-            # Convert based on type
-            try:
-                if col_type in ("INTEGER", "BIGINT"):
-                    # Convert to integer (or bigint)
-                    str_value = str(value).strip()
-                    if str_value:
-                        # Check for invalid/masked values in JV-Data:
-                        # - "***" prefix: masked data (e.g., "***05011005")
-                        # - "****" anywhere: masked data
-                        # - "--", "----", "------": no data available
-                        # - Contains only '-' or '*': invalid
-                        # - Contains non-numeric chars (except leading '-' for negative)
-                        if (str_value.startswith('***') or
-                            '****' in str_value or
-                            all(c in '-*' for c in str_value) or
-                            '--' in str_value):
-                            converted[field_name] = None
-                        else:
-                            # Try to extract numeric value
-                            # Handle cases like "0103-------" by taking only valid digits
-                            numeric_part = ''.join(c for c in str_value if c.isdigit() or c == '-')
-                            if numeric_part and numeric_part != '-':
-                                converted[field_name] = int(numeric_part)
-                            else:
-                                converted[field_name] = None
-                    else:
-                        converted[field_name] = None
-
-                elif col_type == "REAL":
-                    str_value = str(value).strip()
-                    if str_value:
-                        # Check for invalid/masked values in JV-Data:
-                        # - "***" prefix: masked data
-                        # - "****" anywhere: masked data
-                        # - "--", "----", "------": no data available
-                        # - Contains only '-' or '*': invalid
-                        if (str_value.startswith('***') or
-                            '****' in str_value or
-                            all(c in '-*' for c in str_value) or
-                            '--' in str_value):
-                            converted[field_name] = None
-                        else:
-                            # Try to extract numeric value
-                            numeric_part = ''.join(c for c in str_value if c.isdigit() or c in '.-')
-                            if numeric_part and numeric_part not in ('-', '.', '-.'):
-                                float_value = float(numeric_part)
-                                # Check if this field needs to be divided by 10
-                                if _should_divide_by_10(field_name):
-                                    converted[field_name] = float_value / 10.0
-                                else:
-                                    converted[field_name] = float_value
-                            else:
-                                converted[field_name] = None
-                    else:
-                        converted[field_name] = None
-
-                else:
-                    # TEXT type - keep as string, convert None to empty string if needed
-                    if isinstance(value, str):
-                        converted[field_name] = value.strip() if value.strip() else None
-                    else:
-                        converted[field_name] = str(value) if value is not None else None
-
-            except (ValueError, TypeError):
-                # Conversion failed, set to None
-                # Note: 詳細なログ出力は省略（Unicode文字でコンソール出力エラーになる場合があるため）
-                converted[field_name] = None
-
-        return converted
+        return convert_record_types(record, table_name)
 
     def import_records(
         self,
@@ -457,8 +443,8 @@ class DataImporter:
                 error=str(e),
             )
 
-            # PostgreSQL (pg8000.native) uses autocommit mode and doesn't support rollback
-            # Only attempt rollback for databases that support it (e.g., SQLite)
+            # PostgreSQLDatabase performs driver-specific rollback when
+            # insert_many() fails. Avoid a second rollback here.
             try:
                 db_type = self.database.get_db_type()
             except AttributeError:
@@ -470,7 +456,7 @@ class DataImporter:
                     self.database.rollback()
                 except Exception as rollback_error:
                     logger.debug(
-                        "Rollback failed (expected for PostgreSQL autocommit mode)",
+                        "Rollback failed during batch fallback",
                         table=table_name,
                         error=str(rollback_error),
                     )

--- a/src/realtime/updater.py
+++ b/src/realtime/updater.py
@@ -328,6 +328,19 @@ class RealtimeUpdater:
             logger.error(f"Error processing single record: {e}", exc_info=True)
             raise
 
+    def _prepare_data_for_db(self, table_name: str, data: Dict) -> Dict:
+        """Strip metadata and coerce JV-Data sentinel values.
+
+        Mirrors importer.py's _convert_record so that parser metadata is
+        dropped and "*", "****", "0103*****" etc. become NULL instead of
+        failing PostgreSQL's INTEGER/BIGINT/REAL validation. Required because
+        RealtimeUpdater bypasses DataImporter.
+        """
+        from src.importer.importer import convert_record_types
+
+        clean_data = {k: v for k, v in data.items() if not k.startswith("_")}
+        return convert_record_types(clean_data, table_name)
+
     def _handle_new_record(self, table_name: str, data: Dict) -> Dict:
         """Handle new record insertion.
 
@@ -339,8 +352,7 @@ class RealtimeUpdater:
             Result dictionary with operation details
         """
         try:
-            # Remove metadata fields
-            clean_data = {k: v for k, v in data.items() if not k.startswith("_")}
+            clean_data = self._prepare_data_for_db(table_name, data)
 
             # INSERT OR REPLACE handles duplicates (UPSERT semantics)
             self.database.insert(table_name, clean_data)
@@ -374,8 +386,7 @@ class RealtimeUpdater:
             Result dictionary with operation details
         """
         try:
-            # Remove metadata fields
-            clean_data = {k: v for k, v in data.items() if not k.startswith("_")}
+            clean_data = self._prepare_data_for_db(table_name, data)
 
             # INSERT OR REPLACE handles the update (replaces existing row on PK match)
             self.database.insert(table_name, clean_data)

--- a/tests/setup_pg_test_db.py
+++ b/tests/setup_pg_test_db.py
@@ -20,22 +20,23 @@ def setup_test_database():
     print(f"  Target DB: {test_db}")
 
     try:
-        import pg8000.native
-        print(f"\n  [INFO] pg8000ドライバーを使用")
+        import psycopg
+        print(f"\n  [INFO] psycopgドライバーを使用")
     except ImportError:
-        print(f"\n  [ERROR] pg8000がインストールされていません")
-        print(f"  pip install pg8000")
+        print(f"\n  [ERROR] psycopgがインストールされていません")
+        print('  pip install "psycopg[binary]"')
         return False
 
     # まずpostgresデータベースに接続
     print(f"\npostgresデータベースに接続中...")
     try:
-        conn = pg8000.native.Connection(
+        conn = psycopg.connect(
             user=user,
             password=password,
             host=host,
             port=port,
-            database="postgres",  # デフォルトDBに接続
+            dbname="postgres",  # デフォルトDBに接続
+            autocommit=True,
             timeout=10,
         )
         print(f"  [OK] 接続成功")
@@ -49,14 +50,15 @@ def setup_test_database():
     # テスト用データベースが存在するか確認
     print(f"\n'{test_db}'データベースの存在確認...")
     try:
-        rows = conn.run("SELECT datname FROM pg_database WHERE datname = :db", db=test_db)
-        if rows:
-            print(f"  [INFO] データベースは既に存在します")
-        else:
-            # データベースを作成
-            print(f"  データベースを作成中...")
-            conn.run(f"CREATE DATABASE {test_db}")
-            print(f"  [OK] データベース '{test_db}' を作成しました")
+        with conn.cursor() as cur:
+            cur.execute("SELECT datname FROM pg_database WHERE datname = %s", (test_db,))
+            if cur.fetchone():
+                print(f"  [INFO] データベースは既に存在します")
+            else:
+                # データベースを作成
+                print(f"  データベースを作成中...")
+                cur.execute(f"CREATE DATABASE {test_db}")
+                print(f"  [OK] データベース '{test_db}' を作成しました")
     except Exception as e:
         print(f"  [ERROR] データベース作成失敗: {e}")
         conn.close()

--- a/tests/test_batch_processor.py
+++ b/tests/test_batch_processor.py
@@ -1,0 +1,16 @@
+"""Tests for batch processor setup-range splitting decisions."""
+
+from src.importer.batch import BatchProcessor
+
+
+def test_option_3_setup_range_splits_long_periods():
+    assert BatchProcessor._should_split_setup_range("20200101", "20220101", 3) is True
+
+
+def test_option_4_setup_range_does_not_split_long_periods():
+    assert BatchProcessor._should_split_setup_range("20200101", "20220101", 4) is False
+
+
+def test_diff_options_do_not_split_long_periods():
+    assert BatchProcessor._should_split_setup_range("20200101", "20220101", 1) is False
+    assert BatchProcessor._should_split_setup_range("20200101", "20220101", 2) is False

--- a/tests/test_importer_clean_record.py
+++ b/tests/test_importer_clean_record.py
@@ -49,3 +49,40 @@ class TestCleanRecord:
         }
         cleaned = self.importer._clean_record(record)
         assert len(cleaned) == 4
+
+
+def test_convert_record_types_drops_schema_external_fields():
+    """Shared converter should not pass parser metadata to database INSERT."""
+    from src.importer.importer import convert_record_types
+
+    converted = convert_record_types(
+        {
+            "RecordSpec": "RA",
+            "DataKubun": "1",
+            "Year": "2026",
+            "RecordDelimiter": "\r\n",
+            "UnexpectedParserField": "x",
+        },
+        "RT_RA",
+    )
+
+    assert converted["RecordSpec"] == "RA"
+    assert converted["Year"] == 2026
+    assert "RecordDelimiter" not in converted
+    assert "UnexpectedParserField" not in converted
+
+
+def test_convert_record_types_maps_masked_numeric_to_null():
+    """JV-Data masked numeric values should become NULL for typed columns."""
+    from src.importer.importer import convert_record_types
+
+    converted = convert_record_types(
+        {
+            "RecordSpec": "RA",
+            "DataKubun": "1",
+            "Year": "****",
+        },
+        "RT_RA",
+    )
+
+    assert converted["Year"] is None

--- a/tests/test_migration.py
+++ b/tests/test_migration.py
@@ -33,24 +33,30 @@ class MockPostgreSQLDatabase(BaseDatabase):
     def rollback(self): pass
 
     def table_exists(self, table_name: str) -> bool:
-        return table_name in self._tables
+        # Real PostgreSQL stores unquoted identifiers in lowercase.
+        return table_name.lower() in self._tables
 
     def execute(self, sql: str, parameters=None):
         self._executed.append(sql.strip())
         upper = sql.strip().upper()
         if upper.startswith("DROP TABLE"):
             # Extract table name: DROP TABLE "NL_H1" or DROP TABLE NL_H1
+            # IF EXISTS is supported and silently no-ops on missing tables.
             import re
-            m = re.search(r'DROP\s+TABLE\s+"?(\w+)"?', sql, re.IGNORECASE)
+            m = re.search(r'DROP\s+TABLE\s+(?:IF\s+EXISTS\s+)?"?(\w+)"?', sql, re.IGNORECASE)
             if m:
-                self._tables.pop(m.group(1), None)
+                # Real PG: unquoted name is lowercased; quoted name preserves case.
+                # The migration code now uses unquoted lowercase for PG, so just
+                # normalize to lowercase to match real behavior.
+                self._tables.pop(m.group(1).lower(), None)
         elif upper.startswith("CREATE TABLE"):
             from src.database.migration import _extract_columns_from_sql
             import re
             m = re.search(r'CREATE\s+TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?"?(\w+)"?', sql, re.IGNORECASE)
             if m:
                 cols = _extract_columns_from_sql(sql)
-                self._tables[m.group(1)] = list(cols or [])
+                # Real PG lowercases unquoted identifiers when storing.
+                self._tables[m.group(1).lower()] = list(cols or [])
 
     def executemany(self, sql: str, parameters): pass
 
@@ -59,10 +65,12 @@ class MockPostgreSQLDatabase(BaseDatabase):
         return rows[0] if rows else None
 
     def fetch_all(self, sql: str, parameters=None) -> List[Dict[str, Any]]:
-        # Respond to information_schema.columns query used in migration
+        # Respond to information_schema.columns query used in migration.
+        # Real PG stores names lowercased and migration.py passes .lower(),
+        # so compare on lowercase here.
         if "information_schema.columns" in sql.lower():
             table_name = parameters[0] if parameters else None
-            cols = self._tables.get(table_name, [])
+            cols = self._tables.get((table_name or "").lower(), [])
             return [{"name": c} for c in cols]
         return []
 
@@ -218,9 +226,9 @@ def test_pg_migrate_drops_and_recreates_on_mismatch(pg_db):
     result = migrate_table_if_needed(pg_db, "NL_H1", NEW_SCHEMA)
     assert result is True
 
-    # Table should now have new columns
-    assert "BetType" in pg_db._tables["NL_H1"]
-    assert "TanUma" not in pg_db._tables["NL_H1"]
+    # Table should now have new columns (real PG stores names lowercased)
+    assert "BetType" in pg_db._tables["nl_h1"]
+    assert "TanUma" not in pg_db._tables["nl_h1"]
 
 
 def test_pg_migrate_no_op_when_schema_matches(pg_db):
@@ -244,5 +252,6 @@ def test_pg_migrate_all_tables(pg_db):
 
     count = migrate_all_tables(pg_db, {"NL_H1": NEW_SCHEMA, "NL_H6": NEW_H6})
     assert count == 2
-    assert "BetType" in pg_db._tables["NL_H1"]
-    assert "SanrentanKumi" in pg_db._tables["NL_H6"]
+    # Real PG stores unquoted identifiers lowercased.
+    assert "BetType" in pg_db._tables["nl_h1"]
+    assert "SanrentanKumi" in pg_db._tables["nl_h6"]

--- a/tests/test_postgresql.py
+++ b/tests/test_postgresql.py
@@ -167,8 +167,7 @@ def test_connection():
     except ImportError as e:
         print(f"  [ERROR] ドライバーがインストールされていません: {e}")
         print(f"\n  インストール方法:")
-        print(f"    pip install pg8000      # 純粋Python (Win32対応)")
-        print(f"    pip install psycopg     # 高速 (libpq必要)")
+        print('    pip install "psycopg[binary]"')
         pytest.skip("PostgreSQL driver not available")
 
     # 接続テスト


### PR DESCRIPTION
## Summary
- PR #117 のうち、pg8000 対応拡張ではなく実バグ修正として必要な部分を選択取り込み
- PostgreSQL optional dependency と driver 優先順を `psycopg[binary]` 標準に変更
- DIFN option=4、option=4 分割抑止、migration の case-insensitive 比較を反映
- RealtimeUpdater / DataImporter の型変換を共通化し、schema外の parser metadata を INSERT しないよう補強
- Windows用だった pytest basetemp を相対 `.pytest-tmp` に変更して Linux/Windows 両方で動くよう修正

## Not included from #117
- rollback の共通削除は採用しない
- `scripts/drop_pg_tables.py` のような破壊的 helper は採用しない
- 固定値の `quickstart_1month.py` は採用しない

## Tests
- `python3 -m compileall -q src scripts tests`
- `pytest tests/test_migration.py tests/test_importer_clean_record.py tests/test_batch_processor.py -q` -> 19 passed
- `pytest tests/test_realtime.py tests/test_postgresql.py -q` -> 37 passed, 2 skipped
- `pytest tests/test_quickstart_cli.py tests/test_cli.py -q` -> 49 passed
- `pytest tests/test_importer.py tests/test_updater.py tests/test_error_scenarios.py -q` -> 46 passed
- `pytest tests/test_database.py tests/test_all_databases.py -q` -> 15 passed

## Broad suite note
`pytest tests/ -q -m "not slow and not integration"` still has pre-existing Linux/JVLink/parser fixture failures: `pythoncom` missing in JVLink integration tests and O1-O6 parser fixture expectations. These are not introduced by this PR, but the suite labeling should be cleaned up separately.

Related review context: #117


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced data type conversion with improved handling of masked/invalid values to ensure data integrity.

* **Bug Fixes**
  * Updated PostgreSQL driver preference to `psycopg[binary]` with `pg8000` as fallback.
  * Fixed case-sensitivity issues with PostgreSQL table name handling.
  * Improved resource cleanup during data fetching operations.

* **Tests**
  * Added tests for batch processor splitting logic and record conversion functionality.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/miyamamoto/jrvltsql/pull/118)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->