### PR TITLE
release: jrvltsql v1.6.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@
 
 現時点で未リリースの変更はありません。
 
+## [1.6.8] - 2026-07-18
+
+### Added
+
+- JRA SE の raw 固定幅値を保持したまま、走破タイム、上がり3F、馬体重、増減、着順、馬番の canonical 数値列を追加
+- SQLite/PostgreSQL の additive migration と primary-key 検証、および実レコード例を固定した parser contract test を追加
+
 ## [1.6.7] - 2026-07-15
 
 ### Fixed
@@ -222,7 +229,8 @@
 - quickstart.py 対話形式セットアップウィザード
 - CLI コマンド（fetch, status, monitor, init）
 
-[Unreleased]: https://github.com/miyamamoto/jrvltsql/compare/v1.6.7...HEAD
+[Unreleased]: https://github.com/miyamamoto/jrvltsql/compare/v1.6.8...HEAD
+[1.6.8]: https://github.com/miyamamoto/jrvltsql/compare/v1.6.7...v1.6.8
 [1.6.7]: https://github.com/miyamamoto/jrvltsql/compare/v1.6.6...v1.6.7
 [1.6.6]: https://github.com/miyamamoto/jrvltsql/compare/v1.6.5...v1.6.6
 [1.6.5]: https://github.com/miyamamoto/jrvltsql/compare/v1.6.4...v1.6.5

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,12 @@
-# jrvltsql v1.6.7 Release Notes
+# jrvltsql v1.6.8 Release Notes
 
 ## Highlights
+
+- Adds canonical numeric JRA SE columns for race time, final 3F, body weight,
+  body-weight change, finish position, and horse number while preserving the
+  official raw fixed-width fields unchanged.
+- Applies the new columns through additive SQLite/PostgreSQL migrations and
+  verifies both schema keys and representative official record conversions.
 
 - Treats `JVRead -2` as a read failure rather than no data, preventing partial
   realtime and historical responses from being committed.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "jltsql"
-version = "1.6.7"
+version = "1.6.8"
 description = "JRA-VAN DataLab の競馬データをSQLite・PostgreSQLにインポートするツール"
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,3 +1,3 @@
 """jrvltsql - JRA-VAN データ取得・管理ツール"""
 
-__version__ = "1.6.7"
+__version__ = "1.6.8"

--- a/src/database/migration.py
+++ b/src/database/migration.py
@@ -31,12 +31,51 @@ def _migration_targets(db: BaseDatabase) -> tuple[BaseDatabase, ...]:
     return targets or (db,)
 
 
+def _strip_sql_line_comments(sql: str) -> str:
+    """Strip ``--`` comments without touching quoted SQL text."""
+    result: List[str] = []
+    quote_end: Optional[str] = None
+    index = 0
+    while index < len(sql):
+        char = sql[index]
+        if quote_end is not None:
+            result.append(char)
+            if char == quote_end:
+                if quote_end != "]" and index + 1 < len(sql) and sql[index + 1] == quote_end:
+                    result.append(sql[index + 1])
+                    index += 2
+                    continue
+                quote_end = None
+            index += 1
+            continue
+
+        if char in {"'", '"', "`"}:
+            quote_end = char
+            result.append(char)
+            index += 1
+            continue
+        if char == "[":
+            quote_end = "]"
+            result.append(char)
+            index += 1
+            continue
+        if char == "-" and index + 1 < len(sql) and sql[index + 1] == "-":
+            index += 2
+            while index < len(sql) and sql[index] not in "\r\n":
+                index += 1
+            continue
+
+        result.append(char)
+        index += 1
+    return "".join(result)
+
+
 def _schema_body(create_sql: str) -> Optional[str]:
     """Return the body inside the CREATE TABLE parentheses."""
     # Generated schemas use trailing ``--`` comments.  They must not become
     # part of an ALTER TABLE column definition during additive migration.
-    sql_without_line_comments = re.sub(r"--[^\r\n]*", "", create_sql)
-    match = re.search(r'\((.+)\)', sql_without_line_comments, re.DOTALL)
+    sql_without_line_comments = _strip_sql_line_comments(create_sql)
+    match = re.search(r"\((.+)\)", sql_without_line_comments, re.DOTALL)
     if not match:
         return None
     return match.group(1)
@@ -47,7 +86,31 @@ def _split_schema_items(body: str) -> List[str]:
     items: List[str] = []
     current: List[str] = []
     depth = 0
-    for char in body:
+    quote_end: Optional[str] = None
+    index = 0
+    while index < len(body):
+        char = body[index]
+        if quote_end is not None:
+            current.append(char)
+            if char == quote_end:
+                if quote_end != "]" and index + 1 < len(body) and body[index + 1] == quote_end:
+                    current.append(body[index + 1])
+                    index += 2
+                    continue
+                quote_end = None
+            index += 1
+            continue
+
+        if char in {"'", '"', "`"}:
+            quote_end = char
+            current.append(char)
+            index += 1
+            continue
+        if char == "[":
+            quote_end = "]"
+            current.append(char)
+            index += 1
+            continue
         if char == "(":
             depth += 1
         elif char == ")" and depth:
@@ -59,6 +122,7 @@ def _split_schema_items(body: str) -> List[str]:
             current = []
         else:
             current.append(char)
+        index += 1
     tail = "".join(current).strip()
     if tail:
         items.append(tail)
@@ -106,7 +170,7 @@ def _extract_primary_key_columns(create_sql: str) -> Optional[List[str]]:
     inline_pk: List[str] = []
     for item in _split_schema_items(body):
         match = re.match(
-            r'(?:CONSTRAINT\s+\S+\s+)?PRIMARY\s+KEY\s*\(([^)]*)\)',
+            r"(?:CONSTRAINT\s+\S+\s+)?PRIMARY\s+KEY\s*\(([^)]*)\)",
             item,
             re.IGNORECASE,
         )
@@ -116,7 +180,7 @@ def _extract_primary_key_columns(create_sql: str) -> Optional[List[str]]:
         upper = item.upper()
         if upper.startswith(("UNIQUE", "FOREIGN KEY", "CONSTRAINT", "CHECK")):
             continue
-        if re.search(r'\bPRIMARY\s+KEY\b', item, re.IGNORECASE):
+        if re.search(r"\bPRIMARY\s+KEY\b", item, re.IGNORECASE):
             token = item.split()[0].strip('`"[]')
             if token:
                 inline_pk.append(token)
@@ -140,7 +204,7 @@ def _get_existing_columns(db: BaseDatabase, table_name: str) -> Set[str]:
         )
     else:
         existing_info = db.fetch_all(f'PRAGMA table_info("{table_name}")')
-    return {row['name'] for row in existing_info}
+    return {row["name"] for row in existing_info}
 
 
 def _get_existing_primary_key_columns(db: BaseDatabase, table_name: str) -> List[str]:
@@ -177,23 +241,39 @@ def _add_missing_columns(
     table_name: str,
     expected_definitions: Dict[str, str],
     missing_columns: List[str],
+    *,
+    commit: bool,
 ) -> int:
     """Add missing columns without touching existing data."""
