### PR TITLE
fix(jvlink): -100 is not a JVOpen/JVRTOpen return code

### DIFF
--- a/src/jvlink/constants.py
+++ b/src/jvlink/constants.py
@@ -14,7 +14,6 @@ JV_RT_SETUP_CANCELED = -2  # セットアップダイアログでキャンセル
 # src/services/realtime_monitor.py の SUBSCRIPTION_ERROR_CODES は、この
 # 実運用挙動に基づき意図的にこれらのコードを「契約外/未購読につき
 # スキップ」として扱っており、公式仕様の文言だけを見て変更しないこと。
-JV_RT_INVALID_PARAMETER = -100  # パラメータが不正、あるいはレジストリへの保存に失敗
 JV_RT_INVALID_DATASPEC = -111  # dataspec パラメータが不正（実運用では未購読データ種別のエラーとしても観測）
 JV_RT_INVALID_FROMTIME_START = -112  # fromtime パラメータが不正（読み出し開始時刻）
 JV_RT_INVALID_FROMTIME_END = -113  # fromtime パラメータが不正（読み出し終了時刻）
@@ -56,6 +55,14 @@ JV_RT_SERVER_MAINTENANCE = -504  # サーバーメンテナンス中
 JV_RT_SID_NOT_SET = -101  # sid が設定されていない（JVInit）
 JV_RT_SID_TOO_LONG = -102  # sid が64byte を超えている（JVInit）
 JV_RT_SID_INVALID = -103  # sid が不正（1桁目がスペース）（JVInit）
+
+# JVSetUIProperties / JVSetServiceKey / JVSetSaveFlag / JVSetSavePath specific
+#
+# -100 は公式仕様書「3. コード表」上、JVOpen/JVRTOpen の戻り値ではない
+# （それらは -111 以降のパラメータ不正系）。JVSetServiceKey は API 自体が
+# 不安定で -100 を返すことがあるため、wrapper.py はレジストリを直接操作して
+# これを回避している（wrapper.py の JVSetServiceKey 呼び出し箇所を参照）。
+JV_RT_INVALID_PARAMETER = -100  # パラメータが不正、あるいはレジストリへの保存に失敗
 
 # JVRead / JVGets Return Codes
 JV_READ_SUCCESS = 0  # 全ファイル読み込み終了（EOF）
