### PR TITLE
fix: skip unavailable dual migration mirrors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@
 
 現時点で未リリースの変更はありません。
 
+## [1.6.6] - 2026-07-15
+
+### Fixed
+
+- dual mode で secondary PostgreSQL が接続不能な場合は migration/verification 対象から除外し、documented best-effort 動作どおり primary の収集を継続
+
 ## [1.6.5] - 2026-07-15
 
 ### Fixed
@@ -210,7 +216,8 @@
 - quickstart.py 対話形式セットアップウィザード
 - CLI コマンド（fetch, status, monitor, init）
 
-[Unreleased]: https://github.com/miyamamoto/jrvltsql/compare/v1.6.5...HEAD
+[Unreleased]: https://github.com/miyamamoto/jrvltsql/compare/v1.6.6...HEAD
+[1.6.6]: https://github.com/miyamamoto/jrvltsql/compare/v1.6.5...v1.6.6
 [1.6.5]: https://github.com/miyamamoto/jrvltsql/compare/v1.6.4...v1.6.5
 [1.6.4]: https://github.com/miyamamoto/jrvltsql/compare/v1.6.3...v1.6.4
 [1.6.3]: https://github.com/miyamamoto/jrvltsql/compare/v1.6.2...v1.6.3

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,4 +1,4 @@
-# jrvltsql v1.6.5 Release Notes
+# jrvltsql v1.6.6 Release Notes
 
 ## Highlights
 
@@ -7,6 +7,8 @@
   0B14 response cannot replace a valid stored snapshot.
 - Migrates dual SQLite/PostgreSQL schemas against each concrete backend, using
   backend-specific table identifiers and verifying both copies before import.
+- Preserves best-effort dual-mode availability by excluding an unavailable
+  secondary mirror from migration while still validating connected mirrors.
 
 - Treats Wine bridge subscription responses as normal optional-spec skips in
   the non-interactive daily collector path.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "jltsql"
-version = "1.6.5"
+version = "1.6.6"
 description = "JRA-VAN DataLab の競馬データをSQLite・PostgreSQLにインポートするツール"
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/specs/20260715_v1_6_5_review.md
+++ b/specs/20260715_v1_6_5_review.md
@@ -27,3 +27,10 @@
 `gpt-5.6-sol review --base master` completed on 2026-07-15 with no actionable
 findings. The reviewer confirmed that incomplete realtime reads fail closed and
 that migration and verification run independently against both dual backends.
+
+A subsequent runtime-wide review found that an unavailable best-effort
+secondary was still included in migration targets. v1.6.6 limits migration and
+verification to connected backends; a dedicated regression test preserves
+primary-only availability while connected mirrors remain fail-closed.
+The follow-up `gpt-5.6-sol review --base master` completed with no actionable
+findings.

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,3 +1,3 @@
 """jrvltsql - JRA-VAN データ取得・管理ツール"""
 
-__version__ = "1.6.5"
+__version__ = "1.6.6"

--- a/src/database/dual_handler.py
+++ b/src/database/dual_handler.py
@@ -145,9 +145,12 @@ class DualDatabase(BaseDatabase):
         """
         return self._primary.get_db_type()
 
-    def get_migration_targets(self) -> tuple[BaseDatabase, BaseDatabase]:
-        """Return concrete backends for backend-specific schema migration."""
-        return self._primary, self._secondary
+    def get_migration_targets(self) -> tuple[BaseDatabase, ...]:
+        """Return connected backends for backend-specific schema migration."""
+        targets = [self._primary]
+        if self._secondary.is_connected():
+            targets.append(self._secondary)
+        return tuple(targets)
 
     # ------------------------------------------------------------------
     # Reads: primary only

--- a/tests/test_migration.py
+++ b/tests/test_migration.py
@@ -32,6 +32,9 @@ class MockPostgreSQLDatabase(BaseDatabase):
     def get_db_type(self) -> str:
         return "postgresql"
 
+    def is_connected(self) -> bool:
+        return True
+
     def connect(self): pass
     def disconnect(self): pass
     def commit(self): pass
@@ -451,3 +454,20 @@ def test_dual_migration_uses_each_backends_identifier_rules(db, pg_db):
         for statement in pg_db._executed
     )
     verify_table_schema(dual, "NL_H1", NEW_SCHEMA)
+
+
+def test_dual_migration_skips_unavailable_best_effort_secondary(db, pg_db):
+    db.execute(ADDITIVE_OLD_SCHEMA)
+    db.commit()
+    pg_db.execute(ADDITIVE_OLD_SCHEMA)
+    pg_db.is_connected = lambda: False
+    dual = DualDatabase(db, pg_db)
+
+    assert migrate_table_if_needed(dual, "NL_H1", NEW_SCHEMA) is True
+    verify_table_schema(dual, "NL_H1", NEW_SCHEMA)
+
+    sqlite_columns = {
+        row["name"] for row in db.fetch_all('PRAGMA table_info("NL_H1")')
+    }
+    assert "Hyo" in sqlite_columns
+    assert "Hyo" not in pg_db._tables["nl_h1"]


### PR DESCRIPTION
## Summary
- exclude a disconnected best-effort secondary from schema migration and verification
- keep connected secondary mirrors under backend-specific fail-closed verification
- release metadata for v1.6.6

## Validation
- pytest -q: 1407 passed, 43 skipped, 5 subtests passed
- focused migration suite: 30 passed
- independent gpt-5.6-sol review: PASS

## Safety
- no collector credentials, GUI registration, Wine prefix, model, feature, or betting changes