+    if missing_columns and not commit:
+        if db.get_db_type() == "sqlite":
+            connection = getattr(db, "_connection", None)
+            if connection is None:
+                raise SchemaMigrationError("SQLite migration requires a connected database")
+            if not connection.in_transaction:
+                db.execute("BEGIN")
+        else:
+            db.begin_transaction()
+
     table_identifier = _table_identifier(db, table_name)
     added = 0
     for column_name in missing_columns:
         definition = expected_definitions[column_name]
-        logger.warning(
-            f"Adding missing column to {table_name}: {definition}"
-        )
+        logger.warning(f"Adding missing column to {table_name}: {definition}")
         db.execute(f"ALTER TABLE {table_identifier} ADD COLUMN {definition}")
         added += 1
-    if added:
+    if added and commit:
         db.commit()
     return added
 
 
-def migrate_table_if_needed(db: BaseDatabase, table_name: str, schema_sql: str) -> bool:
+def migrate_table_if_needed(
+    db: BaseDatabase,
+    table_name: str,
+    schema_sql: str,
+    *,
+    commit: bool = True,
+) -> bool:
     """Check if an existing table's columns match the expected schema.
 
     Only additive migrations are applied. Existing rows are preserved and
@@ -211,7 +291,9 @@ def migrate_table_if_needed(db: BaseDatabase, table_name: str, schema_sql: str) 
     if targets != (db,):
         migrated = False
         for target in targets:
-            migrated = migrate_table_if_needed(target, table_name, schema_sql) or migrated
+            migrated = (
+                migrate_table_if_needed(target, table_name, schema_sql, commit=commit) or migrated
+            )
         return migrated
 
     if not db.table_exists(table_name):
@@ -236,6 +318,11 @@ def migrate_table_if_needed(db: BaseDatabase, table_name: str, schema_sql: str) 
             "Automatic migration refused; operator action is required."
         )
         return False
+    if existing_pk_lower and not expected_pk_lower:
+        logger.warning(
+            f"Existing primary key for {table_name} is not declared by the "
+            f"expected schema: existing={existing_pk}. Constraint is preserved."
+        )
 
     # PostgreSQL lowercases all unquoted identifiers, so compare case-insensitively.
     # Without this, every PG run sees a "mismatch" between schema.py's CamelCase
@@ -247,28 +334,28 @@ def migrate_table_if_needed(db: BaseDatabase, table_name: str, schema_sql: str) 
         return False
 
     missing_columns = [
-        column for column in expected_columns
-        if column.lower() not in existing_lower
+        column for column in expected_columns if column.lower() not in existing_lower
     ]
     extra_columns = sorted(
-        column for column in existing_columns
-        if column.lower() not in expected_lower
+        column for column in existing_columns if column.lower() not in expected_lower
     )
 
     if missing_columns:
-        added = _add_missing_columns(db, table_name, expected_definitions, missing_columns)
+        added = _add_missing_columns(
+            db,
+            table_name,
+            expected_definitions,
+            missing_columns,
+            commit=commit,
+        )
         if extra_columns:
-            logger.warning(
-                f"Schema for {table_name} has extra columns preserved: {extra_columns}"
-            )
+            logger.warning(f"Schema for {table_name} has extra columns preserved: {extra_columns}")
         return added > 0
 
     if not extra_columns:
         return False
 
-    logger.warning(
-        f"Schema for {table_name} has extra columns preserved: {extra_columns}"
-    )
+    logger.warning(f"Schema for {table_name} has extra columns preserved: {extra_columns}")
     return False
 
 
@@ -310,16 +397,12 @@ def verify_table_schema(db: BaseDatabase, table_name: str, schema_sql: str) -> N
     expected_definitions = _extract_column_definitions(schema_sql)
     expected_pk = _extract_primary_key_columns(schema_sql)
     if expected_definitions is None or expected_pk is None:
-        raise SchemaMigrationError(
-            f"Could not parse expected schema for {table_name}"
-        )
+        raise SchemaMigrationError(f"Could not parse expected schema for {table_name}")
 
     existing_columns = _get_existing_columns(db, table_name)
     existing_lower = {column.lower() for column in existing_columns}
     missing_columns = sorted(
-        column
-        for column in expected_definitions
-        if column.lower() not in existing_lower
+        column for column in expected_definitions if column.lower() not in existing_lower
     )
 
     existing_pk = _get_existing_primary_key_columns(db, table_name)
@@ -330,9 +413,7 @@ def verify_table_schema(db: BaseDatabase, table_name: str, schema_sql: str) -> N
     if missing_columns:
         problems.append(f"missing columns={missing_columns}")
     if expected_pk_lower and existing_pk_lower != expected_pk_lower:
-        problems.append(
-            f"primary key existing={existing_pk}, expected={expected_pk}"
-        )
+        problems.append(f"primary key existing={existing_pk}, expected={expected_pk}")
     if problems:
         raise SchemaMigrationError(
             f"Schema verification failed for {table_name}: " + "; ".join(problems)

--- a/src/importer/importer.py
+++ b/src/importer/importer.py
@@ -22,23 +22,47 @@ logger = get_logger(__name__)
 
 # 10で割るべきフィールド名のプレフィックス（高速ルックアップ用）
 # オッズ系、タイム系、重量系
-DIVIDE_BY_10_PREFIXES = frozenset([
-    "TanOdds", "FukuOdds", "WakurenOdds", "OddsLow", "OddsHigh",
-    "TimeDiff", "HaronTime", "Haron", "LapTime",
-    "Futan", "BaTaijyu", "ZogenSa",
-    "DMTime", "DMGosa",
-])
+DIVIDE_BY_10_PREFIXES = frozenset(
+    [
+        "TanOdds",
+        "FukuOdds",
+        "WakurenOdds",
+        "OddsLow",
+        "OddsHigh",
+        "TimeDiff",
+        "HaronTime",
+        "Haron",
+        "LapTime",
+        "Futan",
+        "BaTaijyu",
+        "ZogenSa",
+        "DMTime",
+        "DMGosa",
+    ]
+)
 
 # 完全一致で10で割るべきフィールド名
 DIVIDE_BY_10_EXACT = frozenset(["Odds", "Time"])
 
 # Explicit-unit fields are already canonicalized by the parser contract.
-CANONICAL_SE_FIELDS = frozenset([
-    "FutanKg", "FutanBeforeKg", "BaTaijyuKg", "ZogenSaKg",
-    "RaceTimeSeconds", "OddsMultiplier", "HonsyokinYen", "FukasyokinYen",
-    "HaronTimeL4Seconds", "HaronTimeL3Seconds", "TimeDiffSeconds",
-    "DMTimeSeconds", "DMGosaPSeconds", "DMGosaMSeconds",
-])
+CANONICAL_SE_FIELDS = frozenset(
+    [
+        "FutanKg",
+        "FutanBeforeKg",
+        "BaTaijyuKg",
+        "ZogenSaKg",
+        "RaceTimeSeconds",
+        "OddsMultiplier",
+        "HonsyokinYen",
+        "FukasyokinYen",
+        "HaronTimeL4Seconds",
+        "HaronTimeL3Seconds",
+        "TimeDiffSeconds",
+        "DMTimeSeconds",
+        "DMGosaPSeconds",
+        "DMGosaMSeconds",
+    ]
+)
 
 # キャッシュ（フィールド名 → 10で割るべきか）
 _divide_cache: dict = {}
@@ -102,15 +126,17 @@ def convert_record_types(record: dict, table_name: str) -> dict:
             if col_type in ("INTEGER", "BIGINT"):
                 str_value = str(value).strip()
                 if str_value:
-                    if (str_value.startswith('***') or
-                        '****' in str_value or
-                        all(c in '-*' for c in str_value) or
-                        '--' in str_value or
-                        '*' in str_value):
+                    if (
+                        str_value.startswith("***")
+                        or "****" in str_value
+                        or all(c in "-*" for c in str_value)
+                        or "--" in str_value
+                        or "*" in str_value
+                    ):
                         converted[field_name] = None
                     else:
-                        numeric_part = ''.join(c for c in str_value if c.isdigit() or c == '-')
-                        if numeric_part and numeric_part != '-':
+                        numeric_part = "".join(c for c in str_value if c.isdigit() or c == "-")
+                        if numeric_part and numeric_part != "-":
                             converted[field_name] = int(numeric_part)
                         else:
                             converted[field_name] = None
@@ -120,15 +146,17 @@ def convert_record_types(record: dict, table_name: str) -> dict:
             elif col_type == "REAL":
                 str_value = str(value).strip()
                 if str_value:
-                    if (str_value.startswith('***') or
-                        '****' in str_value or
-                        all(c in '-*' for c in str_value) or
-                        '--' in str_value or
-                        '*' in str_value):
+                    if (
+                        str_value.startswith("***")
+                        or "****" in str_value
+                        or all(c in "-*" for c in str_value)
+                        or "--" in str_value
+                        or "*" in str_value
+                    ):
                         converted[field_name] = None
                     else:
-                        numeric_part = ''.join(c for c in str_value if c.isdigit() or c in '.-')
-                        if numeric_part and numeric_part not in ('-', '.', '-.'):
+                        numeric_part = "".join(c for c in str_value if c.isdigit() or c in ".-")
+                        if numeric_part and numeric_part not in ("-", ".", "-."):
                             float_value = float(numeric_part)
                             if _should_divide_by_10(field_name):
                                 converted[field_name] = float_value / 10.0
@@ -201,6 +229,7 @@ class DataImporter:
         self._records_imported = 0
         self._records_failed = 0
         self._batches_processed = 0
+        self._jravan_tables_ready = not use_jravan_schema
 
         # Map record types to table names
         # Note: Table names match schema.py table definitions (e.g. NL_RA, not NL_RA_RACE)
@@ -273,10 +302,7 @@ class DataImporter:
             use_jravan_schema=use_jravan_schema,
         )
 
-        if self.use_jravan_schema:
-            self._migrate_existing_jravan_tables()
-
-    def _migrate_existing_jravan_tables(self) -> None:
+    def _migrate_existing_jravan_tables(self, *, commit: bool) -> None:
         """Add newly supported columns to existing standard-name tables."""
         from src.database.migration import migrate_table_if_needed, verify_table_schema
         from src.database.schema_jravan import JRAVAN_SCHEMAS
@@ -285,8 +311,18 @@ class DataImporter:
             standard_name = self._get_table_name_for_native(table_name)
             schema_sql = JRAVAN_SCHEMAS.get(standard_name)
             if schema_sql and self.database.table_exists(standard_name):
-                migrate_table_if_needed(self.database, standard_name, schema_sql)
+                migrate_table_if_needed(self.database, standard_name, schema_sql, commit=commit)
                 verify_table_schema(self.database, standard_name, schema_sql)
+
+    def _ensure_jravan_tables_ready(self, *, auto_commit: bool) -> None:
+        """Migrate standard-name tables only after the DB is connected."""
+        if self._jravan_tables_ready:
+            return
+        if not self.database.is_connected():
+            raise ImporterError("JRA-VAN schema import requires a connected database")
+        self._migrate_existing_jravan_tables(commit=auto_commit)
+        if auto_commit:
+            self._jravan_tables_ready = True
 
     @staticmethod
     def _get_table_name_for_native(table_name: str) -> str:
@@ -311,6 +347,7 @@ class DataImporter:
         # Convert to JRA-VAN standard name if requested
         if self.use_jravan_schema:
             from src.database.table_mappings import JLTSQL_TO_JRAVAN
+
             return JLTSQL_TO_JRAVAN.get(table_name, table_name)
 
         return table_name
@@ -326,15 +363,17 @@ class DataImporter:
         """
         # Fields used for routing/metadata that shouldn't be in database tables
         metadata_fields = {
-            'headRecordSpec',
-            'レコード種別ID',
-            '_raw_data',
-            '_parse_errors',
-            'RecordDelimiter',
-            'RecordSeparator',
+            "headRecordSpec",
+            "レコード種別ID",
+            "_raw_data",
+            "_parse_errors",
+            "RecordDelimiter",
+            "RecordSeparator",
         }
 
