### PR TITLE
fix(postgres,jvlink): resolve remaining PR #143/#144 review feedback

### DIFF
--- a/src/database/migration.py
+++ b/src/database/migration.py
@@ -198,8 +198,8 @@ def _get_existing_columns(db: BaseDatabase, table_name: str) -> Set[str]:
     """Get existing column names for a table."""
     if db.get_db_type() == "postgresql":
         existing_info = db.fetch_all(
-            "SELECT column_name AS name FROM information_schema.columns "
-            "WHERE table_name = ? AND table_schema = current_schema()",
+            "SELECT a.attname AS name FROM pg_attribute a "
+            "WHERE a.attrelid = ?::regclass AND a.attnum > 0 AND NOT a.attisdropped",
             (table_name.lower(),),
         )
     else:

--- a/src/database/migration.py
+++ b/src/database/migration.py
@@ -199,7 +199,7 @@ def _get_existing_columns(db: BaseDatabase, table_name: str) -> Set[str]:
     if db.get_db_type() == "postgresql":
         existing_info = db.fetch_all(
             "SELECT column_name AS name FROM information_schema.columns "
-            "WHERE table_name = ? AND table_schema = 'public'",
+            "WHERE table_name = ? AND table_schema = current_schema()",
             (table_name.lower(),),
         )
     else:

--- a/src/database/migration.py
+++ b/src/database/migration.py
@@ -215,7 +215,7 @@ def _get_existing_primary_key_columns(db: BaseDatabase, table_name: str) -> List
             SELECT a.attname AS name
             FROM pg_index i
             JOIN pg_attribute a ON a.attrelid = i.indrelid AND a.attnum = ANY(i.indkey)
-            WHERE i.indrelid = ?::regclass
+            WHERE i.indrelid = to_regclass(?)
             AND i.indisprimary
             ORDER BY array_position(i.indkey, a.attnum)
             """,

--- a/src/database/migration.py
+++ b/src/database/migration.py
@@ -199,7 +199,7 @@ def _get_existing_columns(db: BaseDatabase, table_name: str) -> Set[str]:
     if db.get_db_type() == "postgresql":
         existing_info = db.fetch_all(
             "SELECT a.attname AS name FROM pg_attribute a "
-            "WHERE a.attrelid = ?::regclass AND a.attnum > 0 AND NOT a.attisdropped",
+            "WHERE a.attrelid = to_regclass(?) AND a.attnum > 0 AND NOT a.attisdropped",
             (table_name.lower(),),
         )
     else:

--- a/src/database/postgresql_handler.py
+++ b/src/database/postgresql_handler.py
@@ -108,7 +108,7 @@ class PostgreSQLDatabase(BaseDatabase):
                 SELECT a.attname
                 FROM pg_index i
                 JOIN pg_attribute a ON a.attrelid = i.indrelid AND a.attnum = ANY(i.indkey)
-                WHERE i.indrelid = ?::regclass
+                WHERE i.indrelid = to_regclass(?)
                 AND i.indisprimary
                 ORDER BY array_position(i.indkey, a.attnum)
             """
@@ -431,7 +431,17 @@ class PostgreSQLDatabase(BaseDatabase):
             raise
 
     def table_exists(self, table_name: str) -> bool:
-        """Check if table exists.
+        """Check if table exists and is visible in the current search_path.
+
+        Uses to_regclass(), the same search_path resolution PostgreSQL applies
+        to an unqualified table reference, so this agrees with the
+        migration/column-existence checks (_get_existing_columns,
+        _get_primary_key_columns) that also resolve via to_regclass(). A plain
+        `pg_tables WHERE tablename = ?` scan (the prior implementation) is
+        schema-unqualified: it returns True for a same-named table that exists
+        only in a schema outside search_path, which then makes those
+        to_regclass()-based checks resolve to NULL/no rows for a table this
+        method claimed exists.
 
         Args:
             table_name: Name of table to check
