### PR TITLE
fix: handle Wine bridge subscription responses (v1.6.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@
 
 現時点で未リリースの変更はありません。
 
+## [1.6.3] - 2026-07-15
+
+### Fixed
+
+- Wine bridge の `JVLinkBridgeError` を未購読・busy の正常なリトライ判定に含め、任意 spec の未購読で同一 polling cycle の正常データを rollback しないよう修正
+- JVRead の回復可能エラーも不完全取得として追跡し、欠損した 0B14 応答で既存の開催変更 snapshot を置換しないよう修正
+- Wine bridge 初期化失敗時に realtime monitor の health を停止状態へ更新するよう修正
+
 ## [1.6.2] - 2026-07-15
 
 ### Fixed

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,18 +1,15 @@
-# jrvltsql v1.6.2 Release Notes
+# jrvltsql v1.6.3 Release Notes
 
 ## Highlights
 
-- Preserved `DataKubun=9` as a cancellation state only for RA/SE/WF while
-  restoring physical deletion semantics for odds, vote, and other records.
-- Rejects an entire 0B14 snapshot before replacement when any source record
-  fails to parse.
-- Keeps background realtime polling alive after transient JV-Link or database
-  failures.
-- Resets historical and realtime fetch statistics for each spec/key response.
-- Prepares realtime schemas once per background-updater lifetime instead of
-  repeating full schema work for every spec and polling cycle.
+- Treats `JVLinkBridgeError` subscription and busy responses the same as the
+  native JV-Link exceptions.
+- Prevents an optional unsubscribed realtime spec under Wine from rolling back
+  valid rows collected by other specs in the same polling cycle.
+- Rejects 0B14 snapshot replacement after recoverable JVRead transport errors.
+- Reports the realtime monitor as stopped when Wine bridge initialization fails.
 
 ## Upgrade Notes
 
-- This is a compatible reliability patch for v1.6.1 data layouts.
+- This is a compatible reliability patch for v1.6.2 data layouts.
 - Docker/Wine runtime changes are not part of this repository release.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "jltsql"
-version = "1.6.2"
+version = "1.6.3"
 description = "JRA-VAN DataLab の競馬データをSQLite・PostgreSQLにインポートするツール"
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,3 +1,3 @@
 """jrvltsql - JRA-VAN データ取得・管理ツール"""
 
-__version__ = "1.6.2"
+__version__ = "1.6.3"

--- a/src/fetcher/base.py
+++ b/src/fetcher/base.py
@@ -69,6 +69,7 @@ class BaseFetcher(ABC):
         self._records_fetched = 0
         self._records_parsed = 0
         self._records_failed = 0
+        self._recoverable_read_errors = 0
         self._files_processed = 0
         self._total_files = 0
         self._service_key = service_key
@@ -253,6 +254,10 @@ class BaseFetcher(ABC):
                         filename=filename,
                         recommended_action="Deleting corrupted file and continuing",
                     )
+                    # Continuing lets non-snapshot imports drain later files,
+                    # but the current response is no longer complete. Snapshot
+                    # callers use this counter to reject destructive replacement.
+                    self._recoverable_read_errors += 1
 
                     # Delete corrupted file for file-related errors
                     if ret_code in (-203, -402, -403, -502, -503) and filename and hasattr(self.jvlink, 'jv_file_delete'):
@@ -287,6 +292,7 @@ class BaseFetcher(ABC):
             "records_fetched": self._records_fetched,
             "records_parsed": self._records_parsed,
             "records_failed": self._records_failed,
+            "recoverable_read_errors": self._recoverable_read_errors,
         }
 
     def reset_statistics(self):
@@ -294,6 +300,7 @@ class BaseFetcher(ABC):
         self._records_fetched = 0
         self._records_parsed = 0
         self._records_failed = 0