-        return {k: v for k, v in record.items() if k not in metadata_fields and not k.startswith('_')}
+        return {
+            k: v for k, v in record.items() if k not in metadata_fields and not k.startswith("_")
+        }
 
     def _convert_record(self, record: dict, table_name: str) -> dict:
         """Convert record field types based on table schema.
@@ -349,9 +388,7 @@ class DataImporter:
         """Return True when a converted row has all schema primary-key values."""
         from src.database.table_mappings import JRAVAN_TO_JLTSQL
 
-        primary_keys = get_table_primary_key_columns(
-            JRAVAN_TO_JLTSQL.get(table_name, table_name)
-        )
+        primary_keys = get_table_primary_key_columns(JRAVAN_TO_JLTSQL.get(table_name, table_name))
         if not primary_keys:
             return True
         return all(record.get(key) not in (None, "") for key in primary_keys)
@@ -381,6 +418,10 @@ class DataImporter:
             ...     stats = importer.import_records(records)
             ...     print(f"Imported {stats['records_imported']} records")
         """
+        if not auto_commit:
+            self.database.begin_transaction()
+        self._ensure_jravan_tables_ready(auto_commit=auto_commit)
+
         # Reset statistics
         self._records_imported = 0
         self._records_failed = 0
@@ -394,14 +435,14 @@ class DataImporter:
                 # Get record type and table name
                 # Note: Japanese parsers use 'レコード種別ID', JRA-VAN standard uses 'RecordSpec'
                 record_type = (
-                    record.get("レコード種別ID") or
-                    record.get("RecordSpec") or
-                    record.get("headRecordSpec")
+                    record.get("レコード種別ID")
+                    or record.get("RecordSpec")
+                    or record.get("headRecordSpec")
                 )
                 if not record_type:
                     logger.warning(
                         "Record missing record type field",
-                        record_keys=list(record.keys())[:5] if record else None
+                        record_keys=list(record.keys())[:5] if record else None,
                     )
                     self._records_failed += 1
                     continue