@@ -440,13 +450,12 @@ class PostgreSQLDatabase(BaseDatabase):
             True if table exists, False otherwise
         """
         try:
-            sql = """
-                SELECT tablename
-                FROM pg_tables
-                WHERE tablename = ?
-            """
+            sql = "SELECT to_regclass(?) AS oid"
             row = self.fetch_one(sql, (table_name.lower(),))
-            return row is not None
+            if row is None:
+                return False
+            oid = row.get("oid") if isinstance(row, dict) else row[0]
+            return oid is not None
 
         except DatabaseError:
             return False

--- a/src/jvlink/constants.py
+++ b/src/jvlink/constants.py
@@ -1,42 +1,58 @@
 """JV-Link constants and definitions."""
 
 # JV-Link Return Codes
+# 出典: JV-Link インターフェース仕様書「3. コード表」
 JV_RT_SUCCESS = 0  # 正常終了
-JV_RT_ERROR = -1  # エラー
-JV_RT_NO_MORE_DATA = -2  # データなし
-JV_RT_FILE_NOT_FOUND = -3  # ファイルが見つからない
-JV_RT_INVALID_PARAMETER = -4  # 無効なパラメータ
-JV_RT_DOWNLOAD_FAILED = -5  # ダウンロード失敗
+JV_RT_ERROR = -1  # 該当データ無し（JVOpen/JVRTOpen）／ファイル切り替わり（JVRead）
+JV_RT_SETUP_CANCELED = -2  # セットアップダイアログでキャンセルが押された（JVOpen）
 
-# Service Key Related Error Codes
-JV_RT_SERVICE_KEY_NOT_SET = -100  # サービスキー未設定
-JV_RT_SERVICE_KEY_INVALID = -101  # サービスキーが無効
-JV_RT_SERVICE_KEY_EXPIRED = -102  # サービスキー有効期限切れ
-JV_RT_SERVICE_UNAVAILABLE = -103  # サービス利用不可
+# Parameter Errors (JVOpen/JVRTOpen)
+JV_RT_INVALID_DATASPEC = -111  # dataspec パラメータが不正
+JV_RT_INVALID_FROMTIME_START = -112  # fromtime パラメータが不正（読み出し開始時刻）
+JV_RT_INVALID_FROMTIME_END = -113  # fromtime パラメータが不正（読み出し終了時刻）
+JV_RT_INVALID_KEY = -114  # key パラメータが不正
+JV_RT_INVALID_OPTION = -115  # option パラメータが不正
+JV_RT_INVALID_DATASPEC_OPTION = -116  # dataspec と option の組み合わせが不正
 
-# Data Specification Error Codes
-JV_RT_UNSUBSCRIBED_DATA = -111  # 契約外データ種別
-JV_RT_UNSUBSCRIBED_DATA_WARNING = -114  # 契約外データ種別（警告レベル）
-JV_RT_DATA_SPEC_UNUSED = -115  # データ種別未使用
+# Call-order / State Errors
+JV_RT_JVINIT_NOT_CALLED = -201  # JVInit が行なわれていない
+JV_RT_NOT_CLOSED = -202  # 前回の Open が JVClose されていない（オープン中）
+JV_RT_JVOPEN_NOT_CALLED = -203  # JVOpen が行なわれていない（JVStatus/JVRead）
+JV_RT_INVALID_REGISTRY = -211  # レジストリ内容が不正
 
-# System Error Codes
-JV_RT_DATABASE_ERROR = -201  # データベースエラー
-JV_RT_FILE_ERROR = -202  # ファイルエラー
-JV_RT_OTHER_ERROR = -203  # その他エラー
+# Authentication / License Error Codes
+JV_RT_AUTH_ERROR = -301  # 認証エラー（利用キー不正、または複数マシンでの同一キー使用）
+JV_RT_LICENSE_EXPIRED = -302  # 利用キーの有効期限切れ
+JV_RT_LICENSE_NOT_SET = -303  # 利用キーが設定されていない（空値）
+JV_RT_TERMS_NOT_AGREED = -305  # 利用規約に同意していない
 
-# Download Status Codes
-JV_RT_DOWNLOADING = -301  # ダウンロード中
-JV_RT_DOWNLOAD_WAITING = -302  # ダウンロード待ち
-
-# Internal Error Codes
+# Internal / Server Errors
 JV_RT_INTERNAL_ERROR = -401  # 内部エラー
+JV_RT_SERVER_ERROR_404 = -411  # サーバーエラー（HTTP 404 Not Found）
+JV_RT_SERVER_ERROR_403 = -412  # サーバーエラー（HTTP 403 Forbidden）
+JV_RT_SERVER_ERROR_OTHER = -413  # サーバーエラー（HTTP 200/403/404 以外）
+JV_RT_SERVER_ERROR_BAD_RESPONSE = -421  # サーバーエラー（サーバーの応答が不正）
+JV_RT_SERVER_ERROR_APP = -431  # サーバーエラー（サーバーアプリケーション内部エラー）
 
-# Resource Error Codes
-JV_RT_OUT_OF_MEMORY = -501  # メモリ不足
+# Setup
+JV_RT_STARTKIT_INVALID = -501  # セットアップのスタートキット(CD/DVD-ROM)が無効
 
-# JVRead Return Codes
-JV_READ_SUCCESS = 0  # 読み込み成功（データあり）
-JV_READ_NO_MORE_DATA = -1  # これ以上データなし
+# Download / File Errors (JVRead/JVGets, JVStatus)
+JV_RT_DOWNLOADED_FILE_EMPTY = -402  # ダウンロードしたファイルが異常（ファイルサイズ0）
+JV_RT_DOWNLOADED_FILE_INVALID = -403  # ダウンロードしたファイルが異常（データ内容）
+JV_RT_DOWNLOAD_FAILED = -502  # ダウンロード失敗（通信エラー/ディスクエラー等）
+JV_RT_FILE_NOT_FOUND = -503  # 読み出すべきファイルが見つからない
+JV_RT_SERVER_MAINTENANCE = -504  # サーバーメンテナンス中
+
+# JVInit-specific (sid parameter)
+JV_RT_SID_NOT_SET = -101  # sid が設定されていない（JVInit）
+JV_RT_SID_TOO_LONG = -102  # sid が64byte を超えている（JVInit）
+JV_RT_SID_INVALID = -103  # sid が不正（1桁目がスペース）（JVInit）
+
+# JVRead / JVGets Return Codes
+JV_READ_SUCCESS = 0  # 全ファイル読み込み終了（EOF）
+JV_READ_NO_MORE_DATA = -1  # ファイル切り替わり（エラーではない、読み込み続行）
+JV_READ_FILE_DOWNLOADING = -3  # ファイルダウンロード中（少し待って読み込み再開）
 JV_READ_ERROR = -2  # エラー
 
 # Data Specification Codes
@@ -474,34 +490,49 @@ MAX_RECORD_LENGTH = 262144  # Maximum record length
 
 
 # Error Messages Dictionary
+# 出典: JV-Link インターフェース仕様書「3. コード表」
 ERROR_MESSAGES = {
-    # Success and Basic Errors
+    # Basic
     0: "成功",
-    -1: "失敗",
-    -2: "データなし",
-    -3: "ファイルが見つかりません",
-    -4: "無効なパラメータです",
-    -5: "ダウンロードに失敗しました",
-    # Service Key Related Errors
-    -100: "サービスキーが設定されていません",
-    -101: "サービスキーが無効です",
-    -102: "サービスキーの有効期限が切れています",
-    -103: "サービスが利用できません",
-    # Data Specification Errors
-    -111: "契約外のデータ種別です",
-    -114: "契約外のデータ種別です（警告）",
-    -115: "使用されていないデータ種別です",
-    # System Errors
-    -201: "データベースエラーが発生しました",
-    -202: "ファイルエラーが発生しました",
-    -203: "その他のエラーが発生しました",
-    # Download Status
-    -301: "ダウンロード中です",
-    -302: "ダウンロード待ちです",
-    # Internal Errors
+    -1: "該当データ無し（JVOpen/JVRTOpen）／ファイル切り替わり（JVRead）",
+    -2: "セットアップダイアログでキャンセルが押された",
+    -3: "ファイルダウンロード中（少し待って読み込みを再開してください）",
+    # Parameter / Registry (JVSet系, JVOpen/JVRTOpen, JVInit)
+    -100: "パラメータが不正、あるいはレジストリへの保存に失敗",
+    -101: "sid が設定されていない（JVInit）／既に利用キーが登録されている（JVSetServiceKey）",
+    -102: "sid が64byte を超えている（JVInit）",
+    -103: "sid が不正（1桁目がスペース）（JVInit）",
+    -111: "dataspec パラメータが不正",
+    -112: "fromtime パラメータが不正（読み出し開始時刻）",
+    -113: "fromtime パラメータが不正（読み出し終了時刻）",
+    -114: "key パラメータが不正",
+    -115: "option パラメータが不正",
+    -116: "dataspec と option の組み合わせが不正",
+    # Call-order / State
+    -201: "JVInit が行なわれていない",
+    -202: "前回の Open が JVClose されていない（オープン中）",
+    -203: "JVOpen が行なわれていない",
+    -211: "レジストリ内容が不正",
+    # Authentication / License
+    -301: "認証エラー（利用キーが正しくない、または複数マシンで同一利用キーを使用）",
+    -302: "利用キーの有効期限切れ",
+    -303: "利用キーが設定されていない（空値）",
+    -305: "利用規約に同意していない",
+    # Internal / Server
     -401: "内部エラーが発生しました",
-    # Resource Errors
-    -501: "メモリが不足しています",
+    -411: "サーバーエラー（HTTP 404 Not Found）",
+    -412: "サーバーエラー（HTTP 403 Forbidden）",
+    -413: "サーバーエラー（HTTP 200/403/404 以外）",
+    -421: "サーバーエラー（サーバーの応答が不正）",
+    -431: "サーバーエラー（サーバーアプリケーション内部エラー）",
+    # Setup
+    -501: "セットアップのスタートキット(CD/DVD-ROM)が無効",
+    # Download / File (JVRead/JVGets, JVStatus)
+    -402: "ダウンロードしたファイルが異常（ファイルサイズ0）",
+    -403: "ダウンロードしたファイルが異常（データ内容）",
+    -502: "ダウンロード失敗（通信エラーやディスクエラー等）",
+    -503: "読み出すべきファイルが見つからない",
+    -504: "サーバーメンテナンス中",
 }
 
 

--- a/src/jvlink/constants.py
+++ b/src/jvlink/constants.py
@@ -4,14 +4,22 @@
 # 出典: JV-Link インターフェース仕様書「3. コード表」
 JV_RT_SUCCESS = 0  # 正常終了
 JV_RT_ERROR = -1  # 該当データ無し（JVOpen/JVRTOpen）／ファイル切り替わり（JVRead）
-JV_RT_SETUP_CANCELED = -2  # セットアップダイアログでキャンセルが押された（JVOpen）
+JV_RT_SETUP_CANCELED = -2  # セットアップダイアログでキャンセルが押された（JVOpen）／エラー（JVRead、JV_READ_ERRORと同値）
 
 # Parameter Errors (JVOpen/JVRTOpen)
-JV_RT_INVALID_DATASPEC = -111  # dataspec パラメータが不正
+#
+# 注意: -111/-114/-115 は公式仕様上はパラメータ不正だが、実運用では
+# 未購読のデータ種別（例: MING）を指定した際にも同じコードが返ることを
+# 確認している（bf69cb6 参照）。呼び出し側の scripts/*.py・
+# src/services/realtime_monitor.py の SUBSCRIPTION_ERROR_CODES は、この
+# 実運用挙動に基づき意図的にこれらのコードを「契約外/未購読につき
+# スキップ」として扱っており、公式仕様の文言だけを見て変更しないこと。
+JV_RT_INVALID_PARAMETER = -100  # パラメータが不正、あるいはレジストリへの保存に失敗
+JV_RT_INVALID_DATASPEC = -111  # dataspec パラメータが不正（実運用では未購読データ種別のエラーとしても観測）
 JV_RT_INVALID_FROMTIME_START = -112  # fromtime パラメータが不正（読み出し開始時刻）
 JV_RT_INVALID_FROMTIME_END = -113  # fromtime パラメータが不正（読み出し終了時刻）
-JV_RT_INVALID_KEY = -114  # key パラメータが不正
-JV_RT_INVALID_OPTION = -115  # option パラメータが不正
+JV_RT_INVALID_KEY = -114  # key パラメータが不正（実運用では未購読データ種別のエラーとしても観測）
+JV_RT_INVALID_OPTION = -115  # option パラメータが不正（実運用では未購読データ種別のエラーとしても観測）
 JV_RT_INVALID_DATASPEC_OPTION = -116  # dataspec と option の組み合わせが不正
 
 # Call-order / State Errors
@@ -495,18 +503,18 @@ ERROR_MESSAGES = {
     # Basic
     0: "成功",
     -1: "該当データ無し（JVOpen/JVRTOpen）／ファイル切り替わり（JVRead）",
-    -2: "セットアップダイアログでキャンセルが押された",
+    -2: "セットアップダイアログでキャンセルが押された（JVOpen）／エラー（JVRead）",
     -3: "ファイルダウンロード中（少し待って読み込みを再開してください）",
     # Parameter / Registry (JVSet系, JVOpen/JVRTOpen, JVInit)
     -100: "パラメータが不正、あるいはレジストリへの保存に失敗",
     -101: "sid が設定されていない（JVInit）／既に利用キーが登録されている（JVSetServiceKey）",
     -102: "sid が64byte を超えている（JVInit）",
     -103: "sid が不正（1桁目がスペース）（JVInit）",
-    -111: "dataspec パラメータが不正",
+    -111: "dataspec パラメータが不正（実運用では未購読データ種別のエラーとしても観測）",
     -112: "fromtime パラメータが不正（読み出し開始時刻）",
     -113: "fromtime パラメータが不正（読み出し終了時刻）",
-    -114: "key パラメータが不正",
-    -115: "option パラメータが不正",
+    -114: "key パラメータが不正（実運用では未購読データ種別のエラーとしても観測）",
+    -115: "option パラメータが不正（実運用では未購読データ種別のエラーとしても観測）",
     -116: "dataspec と option の組み合わせが不正",
     # Call-order / State
     -201: "JVInit が行なわれていない",

--- a/src/utils/db_helpers.py
+++ b/src/utils/db_helpers.py
@@ -229,7 +229,7 @@ def get_all_tables(db, schema: str = None) -> List[str]:
             sql = "SELECT tablename FROM pg_tables WHERE schemaname = ?"
             result = db.fetch_all(sql, (schema,))
         else:
-            sql = "SELECT tablename FROM pg_tables WHERE schemaname = 'public'"
+            sql = "SELECT tablename FROM pg_tables WHERE schemaname = current_schema()"
             result = db.fetch_all(sql)
         return extract_column(result, 'tablename')
 

--- a/tests/test_jvlink_constants.py
+++ b/tests/test_jvlink_constants.py
@@ -1,0 +1,67 @@
+"""Tests for JV-Link return code constants and error messages.
+
+Regression coverage for PR #144 review follow-ups:
+- -100 lacked a named constant despite being referenced in ERROR_MESSAGES
+  and in comments in src/jvlink/wrapper.py (CodeRabbit).
+- -2 means "setup dialog canceled" for JVOpen but "error" for JVRead; the
+  message only documented the JVOpen meaning (Gemini).
+- -111/-114/-115 are documented as parameter errors per the official spec,
+  but SUBSCRIPTION_ERROR_CODES (scripts/quickstart.py, scripts/daily_update.py,
+  scripts/background_updater.py, src/services/realtime_monitor.py) treats the
+  same codes as "unsubscribed data type, skip" based on empirically observed
+  production behavior (commit bf69cb6). The messages must document both
+  meanings so a reader doesn't assume the official-spec wording is exhaustive
+  (Codex).
+"""
+
+from src.jvlink.constants import (
+    ERROR_MESSAGES,
+    JV_RT_INVALID_DATASPEC,
+    JV_RT_INVALID_KEY,
+    JV_RT_INVALID_OPTION,
+    JV_RT_INVALID_PARAMETER,
+    JV_RT_SETUP_CANCELED,
+    JV_READ_ERROR,
+    get_error_message,
+)
+
+
+def test_invalid_parameter_constant_matches_error_message():
+    assert JV_RT_INVALID_PARAMETER == -100
+    assert get_error_message(-100) == ERROR_MESSAGES[-100]
+    assert "パラメータ" in get_error_message(-100)
+
+
+def test_setup_canceled_documents_both_jvopen_and_jvread_meanings():
+    # -2 means "setup dialog canceled" for JVOpen but JV_READ_ERROR for JVRead;
+    # JV_RT_SETUP_CANCELED and JV_READ_ERROR are the same numeric code.
+    assert JV_RT_SETUP_CANCELED == JV_READ_ERROR == -2
+
+    message = get_error_message(-2)
+    assert "JVOpen" in message
+    assert "JVRead" in message
+
+
+def test_subscription_prone_codes_document_dual_meaning():
+    # These three codes are empirically overloaded: official-spec parameter
+    # error vs. observed "unsubscribed data type" in production. See
+    # SUBSCRIPTION_ERROR_CODES in scripts/quickstart.py and
+    # src/services/realtime_monitor.py, which intentionally treat them as
+    # skip-worthy regardless of the official-spec wording.
+    for code in (JV_RT_INVALID_DATASPEC, JV_RT_INVALID_KEY, JV_RT_INVALID_OPTION):
+        message = get_error_message(code)
+        assert "未購読" in message, f"code {code} message missing dual-meaning note: {message}"
+
+
+def test_subscription_error_codes_match_documented_dual_meaning_codes():
+    # Guards against SUBSCRIPTION_ERROR_CODES silently drifting away from the
+    # codes constants.py documents as having this dual meaning (or vice versa).
+    from scripts.quickstart import SUBSCRIPTION_ERROR_CODES
+
+    assert SUBSCRIPTION_ERROR_CODES == frozenset(
+        {JV_RT_INVALID_DATASPEC, JV_RT_INVALID_KEY, JV_RT_INVALID_OPTION}
+    )
+
+
+def test_get_error_message_unknown_code_is_explicit():
+    assert "不明なエラーコード" in get_error_message(-999999)

--- a/tests/test_migration.py
+++ b/tests/test_migration.py
@@ -105,17 +105,18 @@ class MockPostgreSQLDatabase(BaseDatabase):
         return rows[0] if rows else None
 
     def fetch_all(self, sql: str, parameters=None) -> List[Dict[str, Any]]:
-        # Respond to information_schema.columns query used in migration.
-        # Real PG stores names lowercased and migration.py passes .lower(),
-        # so compare on lowercase here.
-        if "information_schema.columns" in sql.lower():
-            table_name = parameters[0] if parameters else None
-            cols = self._tables.get((table_name or "").lower(), [])
-            return [{"name": c} for c in cols]
-        if "pg_index" in sql.lower():
-            table_name = parameters[0] if parameters else None
+        # Respond to the pg_attribute/pg_index + to_regclass() queries used by
+        # migration.py. Real PG stores names lowercased and migration.py passes
+        # .lower(), so compare on lowercase here. "pg_index" is checked first
+        # because the primary-key query also joins pg_attribute.
+        sql_lower = sql.lower()
+        table_name = parameters[0] if parameters else None
+        if "pg_index" in sql_lower:
             pk = self._primary_keys.get((table_name or "").lower(), [])
             return [{"name": c} for c in pk]
+        if "pg_attribute" in sql_lower:
+            cols = self._tables.get((table_name or "").lower(), [])
+            return [{"name": c} for c in cols]
         return []
 
     def create_table(self, table_name: str, schema: str):

--- a/tests/test_postgresql.py
+++ b/tests/test_postgresql.py
@@ -189,7 +189,7 @@ def test_pg8000_primary_key_lookup_failure_aborts_caller_transaction(monkeypatch
                 SELECT a.attname
                 FROM pg_index i
                 JOIN pg_attribute a ON a.attrelid = i.indrelid AND a.attnum = ANY(i.indkey)
-                WHERE i.indrelid = :param1::regclass
+                WHERE i.indrelid = to_regclass(:param1)
                 AND i.indisprimary
                 ORDER BY array_position(i.indkey, a.attnum)
             """,
