### PR TITLE
[codex] chore(release): prepare v1.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,14 +7,46 @@
 
 ## [Unreleased]
 
+現時点で未リリースの変更はありません。
+
+## [1.6.1] - 2026-06-30
+
+### Fixed
+
+- 非対話の JRA daily sync 経路で、坂路調教 `SLOP` / `NL_HC` とウッドチップ調教 `WOOD` / `NL_WC` を通常差分として毎日取得するよう修正
+- `daily_sync.bat` の既定 `JRA_DAILY_UPDATE_SPECS` に `SLOP,WOOD` を追加し、Windows タスクスケジューラ実行でも調教データが初回セットアップ後に stale にならないよう修正
+
+### Notes
+
+- 公開リリースには Docker/Wine ランタイム変更を含めていません
+- スキーマ変更はありません
+
+## [1.6.0] - 2026-06-16
+
+### Fixed
+
+- JV-Data490 の HC / AV / H6 / O1〜O6 レイアウト不整合を修正
+- 展開済みオッズ・払戻行を保持できるよう保存キーと不完全な primary-key 行の扱いを修正
+- SQLite / PostgreSQL import、PostgreSQL batch insert grouping、migration metadata、realtime expanded-record storage を堅牢化
+
+### Notes
+
+- 既存 DB に旧 O1 / H6 / HC / AV 関連テーブル定義がある場合は、対象レコードの再 import 前に table recreation または migration を確認してください
+
+## [1.5.0] - 2026-06-11
+
 ### Added
 
+- HR 払戻配列の全エントリ抽出を追加
+- コーナー通過順位を最大4セットの配列として収集
+- `0B12` / `0B15` の daily sync 統合を追加
 - JVOpen/JVRTOpen の対応データ種別、レコード種別、保存先テーブル、運用コマンドをまとめた `docs/data_support.md` を追加
 - 初回ユーザー向けの実行順序をまとめた `docs/getting_started.md` を追加
 - SQLite / PostgreSQL 共通の範囲指定つき時系列 quickstart `quickstart_timeseries.bat` を追加
 
 ### Changed
 
+- a6 運用設定を upstream 化し、`.codex_backups/` を `.gitignore` に追加
 - 公開ドキュメントを日本語表記へ統一
 - README と MkDocs ホームを、初回導線・目的別コマンド・重要なデータ区分が一目で分かる構成へ整理
 - `quickstart.bat --yes --include-timeseries` の既定取得範囲をドキュメントに明記
@@ -142,7 +174,11 @@
 - quickstart.py 対話形式セットアップウィザード
 - CLI コマンド（fetch, status, monitor, init）
 
-[Unreleased]: https://github.com/miyamamoto/jrvltsql/compare/v1.4.0...HEAD
+[Unreleased]: https://github.com/miyamamoto/jrvltsql/compare/v1.6.1...HEAD
+[1.6.1]: https://github.com/miyamamoto/jrvltsql/compare/v1.6.0...v1.6.1
+[1.6.0]: https://github.com/miyamamoto/jrvltsql/releases/tag/v1.6.0
+[1.5.0]: https://github.com/miyamamoto/jrvltsql/releases/tag/v1.5.0
+[1.4.1]: https://github.com/miyamamoto/jrvltsql/releases/tag/v1.4.1
 [1.4.0]: https://github.com/miyamamoto/jrvltsql/compare/v1.3.0...v1.4.0
 [1.3.0]: https://github.com/miyamamoto/jrvltsql/compare/v1.2.0...v1.3.0
 [1.2.0]: https://github.com/miyamamoto/jrvltsql/compare/v1.1.0...v1.2.0

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,54 +1,31 @@
-# jrvltsql v1.4.0 Release Notes
+# jrvltsql v1.6.1 Release Notes
 
-## Highlights
+## Summary
 
-### PostgreSQL time-series odds workflow
+- Fixed the non-interactive JRA daily sync path so training data is refreshed every day.
+- Added `SLOP` and `WOOD` to the default `JRA_DAILY_UPDATE_SPECS` used by `daily_sync.bat`.
+- Kept this public release scoped to the core Windows/JRA collector. Docker/Wine runtime work is not included.
 