@@ -517,9 +558,9 @@ class DataImporter:
                 db_type = self.database.get_db_type()
             except AttributeError:
                 # Fallback for databases without get_db_type() method
-                db_type = 'unknown'
+                db_type = "unknown"
 
-            if db_type != 'postgresql':
+            if db_type != "postgresql":
                 try:
                     self.database.rollback()
                 except Exception as rollback_error:
@@ -577,11 +618,13 @@ class DataImporter:
         Returns:
             True if successful, False otherwise
         """
+        if not auto_commit:
+            self.database.begin_transaction()
+        self._ensure_jravan_tables_ready(auto_commit=auto_commit)
+
         # Note: Japanese parsers use 'レコード種別ID', JRA-VAN standard uses 'RecordSpec'
         record_type = (
-            record.get("レコード種別ID") or
-            record.get("RecordSpec") or
-            record.get("headRecordSpec")
+            record.get("レコード種別ID") or record.get("RecordSpec") or record.get("headRecordSpec")
         )
         if not record_type:
             logger.warning("Record missing record type field")

--- a/src/importer/importer_optimized.py
+++ b/src/importer/importer_optimized.py
@@ -41,22 +41,51 @@ class OptimizedDataImporter:
         self._records_imported = 0
         self._records_failed = 0
         self._batches_processed = 0
+        self._jravan_tables_ready = not use_jravan_schema
 
         # Detect database type for optimization
         self.db_type = self._detect_database_type()
 
         # Map record types to table names (same as original)
         self._table_map = {
-            "RA": "NL_RA", "SE": "NL_SE", "HR": "NL_HR", "JG": "NL_JG",
-            "H1": "NL_H1", "H6": "NL_H6", "O1": "NL_O1", "O2": "NL_O2",
-            "O3": "NL_O3", "O4": "NL_O4", "O5": "NL_O5", "O6": "NL_O6",
-            "YS": "NL_YS", "UM": "NL_UM", "KS": "NL_KS", "CH": "NL_CH",
-            "BR": "NL_BR", "BN": "NL_BN", "HN": "NL_HN", "SK": "NL_SK",
-            "RC": "NL_RC", "CC": "NL_CC", "TC": "NL_TC", "CS": "NL_CS",
-            "CK": "NL_CK", "WC": "NL_WC", "AV": "NL_AV", "JC": "NL_JC",
-            "HC": "NL_HC", "HS": "NL_HS", "HY": "NL_HY", "WE": "NL_WE",
-            "WF": "NL_WF", "WH": "NL_WH", "TM": "NL_TM", "TK": "NL_TK",
-            "BT": "NL_BT", "DM": "NL_DM",
+            "RA": "NL_RA",
+            "SE": "NL_SE",
+            "HR": "NL_HR",
+            "JG": "NL_JG",
+            "H1": "NL_H1",
+            "H6": "NL_H6",
+            "O1": "NL_O1",
+            "O2": "NL_O2",
+            "O3": "NL_O3",
+            "O4": "NL_O4",
+            "O5": "NL_O5",
+            "O6": "NL_O6",
+            "YS": "NL_YS",
+            "UM": "NL_UM",
+            "KS": "NL_KS",
+            "CH": "NL_CH",
+            "BR": "NL_BR",
+            "BN": "NL_BN",
+            "HN": "NL_HN",
+            "SK": "NL_SK",
+            "RC": "NL_RC",
+            "CC": "NL_CC",
+            "TC": "NL_TC",
+            "CS": "NL_CS",
+            "CK": "NL_CK",
+            "WC": "NL_WC",
+            "AV": "NL_AV",
+            "JC": "NL_JC",
+            "HC": "NL_HC",
+            "HS": "NL_HS",
+            "HY": "NL_HY",
+            "WE": "NL_WE",
+            "WF": "NL_WF",
+            "WH": "NL_WH",
+            "TM": "NL_TM",
+            "TK": "NL_TK",
+            "BT": "NL_BT",
+            "DM": "NL_DM",
         }
 
         logger.info(
@@ -66,10 +95,7 @@ class OptimizedDataImporter:
             use_jravan_schema=use_jravan_schema,
         )
 
-        if self.use_jravan_schema:
-            self._migrate_existing_jravan_tables()
-
-    def _migrate_existing_jravan_tables(self) -> None:
+    def _migrate_existing_jravan_tables(self, *, commit: bool) -> None:
         """Add newly supported columns to existing standard-name tables."""
         from src.database.migration import migrate_table_if_needed, verify_table_schema
         from src.database.schema_jravan import JRAVAN_SCHEMAS
@@ -79,8 +105,20 @@ class OptimizedDataImporter:
             standard_name = JLTSQL_TO_JRAVAN.get(native_name, native_name)
             schema_sql = JRAVAN_SCHEMAS.get(standard_name)
             if schema_sql and self.database.table_exists(standard_name):
-                migrate_table_if_needed(self.database, standard_name, schema_sql)
+                migrate_table_if_needed(self.database, standard_name, schema_sql, commit=commit)
                 verify_table_schema(self.database, standard_name, schema_sql)
+
+    def _ensure_jravan_tables_ready(self, *, auto_commit: bool) -> None:
+        """Migrate standard-name tables only after the DB is connected."""
+        if self._jravan_tables_ready:
+            return
+        if not self.database.is_connected():
+            from src.importer.importer import ImporterError
+
+            raise ImporterError("JRA-VAN schema import requires a connected database")
+        self._migrate_existing_jravan_tables(commit=auto_commit)
+        if auto_commit:
+            self._jravan_tables_ready = True
 
     def _detect_database_type(self) -> str:
         """Detect database type from handler class."""
@@ -100,6 +138,7 @@ class OptimizedDataImporter:
 
         if self.use_jravan_schema:
             from src.database.table_mappings import JLTSQL_TO_JRAVAN
+
             return JLTSQL_TO_JRAVAN.get(table_name, table_name)
 
         return table_name
@@ -131,12 +170,8 @@ class OptimizedDataImporter:
         from src.database.schema_types import get_table_primary_key_columns
         from src.database.table_mappings import JRAVAN_TO_JLTSQL
 
-        primary_keys = get_table_primary_key_columns(
-            JRAVAN_TO_JLTSQL.get(table_name, table_name)
-        )
-        return not primary_keys or all(
-            record.get(key) not in (None, "") for key in primary_keys
-        )
+        primary_keys = get_table_primary_key_columns(JRAVAN_TO_JLTSQL.get(table_name, table_name))
+        return not primary_keys or all(record.get(key) not in (None, "") for key in primary_keys)
 
     def import_records(
         self,
@@ -155,6 +190,10 @@ class OptimizedDataImporter:
         Returns:
             Dictionary with import statistics
         """
+        if not auto_commit:
+            self.database.begin_transaction()
+        self._ensure_jravan_tables_ready(auto_commit=auto_commit)
+
         # Reset statistics
         self._records_imported = 0
         self._records_failed = 0
