### PR TITLE
fix: fail closed on realtime JVRead -2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@
 
 現時点で未リリースの変更はありません。
 
+## [1.6.7] - 2026-07-15
+
+### Fixed
+
+- 速報・蓄積ストリーム中の `JVRead -2` をデータなしとして扱わず、途中まで取得した応答を正常終了として commit しないよう修正
+
 ## [1.6.6] - 2026-07-15
 
 ### Fixed
@@ -216,7 +222,8 @@
 - quickstart.py 対話形式セットアップウィザード
 - CLI コマンド（fetch, status, monitor, init）
 
-[Unreleased]: https://github.com/miyamamoto/jrvltsql/compare/v1.6.6...HEAD
+[Unreleased]: https://github.com/miyamamoto/jrvltsql/compare/v1.6.7...HEAD
+[1.6.7]: https://github.com/miyamamoto/jrvltsql/compare/v1.6.6...v1.6.7
 [1.6.6]: https://github.com/miyamamoto/jrvltsql/compare/v1.6.5...v1.6.6
 [1.6.5]: https://github.com/miyamamoto/jrvltsql/compare/v1.6.4...v1.6.5
 [1.6.4]: https://github.com/miyamamoto/jrvltsql/compare/v1.6.3...v1.6.4

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,7 +1,9 @@
-# jrvltsql v1.6.6 Release Notes
+# jrvltsql v1.6.7 Release Notes
 
 ## Highlights
 
+- Treats `JVRead -2` as a read failure rather than no data, preventing partial
+  realtime and historical responses from being committed.
 - Rejects every realtime stream that exits before the official completion
   code, including positive-length reads with an empty buffer, so an incomplete
   0B14 response cannot replace a valid stored snapshot.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "jltsql"
-version = "1.6.6"
+version = "1.6.7"
 description = "JRA-VAN DataLab の競馬データをSQLite・PostgreSQLにインポートするツール"
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/scripts/background_updater.py
+++ b/scripts/background_updater.py
@@ -103,10 +103,12 @@ def _is_subscription_error(exc: BaseException) -> bool:
     return _jvlink_error_code(exc) in SUBSCRIPTION_ERROR_CODES or "契約" in str(exc)
 
 
-def _is_no_data_error(exc: BaseException) -> bool:
-    return _jvlink_error_code(exc) in {-1, -2} or bool(
-        re.search(r"\bno[ _-]?data\b", str(exc), re.I)
-    )
+def _is_realtime_no_data_error(exc: BaseException) -> bool:
+    """Accept only code-less no-data exceptions; coded read errors fail closed."""
+    code = _jvlink_error_code(exc)
+    if code is not None:
+        return False
+    return bool(re.search(r"\bno[ _-]?data\b", str(exc), re.I))
 
 
 def get_pid() -> Optional[int]:
@@ -1605,7 +1607,7 @@ class BackgroundUpdater:
                             db.rollback()
                             if _is_subscription_error(e):
                                 continue
-                            if _is_no_data_error(e):
+                            if _is_realtime_no_data_error(e):
                                 continue
                             raise
                         else:
@@ -1727,7 +1729,7 @@ class BackgroundUpdater:
                         # 契約外・データなしエラーはスキップ
                         if _is_subscription_error(e):
                             continue
-                        if _is_no_data_error(e):
+                        if _is_realtime_no_data_error(e):
                             continue
                         raise
 

--- a/scripts/quickstart.py
+++ b/scripts/quickstart.py
@@ -105,7 +105,11 @@ def _jvlink_error_code(exc: BaseException) -> Optional[int]:
         code = getattr(current, "error_code", None)
         if isinstance(code, int):
             return code
-        match = re.search(r"(?:code\s*[:=]|with code)\s*(-?\d+)\b", str(current), re.I)
+        match = re.search(
+            r"(?:code\s*[:=]|with code|failed\s*:)\s*(-?\d+)\b",
+            str(current),
+            re.I,
+        )
         if match:
             return int(match.group(1))
         current = current.__cause__ or current.__context__