+        self._recoverable_read_errors = 0
 
     def _is_within_date_range(self, data: dict, to_date: str) -> bool:
         """Check if a record's date is within the specified range (up to to_date).

--- a/src/fetcher/realtime.py
+++ b/src/fetcher/realtime.py
@@ -27,12 +27,15 @@ def materialize_complete_records(
     data_spec: str,
     key: str,
 ) -> list[dict]:
-    """Materialize one realtime response and reject parser loss."""
+    """Materialize one realtime response and reject parser or transport loss."""
     materialized = list(records)
-    failed = int(fetcher.get_statistics().get("records_failed", 0) or 0)
-    if failed:
+    statistics = fetcher.get_statistics()
+    parser_failed = int(statistics.get("records_failed", 0) or 0)
+    read_errors = int(statistics.get("recoverable_read_errors", 0) or 0)
+    if parser_failed or read_errors:
         raise FetcherError(
-            f"{data_spec} {key} parser rejected {failed} record(s)"
+            f"{data_spec} {key} response incomplete: "
+            f"parser_failed={parser_failed}, recoverable_read_errors={read_errors}"
         )
     return materialized
 

--- a/src/services/realtime_monitor.py
+++ b/src/services/realtime_monitor.py
@@ -11,6 +11,7 @@ from datetime import datetime
 
 from src.fetcher.realtime import RealtimeFetcher
 from src.jvlink.constants import is_time_series_spec
+from src.jvlink.bridge import JVLinkBridgeError
 from src.jvlink.wrapper import JVLinkError
 from src.realtime.updater import RealtimeUpdater, summarize_update_result
 from src.database.base import BaseDatabase
@@ -230,14 +231,14 @@ class RealtimeMonitor:
         today and poll each one, storing速報 odds results in TS_SOKUHO_O*
         tables with timeseries=True so multiple odds snapshots are preserved.
         """
-        fetcher = RealtimeFetcher(sid=self.sid)
-        jvlink = fetcher.jvlink
-        updater = RealtimeUpdater(database=self.database)
-
         try:
+            fetcher = RealtimeFetcher(sid=self.sid)
+            jvlink = fetcher.jvlink
+            updater = RealtimeUpdater(database=self.database)
             jvlink.jv_init()
         except Exception as e:
-            logger.error(f"JV-Link init failed: {e}")
+            logger.error(f"JV-Link monitor initialization failed: {e}")
+            self._add_error("initialization", str(e))
             with self._lock:
                 self.status.is_running = False
                 self.status.stopped_at = datetime.now()
@@ -369,7 +370,7 @@ class RealtimeMonitor:
             jvlink.jv_close()
             return n, failed_count
 
-        except JVLinkError as e:
+        except (JVLinkError, JVLinkBridgeError) as e:
             code = getattr(e, "error_code", None)
             if snapshot_replaced:
                 logger.error(

--- a/tests/test_batch_processor.py
+++ b/tests/test_batch_processor.py
@@ -42,6 +42,7 @@ def test_historical_no_data_resets_statistics_from_previous_spec():
         "records_fetched": 0,
         "records_parsed": 0,
         "records_failed": 0,
+        "recoverable_read_errors": 0,
     }
 
 

--- a/tests/test_realtime.py
+++ b/tests/test_realtime.py
@@ -179,15 +179,52 @@ def test_summarize_update_result_counts_explicit_failures():
 
 def test_materialize_complete_records_rejects_parser_loss():
     fetcher = MagicMock()
-    fetcher.get_statistics.return_value = {"records_failed": 1}
+    fetcher.get_statistics.return_value = {
+        "records_failed": 1,
+        "recoverable_read_errors": 0,
+    }
 
-    with pytest.raises(Exception, match="0B14 20260715 parser rejected 1"):
+    with pytest.raises(Exception, match="parser_failed=1, recoverable_read_errors=0"):
         materialize_complete_records(
             fetcher,
             iter([{"RecordSpec": "WE"}]),
             data_spec="0B14",
             key="20260715",
         )
