### PR TITLE
chore: a6 ops .codex_backups/ を .gitignore に追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -254,3 +254,6 @@ quickstart_debug.bat
 setup_dll_surrogate.bat
 uv.lock
 .pytest-tmp/
+
+# Codex automatic backups (a6 ops machine)
+.codex_backups/


### PR DESCRIPTION
## 背景

a6 配備版からの回収。背景: [DEPLOYED_CODE_AUDIT.md](../../reports/crawler_audit_20260612/DEPLOYED_CODE_AUDIT.md) 参照。

監査分類:
- **(b) 配備機固有の正当な運用設定** → upstream 化が適切なもの

## 変更内容

- `.gitignore` に `.codex_backups/` を追加
  - a6 (Windows コレクター機) において Codex が自動生成するバックアップディレクトリ
  - VCS に含めるべきでない一時ファイル群

## 監査で確認した「origin に既包含」ファイル (変更不要と判断)

| ファイル | 理由 |
|---|---|
| `pyproject.toml` (version=1.4.1) | #121/#122 で origin/master に包含済み |
| `src/__init__.py` (version=1.4.1) | 同上 |
| `scripts/fill_empty_postgresql_tables.py` | `_scalar` helper / `_fill_tables_connected` は #121 で包含済み |
| `src/database/schema.py` | `Dict[str, Any]` 型注釈は #121 で包含済み |
| `tests/test_daily_update.py` | a6 版は origin の subset (origin は `_is_realtime_spec` / `_sync_realtime_spec` 等を含む拡張版) |
| `src/database/migration.py` | additive migration / `_table_identifier` / `JLTSQL_ALLOW_DESTRUCTIVE_MIGRATIONS` は #121 で包含済み |

## テスト結果

```
pytest tests/ -q --ignore=tests/integration (origin e9d9681 + 本PR)
1243 passed, 35 skipped, 31 failed (失敗は JVLink 未インストール等の環境依存、本PR起因なし)
```

## 今夜の a6 配備時に「上書きで消えるが問題ない」ファイル

a6 の未コミット差分のうち、origin 包含済みと確認されたもの:
- `pyproject.toml`, `src/__init__.py`, `src/database/schema.py`, `src/database/migration.py`
- `scripts/daily_update.py`, `scripts/fill_empty_postgresql_tables.py`
- `src/database/schema_metadata.py`, `src/parser/o1_parser.py`, `src/realtime/updater.py`
- `tests/test_daily_update.py`, `tests/test_metadata_application.py`, `tests/test_migration.py`
- `tests/test_quickstart_cli.py`, `tests/test_ra_parser_jravan.py`, `tests/test_realtime.py`, `tests/test_time_series.py`
- `daily_sync.bat`, `src/parser/ra_parser.py` (の拡張レイアウト部分は包含済み、Corner展開も origin が完全版)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated version control configuration to prevent automatic backup files from being tracked in the repository.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->