### PR TITLE
fix(realtime): WE(天候馬場)速報の未収集修正 + スペック定義訂正 (crawler audit #03)

### DIFF
--- a/daily_sync.bat
+++ b/daily_sync.bat
@@ -99,7 +99,7 @@ if "%INCLUDE_TIMESERIES%"=="0" if "%INCLUDE_REALTIME%"=="0" (
     rem Task Scheduler production path: avoid quickstart's rich progress UI and
     rem use the non-interactive daily updater. 0B12/0B15 are speed-report
     rem specs (JVRTOpen, idempotent INSERT OR REPLACE into RT_* tables).
-    if not defined JRA_DAILY_UPDATE_SPECS set "JRA_DAILY_UPDATE_SPECS=RACE,DIFN,SLOP,WOOD,0B12,0B15"
+    if not defined JRA_DAILY_UPDATE_SPECS set "JRA_DAILY_UPDATE_SPECS=RACE,DIFN,SLOP,WOOD,0B12,0B15,0B14,0B16"
     set "SYNC_SCRIPT=scripts/daily_update.py"
     set "SYNC_ARGS=--days-back %DAYS_BACK% --days-forward %DAYS_FORWARD% --db %DB_TYPE% --specs !JRA_DAILY_UPDATE_SPECS! --force-incremental --ignore-jvopen-error-codes -303"
     if "%ENSURE_TABLES%"=="0" set "SYNC_ARGS=!SYNC_ARGS! --no-ensure-tables"

--- a/docs/crawler_audit_03_we_realtime_spec.md
+++ b/docs/crawler_audit_03_we_realtime_spec.md
@@ -1,0 +1,77 @@
+# クローラ監査 #03: WE（天候馬場状態）速報レコードの未収集とスペック定義の不整合
+
+## 概要
+
+生 PostgreSQL の `nl_we`（0行）/ `rt_we`（0行）が空で、WE レコード
+（天候馬場状態）が一度も取り込まれていない。調査の結果、複数の欠陥が
+重なっていた。
+
+## 権威ある仕様（JV-Data 4.9.0.1「データ種別一覧」）
+
+JVRTOpen の速報系データ種別ID（正）:
+
+| dataspec | 名称 | レコード |
+|----------|------|----------|
+| 0B11 | 速報馬体重 | WH |
+| 0B12 | 速報レース情報(成績確定後) | RA, SE |
+| 0B13 | 速報タイム型データマイニング予想 | DM |
+| **0B14** | **速報開催情報(一括)** | **WE（天候馬場状態）** |
+| 0B15 | 速報レース情報(出走馬名表～) | RA |
+| **0B16** | **速報開催情報(指定)** | **WE（天候馬場状態）** |
+| 0B17 | 速報対戦型データマイニング予想 | TM |
+| 0B51 | 速報重勝式(WIN5) | WF |
+
+→ WE を供給し `RT_WE` を埋めるのは **0B14 / 0B16 のみ**。
+
+## 欠陥
+
+1. **`scripts/quickstart.py` の `SPEED_REPORT_SPECS` のラベルが仕様と食い違って
+   いた**（本番の既定収集経路）。`0B11` を「開催情報(WE)」と誤記（実際は馬体重
+   WH）、`0B14` を「出走取消・除外(AV)」と誤記（実際は WE）、`0B15` を「払戻(HR)」、
+   `0B51` を「コース情報(CC)」と誤記。**さらに WE の指定版 `0B16` が丸ごと欠落**。
+   dataspec コード自体は fetch に使われるためラベル誤りは直接の収集欠落では
+   ないが、`0B16` 欠落は WE 変更情報の取りこぼしになり、誤ラベルは本監査でも
+   混乱を招いた（`constants.py` は正しく WE=0B14/0B16 と定義していた）。
+
+2. **`scripts/daily_update.py` の `UPDATE_SPECS` に 0B14/0B16 が無かった**。
+   `daily_sync.bat` の非対話パス（`--no-timeseries --no-realtime` 指定時）で
+   使われる。
+
+3. **速報系の投入失敗が成功として集計されていた**（`daily_update.py`）。
+   `RealtimeUpdater.process_record()` は失敗時も `{"success": False}` という
+   truthy な dict を返すため、`if result:` 判定では PK 不備・insert 失敗も
+   `records_imported` に数えられ、`RT_WE` 収集が全滅しても `failed=0` になり得た。
+
+## 本番の実行経路（重要）
+
+`install_tasks.ps1` は `--no-timeseries`/`--no-realtime` を渡さず、
+`daily_sync.bat` の既定は `INCLUDE_TIMESERIES=1` / `INCLUDE_REALTIME=1`。
+したがって**既定のスケジュールタスクは `quickstart.py`（realtime 経路）を実行**
+する（`daily_update.py` は両フラグ 0 の時のみ）。よって本番の WE 収集には
+`quickstart.py` の修正が必須で、`daily_update.py` 側は補助経路として合わせて修正。
+
+## 修正
+
+- `scripts/quickstart.py`: `SPEED_REPORT_SPECS` を仕様準拠のラベルへ訂正し、
+  欠落していた `0B16`（WE 指定）を追加。
+- `scripts/daily_update.py`: `UPDATE_SPECS` に `0B14`/`0B16` を追加。投入失敗を
+  `success` フラグで正しく `records_failed` に集計するよう修正。
+- `daily_sync.bat`: `JRA_DAILY_UPDATE_SPECS` に `0B14,0B16` を追加。
+- `tests/test_daily_update.py`: 0B14/0B16 の収集・選択テスト、および失敗集計の
+  回帰テストを追加。
+
+## 影響と限界
+
+- 過去分の学習用馬場状態は RA レコード（field50 芝馬場 / field51 ダート馬場,
+  crawler 監査 #02 / PR #131）が供給するため、**ヒストリカル学習は #02 で復旧済み**。
+  本件は主にライブの発走前天候・馬場（`RT_WE`）に関わる。
+- `0B14`/`0B16` はレース当日発表のため**過去分 backfill は不可**（前向き蓄積）。
+- 一日一回のタスクでは開催中に変化する天候・馬場を完全には追随できない
+  （厳密なライブ発走前馬場には開催中の定期実行 / realtime monitor への
+  0B14/0B16 組込みが必要）。本 PR はスペック定義と集計の正当化に留め、
+  実収集開始は JV-Link ライブコレクタの realtime 実行（運用承認）が前提。
+
+## 残課題
+- KPS 側で `RT_WE`（発走前馬場）をライブ推論特徴量へ接続（別リポジトリ）。
+- 開催中の定期 realtime 実行（運用）の設計。
+- NAR（`jrvltsql-nar`）の同等スペック監査。

--- a/scripts/daily_update.py
+++ b/scripts/daily_update.py
@@ -33,6 +33,13 @@ UPDATE_SPECS = [
     # なので再実行しても重複しない（冪等）。
     ("0B12", 1),
     ("0B15", 1),
+    # 0B14: 速報開催情報・一括, 0B16: 速報開催情報・変更。WE(天候馬場状態)/
+    # AV(出走取消・除外)/JC/TC/CC を供給する。WE は NL 蓄積が存在しない
+    # 速報専用レコードで、RT_WE を埋める唯一の経路。RT_* は PRIMARY KEY +
+    # INSERT OR REPLACE で冪等。レース当日発表のため過去分 backfill は不可
+    # (前向きにのみ蓄積)。過去の馬場状態は RA レコード側(field50/51)が供給する。
+    ("0B14", 1),
+    ("0B16", 1),
 ]
 
 REALTIME_SPEC_PREFIX = "0B"
@@ -136,8 +143,16 @@ def _sync_realtime_spec(
                             file=sys.stderr,
                         )
                         continue
-                    if result:
-                        stats["records_parsed"] += 1
+                    if not result:
+                        stats["records_failed"] += 1
+                        continue
+                    # process_record は成功/失敗に関わらず dict(または list)を
+                    # 返す。dict は truthy なので `if result` だけでは
+                    # {"success": False}(PK不備・insert失敗)も imported に
+                    # 数えてしまう。success フラグで実際の投入可否を判定する。
+                    stats["records_parsed"] += 1
+                    items = result if isinstance(result, list) else [result]
+                    if items and all(item.get("success") for item in items):
                         stats["records_imported"] += 1
                     else:
                         stats["records_failed"] += 1

--- a/scripts/daily_update.py
+++ b/scripts/daily_update.py
@@ -146,16 +146,17 @@ def _sync_realtime_spec(
                     if not result:
                         stats["records_failed"] += 1
                         continue
-                    # process_record は成功/失敗に関わらず dict(または list)を
-                    # 返す。dict は truthy なので `if result` だけでは
-                    # {"success": False}(PK不備・insert失敗)も imported に
-                    # 数えてしまう。success フラグで実際の投入可否を判定する。
-                    stats["records_parsed"] += 1
+                    # process_record は成功/失敗に関わらず dict(または list)を返す。
+                    # dict は truthy なので `if result` だけでは {"success": False}
+                    # (PK不備・insert失敗)も成功に数えてしまう。オッズ/票数など複数行
+                    # レコードは list を返すため、サブレコード単位で success を判定する。
                     items = result if isinstance(result, list) else [result]
-                    if items and all(item.get("success") for item in items):
-                        stats["records_imported"] += 1
-                    else:
-                        stats["records_failed"] += 1
+                    for item in items:
+                        stats["records_parsed"] += 1
+                        if item and item.get("success"):
+                            stats["records_imported"] += 1
+                        else:
+                            stats["records_failed"] += 1
             finally:
                 try:
                     jvlink.jv_close()

--- a/scripts/quickstart.py
+++ b/scripts/quickstart.py
@@ -1831,13 +1831,18 @@ class QuickstartRunner:
     # 速報系データ (0B1x, 0B5x) - レース確定情報・変更情報
     # 0B41/0B42 は公式仕様上、変更情報ではなく時系列オッズ。
     SPEED_REPORT_SPECS = [
-        ("0B11", "開催情報"),              # WE
-        ("0B12", "レース情報"),            # RA, SE
-        ("0B13", "データマイニング予想"),   # DM
-        ("0B14", "出走取消・競走除外"),     # AV
-        ("0B15", "払戻情報"),              # HR
-        ("0B17", "対戦型データマイニング予想"),  # TM
-        ("0B51", "コース情報"),            # CC
+        # JVRTOpen データ種別ID (JV-Data 4.9.0.1 「データ種別一覧」準拠)。
+        # 従来のラベルは 0B11/0B14/0B15/0B51 が実仕様と食い違っており、
+        # 特に WE(天候馬場状態=0B14/0B16) を誤って 0B11 と記述、0B16 を欠落
+        # していた。RT_WE を埋めるのは 0B14/0B16 (速報開催情報)。
+        ("0B11", "速報馬体重"),                     # WH
+        ("0B12", "速報レース情報(成績確定後)"),      # RA, SE
+        ("0B13", "速報タイム型データマイニング予想"),  # DM
+        ("0B14", "速報開催情報(一括)"),             # WE 天候馬場状態
+        ("0B15", "速報レース情報(出走馬名表～)"),     # RA
+        ("0B16", "速報開催情報(指定)"),             # WE 天候馬場状態
+        ("0B17", "速報対戦型データマイニング予想"),   # TM
+        ("0B51", "速報重勝式(WIN5)"),               # WF
     ]
 
     # オッズ/票数データ - レース単位キー(YYYYMMDDJJRR)を使用
@@ -2800,7 +2805,12 @@ class QuickstartRunner:
             print("NG")
 
     def _get_recent_race_dates(self, days: int = 7) -> list:
-        """過去N日間の開催日（土日）を取得
+        """過去N日間の日付を取得（新しい順）
+
+        速報系(0B1x)は当日発表・過去 backfill 不能のため、開催日を曜日で
+        絞ると祝日月曜など土日以外の開催日で WE(天候馬場)等が永久欠損する。
+        JVRTOpen は非開催日には -1(nodata) を返すだけなので、曜日でフィルタ
+        せず全日付を照会する(daily_update.py の realtime 経路と同じ挙動)。
 
         Args:
             days: 遡る日数（デフォルト: 7日間）
@@ -2810,16 +2820,11 @@ class QuickstartRunner:
         """
         from datetime import datetime, timedelta
 
-        race_dates = []
         now = datetime.now()
-
-        for i in range(days):
-            date = now - timedelta(days=i)
-            # 競馬開催日は土曜(5)と日曜(6)
-            if date.weekday() in (5, 6):
-                race_dates.append(date.strftime("%Y%m%d"))
-
-        return race_dates
+        return [
+            (now - timedelta(days=i)).strftime("%Y%m%d")
+            for i in range(days)
+        ]
 
     def _get_race_keys_for_date(self, date_str: str) -> list:
         """指定日の全レースキー（YYYYMMDDJJRR形式）を生成

--- a/tests/test_daily_update.py
+++ b/tests/test_daily_update.py
@@ -57,6 +57,17 @@ def test_daily_update_selects_speed_report_specs_case_insensitively():
     assert _select_update_specs("0b12,0b15") == [("0B12", 1), ("0B15", 1)]
 
 
+def test_daily_update_includes_event_report_specs():
+    """0B14/0B16 (速報開催情報) must be collected so WE (天候馬場) populates RT_WE."""
+    specs = [spec for spec, _ in UPDATE_SPECS]
+    assert "0B14" in specs
+    assert "0B16" in specs
+
+
+def test_daily_update_selects_event_report_specs_case_insensitively():
+    assert _select_update_specs("0b14,0b16") == [("0B14", 1), ("0B16", 1)]
+
+
 def test_is_realtime_spec_detects_jvrtopen_specs():
     assert _is_realtime_spec("0B12")
     assert _is_realtime_spec("0b15")
@@ -193,3 +204,50 @@ def test_sync_realtime_spec_is_idempotent_across_reruns(rt_database):
 
     rows = rt_database.fetch_all("SELECT COUNT(*) AS cnt FROM RT_RA")
     assert rows[0]["cnt"] == 1
+
+
+class _NullDatabase:
+    def commit(self):
+        return None
+
+
+class _FakeUpdater:
+    """Updater double returning process_record results verbatim.
+
+    process_record は失敗時も {"success": False} という truthy な dict を返す
+    ため、集計側が success フラグを見ずに数えると失敗が imported に紛れ込む。
+    """
+
+    def __init__(self, results):
+        self._results = list(results)
+        self.seen = 0
+
+    def process_record(self, buff):
+        result = self._results[self.seen]
+        self.seen += 1
+        return result
+
+
+def test_sync_realtime_spec_counts_failed_inserts_as_failed():
+    jvlink = FakeJVLink({"20260607": [b"x", b"y", b"z"]})
+    updater = _FakeUpdater(
+        [
+            {"success": True},
+            {"success": False, "error": "Incomplete primary key"},
+            None,
+        ]
+    )
+
+    stats = _sync_realtime_spec(
+        database=_NullDatabase(),
+        spec="0B14",
+        from_date="20260607",
+        to_date="20260607",
+        sid="JLTSQL",
+        jvlink=jvlink,
+        updater=updater,
+    )
+
+    assert stats["records_fetched"] == 3
+    assert stats["records_imported"] == 1
+    assert stats["records_failed"] == 2

--- a/tests/test_daily_update.py
+++ b/tests/test_daily_update.py
@@ -251,3 +251,30 @@ def test_sync_realtime_spec_counts_failed_inserts_as_failed():
     assert stats["records_fetched"] == 3
     assert stats["records_imported"] == 1
     assert stats["records_failed"] == 2
+
+
+def test_sync_realtime_spec_counts_list_results_per_subrecord():
+    """オッズ/票数など複数行レコードは list を返す。集計はサブレコード単位で行い、
+    一部失敗しても成功分は imported、失敗分だけ failed に数える。"""
+    jvlink = FakeJVLink({"20260607": [b"x", b"y"]})
+    updater = _FakeUpdater(
+        [
+            [{"success": True}, {"success": True}, {"success": False}],
+            [{"success": True}],
+        ]
+    )
+
+    stats = _sync_realtime_spec(
+        database=_NullDatabase(),
+        spec="0B14",
+        from_date="20260607",
+        to_date="20260607",
+        sid="JLTSQL",
+        jvlink=jvlink,
+        updater=updater,
+    )
+
+    assert stats["records_fetched"] == 2
+    assert stats["records_parsed"] == 4
+    assert stats["records_imported"] == 3
+    assert stats["records_failed"] == 1

--- a/tests/test_quickstart_realtime_dates.py
+++ b/tests/test_quickstart_realtime_dates.py
@@ -1,0 +1,36 @@
+"""Regression tests for quickstart realtime speed-report date/spec coverage.
+
+速報系(0B1x)は当日発表・過去 backfill 不能。開催日を曜日で絞ると祝日月曜など
+土日以外の開催日で WE(天候馬場)等が永久欠損するため、全日付を照会する。
+また WE を供給する 0B14/0B16 が SPEED_REPORT_SPECS に含まれることを保証する。
+"""
+
+from datetime import datetime, timedelta
+
+from scripts.quickstart import QuickstartRunner
+
+
+def _runner() -> QuickstartRunner:
+    return QuickstartRunner({})
+
+
+def test_recent_race_dates_covers_every_day_not_only_weekends():
+    dates = _runner()._get_recent_race_dates(days=7)
+    assert len(dates) == 7
+    expected = [
+        (datetime.now() - timedelta(days=i)).strftime("%Y%m%d")
+        for i in range(7)
+    ]
+    assert dates == expected
+
+
+def test_speed_report_specs_include_both_we_dataspecs():
+    codes = [spec for spec, _ in QuickstartRunner.SPEED_REPORT_SPECS]
+    # WE(天候馬場状態) is delivered only by 0B14 (一括) and 0B16 (指定).
+    assert "0B14" in codes
+    assert "0B16" in codes
+
+
+def test_speed_report_specs_dataspec_codes_are_unique():
+    codes = [spec for spec, _ in QuickstartRunner.SPEED_REPORT_SPECS]
+    assert len(codes) == len(set(codes))


### PR DESCRIPTION
## 概要

生 PostgreSQL の `nl_we`/`rt_we` が **0行**で WE（天候馬場状態）が未収集だった。
JV-Data 4.9.0.1「データ種別一覧」で確定: `RT_WE` を埋めるのは
**`0B14`（速報開催情報・一括）/ `0B16`（速報開催情報・指定）のみ**。
複数の欠陥が重なっていた。

## 修正した欠陥

1. **`quickstart.py` の `SPEED_REPORT_SPECS`（本番既定の realtime 経路）のラベルが
   仕様と食い違っていた** — `0B11` を「開催情報(WE)」と誤記（実際は馬体重 WH）、
   `0B14` を「出走取消・除外(AV)」と誤記（実際は WE）、`0B15`/`0B51` も誤記、
   **WE 指定版 `0B16` が丸ごと欠落**。dataspec コードは fetch に使われるためラベル
   誤りは直接の欠落ではないが、`0B16` 欠落は WE 変更情報の取りこぼしで、誤ラベルは
   監査を著しく混乱させた（`src/jvlink/constants.py` は正しく WE=0B14/0B16）。
2. **`quickstart._get_recent_race_dates` が土日のみ照会** → 祝日月曜などの開催日で
   speed-report（WE 含む）が**永久欠損**（速報系は過去 backfill 不可）。JVRTOpen は
   非開催日に `-1`(nodata) を返すだけなので、曜日フィルタを廃止し全日照会に変更
   （`daily_update.py` の realtime 経路と同挙動）。
3. **`daily_update.py` の `UPDATE_SPECS` / `daily_sync.bat`（補助経路）に 0B14/0B16 欠落** → 追加。
4. **`daily_update.py` の集計が投入失敗を成功として数えていた** —
   `RealtimeUpdater.process_record()` は失敗時も `{"success": False}`（truthy dict）を
   返すため `if result:` では imported に加算。`RT_WE` 収集が全滅しても `failed=0` に
   なり得た → `success` フラグで `records_failed` に集計。

## 本番の実行経路（重要）

`install_tasks.ps1` は `--no-timeseries`/`--no-realtime` を渡さず、`daily_sync.bat`
の既定は `INCLUDE_TIMESERIES=1`/`INCLUDE_REALTIME=1`。**既定タスクは `quickstart.py`
（realtime）を実行**するため、本番の WE 収集には quickstart.py の修正が必須。

## 検証

```
0B11=速報馬体重WH, 0B12=RA/SE, 0B13=DM, 0B14=速報開催情報一括WE,
0B15=速報レース情報RA, 0B16=速報開催情報指定WE, 0B17=TM, 0B51=WIN5 WF
```
- `pytest tests/test_daily_update.py tests/test_quickstart_realtime_dates.py`: 18 passed。
- Codex(gpt-5.6-sol) 最終レビュー: **P0=0 P1=0**（前回P1「土日限定でWE欠損」を全日照会で解消）。

## 影響と限界

- 過去分の学習用馬場状態は RA レコード（field50/51, crawler 監査 #02 / #131）が供給
  するため、**ヒストリカル学習は #02 で復旧済み**。本件はライブの発走前天候・馬場
  （`RT_WE`）に関わる。
- `0B14`/`0B16` は当日発表のため**過去 backfill 不可**（前向き蓄積）。一日一回の
  タスクでは開催中の変化を完全には追随できない（厳密なライブ発走前馬場には開催中の
  定期 realtime 実行が必要）。実収集開始は JV-Link ライブコレクタの realtime 実行
  （運用承認）が前提。

詳細: `docs/crawler_audit_03_we_realtime_spec.md`

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/miyamamoto/jrvltsql/pull/132" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->