+
+
+def test_materialize_complete_records_rejects_recoverable_read_loss():
+    fetcher = MagicMock()
+    fetcher.get_statistics.return_value = {
+        "records_failed": 0,
+        "recoverable_read_errors": 1,
+    }
+
+    with pytest.raises(Exception, match="parser_failed=0, recoverable_read_errors=1"):
+        materialize_complete_records(
+            fetcher,
+            iter([{"RecordSpec": "WE"}]),
+            data_spec="0B14",
+            key="20260715",
+        )
+
+
+def test_realtime_fetcher_tracks_recoverable_read_loss():
+    fetcher = RealtimeFetcher.__new__(RealtimeFetcher)
+    fetcher.reset_statistics()
+    fetcher._files_processed = 0
+    fetcher._total_files = 0
+    fetcher.progress_display = None
+    fetcher.parser_factory = MagicMock()
+    fetcher.jvlink = MagicMock()
+    fetcher.jvlink.jv_read.side_effect = [
+        (-203, None, "corrupt.jvd"),
+        (0, None, None),
+    ]
+
+    assert list(fetcher._fetch_and_parse()) == []
+    assert fetcher.get_statistics()["recoverable_read_errors"] == 1
+    fetcher.jvlink.jv_file_delete.assert_called_once_with("corrupt.jvd")
 
 
 def test_process_parsed_record_preserves_failed_expanded_rows():
@@ -458,6 +495,22 @@ class TestRealtimeMonitor(unittest.TestCase):
         self.assertEqual(monitor.status.records_failed, 1)
         self.assertFalse(monitor.status.is_running)
         self.assertIsNotNone(monitor.status.stopped_at)
+
+    @patch("src.services.realtime_monitor.RealtimeFetcher")
+    def test_fetcher_initialization_failure_marks_monitor_unhealthy(self, fetcher_cls):
+        from src.jvlink.bridge import JVLinkBridgeError
+
+        monitor = RealtimeMonitor(database=self.mock_db, data_specs=["0B12"])
+        monitor.status.is_running = True
+        fetcher_cls.side_effect = JVLinkBridgeError(
+            "bridge executable unavailable", error_code=-1
+        )
+
+        monitor._monitor_sequential()
+
+        self.assertFalse(monitor.status.is_running)
+        self.assertIsNotNone(monitor.status.stopped_at)
+        self.assertEqual(monitor.status.errors[-1]["context"], "initialization")
 
     def test_error_limit(self):
         """Test error list size limit."""
@@ -801,6 +854,38 @@ class TestRealtimeUpdater(unittest.TestCase):
 
         self.assertEqual((imported, failed), (0, 1))
         updater.replace_date_snapshot.assert_called_once_with("20260715")
+
+    def test_wine_bridge_unsubscribed_spec_does_not_fail_cycle(self):
+        from src.jvlink.bridge import JVLinkBridgeError
+
+        monitor = RealtimeMonitor(database=self.mock_db)
+        jvlink = MagicMock()
+        jvlink.jv_rt_open.side_effect = JVLinkBridgeError(
+            "not subscribed", error_code=-114
+        )
+
+        imported, failed = monitor._drain_key(
+            jvlink, MagicMock(), "0B51", "20260715"
+        )
+
+        self.assertEqual((imported, failed), (0, 0))
+        jvlink.jv_close.assert_called_once()
+
+    def test_wine_bridge_busy_spec_retries_without_failing_cycle(self):
+        from src.jvlink.bridge import JVLinkBridgeError
+
+        monitor = RealtimeMonitor(database=self.mock_db)
+        jvlink = MagicMock()
+        jvlink.jv_rt_open.side_effect = JVLinkBridgeError(
+            "bridge busy", error_code=-202
+        )
+
+        imported, failed = monitor._drain_key(
+            jvlink, MagicMock(), "0B12", "20260715"
+        )
+
+        self.assertEqual((imported, failed), (0, 0))
+        jvlink.jv_close.assert_called_once()
 
     @patch('src.realtime.updater.ParserFactory')
     def test_process_record_rc_mapping(self, mock_factory_class):

--- a/uv.lock
+++ b/uv.lock
@@ -311,7 +311,7 @@ wheels = [
 
 [[package]]
 name = "jltsql"
-version = "1.6.2"
+version = "1.6.3"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary
- handle `JVLinkBridgeError` alongside native `JVLinkError` in realtime monitoring
- mark monitor health stopped when Wine bridge initialization fails
- reject 0B14 snapshot replacement after parser or recoverable JVRead transport loss
- add regression coverage and prepare the v1.6.3 release metadata

## Verification
- `pytest -q`: 1401 passed, 43 skipped, 5 subtests
- independent `gpt-5.6-sol` critical review rerun after fixes

## Boundary
Docker/Wine runtime packaging remains in `jrvltsql-wine-runtime`; this PR only fixes shared core realtime semantics.