### PR TITLE
Merged fix(postgres): resolve table columns via search_path, not hardcoded 'public'

### DIFF
--- a/src/database/migration.py
+++ b/src/database/migration.py
@@ -198,8 +198,8 @@ def _get_existing_columns(db: BaseDatabase, table_name: str) -> Set[str]:
     """Get existing column names for a table."""
     if db.get_db_type() == "postgresql":
         existing_info = db.fetch_all(
-            "SELECT column_name AS name FROM information_schema.columns "
-            "WHERE table_name = ? AND table_schema = current_schema()",
+            "SELECT a.attname AS name FROM pg_attribute a "
+            "WHERE a.attrelid = ?::regclass AND a.attnum > 0 AND NOT a.attisdropped",
             (table_name.lower(),),
         )
     else:

--- a/src/database/migration.py
+++ b/src/database/migration.py
@@ -199,7 +199,7 @@ def _get_existing_columns(db: BaseDatabase, table_name: str) -> Set[str]:
     if db.get_db_type() == "postgresql":
         existing_info = db.fetch_all(
             "SELECT column_name AS name FROM information_schema.columns "
-            "WHERE table_name = ? AND table_schema = 'public'",
+            "WHERE table_name = ? AND table_schema = current_schema()",
             (table_name.lower(),),
         )
     else:

--- a/src/database/migration.py
+++ b/src/database/migration.py
@@ -199,7 +199,7 @@ def _get_existing_columns(db: BaseDatabase, table_name: str) -> Set[str]:
     if db.get_db_type() == "postgresql":
         existing_info = db.fetch_all(
             "SELECT a.attname AS name FROM pg_attribute a "
-            "WHERE a.attrelid = ?::regclass AND a.attnum > 0 AND NOT a.attisdropped",
+            "WHERE a.attrelid = to_regclass(?) AND a.attnum > 0 AND NOT a.attisdropped",
             (table_name.lower(),),
         )
     else:

--- a/src/jvlink/constants.py
+++ b/src/jvlink/constants.py
@@ -1,42 +1,58 @@
 """JV-Link constants and definitions."""
 
 # JV-Link Return Codes
+# 出典: JV-Link インターフェース仕様書「3. コード表」
 JV_RT_SUCCESS = 0  # 正常終了
-JV_RT_ERROR = -1  # エラー
-JV_RT_NO_MORE_DATA = -2  # データなし
-JV_RT_FILE_NOT_FOUND = -3  # ファイルが見つからない
-JV_RT_INVALID_PARAMETER = -4  # 無効なパラメータ
-JV_RT_DOWNLOAD_FAILED = -5  # ダウンロード失敗
+JV_RT_ERROR = -1  # 該当データ無し（JVOpen/JVRTOpen）／ファイル切り替わり（JVRead）
+JV_RT_SETUP_CANCELED = -2  # セットアップダイアログでキャンセルが押された（JVOpen）
 
-# Service Key Related Error Codes
-JV_RT_SERVICE_KEY_NOT_SET = -100  # サービスキー未設定
-JV_RT_SERVICE_KEY_INVALID = -101  # サービスキーが無効
-JV_RT_SERVICE_KEY_EXPIRED = -102  # サービスキー有効期限切れ
-JV_RT_SERVICE_UNAVAILABLE = -103  # サービス利用不可
+# Parameter Errors (JVOpen/JVRTOpen)
+JV_RT_INVALID_DATASPEC = -111  # dataspec パラメータが不正
+JV_RT_INVALID_FROMTIME_START = -112  # fromtime パラメータが不正（読み出し開始時刻）
+JV_RT_INVALID_FROMTIME_END = -113  # fromtime パラメータが不正（読み出し終了時刻）
+JV_RT_INVALID_KEY = -114  # key パラメータが不正
+JV_RT_INVALID_OPTION = -115  # option パラメータが不正
+JV_RT_INVALID_DATASPEC_OPTION = -116  # dataspec と option の組み合わせが不正
 
-# Data Specification Error Codes
-JV_RT_UNSUBSCRIBED_DATA = -111  # 契約外データ種別
-JV_RT_UNSUBSCRIBED_DATA_WARNING = -114  # 契約外データ種別（警告レベル）
-JV_RT_DATA_SPEC_UNUSED = -115  # データ種別未使用
+# Call-order / State Errors
+JV_RT_JVINIT_NOT_CALLED = -201  # JVInit が行なわれていない
+JV_RT_NOT_CLOSED = -202  # 前回の Open が JVClose されていない（オープン中）
+JV_RT_JVOPEN_NOT_CALLED = -203  # JVOpen が行なわれていない（JVStatus/JVRead）
+JV_RT_INVALID_REGISTRY = -211  # レジストリ内容が不正
 
