### PR TITLE
fix: preserve realtime snapshots and dual migrations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@
 
 現時点で未リリースの変更はありません。
 
+## [1.6.5] - 2026-07-15
+
+### Fixed
+
+- `JVRead` が正の長さと空バッファを返した不完全な速報取得を失敗として扱い、0B14 の既存 snapshot を空または部分データで置換しないよう修正
+- dual SQLite/PostgreSQL の additive schema migration を各 backend へ個別適用し、PostgreSQL の小文字 table identifier を誤って引用して追加列移行が止まる問題を修正
+
 ## [1.6.4] - 2026-07-15
 
 ### Fixed
@@ -203,7 +210,8 @@
 - quickstart.py 対話形式セットアップウィザード
 - CLI コマンド（fetch, status, monitor, init）
 
-[Unreleased]: https://github.com/miyamamoto/jrvltsql/compare/v1.6.4...HEAD
+[Unreleased]: https://github.com/miyamamoto/jrvltsql/compare/v1.6.5...HEAD
+[1.6.5]: https://github.com/miyamamoto/jrvltsql/compare/v1.6.4...v1.6.5
 [1.6.4]: https://github.com/miyamamoto/jrvltsql/compare/v1.6.3...v1.6.4
 [1.6.3]: https://github.com/miyamamoto/jrvltsql/compare/v1.6.2...v1.6.3
 [1.6.2]: https://github.com/miyamamoto/jrvltsql/compare/v1.6.1...v1.6.2

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,12 @@
-# jrvltsql v1.6.4 Release Notes
+# jrvltsql v1.6.5 Release Notes
 
 ## Highlights
+
+- Rejects every realtime stream that exits before the official completion
+  code, including positive-length reads with an empty buffer, so an incomplete
+  0B14 response cannot replace a valid stored snapshot.
+- Migrates dual SQLite/PostgreSQL schemas against each concrete backend, using
+  backend-specific table identifiers and verifying both copies before import.
 
 - Treats Wine bridge subscription responses as normal optional-spec skips in
   the non-interactive daily collector path.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "jltsql"
-version = "1.6.4"
+version = "1.6.5"
 description = "JRA-VAN DataLab の競馬データをSQLite・PostgreSQLにインポートするツール"
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/specs/20260715_v1_6_5_review.md
+++ b/specs/20260715_v1_6_5_review.md
@@ -1,0 +1,29 @@
+# v1.6.5 data-integrity review
+
+## Scope
+
+- Realtime 0B14 snapshot completion handling.
+- Additive schema migration in dual SQLite/PostgreSQL mode.
+
+## Required checks
+
+- A realtime snapshot is committed only after `JVRead` returns completion code
+  `0`. Negative responses and positive responses without a buffer fail the
+  transaction.
+- No race result, payout, or future information is introduced into parsing or
+  selection logic. This change only tightens transport completeness handling.
+- Dual migrations run against each concrete backend. SQLite keeps quoted table
+  names; PostgreSQL uses its lowercase unquoted identifiers.
+- Both backend schemas are verified after migration. Missing columns or primary
+  key mismatches remain fail-closed.
+
+## Regression coverage
+
+- `test_drain_0b14_positive_read_without_buffer_rejects_snapshot`
+- `test_dual_migration_uses_each_backends_identifier_rules`
+
+## Independent review
+
+`gpt-5.6-sol review --base master` completed on 2026-07-15 with no actionable
+findings. The reviewer confirmed that incomplete realtime reads fail closed and
+that migration and verification run independently against both dual backends.

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,3 +1,3 @@
 """jrvltsql - JRA-VAN データ取得・管理ツール"""
 
-__version__ = "1.6.4"
+__version__ = "1.6.5"

--- a/src/database/dual_handler.py
+++ b/src/database/dual_handler.py
@@ -145,6 +145,10 @@ class DualDatabase(BaseDatabase):
         """
         return self._primary.get_db_type()
 
+    def get_migration_targets(self) -> tuple[BaseDatabase, BaseDatabase]:
+        """Return concrete backends for backend-specific schema migration."""
+        return self._primary, self._secondary
+
     # ------------------------------------------------------------------
     # Reads: primary only
     # ------------------------------------------------------------------

--- a/src/database/migration.py
+++ b/src/database/migration.py
@@ -22,6 +22,15 @@ class SchemaMigrationError(RuntimeError):
     """Raised when a table cannot satisfy its required schema safely."""
 
 
+def _migration_targets(db: BaseDatabase) -> tuple[BaseDatabase, ...]:
+    """Return concrete databases that must be migrated independently."""
+    getter = getattr(db, "get_migration_targets", None)
+    if getter is None:
+        return (db,)
+    targets = tuple(getter())
+    return targets or (db,)
+
+
 def _schema_body(create_sql: str) -> Optional[str]:
     """Return the body inside the CREATE TABLE parentheses."""
     match = re.search(r'\((.+)\)', create_sql, re.DOTALL)
@@ -195,6 +204,13 @@ def migrate_table_if_needed(db: BaseDatabase, table_name: str, schema_sql: str) 
     Returns:
         True if a schema change was applied, False otherwise
     """