-- Added `quickstart_postgres_timeseries.bat` for PostgreSQL race-data setup plus
-  official `TS_O1/TS_O2` time-series odds ingestion.
-- Added `fetch_timeseries_postgres.bat` for adding time-series odds to an
-  existing PostgreSQL installation.
-- Added `daily_sync.bat` for scheduled recent race-card/result synchronization.
+## Impact
 
-### Expanded odds storage
+Before this release, `SLOP` / `NL_HC` and `WOOD` / `NL_WC` were fetched during initial setup but were not included in the non-interactive daily incremental path. Scheduled daily updates could therefore leave training-derived fields stale after setup.
 
-- Expanded JRA-VAN time-series odds records into one row per ticket combination.
-- Added direct storage of expanded `TS_O1` to `TS_O6` rows.
-- Added multi-row PostgreSQL inserts for expanded time-series odds rows.
+After upgrading, the default scheduled daily sync fetches:
 
-### Data correctness
-
-- Fixed JRA-VAN time-series odds key generation.
-- Normalized blank and unavailable odds placeholders before PostgreSQL writes.
-- Updated tests so O1 to O6 expanded parser outputs are treated as `list[dict]`.
-
-### Documentation cleanup
-
-- Added current architecture, PostgreSQL, time-series odds, and scripts docs.
-- Removed stale script README files.
-- Replaced downstream-system-specific naming with collector-generic wording.
-
-## Requirements
-
-- Windows 10/11 for real JV-Link collection.
-- Python 3.12.
-- JRA-VAN DataLab and JV-Link.
-- PostgreSQL is optional but required for shared time-series odds collection.
-
-## Upgrade
-
-```powershell
-irm https://raw.githubusercontent.com/miyamamoto/jrvltsql/master/install.ps1 | iex
+```text
+RACE,DIFN,SLOP,WOOD,0B12,0B15
 ```
 
-For PostgreSQL time-series odds setup:
+Existing users who override `JRA_DAILY_UPDATE_SPECS` should add `SLOP,WOOD` to their environment if they want the same behavior.
 
-```bat
-quickstart_postgres_timeseries.bat 20250426 20260412
-```
+## Validation
 
-For time-series-only backfill:
+- GitHub Actions on PR #127: `lint` passed, `test` passed, `performance-test` skipped by workflow policy.
+- Local focused tests: `uv run pytest tests/test_daily_update.py tests/test_quickstart_cli.py -q` passed with 41 tests.
+- JRA readiness scan: target `jra`, 54 pass, 2 warnings for unrelated KPS working-tree/cache state.
 
-```bat
-fetch_timeseries_postgres.bat 20250426 20260412
-```
+## Migration Notes
+
+- No database schema migration is required.
+- No service key or JV-Link registration change is required.
+- Rollback: return to `v1.6.0` or remove `SLOP,WOOD` from `JRA_DAILY_UPDATE_SPECS`.

--- a/daily_sync.bat
+++ b/daily_sync.bat
@@ -9,7 +9,7 @@ cd /d "%~dp0"
 set "DB_TYPE=postgresql"
 set "DAYS_BACK=7"
 set "DAYS_FORWARD=3"
-set "ENSURE_TABLES=0"
+set "ENSURE_TABLES=1"
 set "INCLUDE_TIMESERIES=1"
 set "INCLUDE_REALTIME=1"
 
@@ -35,6 +35,11 @@ if /I "%~1"=="--days-forward" (
 )
 if /I "%~1"=="--ensure-tables" (
     set "ENSURE_TABLES=1"
+    shift
+    goto :parse_args
+)
+if /I "%~1"=="--no-ensure-tables" (
+    set "ENSURE_TABLES=0"
     shift
     goto :parse_args
 )
@@ -97,7 +102,7 @@ if "%INCLUDE_TIMESERIES%"=="0" if "%INCLUDE_REALTIME%"=="0" (
     if not defined JRA_DAILY_UPDATE_SPECS set "JRA_DAILY_UPDATE_SPECS=RACE,DIFN,SLOP,WOOD,0B12,0B15"
     set "SYNC_SCRIPT=scripts/daily_update.py"
     set "SYNC_ARGS=--days-back %DAYS_BACK% --days-forward %DAYS_FORWARD% --db %DB_TYPE% --specs !JRA_DAILY_UPDATE_SPECS! --force-incremental --ignore-jvopen-error-codes -303"
-    if "%ENSURE_TABLES%"=="1" set "SYNC_ARGS=!SYNC_ARGS! --ensure-tables"
+    if "%ENSURE_TABLES%"=="0" set "SYNC_ARGS=!SYNC_ARGS! --no-ensure-tables"
 )
 
 if defined PYTHON (

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "jltsql"
-version = "1.4.1"
+version = "1.6.1"
 description = "JRA-VAN DataLab の競馬データをSQLite・PostgreSQLにインポートするツール"
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,8 +55,8 @@ Documentation = "https://github.com/miyamamoto/jrvltsql/docs"
 Repository = "https://github.com/miyamamoto/jrvltsql"
 Issues = "https://github.com/miyamamoto/jrvltsql/issues"
 
-[tool.setuptools]
-packages = ["src"]
+[tool.setuptools.packages.find]
+include = ["src", "src.*"]
 
 [tool.black]
 line-length = 100

--- a/scripts/daily_update.py
+++ b/scripts/daily_update.py
@@ -207,7 +207,19 @@ def main() -> int:
     parser.add_argument("--days-back", type=int, default=7, help="Fetch window size in days")
     parser.add_argument("--days-forward", type=int, default=0, help="Fetch future card window size in days")
     parser.add_argument("--db", default=None, choices=["sqlite", "postgresql"], help="Override database type")
-    parser.add_argument("--ensure-tables", action="store_true", help="Create/migrate tables before sync")
+    parser.add_argument(
+        "--ensure-tables",
+        dest="ensure_tables",
+        action="store_true",
+        default=True,
+        help="Create/migrate tables before sync (default)",
+    )
+    parser.add_argument(
+        "--no-ensure-tables",
+        dest="ensure_tables",
+        action="store_false",
+        help="Skip table creation/migration before sync",
+    )
     parser.add_argument("--specs", default=None, help="Comma-separated subset of daily update specs")
     parser.add_argument("--force-incremental", action="store_true",
                         help="Use JVOpen option=1 instead of option=2 for selected update specs")

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,3 +1,3 @@
 """jrvltsql - JRA-VAN データ取得・管理ツール"""
 
-__version__ = "1.4.1"
+__version__ = "1.6.1"

--- a/src/cli/main.py
+++ b/src/cli/main.py
@@ -22,7 +22,11 @@ def _read_version():
     """Read version from pyproject.toml."""
     try:
         from importlib.metadata import version as _get_version
-        return _get_version("jrvltsql")
+        for dist_name in ("jltsql", "jrvltsql"):
+            try:
+                return _get_version(dist_name)
+            except Exception:
+                pass
     except Exception:
         pass
     try:

--- a/uv.lock
+++ b/uv.lock
@@ -311,7 +311,7 @@ wheels = [
 
 [[package]]
 name = "jltsql"
-version = "1.4.1"
+version = "1.6.1"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary
- Prepare v1.6.1 release metadata and package discovery so installed wheels include subpackages.
- Harden daily sync by defaulting table creation on, adding --no-ensure-tables, and including SLOP/WOOD in the non-interactive daily path.
- Fix CLI version lookup for the jltsql distribution name.

## Validation
- uv run --extra dev python -m pytest tests/test_cli.py tests/test_daily_update.py tests/test_parser.py -q --no-cov
- Runtime validation was performed in the private Wine runtime repo; Docker/Wine files are intentionally not included here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for turning table creation/migration checks on or off in daily sync commands.
  * Updated the release packaging to recognize the latest version and broader installed package layouts.

* **Bug Fixes**
  * Fixed daily sync behavior so non-interactive runs refresh training-related data correctly.
  * Improved handling of incomplete or irregular records during import and storage operations.
  * Clarified release notes and upgrade guidance for the latest release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->