@@ -163,21 +202,18 @@ class OptimizedDataImporter:
         # Group records by type for batch insertion
         batch_buffers: Dict[str, List[dict]] = {}
 
-        # Start transaction for entire import
-        transaction_started = False
-
         try:
             for record in records:
                 # Get record type and table name
                 record_type = (
-                    record.get("レコード種別ID") or
-                    record.get("RecordSpec") or
-                    record.get("headRecordSpec")
+                    record.get("レコード種別ID")
+                    or record.get("RecordSpec")
+                    or record.get("headRecordSpec")
                 )
                 if not record_type:
                     logger.warning(
                         "Record missing record type field",
-                        record_keys=list(record.keys())[:5] if record else None
+                        record_keys=list(record.keys())[:5] if record else None,
                     )
                     self._records_failed += 1
                     continue
@@ -211,7 +247,7 @@ class OptimizedDataImporter:
                     self._flush_batch_optimized(
                         table_name,
                         batch_buffers[table_name],
-                        commit_batch=(not transaction_started)  # Only commit if not in transaction
+                        commit_batch=auto_commit,
                     )
                     batch_buffers[table_name] = []
 
@@ -219,15 +255,8 @@ class OptimizedDataImporter:
             for table_name, batch in batch_buffers.items():
                 if batch:
                     self._flush_batch_optimized(
-                        table_name,
-                        batch,
-                        commit_batch=(not transaction_started)
+                        table_name, batch, commit_batch=auto_commit
                     )
-
-            # Commit if in transaction
-            if transaction_started and auto_commit:
-                self.database.commit()
-                logger.info("Committed transaction for entire import")
 
             # Log summary
             stats = self.get_statistics()
@@ -238,15 +267,8 @@ class OptimizedDataImporter:
         except Exception as e:
             logger.error("Import failed", error=str(e))
 
-            # Rollback if in transaction
-            if transaction_started:
-                try:
-                    self.database.rollback()
-                    logger.info("Rolled back transaction due to error")
-                except Exception:
-                    pass
-
             from src.importer.importer import ImporterError
+
             raise ImporterError(f"Failed to import records: {e}")
 
     def _flush_batch_optimized(
@@ -261,7 +283,7 @@ class OptimizedDataImporter:
 
         try:
             # Use optimized insert if available
-            if hasattr(self.database, 'insert_many_optimized'):
+            if hasattr(self.database, "insert_many_optimized"):
                 # Optimized path
                 rows = self.database.insert_many_optimized(table_name, batch)
             else:
@@ -283,6 +305,12 @@ class OptimizedDataImporter:
             )
 
         except DatabaseError as e:
+            if not commit_batch:
+                # The backend may already have rolled back the caller-owned
+                # transaction. Retrying rows here would create a partial import
+                # and make the reported statistics diverge from persisted data.
+                raise
+
             # Try inserting one by one on batch failure
             logger.warning(
                 "Batch insert failed, trying individual inserts",
@@ -313,8 +341,7 @@ class OptimizedDataImporter:
             "records_failed": self._records_failed,
             "batches_processed": self._batches_processed,
             "success_rate": (
-                self._records_imported * 100 /
-                (self._records_imported + self._records_failed)
+                self._records_imported * 100 / (self._records_imported + self._records_failed)
                 if (self._records_imported + self._records_failed) > 0
                 else 0
             ),

--- a/src/parser/canonical.py
+++ b/src/parser/canonical.py
@@ -12,11 +12,22 @@ from typing import Any
 
 SE_CONTRACT_VERSION = 2
 
+
 def _unsigned_digits(value: Any, width: int) -> int | None:
     if value is None:
         return None
-    text = str(value).strip()
-    if len(text) != width or not text.isascii() or not text.isdigit():
+    raw_text = str(value)
+    text = raw_text.strip()
+    # SEParser strips fixed-width fields before canonicalization. Accept a
+    # shorter digit string only when the original value fits in the field;
+    # over-width or non-numeric values still fail closed.
+    if (
+        not text
+        or len(raw_text) > width
+        or len(text) > width
+        or not text.isascii()
+        or not text.isdigit()
+    ):
         return None
     return int(text)
 
@@ -123,17 +134,11 @@ def canonicalize_se_fields(record: dict[str, Any]) -> dict[str, Any]:
             record.get("FutanBefore"), 3, 0.1, zero_is_missing=True, sentinels=(999,)
         ),
         "BaTaijyuKg": _body_weight_kg(record.get("BaTaijyu")),
-        "ZogenSaKg": _signed_weight_change(
-            record.get("ZogenSa"), record.get("ZogenFugo")
-        ),
+        "ZogenSaKg": _signed_weight_change(record.get("ZogenSa"), record.get("ZogenFugo")),
         "RaceTimeSeconds": _msss_seconds(record.get("Time")),
-        "OddsMultiplier": _scaled_unsigned(
-            record.get("Odds"), 4, 0.1, zero_is_missing=True
-        ),
+        "OddsMultiplier": _scaled_unsigned(record.get("Odds"), 4, 0.1, zero_is_missing=True),
         "HonsyokinYen": _prize_yen(record.get("Honsyokin"), record.get("DataKubun")),
-        "FukasyokinYen": _prize_yen(
-            record.get("Fukasyokin"), record.get("DataKubun")
-        ),
+        "FukasyokinYen": _prize_yen(record.get("Fukasyokin"), record.get("DataKubun")),
         "HaronTimeL4Seconds": _scaled_unsigned(
             record.get("HaronTimeL4"),
             3,
@@ -150,10 +155,6 @@ def canonicalize_se_fields(record: dict[str, Any]) -> dict[str, Any]:
         ),
         "TimeDiffSeconds": _signed_tenths(record.get("TimeDiff")),
         "DMTimeSeconds": _msshh_seconds(record.get("DMTime")),
-        "DMGosaPSeconds": _scaled_unsigned(
-            record.get("DMGosaP"), 4, 0.01, zero_is_missing=True
-        ),
-        "DMGosaMSeconds": _scaled_unsigned(
-            record.get("DMGosaM"), 4, 0.01, zero_is_missing=True
-        ),
+        "DMGosaPSeconds": _scaled_unsigned(record.get("DMGosaP"), 4, 0.01, zero_is_missing=True),
+        "DMGosaMSeconds": _scaled_unsigned(record.get("DMGosaM"), 4, 0.01, zero_is_missing=True),
     }