@@ -506,7 +513,7 @@ ERROR_MESSAGES = {
     -2: "セットアップダイアログでキャンセルが押された（JVOpen）／エラー（JVRead）",
     -3: "ファイルダウンロード中（少し待って読み込みを再開してください）",
     # Parameter / Registry (JVSet系, JVOpen/JVRTOpen, JVInit)
-    -100: "パラメータが不正、あるいはレジストリへの保存に失敗",
+    -100: "パラメータが不正、あるいはレジストリへの保存に失敗（JVSetUIProperties/JVSetServiceKey/JVSetSaveFlag/JVSetSavePath。JVOpen/JVRTOpenの戻り値ではない）",
     -101: "sid が設定されていない（JVInit）／既に利用キーが登録されている（JVSetServiceKey）",
     -102: "sid が64byte を超えている（JVInit）",
     -103: "sid が不正（1桁目がスペース）（JVInit）",

--- a/src/jvlink/wrapper.py
+++ b/src/jvlink/wrapper.py
@@ -264,13 +264,16 @@ class JVLinkWrapper:
                 # Unexpected single value
                 raise ValueError(f"Unexpected JVOpen return type: {type(jv_result)}, expected tuple")
 
-            # Handle result codes for JVOpen:
+            # Handle result codes for JVOpen (per official spec "3. コード表",
+            # JVOpen/JVRTOpen never returns -100/-101/-102/-103 -- those are
+            # JVSetUIProperties/JVSetServiceKey/JVInit codes; JVOpen's actual
+            # errors start at -111):
             # 0 (JV_RT_SUCCESS): Success with data
             # -1: No data available (NOT an error - normal when no new data)
             # -2: No data available (alternative code)
-            # < -100: Actual errors (e.g., -100=setup required, -101=auth error, etc.)
+            # <= -111: Actual errors (e.g., -111=dataspec invalid, -301=auth error, etc.)
             if result < -2:
-                # Real errors are typically -100 or below
+                # Real errors are -111 or below (see comment above)
                 logger.error(
                     "JVOpen failed",
                     data_spec=data_spec,

--- a/tests/test_jvlink_constants.py
+++ b/tests/test_jvlink_constants.py
@@ -12,6 +12,14 @@ Regression coverage for PR #144 review follow-ups:
   production behavior (commit bf69cb6). The messages must document both
   meanings so a reader doesn't assume the official-spec wording is exhaustive
   (Codex).
+
+Verified directly against the official JV-Link4901.pdf ("3. コード表",
+Ver.4.9.0.1, 2024/8/7, https://jra-van.jp/dlb/sdv/sdk/JV-Link4901.pdf) rather
+than the PR description alone: -100 was correctly valued but grouped under a
+"Parameter Errors (JVOpen/JVRTOpen)" comment alongside -111..-116 by the
+initial follow-up fix, which is wrong -- the spec's JVOpen/JVRTOpen table has
+no -100 entry at all; -100 belongs to JVSetUIProperties/JVSetServiceKey/
+JVSetSaveFlag/JVSetSavePath. Corrected here.
 """
 
 from src.jvlink.constants import (
@@ -30,6 +38,18 @@ def test_invalid_parameter_constant_matches_error_message():
     assert JV_RT_INVALID_PARAMETER == -100
     assert get_error_message(-100) == ERROR_MESSAGES[-100]
     assert "パラメータ" in get_error_message(-100)
+
+
+def test_invalid_parameter_is_not_mislabeled_as_jvopen():
+    # Per the official spec ("3. コード表", JV-Link4901.pdf), -100 is returned
+    # by JVSetUIProperties/JVSetServiceKey/JVSetSaveFlag/JVSetSavePath, never
+    # by JVOpen/JVRTOpen (whose parameter errors start at -111). Guards
+    # against re-introducing the earlier miscategorization, where -100 was
+    # grouped under a "Parameter Errors (JVOpen/JVRTOpen)" comment alongside
+    # -111..-116.
+    message = get_error_message(-100)
+    assert "の戻り値ではない" in message
+    assert "JVSetServiceKey" in message
 
 
 def test_setup_canceled_documents_both_jvopen_and_jvread_meanings():


### PR DESCRIPTION
## 概要

ユーザー指摘により、#145 でマージした戻り値コード定義を **公式JV-Linkインターフェース仕様書(JV-Link4901.pdf, Ver.4.9.0.1, 2024/8/7, https://jra-van.jp/dlb/sdv/sdk/JV-Link4901.pdf)の「3. コード表」に直接照合**して検証しました。

## 発見した誤り

`-100`（`JV_RT_INVALID_PARAMETER`）を、`-111`〜`-116`と同じ「Parameter Errors (JVOpen/JVRTOpen)」セクションに配置していましたが、**公式仕様書のJVOpen/JVRTOpenの戻り値表には`-100`は存在しません**。JVOpen/JVRTOpenのパラメータエラーは`-111`から始まります。

`-100`は実際には別の関数群（`JVSetUIProperties`／`JVSetServiceKey`／`JVSetSaveFlag`／`JVSetSavePath`）専用の戻り値です。`wrapper.py`のコメント（「JVSetServiceKey API is unreliable (returns -100)」）とも整合します。CodeRabbitが提案した配置をそのまま採用したため、この誤配置に気づいていませんでした。

修正:
- `JV_RT_INVALID_PARAMETER = -100` を `JVInit`固有定数(`sid`関連)の隣に独立したセクションとして移動し、コメントで正しい関数群を明記。
- `ERROR_MESSAGES[-100]`のメッセージに「JVOpen/JVRTOpenの戻り値ではない」旨を明記。
- `wrapper.py`のJVOpenハンドラ内コメント（`< -100: Actual errors (e.g., -100=setup required, ...)`）も、実際にJVOpenが返すエラーコードの下限は`-111`である旨に修正（コメントのみ、`if result < -2:`の実際の判定ロジックは変更なし）。

## 追加検証

同じPDFで以下も突き合わせ、現行の記述と一致することを確認済み（既存の言い換え表現の範囲内）:
- JVOpen/JVRTOpen: `-1`, `-2`, `-111`〜`-116`, `-201`, `-202`, `-211`, `-301`〜`-305`, `-401`, `-411`〜`-431`, `-501`, `-504`
- JVRead/JVGets, JVStatus: `-402`, `-403`, `-502`, `-503`

なお、`-118`（filepathパラメータ不正）と`-304`（JRAレーシングビュアー連携機能認証エラー）は仕様書に実在するコードですが、それぞれ`JVFukuFile`（勝負服画像）・`JVMVPlay`/`JVMVPlayWithType`（動画再生）専用で、本リポジトリが実装していない機能のため追加していません。

## テスト

- `tests/test_jvlink_constants.py`に回帰テストを追加（`-100`のメッセージが「JVOpenの戻り値ではない」旨とJVSetServiceKeyへの言及を含むことを検証）
- 全体: `1461 passed, 41 skipped`（ローカルPostgreSQL接続時、test_cli.pyの2件は既知のオーダー依存flakeで本PRと無関係）