@@ -480,6 +480,82 @@ def test_schema_creation():
         import traceback
         traceback.print_exc()
         pytest.skip("PostgreSQL driver not available")
+
+
+def test_table_exists_and_column_lookups_respect_search_path():
+    """search_path が非 public スキーマを指す環境で、table_exists() /
+    migration.py の既存カラム・主キー取得が正しいテーブルを解決すること。
+
+    PR #143 が修正した2つの不具合の回帰テスト:
+    1. table_exists() が pg_tables をスキーマ非限定で参照し、search_path に
+       無いスキーマの同名テーブルにも True を返していた（migration.py 側の
+       to_regclass() ベースの解決と食い違う）。
+    2. 複数スキーマに同名テーブルがある場合、current_schema() だけでは
+       search_path の優先順位どおりに一意特定できなかった。
+    """
+    config = {
+        "host": os.environ.get("PGHOST", "localhost"),
+        "port": int(os.environ.get("PGPORT", 5432)),
+        "database": os.environ.get("PGDATABASE", "keiba_test"),
+        "user": os.environ.get("PGUSER", "postgres"),
+        "password": os.environ.get("PGPASSWORD", "postgres"),
+        "connect_timeout": 5,
+    }
+
+    try:
+        from src.database.postgresql_handler import PostgreSQLDatabase
+        from src.database.migration import (
+            _get_existing_columns,
+            _get_existing_primary_key_columns,
+        )
+
+        db = PostgreSQLDatabase(config)
+        db.connect()
+    except Exception:
+        pytest.skip("PostgreSQL driver not available")
+
+    schema_a = "jltsql_test_search_path_a"
+    schema_b = "jltsql_test_search_path_b"
+    probe_table = "jltsql_search_path_probe"
+
+    try:
+        db.execute(f"DROP SCHEMA IF EXISTS {schema_a} CASCADE")
+        db.execute(f"DROP SCHEMA IF EXISTS {schema_b} CASCADE")
+        db.execute(f"CREATE SCHEMA {schema_a}")
+        db.execute(f"CREATE SCHEMA {schema_b}")
+        # 同名テーブルを両スキーマに作成し、カラム構成をあえて変える。
+        db.execute(f"CREATE TABLE {schema_a}.{probe_table} (col_a INTEGER PRIMARY KEY)")
+        db.execute(f"CREATE TABLE {schema_b}.{probe_table} (col_b TEXT PRIMARY KEY)")
+        db.commit()
+
+        # search_path が schema_a を指す場合、schema_a 側のテーブルが解決される。
+        db.execute(f"SET search_path TO {schema_a}, public")
+        assert db.table_exists(probe_table) is True
+        assert _get_existing_columns(db, probe_table) == {"col_a"}
+        assert _get_existing_primary_key_columns(db, probe_table) == ["col_a"]
+
+        # search_path を schema_b へ切り替えると、同じ呼び出しが schema_b 側へ
+        # 追従する（current_schema() 決め打ちでは一意特定できなかった問題）。
+        db.execute(f"SET search_path TO {schema_b}, public")
+        assert db.table_exists(probe_table) is True
+        assert _get_existing_columns(db, probe_table) == {"col_b"}
+        assert _get_existing_primary_key_columns(db, probe_table) == ["col_b"]
+
+        # schema_b のテーブルを削除すると、schema_a にだけ同名テーブルが残る。
+        # search_path は schema_b のままなので、table_exists() は
+        # False を返さねばならない（旧実装は pg_tables をスキーマ非限定で見て
+        # True を返し、直後の to_regclass() ベースの解決と食い違っていた）。
+        db.execute(f"DROP TABLE {schema_b}.{probe_table}")
+        db.commit()
+        assert db.table_exists(probe_table) is False
+        assert _get_existing_columns(db, probe_table) == set()
+        assert _get_existing_primary_key_columns(db, probe_table) == []
+    finally:
+        db.execute(f"DROP SCHEMA IF EXISTS {schema_a} CASCADE")
+        db.execute(f"DROP SCHEMA IF EXISTS {schema_b} CASCADE")
+        db.execute("SET search_path TO public")
+        db.commit()
+        db.disconnect()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 概要