+    targets = _migration_targets(db)
+    if targets != (db,):
+        migrated = False
+        for target in targets:
+            migrated = migrate_table_if_needed(target, table_name, schema_sql) or migrated
+        return migrated
+
     if not db.table_exists(table_name):
         return False
 
@@ -279,6 +295,12 @@ def verify_table_schema(db: BaseDatabase, table_name: str, schema_sql: str) -> N
     additive. Missing required columns or a primary-key mismatch are unsafe:
     imports must stop instead of writing records against an obsolete layout.
     """
+    targets = _migration_targets(db)
+    if targets != (db,):
+        for target in targets:
+            verify_table_schema(target, table_name, schema_sql)
+        return
+
     if not db.table_exists(table_name):
         raise SchemaMigrationError(f"Required table does not exist: {table_name}")
 

--- a/src/services/realtime_monitor.py
+++ b/src/services/realtime_monitor.py
@@ -356,8 +356,12 @@ class RealtimeMonitor:
                         logger.error(f"process_record error ({data_spec}/{key}): {e}")
                         failed_count += 1
                 else:
-                    if ret_code < 0:
-                        failed_count += 1
+                    failed_count += 1
+                    self._add_error(
+                        data_spec,
+                        f"Incomplete JVRead response for {key}: "
+                        f"code={ret_code}, buffer_present={bool(buff)}",
+                    )
                     break
 
             if not stream_complete and self._stop_event.is_set():

--- a/tests/test_migration.py
+++ b/tests/test_migration.py
@@ -9,6 +9,7 @@ import pytest
 
 from src.database.base import BaseDatabase
 from src.database.sqlite_handler import SQLiteDatabase
+from src.database.dual_handler import DualDatabase
 from src.database.migration import (
     SchemaMigrationError,
     _extract_columns_from_sql,
@@ -430,3 +431,23 @@ def test_pg_migrate_all_tables(pg_db):
     # Real PG stores unquoted identifiers lowercased.
     assert "BetType" in pg_db._tables["nl_h1"]
     assert "SanrentanKumi" in pg_db._tables["nl_h6"]
+
+
+def test_dual_migration_uses_each_backends_identifier_rules(db, pg_db):
+    db.execute(ADDITIVE_OLD_SCHEMA)
+    db.commit()
+    pg_db.execute(ADDITIVE_OLD_SCHEMA)
+    dual = DualDatabase(db, pg_db)
+
+    assert migrate_table_if_needed(dual, "NL_H1", NEW_SCHEMA) is True
+
+    sqlite_columns = {
+        row["name"] for row in db.fetch_all('PRAGMA table_info("NL_H1")')
+    }
+    assert "Hyo" in sqlite_columns
+    assert "Hyo" in pg_db._tables["nl_h1"]
+    assert any(
+        statement.startswith("ALTER TABLE nl_h1 ADD COLUMN Hyo")
+        for statement in pg_db._executed
+    )
+    verify_table_schema(dual, "NL_H1", NEW_SCHEMA)

--- a/tests/test_realtime.py
+++ b/tests/test_realtime.py
@@ -839,6 +839,20 @@ class TestRealtimeUpdater(unittest.TestCase):
         self.assertEqual(failed, 1)
         updater.replace_date_snapshot.assert_called_once_with("20260715")
 
+    def test_drain_0b14_positive_read_without_buffer_rejects_snapshot(self):
+        monitor = RealtimeMonitor(database=self.mock_db)
+        jvlink = MagicMock()
+        jvlink.jv_rt_open.return_value = (0, 1)
+        jvlink.jv_read.return_value = (100, None, "RT")
+        updater = MagicMock()
+
+        imported, failed = monitor._drain_key(
+            jvlink, updater, "0B14", "20260715"
+        )
+
+        self.assertEqual((imported, failed), (0, 1))
+        updater.replace_date_snapshot.assert_called_once_with("20260715")
+
     def test_drain_0b14_busy_after_clear_rejects_snapshot(self):
         from src.jvlink.wrapper import JVLinkError
 


### PR DESCRIPTION
## Summary
- fail closed when JVRead exits before completion, including positive reads with an empty buffer
- migrate and verify dual SQLite/PostgreSQL schemas against each concrete backend
- release metadata for v1.6.5

## Validation
- pytest -q: 1406 passed, 43 skipped, 5 subtests passed
- focused regression suite: 90 passed, 3 subtests passed
- independent gpt-5.6-sol review: PASS

## Safety
- no JRA-VAN GUI, service key, or Wine prefix changes
- no betting/model/feature logic changes
- 0B14 incomplete snapshots and incompatible schemas fail closed