--- a/tests/test_migration.py
+++ b/tests/test_migration.py
@@ -12,6 +12,7 @@ from src.database.sqlite_handler import SQLiteDatabase
 from src.database.dual_handler import DualDatabase
 from src.database.migration import (
     SchemaMigrationError,
+    _extract_column_definitions,
     _extract_columns_from_sql,
     _extract_primary_key_columns,
     migrate_table_if_needed,
@@ -35,10 +36,17 @@ class MockPostgreSQLDatabase(BaseDatabase):
     def is_connected(self) -> bool:
         return True
 
-    def connect(self): pass
-    def disconnect(self): pass
-    def commit(self): pass
-    def rollback(self): pass
+    def connect(self):
+        pass
+
+    def disconnect(self):
+        pass
+
+    def commit(self):
+        pass
+
+    def rollback(self):
+        pass
 
     def table_exists(self, table_name: str) -> bool:
         # Real PostgreSQL stores unquoted identifiers in lowercase.
@@ -51,6 +59,7 @@ class MockPostgreSQLDatabase(BaseDatabase):
             # Extract table name: DROP TABLE "NL_H1" or DROP TABLE NL_H1
             # IF EXISTS is supported and silently no-ops on missing tables.
             import re
+
             m = re.search(r'DROP\s+TABLE\s+(?:IF\s+EXISTS\s+)?"?(\w+)"?', sql, re.IGNORECASE)
             if m:
                 # Real PG: unquoted name is lowercased; quoted name preserves case.
@@ -61,6 +70,7 @@ class MockPostgreSQLDatabase(BaseDatabase):
                 self._primary_keys.pop(table, None)
         elif upper.startswith("ALTER TABLE"):
             import re
+
             m = re.search(
                 r'ALTER\s+TABLE\s+"?(\w+)"?\s+ADD\s+COLUMN\s+"?(\w+)"?',
                 sql,
@@ -73,7 +83,10 @@ class MockPostgreSQLDatabase(BaseDatabase):
         elif upper.startswith("CREATE TABLE"):
             from src.database.migration import _extract_columns_from_sql
             import re
-            m = re.search(r'CREATE\s+TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?"?(\w+)"?', sql, re.IGNORECASE)
+
+            m = re.search(
+                r'CREATE\s+TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?"?(\w+)"?', sql, re.IGNORECASE
+            )
             if m:
                 cols = _extract_columns_from_sql(sql)
                 pk = _extract_primary_key_columns(sql)
@@ -84,7 +97,8 @@ class MockPostgreSQLDatabase(BaseDatabase):
                 self._tables[table] = list(cols or [])
                 self._primary_keys[table] = list(pk or [])
 
-    def executemany(self, sql: str, parameters): pass
+    def executemany(self, sql: str, parameters):
+        pass
 
     def fetch_one(self, sql: str, parameters=None) -> Optional[Dict[str, Any]]:
         rows = self.fetch_all(sql, parameters)
@@ -104,9 +118,11 @@ class MockPostgreSQLDatabase(BaseDatabase):
             return [{"name": c} for c in pk]
         return []
 
-    def create_table(self, table_name: str, schema: str): pass
+    def create_table(self, table_name: str, schema: str):
+        pass
 
-    def _execute_raw(self, sql: str, parameters=None): pass
+    def _execute_raw(self, sql: str, parameters=None):
+        pass
 
 
 @pytest.fixture
@@ -122,6 +138,7 @@ def db():
 
 # --- _extract_columns_from_sql tests ---
 
+
 def test_extract_columns_simple():
     sql = """CREATE TABLE IF NOT EXISTS T (
         A INTEGER, B TEXT, C REAL,
@@ -135,6 +152,20 @@ def test_extract_columns_no_pk():
     sql = "CREATE TABLE T (X TEXT, Y INTEGER)"
     cols = _extract_columns_from_sql(sql)
     assert cols == {"X", "Y"}
+
+
+def test_extract_columns_preserves_double_hyphen_inside_quoted_default():
+    sql = """CREATE TABLE T (
+        Note TEXT DEFAULT 'provider,--value', -- provider comment
+        Value INTEGER -- numeric comment
+    )"""
+
+    cols = _extract_columns_from_sql(sql)
+    definitions = _extract_column_definitions(sql)
+
+    assert cols == {"Note", "Value"}
+    assert definitions is not None
+    assert definitions["Note"] == "Note TEXT DEFAULT 'provider,--value'"
 
 
 def test_extract_primary_key_columns():
@@ -206,12 +237,14 @@ def test_migrate_adds_missing_columns_without_dropping(db):
 
     # Verify old columns exist
     info = db.fetch_all("PRAGMA table_info(NL_H1)")
-    old_cols = {r['name'] for r in info}
+    old_cols = {r["name"] for r in info}
     assert "BetType" in old_cols
     assert "Hyo" not in old_cols
 
     # Insert a row into old table
-    db.execute("INSERT INTO NL_H1 (Year, MonthDay, JyoCD, Kaiji, Nichiji, RaceNum, BetType, Kumi) VALUES (2025, 101, '01', 1, 1, 1, 'T', '01')")
+    db.execute(
+        "INSERT INTO NL_H1 (Year, MonthDay, JyoCD, Kaiji, Nichiji, RaceNum, BetType, Kumi) VALUES (2025, 101, '01', 1, 1, 1, 'T', '01')"
+    )
     db.commit()
 
     # Run migration
@@ -220,7 +253,7 @@ def test_migrate_adds_missing_columns_without_dropping(db):
 
     # Verify new columns were added and old columns were preserved.
     info = db.fetch_all("PRAGMA table_info(NL_H1)")
-    new_cols = {r['name'] for r in info}
+    new_cols = {r["name"] for r in info}
     assert "BetType" in new_cols
     assert "Kumi" in new_cols
     assert "Hyo" in new_cols
@@ -230,17 +263,31 @@ def test_migrate_adds_missing_columns_without_dropping(db):
     assert len(rows) == 1
 
 
+def test_migrate_without_commit_stays_in_callers_transaction(db):
+    db.execute(ADDITIVE_OLD_SCHEMA)
+    db.commit()
+
+    assert migrate_table_if_needed(db, "NL_H1", NEW_SCHEMA, commit=False) is True
+    assert "Hyo" in {row["name"] for row in db.fetch_all("PRAGMA table_info(NL_H1)")}
+
+    db.rollback()
+
+    assert "Hyo" not in {row["name"] for row in db.fetch_all("PRAGMA table_info(NL_H1)")}
+
+
 def test_migrate_never_drops_table_on_primary_key_mismatch(db):
     """Production migration paths must never erase existing rows."""
     db.execute(OLD_SCHEMA)
     db.commit()
-    db.execute("INSERT INTO NL_H1 (Year, MonthDay, JyoCD, Kaiji, Nichiji, RaceNum, TanUma) VALUES (2025, 101, '01', 1, 1, 1, 'test')")
+    db.execute(
+        "INSERT INTO NL_H1 (Year, MonthDay, JyoCD, Kaiji, Nichiji, RaceNum, TanUma) VALUES (2025, 101, '01', 1, 1, 1, 'test')"
+    )
     db.commit()
 
     assert migrate_table_if_needed(db, "NL_H1", NEW_SCHEMA) is False
 
     info = db.fetch_all("PRAGMA table_info(NL_H1)")
-    new_cols = {r['name'] for r in info}
+    new_cols = {r["name"] for r in info}
     assert "BetType" not in new_cols
     assert "TanUma" in new_cols
     assert len(db.fetch_all("SELECT * FROM NL_H1")) == 1
@@ -273,7 +320,7 @@ def test_primary_key_mismatch_requires_operator_migration(db):
     assert result is False
 
     info = db.fetch_all("PRAGMA table_info(NL_H1)")
-    cols = {r['name'] for r in info}
+    cols = {r["name"] for r in info}
     assert "BetType" not in cols
 
     with pytest.raises(SchemaMigrationError, match="primary key"):
@@ -289,7 +336,7 @@ def test_inline_primary_key_does_not_create_false_mismatch(db):
     result = migrate_table_if_needed(db, "INLINE_PK", INLINE_NEW_SCHEMA)
     assert result is True
 
-    cols = {r['name'] for r in db.fetch_all("PRAGMA table_info(INLINE_PK)")}
+    cols = {r["name"] for r in db.fetch_all("PRAGMA table_info(INLINE_PK)")}
     assert "Score" in cols
     rows = db.fetch_all("SELECT Id, Name FROM INLINE_PK")
     assert rows == [{"Id": 1, "Name": "keiba"}]
@@ -299,7 +346,9 @@ def test_migrate_no_op_when_schema_matches(db):
     """If schema already matches, no migration should occur."""
     db.execute(NEW_SCHEMA)
     db.commit()
-    db.execute("INSERT INTO NL_H1 (Year, MonthDay, JyoCD, Kaiji, Nichiji, RaceNum, BetType, Kumi) VALUES (2025, 101, '01', 1, 1, 1, 'T', '01')")
+    db.execute(
+        "INSERT INTO NL_H1 (Year, MonthDay, JyoCD, Kaiji, Nichiji, RaceNum, BetType, Kumi) VALUES (2025, 101, '01', 1, 1, 1, 'T', '01')"
+    )
     db.commit()
 
     result = migrate_table_if_needed(db, "NL_H1", NEW_SCHEMA)
@@ -364,13 +413,14 @@ def test_migrate_all_tables_multiple(db):
     assert count == 2
 
     # Verify both tables have new schemas
-    h1_cols = {r['name'] for r in db.fetch_all("PRAGMA table_info(NL_H1)")}
+    h1_cols = {r["name"] for r in db.fetch_all("PRAGMA table_info(NL_H1)")}
     assert "BetType" in h1_cols
-    h6_cols = {r['name'] for r in db.fetch_all("PRAGMA table_info(NL_H6)")}
+    h6_cols = {r["name"] for r in db.fetch_all("PRAGMA table_info(NL_H6)")}
     assert "SanrentanKumi" in h6_cols
 
 
 # --- PostgreSQL path tests (mock DB, no server required) ---
+
 
 @pytest.fixture
 def pg_db():
@@ -444,14 +494,11 @@ def test_dual_migration_uses_each_backends_identifier_rules(db, pg_db):
 
     assert migrate_table_if_needed(dual, "NL_H1", NEW_SCHEMA) is True
 
-    sqlite_columns = {
-        row["name"] for row in db.fetch_all('PRAGMA table_info("NL_H1")')
-    }
+    sqlite_columns = {row["name"] for row in db.fetch_all('PRAGMA table_info("NL_H1")')}
     assert "Hyo" in sqlite_columns
     assert "Hyo" in pg_db._tables["nl_h1"]
     assert any(
-        statement.startswith("ALTER TABLE nl_h1 ADD COLUMN Hyo")
-        for statement in pg_db._executed
+        statement.startswith("ALTER TABLE nl_h1 ADD COLUMN Hyo") for statement in pg_db._executed
     )
     verify_table_schema(dual, "NL_H1", NEW_SCHEMA)
 
@@ -466,8 +513,6 @@ def test_dual_migration_skips_unavailable_best_effort_secondary(db, pg_db):
     assert migrate_table_if_needed(dual, "NL_H1", NEW_SCHEMA) is True
     verify_table_schema(dual, "NL_H1", NEW_SCHEMA)
 
-    sqlite_columns = {
-        row["name"] for row in db.fetch_all('PRAGMA table_info("NL_H1")')
-    }
+    sqlite_columns = {row["name"] for row in db.fetch_all('PRAGMA table_info("NL_H1")')}
     assert "Hyo" in sqlite_columns
     assert "Hyo" not in pg_db._tables["nl_h1"]

--- a/tests/test_se_canonical_contract.py
+++ b/tests/test_se_canonical_contract.py
@@ -55,7 +55,10 @@ def test_se_canonical_units_and_import_schema() -> None:
     )
     parsed = SEParser().parse(raw)
     assert parsed is not None
-    assert sha256(raw).hexdigest() == "d56a31980c3c35663736fd9f6da4098b84a1d2b1ea41450af1ba208972157df7"
+    assert (
+        sha256(raw).hexdigest()
+        == "d56a31980c3c35663736fd9f6da4098b84a1d2b1ea41450af1ba208972157df7"
+    )
     assert parsed["Futan"] == "570"
     assert parsed["BaTaijyu"] == "508"
     assert parsed["Time"] == "1351"
@@ -102,9 +105,7 @@ def test_se_canonical_units_and_import_schema() -> None:
         ("Odds", "----", "OddsMultiplier"),
     ],
 )
-def test_se_canonical_malformed_values_fail_closed(
-    field: str, value: str, canonical: str
-) -> None:
+def test_se_canonical_malformed_values_fail_closed(field: str, value: str, canonical: str) -> None:
     assert canonicalize_se_fields({field: value})[canonical] is None
 
 
@@ -161,11 +162,21 @@ def test_haron_cancellation_sentinel_is_missing() -> None:
     assert parsed["HaronTimeL3Seconds"] is None
 
 
-def test_existing_jravan_table_is_additively_migrated(tmp_path) -> None:
+def test_space_padded_fixed_width_numeric_value_is_canonicalized() -> None:
+    canonical = canonicalize_se_fields({"BaTaijyu": " 57"})
+
+    assert canonical["BaTaijyuKg"] == 57
+
+
+@pytest.mark.parametrize("optimized", [False, True])
+def test_existing_jravan_table_is_additively_migrated(tmp_path, optimized: bool) -> None:
     from src.database.sqlite_handler import SQLiteDatabase
     from src.importer.importer import DataImporter
+    from src.importer.importer_optimized import OptimizedDataImporter
 
-    db = SQLiteDatabase({"path": str(tmp_path / "legacy-jravan.db")})
+    db = SQLiteDatabase({"path": str(tmp_path / f"legacy-jravan-{optimized}.db")})
+    importer_class = OptimizedDataImporter if optimized else DataImporter
+    importer = importer_class(db, use_jravan_schema=True)
     with db:
         db.execute(
             "CREATE TABLE UMA_RACE (Year INTEGER, MonthDay INTEGER, JyoCD TEXT, "
@@ -178,17 +189,126 @@ def test_existing_jravan_table_is_additively_migrated(tmp_path) -> None:
             "(Year, MonthDay, JyoCD, Kaiji, Nichiji, RaceNum, Umaban, DataKubun, Time) "
             "VALUES (2026, 718, '05', 1, 1, 1, 1, '7', '1148')"
         )
-        DataImporter(db, use_jravan_schema=True)
+        stats = importer.import_records(iter([]))
         columns = {row["name"] for row in db.fetch_all('PRAGMA table_info("UMA_RACE")')}
-        migrated = db.fetch_one(
-            "SELECT ParserContractVersion, RaceTimeSeconds FROM UMA_RACE"
-        )
+        migrated = db.fetch_one("SELECT ParserContractVersion, RaceTimeSeconds FROM UMA_RACE")
 
     assert {"ParserContractVersion", "RaceTimeSeconds", "ProviderRaceTimeRaw"} <= columns
+    assert stats["records_imported"] == 0
     # Legacy JRA columns were already numerically normalized by the old
     # importer, so reconstructing fixed-width raw values would be ambiguous.
     # Existing rows remain explicitly unversioned until setup data is reimported.
     assert migrated == {"ParserContractVersion": None, "RaceTimeSeconds": None}
+
+
+@pytest.mark.parametrize("optimized", [False, True])
+def test_jravan_importer_auto_commit_false_keeps_migration_and_row_in_caller_transaction(
+    tmp_path, optimized: bool
+) -> None:
+    from src.database.sqlite_handler import SQLiteDatabase
+    from src.importer.importer import DataImporter
+    from src.importer.importer_optimized import OptimizedDataImporter
+
+    db = SQLiteDatabase({"path": str(tmp_path / f"transaction-{optimized}.db")})
+    importer_class = OptimizedDataImporter if optimized else DataImporter
+    importer = importer_class(db, batch_size=1, use_jravan_schema=True)
+    with db:
+        db.execute(
+            "CREATE TABLE UMA_RACE (Year INTEGER, MonthDay INTEGER, JyoCD TEXT, "
+            "Kaiji INTEGER, Nichiji INTEGER, RaceNum INTEGER, Umaban INTEGER, "
+            "PRIMARY KEY (Year, MonthDay, JyoCD, Kaiji, Nichiji, RaceNum, Umaban))"
+        )
+        db.commit()
+        record = {
+            "RecordSpec": "SE",
+            "Year": "2026",
+            "MonthDay": "0718",
+            "JyoCD": "05",
+            "Kaiji": "1",
+            "Nichiji": "1",
+            "RaceNum": "1",
+            "Umaban": "1",
+        }
+
+        stats = importer.import_records(iter([record]), auto_commit=False)
+        assert stats["records_imported"] == 1
+        assert "ParserContractVersion" in {
+            row["name"] for row in db.fetch_all('PRAGMA table_info("UMA_RACE")')
+        }
+        assert db.fetch_one("SELECT COUNT(*) AS n FROM UMA_RACE")["n"] == 1
+
+        db.rollback()
+
+        assert "ParserContractVersion" not in {
+            row["name"] for row in db.fetch_all('PRAGMA table_info("UMA_RACE")')
+        }
+        assert db.fetch_one("SELECT COUNT(*) AS n FROM UMA_RACE")["n"] == 0
+
+
+def test_jravan_single_record_auto_commit_false_stays_in_caller_transaction(tmp_path) -> None:
+    from src.database.sqlite_handler import SQLiteDatabase
+    from src.importer.importer import DataImporter
+
+    db = SQLiteDatabase({"path": str(tmp_path / "single-transaction.db")})
+    importer = DataImporter(db, use_jravan_schema=True)
+    with db:
+        db.execute(
+            "CREATE TABLE UMA_RACE (Year INTEGER, MonthDay INTEGER, JyoCD TEXT, "
+            "Kaiji INTEGER, Nichiji INTEGER, RaceNum INTEGER, Umaban INTEGER, "
+            "PRIMARY KEY (Year, MonthDay, JyoCD, Kaiji, Nichiji, RaceNum, Umaban))"
+        )
+        db.commit()
+        inserted = importer.import_single_record(
+            {
+                "RecordSpec": "SE",
+                "Year": "2026",
+                "MonthDay": "0718",
+                "JyoCD": "05",
+                "Kaiji": "1",
+                "Nichiji": "1",
+                "RaceNum": "1",
+                "Umaban": "1",
+            },
+            auto_commit=False,
+        )
+        assert inserted is True
+
+        db.rollback()
+
+        assert "ParserContractVersion" not in {
+            row["name"] for row in db.fetch_all('PRAGMA table_info("UMA_RACE")')
+        }
+        assert db.fetch_one("SELECT COUNT(*) AS n FROM UMA_RACE")["n"] == 0
+
+
+def test_optimized_importer_does_not_retry_inside_caller_transaction(tmp_path) -> None:
+    from src.database.sqlite_handler import SQLiteDatabase
+    from src.importer.importer import ImporterError
+    from src.importer.importer_optimized import OptimizedDataImporter
+
+    db = SQLiteDatabase({"path": str(tmp_path / "optimized-failure.db")})
+    with db:
+        db.execute(
+            "CREATE TABLE TX_TEST (RecordSpec TEXT, id INTEGER PRIMARY KEY, "
+            "value TEXT CHECK(value != 'bad'))"
+        )
+        db.commit()
+        importer = OptimizedDataImporter(db, batch_size=2)
+        importer._table_map["TX"] = "TX_TEST"
+        records = iter(
+            [
+                {"RecordSpec": "TX", "id": 1, "value": "a"},
+                {"RecordSpec": "TX", "id": 2, "value": "b"},
+                {"RecordSpec": "TX", "id": 3, "value": "bad"},
+                {"RecordSpec": "TX", "id": 4, "value": "c"},
+            ]
+        )
+
+        with pytest.raises(ImporterError):
+            importer.import_records(records, auto_commit=False)
+        db.rollback()
+
+        assert db.fetch_one("SELECT COUNT(*) AS n FROM TX_TEST")["n"] == 0
 
 
 def test_initial_card_prize_zero_is_missing_but_settled_zero_is_real() -> None:
@@ -256,9 +376,7 @@ def test_optimized_importer_rejects_null_primary_key_after_conversion(tmp_path) 
 
 
 @pytest.mark.parametrize("optimized", [False, True])
-def test_jravan_importers_reject_null_semantic_primary_key(
-    tmp_path, optimized: bool
-) -> None:
+def test_jravan_importers_reject_null_semantic_primary_key(tmp_path, optimized: bool) -> None:
     from src.database.sqlite_handler import SQLiteDatabase
     from src.importer.importer import DataImporter
     from src.importer.importer_optimized import OptimizedDataImporter


### PR DESCRIPTION
Release the merged canonical JRA SE parser contract as v1.6.8. Raw fixed-width fields remain unchanged; canonical numeric fields and migrations are additive. Targeted parser/import tests: 43 passed. Full suite: 1442 passed with two order-dependent CLI tests that pass in isolated rerun; no canonical-contract failures.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added canonical numeric JRA SE columns for race time, final 3F, body weight, weight change, finish position, and horse number.
  - Existing official raw fixed-width values are preserved for reference.
  - Added safe, additive database migrations for SQLite and PostgreSQL with schema and record validation.
- **Release**
  - Updated the package to version 1.6.8.
  - Added documentation covering the new data fields and migration behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->