PR #143（@hayato1980 作成、PostgreSQL search_path 修正）と PR #144（同、JV-Link 戻り値コード表修正）を取り込み、レビューで指摘済みだが未対応だった箇所を追加修正しました。PR #143 は PR #144 のコミットを内包しているため、本PRはその両方を base として、フォローアップ修正のみを追加しています。

## PR #143 フォローアップ（コミット1）

Gemini・Codex のレビューで指摘され、`hayato1980` さんが「修正済み」とコメントしていた箇所のうち、実際には未反映だったものを修正:

- `_get_existing_columns()`（migration.py）は `to_regclass()` 化済みでしたが、`_get_existing_primary_key_columns()`（migration.py）と `_get_primary_key_columns()`（postgresql_handler.py）は依然として安全でない `?::regclass` のままでした（search_path 上に見えないテーブルで `UndefinedTable` 例外）。
- `table_exists()` も `pg_tables WHERE tablename = ?` のスキーマ非限定のままで、Codexが指摘した「search_path 外のスキーマにある同名テーブルにも True を返す」問題が残っていました。これは上の `to_regclass()` ベースの解決と食い違います。

また、`tests/test_migration.py` の `MockPostgreSQLDatabase.fetch_all()` が旧 `information_schema.columns` ベースのSQL文字列にパターンマッチしたままで、PR #143 で実クエリが `pg_attribute`/`to_regclass()` に変わった後は常に空集合を返していました。そのため `test_pg_migrate_no_op_when_schema_matches` 等が「間違った理由で通っていた」状態でした（このPRで気づき、修正）。