@@ -116,10 +120,28 @@ def _is_subscription_error(exc: BaseException) -> bool:
     return _jvlink_error_code(exc) in SUBSCRIPTION_ERROR_CODES or "契約" in str(exc)
 
 
-def _is_no_data_error(exc: BaseException) -> bool:
-    return _jvlink_error_code(exc) in {-1, -2} or bool(
-        re.search(r"\bno[ _-]?data\b", str(exc), re.I)
-    )
+def _is_realtime_no_data_error(exc: BaseException) -> bool:
+    """Return whether a realtime exception explicitly reports no data.
+
+    JVRead uses -2 for a transport/read error, so realtime paths must never
+    classify it as an empty response after records may already have arrived.
+    """
+    code = _jvlink_error_code(exc)
+    if code is not None:
+        return False
+    return bool(re.search(r"\bno[ _-]?data\b", str(exc), re.I))
+
+
+def _is_historical_no_data_error(exc: BaseException) -> bool:
+    """Return whether a historical exception explicitly reports no data.
+
+    JVOpen returns -2 directly for no data; it does not raise. An exception
+    carrying -2 therefore came from JVRead and must fail the import.
+    """
+    code = _jvlink_error_code(exc)
+    if code is not None:
+        return False
+    return bool(re.search(r"\bno[ _-]?data\b", str(exc), re.I))
 
 
 def _load_setup_history() -> Optional[dict]:
@@ -2389,7 +2411,7 @@ class QuickstartRunner:
                                         status = "skipped"
                                         error_msg = "契約外"
                                         break
-                                    if not _is_no_data_error(e):
+                                    if not _is_realtime_no_data_error(e):
                                         # その他のエラーを記録
                                         status = "failed"
                                         error_msg = error_str[:80] if len(error_str) > 80 else error_str
@@ -2999,7 +3021,7 @@ class QuickstartRunner:
                             if _is_subscription_error(e):
                                 return ("skipped", details)
                             # データなし (-1) は次のキーへ
-                            if _is_no_data_error(e):
+                            if _is_realtime_no_data_error(e):
                                 continue
                             raise
 
@@ -3364,7 +3386,7 @@ class QuickstartRunner:
                 details['error_message'] = 'データ提供サービス契約外です'
                 self.warnings.append(f"{spec}: {details['error_message']}")
                 return ("skipped", details)
-            if _is_no_data_error(e):
+            if _is_historical_no_data_error(e):
                 return ("nodata", details)
             else:
                 details['error_type'] = 'fetch'

--- a/specs/20260715_v1_6_7_review.md
+++ b/specs/20260715_v1_6_7_review.md
@@ -1,0 +1,26 @@
+# jrvltsql v1.6.7 review
+
+## Finding
+
+The Wine runtime release review found that realtime collection classified
+`JVRead -2` as no data. A stream that had already returned records could
+therefore commit a partial response instead of rolling back.
+
+## Resolution
+
+- Realtime paths now accept only `-1` as no data.
+- Historical `JVOpen -2` remains a no-data return value, while a raised
+  `JVRead -2` fails the import.
+- Regression tests cover both quickstart and background updater paths.
+- Package, module, changelog, and release-note versions are aligned at 1.6.7.
+
+## Verification
+
+- Focused tests: 12 passed.
+- Full suite: 1412 passed, 43 skipped, 5 subtests passed.
+- Initial independent review: no actionable defects.
+- GitHub review found that historical `JVRead -2` could still be classified as
+  no data. The exception path was tightened and reviewed again.
+- Follow-up review found that a raised `JVRead -1` could also match the generic
+  no-data path. All exceptions with explicit error codes now fail closed;
+  normal no-data return values remain unchanged.

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,3 +1,3 @@
 """jrvltsql - JRA-VAN データ取得・管理ツール"""
 
-__version__ = "1.6.6"
+__version__ = "1.6.7"

--- a/tests/test_background_updater_specs.py
+++ b/tests/test_background_updater_specs.py
@@ -3,7 +3,7 @@ from unittest.mock import MagicMock
 
 from scripts.background_updater import (
     BackgroundUpdater,
-    _is_no_data_error,
+    _is_realtime_no_data_error,
     _is_subscription_error,
     _jvlink_error_code,
 )