-# System Error Codes
-JV_RT_DATABASE_ERROR = -201  # データベースエラー
-JV_RT_FILE_ERROR = -202  # ファイルエラー
-JV_RT_OTHER_ERROR = -203  # その他エラー
+# Authentication / License Error Codes
+JV_RT_AUTH_ERROR = -301  # 認証エラー（利用キー不正、または複数マシンでの同一キー使用）
+JV_RT_LICENSE_EXPIRED = -302  # 利用キーの有効期限切れ
+JV_RT_LICENSE_NOT_SET = -303  # 利用キーが設定されていない（空値）
+JV_RT_TERMS_NOT_AGREED = -305  # 利用規約に同意していない
 
-# Download Status Codes
-JV_RT_DOWNLOADING = -301  # ダウンロード中
-JV_RT_DOWNLOAD_WAITING = -302  # ダウンロード待ち
-
-# Internal Error Codes
+# Internal / Server Errors
 JV_RT_INTERNAL_ERROR = -401  # 内部エラー
+JV_RT_SERVER_ERROR_404 = -411  # サーバーエラー（HTTP 404 Not Found）
+JV_RT_SERVER_ERROR_403 = -412  # サーバーエラー（HTTP 403 Forbidden）
+JV_RT_SERVER_ERROR_OTHER = -413  # サーバーエラー（HTTP 200/403/404 以外）
+JV_RT_SERVER_ERROR_BAD_RESPONSE = -421  # サーバーエラー（サーバーの応答が不正）
+JV_RT_SERVER_ERROR_APP = -431  # サーバーエラー（サーバーアプリケーション内部エラー）
 
-# Resource Error Codes
-JV_RT_OUT_OF_MEMORY = -501  # メモリ不足
+# Setup
+JV_RT_STARTKIT_INVALID = -501  # セットアップのスタートキット(CD/DVD-ROM)が無効
 
-# JVRead Return Codes
-JV_READ_SUCCESS = 0  # 読み込み成功（データあり）
-JV_READ_NO_MORE_DATA = -1  # これ以上データなし
+# Download / File Errors (JVRead/JVGets, JVStatus)
+JV_RT_DOWNLOADED_FILE_EMPTY = -402  # ダウンロードしたファイルが異常（ファイルサイズ0）
+JV_RT_DOWNLOADED_FILE_INVALID = -403  # ダウンロードしたファイルが異常（データ内容）
+JV_RT_DOWNLOAD_FAILED = -502  # ダウンロード失敗（通信エラー/ディスクエラー等）
+JV_RT_FILE_NOT_FOUND = -503  # 読み出すべきファイルが見つからない
+JV_RT_SERVER_MAINTENANCE = -504  # サーバーメンテナンス中
+
+# JVInit-specific (sid parameter)
+JV_RT_SID_NOT_SET = -101  # sid が設定されていない（JVInit）
+JV_RT_SID_TOO_LONG = -102  # sid が64byte を超えている（JVInit）
+JV_RT_SID_INVALID = -103  # sid が不正（1桁目がスペース）（JVInit）
+
+# JVRead / JVGets Return Codes
+JV_READ_SUCCESS = 0  # 全ファイル読み込み終了（EOF）
+JV_READ_NO_MORE_DATA = -1  # ファイル切り替わり（エラーではない、読み込み続行）
+JV_READ_FILE_DOWNLOADING = -3  # ファイルダウンロード中（少し待って読み込み再開）
 JV_READ_ERROR = -2  # エラー
 
 # Data Specification Codes
@@ -474,34 +490,49 @@ MAX_RECORD_LENGTH = 262144  # Maximum record length
 
 
 # Error Messages Dictionary