実 PostgreSQL（2スキーマに同名テーブルを作成し search_path を切り替える）による回帰テストも追加しました。修正前の `table_exists()` に対して実際に fail することを確認済みです。

## PR #144 フォローアップ（コミット2）

- CodeRabbit 指摘の `JV_RT_INVALID_PARAMETER = -100` 定数を追加。
- Gemini 指摘の `-2`（JVOpen: セットアップキャンセル／JVRead: エラー）の両義をメッセージに反映。
- Codex 指摘の `-111`/`-114`/`-115` について調査: 公式仕様上はパラメータ不正ですが、`SUBSCRIPTION_ERROR_CODES`（quickstart.py 等、commit bf69cb6 参照）は未購読データ種別（MING等）検出時の実運用挙動としてこれらのコードを意図的に「契約外スキップ」扱いしています。挙動は実測に基づき正しいため変更せず、両義をコメント・メッセージに明記しました。

## テスト

- `tests/test_jvlink_constants.py`（新規）: -100定数、-2/-111/-114/-115の両義メッセージ、`SUBSCRIPTION_ERROR_CODES` との整合性
- `tests/test_postgresql.py`: search_path 切り替え時の `table_exists()`/`_get_existing_columns()`/`_get_existing_primary_key_columns()` 解決を検証する統合テスト（PostgreSQL未接続時はskip）
- 全体: `1460 passed, 41 skipped`（ローカル PostgreSQL 接続時）

Credit: 元となる PR #143 / #144 は @hayato1980 さんによる作業です。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved PostgreSQL table and column detection to respect the active schema search path.
  - Corrected table-existence checks for tables outside the default schema.
  - Updated database migration metadata handling for more reliable column and primary-key detection.
  - Expanded JV-Link error and return-code coverage, including clearer messages for authentication, licensing, setup, server, and download issues.
  - Table listings now default to the current schema rather than a fixed schema.

- **Tests**
  - Added coverage for schema-aware lookups and updated JV-Link error-code behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->