### PR TITLE
fix: skip Wine bridge subscription errors in daily sync (v1.6.4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@
 
 現時点で未リリースの変更はありません。
 
+## [1.6.4] - 2026-07-15
+
+### Fixed
+
+- 非対話 `daily_update.py` でも Wine bridge の未購読例外を正常な spec スキップとして扱い、0B14/0B51 など任意購読 feed が未契約でも他 feed の収集を継続するよう修正
+
 ## [1.6.3] - 2026-07-15
 
 ### Fixed
@@ -197,7 +203,9 @@
 - quickstart.py 対話形式セットアップウィザード
 - CLI コマンド（fetch, status, monitor, init）
 
-[Unreleased]: https://github.com/miyamamoto/jrvltsql/compare/v1.6.2...HEAD
+[Unreleased]: https://github.com/miyamamoto/jrvltsql/compare/v1.6.4...HEAD
+[1.6.4]: https://github.com/miyamamoto/jrvltsql/compare/v1.6.3...v1.6.4
+[1.6.3]: https://github.com/miyamamoto/jrvltsql/compare/v1.6.2...v1.6.3
 [1.6.2]: https://github.com/miyamamoto/jrvltsql/compare/v1.6.1...v1.6.2
 [1.6.1]: https://github.com/miyamamoto/jrvltsql/compare/v1.6.0...v1.6.1
 [1.6.0]: https://github.com/miyamamoto/jrvltsql/releases/tag/v1.6.0

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,15 +1,13 @@
-# jrvltsql v1.6.3 Release Notes
+# jrvltsql v1.6.4 Release Notes
 
 ## Highlights
 
-- Treats `JVLinkBridgeError` subscription and busy responses the same as the
-  native JV-Link exceptions.
-- Prevents an optional unsubscribed realtime spec under Wine from rolling back
-  valid rows collected by other specs in the same polling cycle.
-- Rejects 0B14 snapshot replacement after recoverable JVRead transport errors.
-- Reports the realtime monitor as stopped when Wine bridge initialization fails.
+- Treats Wine bridge subscription responses as normal optional-spec skips in
+  the non-interactive daily collector path.
+- Prevents an unsubscribed 0B14 or 0B51 feed from aborting collection of other
+  configured feeds.
 
 ## Upgrade Notes
 
-- This is a compatible reliability patch for v1.6.2 data layouts.
+- This is a compatible reliability patch for v1.6.3 data layouts.
 - Docker/Wine runtime changes are not part of this repository release.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "jltsql"
-version = "1.6.3"
+version = "1.6.4"
 description = "JRA-VAN DataLab の競馬データをSQLite・PostgreSQLにインポートするツール"
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/scripts/daily_update.py
+++ b/scripts/daily_update.py
@@ -102,6 +102,7 @@ def _sync_realtime_spec(
         updater: Optional RealtimeUpdater override (tests).
     """
 
+    from src.jvlink.bridge import JVLinkBridgeError
     from src.jvlink.wrapper import JVLinkError
     from src.database.schema import create_all_tables
     from src.realtime.updater import RealtimeUpdater, summarize_update_result
@@ -132,7 +133,7 @@ def _sync_realtime_spec(
         for key in _iter_date_keys(from_date, to_date):
             try:
                 ret, _count = jvlink.jv_rt_open(spec, key)
-            except JVLinkError as exc:
+            except (JVLinkError, JVLinkBridgeError) as exc:
                 code = getattr(exc, "error_code", None)
                 if code in SUBSCRIPTION_ERROR_CODES:
                     print(f"[daily-sync] {spec} not subscribed, skipping spec")

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,3 +1,3 @@
 """jrvltsql - JRA-VAN データ取得・管理ツール"""
 
-__version__ = "1.6.3"
+__version__ = "1.6.4"

--- a/tests/test_daily_update.py
+++ b/tests/test_daily_update.py
@@ -259,6 +259,33 @@ def test_sync_realtime_spec_stops_after_subscription_error(rt_database, error_co
     assert jvlink.opened_keys == [("0B12", "20260606")]
 
 
+@pytest.mark.parametrize("error_code", sorted(SUBSCRIPTION_ERROR_CODES))
+def test_sync_realtime_spec_stops_after_wine_bridge_subscription_error(
+    rt_database, error_code
+):
+    """Wine bridge の未購読応答も spec 単位の正常スキップにする。"""
+    from src.jvlink.bridge import JVLinkBridgeError
+
+    class UnsubscribedBridge(FakeJVLink):
+        def jv_rt_open(self, data_spec, key):
+            self.opened_keys.append((data_spec, key))
+            raise JVLinkBridgeError("not subscribed", error_code=error_code)
+
+    jvlink = UnsubscribedBridge({})
+
+    stats = _sync_realtime_spec(
+        database=rt_database,
+        spec="0B51",
+        from_date="20260606",
+        to_date="20260608",
+        sid="JLTSQL",
+        jvlink=jvlink,
+    )
+
+    assert stats["records_failed"] == 0
+    assert jvlink.opened_keys == [("0B51", "20260606")]
+
+
 def test_sync_realtime_spec_stops_before_open_when_schema_setup_fails(rt_database, monkeypatch):
     jvlink = FakeJVLink({"20260607": [_build_rt_ra_record()]})
 

--- a/uv.lock
+++ b/uv.lock
@@ -311,7 +311,7 @@ wheels = [
 
 [[package]]
 name = "jltsql"
-version = "1.6.3"
+version = "1.6.4"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary
- handle `JVLinkBridgeError` subscription codes in the non-interactive daily sync path
- skip optional unsubscribed 0B14/0B51 feeds without aborting other configured feeds
- add native/Wine parity regression tests and v1.6.4 release metadata

## Verification
- `pytest -q`: 1404 passed, 43 skipped, 5 subtests

## Context
This is a follow-up to v1.6.3. The Docker collector service uses `scripts/daily_update.py`, so its Wine exception path must match the realtime monitor.