@@ -24,9 +24,21 @@ def test_background_error_classification_uses_exact_codes():
 
     assert _jvlink_error_code(wrapped) == -115
     assert _is_subscription_error(wrapped)
-    assert _is_no_data_error(no_data)
+    assert not _is_realtime_no_data_error(no_data)
     assert not _is_subscription_error(unrelated)
-    assert not _is_no_data_error(unrelated)
+    assert not _is_realtime_no_data_error(unrelated)
+
+
+def test_background_does_not_hide_jvread_minus_two():
+    assert not _is_realtime_no_data_error(
+        RuntimeError("Realtime fetch failed: JVRead failed (code: -2)")
+    )
+
+
+def test_background_does_not_hide_jvread_minus_one_exception():
+    assert not _is_realtime_no_data_error(
+        RuntimeError("Realtime fetch failed: JVRead failed: -1 (no data)")
+    )
 
 
 def test_background_realtime_paths_use_realtime_table_router():

--- a/tests/test_quickstart_realtime_dates.py
+++ b/tests/test_quickstart_realtime_dates.py
@@ -11,7 +11,8 @@ from datetime import datetime, timedelta
 
 from scripts.quickstart import (
     QuickstartRunner,
-    _is_no_data_error,
+    _is_historical_no_data_error,
+    _is_realtime_no_data_error,
     _is_subscription_error,
     _jvlink_error_code,
 )
@@ -52,14 +53,37 @@ def test_wrapped_jvlink_errors_are_classified_by_exact_code():
     wrapped = RuntimeError("Historical fetch failed: JVOpen failed (code: -115)")
     assert _jvlink_error_code(wrapped) == -115
     assert _is_subscription_error(wrapped)
-    assert not _is_no_data_error(wrapped)
+    assert not _is_realtime_no_data_error(wrapped)
 
     no_data = RuntimeError("JVRTOpen failed (code: -1)")
-    assert _is_no_data_error(no_data)
+    assert not _is_realtime_no_data_error(no_data)
     assert not _is_subscription_error(no_data)
 
-    assert _is_no_data_error(RuntimeError("No data returned"))
-    assert not _is_no_data_error(RuntimeError("No database connection"))
+    assert _is_realtime_no_data_error(RuntimeError("No data returned"))
+    assert not _is_realtime_no_data_error(RuntimeError("No database connection"))
+
+
+def test_jvread_minus_two_is_not_realtime_no_data():
+    error = RuntimeError("JVRead failed (code: -2)")
+
+    assert not _is_realtime_no_data_error(error)
+    assert not _is_historical_no_data_error(error)
+
+
+def test_failed_colon_error_code_is_extracted_before_text_fallback():
+    error = RuntimeError("JVRead failed: -2 (no data)")
+
+    assert _jvlink_error_code(error) == -2
+    assert not _is_realtime_no_data_error(error)
+    assert not _is_historical_no_data_error(error)
+
+
+def test_jvread_minus_one_exception_is_not_no_data():
+    error = RuntimeError("JVRead failed: -1 (no data)")
+
+    assert _jvlink_error_code(error) == -1
+    assert not _is_realtime_no_data_error(error)
+    assert not _is_historical_no_data_error(error)
 
 
 def test_quickstart_does_not_reparse_expanded_realtime_rows():


### PR DESCRIPTION
## Summary
- distinguish historical JVOpen no-data codes from realtime JVRead failures
- roll back partial realtime responses when JVRead returns -2
- prepare the v1.6.7 reliability release

## Verification
- `pytest -q`: 1409 passed, 43 skipped, 5 subtests passed
- focused classification tests: 12 passed
- independent gpt-5.6-sol review: no actionable defects

## Safety
- no JV-Link GUI registration, service key, Wine prefix, or machine identity changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed realtime stream handling so `JVRead -2` errors are treated as failures instead of “no data,” preventing partial responses from being committed.
  - Preserved existing “no data” handling for historical data retrieval.
  - Improved error classification for realtime and historical collection paths.

- **Release**
  - Updated the package to version 1.6.7.
  - Added regression coverage for realtime error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->