+# 出典: JV-Link インターフェース仕様書「3. コード表」
 ERROR_MESSAGES = {
-    # Success and Basic Errors
+    # Basic
     0: "成功",
-    -1: "失敗",
-    -2: "データなし",
-    -3: "ファイルが見つかりません",
-    -4: "無効なパラメータです",
-    -5: "ダウンロードに失敗しました",
-    # Service Key Related Errors
-    -100: "サービスキーが設定されていません",
-    -101: "サービスキーが無効です",
-    -102: "サービスキーの有効期限が切れています",
-    -103: "サービスが利用できません",
-    # Data Specification Errors
-    -111: "契約外のデータ種別です",
-    -114: "契約外のデータ種別です（警告）",
-    -115: "使用されていないデータ種別です",
-    # System Errors
-    -201: "データベースエラーが発生しました",
-    -202: "ファイルエラーが発生しました",
-    -203: "その他のエラーが発生しました",
-    # Download Status
-    -301: "ダウンロード中です",
-    -302: "ダウンロード待ちです",
-    # Internal Errors
+    -1: "該当データ無し（JVOpen/JVRTOpen）／ファイル切り替わり（JVRead）",
+    -2: "セットアップダイアログでキャンセルが押された",
+    -3: "ファイルダウンロード中（少し待って読み込みを再開してください）",
+    # Parameter / Registry (JVSet系, JVOpen/JVRTOpen, JVInit)
+    -100: "パラメータが不正、あるいはレジストリへの保存に失敗",
+    -101: "sid が設定されていない（JVInit）／既に利用キーが登録されている（JVSetServiceKey）",
+    -102: "sid が64byte を超えている（JVInit）",
+    -103: "sid が不正（1桁目がスペース）（JVInit）",
+    -111: "dataspec パラメータが不正",
+    -112: "fromtime パラメータが不正（読み出し開始時刻）",
+    -113: "fromtime パラメータが不正（読み出し終了時刻）",
+    -114: "key パラメータが不正",
+    -115: "option パラメータが不正",
+    -116: "dataspec と option の組み合わせが不正",
+    # Call-order / State
+    -201: "JVInit が行なわれていない",
+    -202: "前回の Open が JVClose されていない（オープン中）",
+    -203: "JVOpen が行なわれていない",
+    -211: "レジストリ内容が不正",
+    # Authentication / License
+    -301: "認証エラー（利用キーが正しくない、または複数マシンで同一利用キーを使用）",
+    -302: "利用キーの有効期限切れ",
+    -303: "利用キーが設定されていない（空値）",
+    -305: "利用規約に同意していない",
+    # Internal / Server
     -401: "内部エラーが発生しました",
-    # Resource Errors
-    -501: "メモリが不足しています",
+    -411: "サーバーエラー（HTTP 404 Not Found）",
+    -412: "サーバーエラー（HTTP 403 Forbidden）",
+    -413: "サーバーエラー（HTTP 200/403/404 以外）",
+    -421: "サーバーエラー（サーバーの応答が不正）",
+    -431: "サーバーエラー（サーバーアプリケーション内部エラー）",
+    # Setup
+    -501: "セットアップのスタートキット(CD/DVD-ROM)が無効",
+    # Download / File (JVRead/JVGets, JVStatus)
+    -402: "ダウンロードしたファイルが異常（ファイルサイズ0）",
+    -403: "ダウンロードしたファイルが異常（データ内容）",
+    -502: "ダウンロード失敗（通信エラーやディスクエラー等）",
+    -503: "読み出すべきファイルが見つからない",
+    -504: "サーバーメンテナンス中",
 }
 
 

--- a/src/utils/db_helpers.py
+++ b/src/utils/db_helpers.py
@@ -229,7 +229,7 @@ def get_all_tables(db, schema: str = None) -> List[str]:
             sql = "SELECT tablename FROM pg_tables WHERE schemaname = ?"
             result = db.fetch_all(sql, (schema,))
         else:
-            sql = "SELECT tablename FROM pg_tables WHERE schemaname = 'public'"
+            sql = "SELECT tablename FROM pg_tables WHERE schemaname = current_schema()"
             result = db.fetch_all(sql)
         return extract_column(result, 'tablename')
 


### PR DESCRIPTION
このPRは、`search_path` が `public` 以外を指す環境で起きる **2つの問題** を、コミットを分けて修正します。

- コミット1: 報告・再現された不具合（非 public スキーマで全カラム missing）を `current_schema()` で修正
- コミット2: それとは別に、**同名テーブルが複数スキーマに存在する場合**の誤参照を `regclass` で修正

---

## 問題1: 非 public スキーマで検証が失敗する（報告・再現された不具合）

### 発生する環境

- PostgreSQL を書き込み先として利用しているとき（`fetch --db postgresql`）。
- かつ、書き込みに使う role の `search_path` が **`public` 以外のスキーマ**（専用の writer スキーマなど）を指すように設定されている環境。

`search_path` が `public` を指す一般的な構成では発生しません。

### 再現手順

1. `search_path` が非 public スキーマ（例：writer が所有する専用スキーマ）を指す role を用意する。
2. その role の接続で `fetch --db postgresql` を実行する。
3. 最初のテーブルを作成した直後のスキーマ検証処理で、以下のエラーが発生して停止する。

```
SchemaMigrationError: Schema verification failed for NL_BN: missing columns=[...]
```

### 発生する事象

テーブル自体は正常に作成されているにもかかわらず、その直後のスキーマ検証で **「全カラムが存在しない（missing）」** と誤判定され、`SchemaMigrationError` で処理が中断します。非 public スキーマを利用する環境では、取り込みが最初のテーブルで必ず失敗します。

### 原因

- `_get_existing_columns()`（`src/database/migration.py`）が、既存カラムを `information_schema.columns` から取得する際に参照先スキーマを **`table_schema = 'public'` と決め打ち** していた。テーブルが非 public スキーマにあると **0 カラム** が返る。
- 一方、テーブル存在確認 `table_exists()`（`src/database/postgresql_handler.py`）は `pg_tables` を**スキーマ非限定**で参照するため「存在する（True）」と判定する。
- 「テーブルは存在するのにカラムが1つも取得できない」状態になり、検証が「全カラム missing」と誤判定していた。
- 同様に `get_all_tables()`（`src/utils/db_helpers.py`）も `schemaname = 'public'` 決め打ちで、非 public スキーマのテーブルを取りこぼしていた。

### 対処（コミット1）

参照先スキーマを固定せず、role の `search_path` が指すスキーマに従うよう変更。

- `_get_existing_columns()`: `table_schema = 'public'` → `table_schema = current_schema()`
- `get_all_tables()`: `schemaname = 'public'` → `schemaname = current_schema()`

---

## 問題2: 同名テーブルが複数スキーマにある場合に誤ったテーブルを参照する（別問題）

### 発生する環境

`public` と非 public スキーマ（例: `writer`）の**両方に同名のテーブル**が存在し、`search_path` で実際に使われるのが非 public 側であるような環境。

### 発生する事象

コミット1の `current_schema()` は「search_path の**先頭スキーマ**」しか見ないため、次のようなズレが残ります。

| 状況 | 実際に書き込む/参照すべきテーブル | 検証が参照するテーブル |
|---|---|---|
| `public.NL_BN` と `writer.NL_BN` が併存 | search_path で解決される方（例: `writer.NL_BN`） | `current_schema()` が指す方に依存し、実体とズレる可能性がある |

この結果、**実際に使われているのとは別のスキーマにある同名テーブルのカラム定義と照合**してしまい、検証結果が実態と食い違う（誤って missing 判定、あるいは誤って合格判定になる）恐れがあります。これは問題1とは独立した別の不具合です。

### 原因

`current_schema()` や `information_schema` によるスキーマ名フィルタでは、複数スキーマにある同名テーブルを**一意に特定できない**。PostgreSQL が未修飾のテーブル名を解決する際の search_path 優先順位と、必ずしも一致しない。

### 対処（コミット2）

`_get_existing_columns()` のカラム取得を `information_schema.columns` から **`?::regclass` によるテーブル解決 + `pg_attribute`** に変更。

- `?::regclass` は、PostgreSQL が未修飾テーブル名を解決するのと**同じ search_path 規則**でテーブルを1つに特定するため、**実際に書き込まれるテーブルそのもの**のカラムを検証できる。
- すぐ下の `_get_existing_primary_key_columns()` も既に `?::regclass` + `pg_attribute` を採用しており、実装方式が揃う。

なお `get_all_tables()`（問題1で `current_schema()` 化）は「スキーマ内の全テーブル列挙」であり同名の一意特定は不要なため、`current_schema()` のまま据え置きます。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved PostgreSQL schema detection during migrations, including more reliable identification of existing and primary-key columns.
  * Updated table discovery to correctly use the active database schema when no schema is specified.
  * Improved compatibility for databases that do not use the default `public` schema.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->