### PR TITLE
fix(jvlink): stop mislabeling JVInit sid errors as service-key errors

### DIFF
--- a/scripts/quickstart.py
+++ b/scripts/quickstart.py
@@ -372,18 +372,24 @@ def _check_jvlink_service_key() -> tuple[bool, str]:
         jvlink = win32com.client.Dispatch("JVDTLab.JVLink")
 
         # JVInitで認証チェック（sidは任意の文字列）
+        #
+        # JVInitの戻り値は公式仕様書「3. コード表」の JVInit セクションで
+        # -101/-102/-103 のみが定義されている（-100 はJVInitの戻り値ではなく
+        # JVSetUIProperties/JVSetServiceKey等の戻り値。src/jvlink/constants.py
+        # のJV_RT_INVALID_PARAMETER参照）。これらはいずれも sid パラメータの
+        # 形式不正を示すコードで、サービスキー(利用キー)自体の状態を示すもの
+        # ではない。サービスキー関連のエラー（未設定・無効・期限切れ等）は
+        # JVOpen/JVRTOpen が -301/-302/-303 として返す。
         result = jvlink.JVInit("JLTSQL")
 
         if result == 0:
             return True, "JV-Link認証OK"
-        elif result == -100:
-            return False, "サービスキー未設定"
         elif result == -101:
-            return False, "サービスキーが無効"
+            return False, "JVInit: sid パラメータが設定されていません（内部エラー）"
         elif result == -102:
-            return False, "サービスキーの有効期限切れ"
+            return False, "JVInit: sid パラメータが64byteを超えています（内部エラー）"
         elif result == -103:
-            return False, "サービス利用不可"
+            return False, "JVInit: sid パラメータが不正です（内部エラー）"
         else:
             return False, f"JV-Link初期化エラー (code: {result})"
     except Exception as e:
@@ -3154,15 +3160,31 @@ class QuickstartRunner:
             output_lower = combined_errors.lower()
 
         # JV-Link接続エラー
-        if 'jvinit' in output_lower or 'jvlink' in output_lower:
-            if '-100' in output or 'サービスキー未設定' in output:
-                return ('auth', 'サービスキーが未設定です')
-            elif '-101' in output or 'サービスキーが無効' in output:
-                return ('auth', 'サービスキーが無効です')
-            elif '-102' in output or '有効期限切れ' in output:
-                return ('auth', 'サービスキーの有効期限が切れています')
-            elif '-103' in output or 'サービス利用不可' in output:
-                return ('auth', 'サービスが利用できません')
+        #
+        # JVInitの戻り値は -101/-102/-103 のみが定義されており（公式仕様書
+        # 「3. コード表」JVInitセクション参照）、いずれも sid パラメータの
+        # 形式不正を示す。サービスキー(利用キー)自体の未設定・無効・期限切れは
+        # JVOpen/JVRTOpen が返す -301/-302/-303 で判定される別のエラーであり、
+        # JVInit失敗の文脈でそれらのラベルを出すのは誤り。
+        #
+        # -301/-302/-303 のチェックを 'jvinit'/'jvlink' ゲートより先に置く:
+        # JVLinkError の文字列表現は例外クラス名（"JVLinkError"）を含み得るため、
+        # 'jvlink' という緩い部分文字列一致では JVOpen 起因のサービスキー
+        # エラーも JVInit 分岐に誤って落ちてしまう。コード番号を先に見れば
+        # この優先順位問題を避けられる。
+        if '-301' in output:
+            return ('auth', 'サービスキーが無効です（認証エラー）')
+        elif '-302' in output:
+            return ('auth', 'サービスキーの有効期限が切れています')
+        elif '-303' in output:
+            return ('auth', 'サービスキーが設定されていません')
+        elif 'jvinit' in output_lower or 'jvlink' in output_lower:
+            if '-101' in output:
+                return ('auth', 'JVInit: sid パラメータが設定されていません（内部エラー）')
+            elif '-102' in output:
+                return ('auth', 'JVInit: sid パラメータが64byteを超えています（内部エラー）')
+            elif '-103' in output:
+                return ('auth', 'JVInit: sid パラメータが不正です（内部エラー）')
             else:
                 return ('connection', 'JV-Link接続エラー - JRA-VAN DataLabソフトウェアを確認してください')
 

--- a/src/fetcher/base.py
+++ b/src/fetcher/base.py
@@ -229,22 +229,33 @@ class BaseFetcher(ABC):
 
                 elif ret_code in (-201, -202, -203, -402, -403, -502, -503):
                     # Recoverable errors - delete corrupted file and continue
-                    # Based on kmy-keiba's JVLinkReader.cs error handling:
-                    # -201: Database busy (リトライ可能)
-                    # -202: File busy (リトライ可能)
-                    # -203: Setup not complete or file corruption (セットアップ未完了またはファイル破損)
-                    # -402, -403: Database errors (データベースエラー)
-                    # -502, -503: File errors (ファイルエラー)
+                    #
+                    # Official meanings (JV-Link "3. コード表", JVRead/JVGets
+                    # section) differ from the original kmy-keiba-derived
+                    # labels below:
+                    # -201: JVInit not called (not "database busy")
+                    # -202: previous JVOpen/JVRTOpen/JVMVOpen not JVClose'd (not "file busy")
+                    # -203: JVOpen not called (not "setup not complete or file corruption")
+                    # -402, -403: downloaded file abnormal -- size 0 / bad content (file, not database)
+                    # -502: download failed (communication/disk error)
+                    # -503: file not found
+                    #
+                    # -201/-203 in particular indicate a call-order bug (JVInit/
+                    # JVOpen genuinely not called), which deleting a file and
+                    # retrying jv_read() cannot fix -- retrying will just hit
+                    # the same code again. They remain in this recoverable set
+                    # unchanged pending a decision on whether that's still the
+                    # right classification; see the PR description.
 
                     # Error-specific guidance
                     error_messages = {
-                        -201: "データベースビジー状態です。一時的なエラーのため続行します。",
-                        -202: "ファイルビジー状態です。一時的なエラーのため続行します。",
-                        -203: "セットアップ未完了またはファイル破損が検出されました。ファイルを削除して続行します。",
-                        -402: "データベースエラーが発生しました。破損ファイルを削除して続行します。",
-                        -403: "データベースエラーが発生しました。破損ファイルを削除して続行します。",
-                        -502: "ファイルエラーが発生しました。破損ファイルを削除して続行します。",
-                        -503: "ファイルエラーが発生しました。破損ファイルを削除して続行します。",
+                        -201: "JVInitが行なわれていません（内部エラー）。一時的なエラーとして続行します。",
+                        -202: "前回のOpenがJVCloseされていません（オープン中）。一時的なエラーとして続行します。",
+                        -203: "JVOpenが行なわれていません（内部エラー）。ファイルを削除して続行します。",
+                        -402: "ダウンロードしたファイルが異常です（サイズ0）。破損ファイルを削除して続行します。",
+                        -403: "ダウンロードしたファイルが異常です（データ内容）。破損ファイルを削除して続行します。",
+                        -502: "ダウンロードに失敗しました（通信エラーやディスクエラーなど）。破損ファイルを削除して続行します。",
+                        -503: "読み出すべきファイルが見つかりません。ファイルを削除して続行します。",
                     }
 
                     error_msg = error_messages.get(ret_code, "リカバリー可能なエラーが発生しました。")

--- a/src/fetcher/historical.py
+++ b/src/fetcher/historical.py
@@ -367,11 +367,22 @@ class HistoricalFetcher(BaseFetcher):
         stall_timeout = 300.0  # 5 minutes before stall abort
 
         # Retryable error codes (temporary errors that may resolve)
-        # -201: Database error (might be busy)
-        # -202: File error (might be busy)
-        # -203: Other error (may indicate incomplete JVDTLab setup or cache issue)
-        # -502: Download failed
-        # -503: Similar download error
+        #
+        # Official meanings (JV-Link "3. コード表", JVStatus section) differ
+        # from the labels below:
+        # -201: JVInit not called (not "database busy")
+        # -202: previous JVOpen/JVRTOpen/JVMVOpen not JVClose'd (not "file busy")
+        # -203: JVOpen not called (not "incomplete setup/cache issue")
+        # -502: download failed (communication/disk error)
+        # -503: (JVStatus doesn't define -503; kept here for the bounded
+        #        max_retries=2 safety net below in case JVRead's -503,
+        #        file not found, surfaces through this status poll)
+        #
+        # -201/-203 indicate a call-order bug (JVInit/JVOpen genuinely not
+        # called), which polling jv_status() again cannot fix -- it will keep
+        # returning the same code. They remain in this retryable set
+        # unchanged (bounded by max_retries=2 below) pending a decision on
+        # whether that's still the right classification.
         retryable_errors = {-201, -202, -203, -502, -503}
 
         while True:

--- a/tests/test_quickstart_cli.py
+++ b/tests/test_quickstart_cli.py
@@ -348,3 +348,61 @@ class TestQuickstartUpdateSpecs:
         # MING は蓄積系のため option=1 (option=2 は TOKU/RACE/TCVN/RCVN のみ)
         ming = [row for row in QuickstartRunner.UPDATE_SPECS if row[0] == "MING"]
         assert ming and ming[0][2] == 1
+
+
+class TestAnalyzeErrorJVInitCodes:
+    """_analyze_error must classify JVInit/JVOpen error codes per the official
+    spec ("3. コード表", JV-Link4901.pdf), not the fabricated pre-PR#144
+    meanings. JVInit only ever returns -101/-102/-103 (sid parameter format
+    errors); service-key state (-301/-302/-303) is returned by JVOpen/
+    JVRTOpen, never by JVInit.
+    """
+
+    @pytest.fixture
+    def runner(self, tmp_path):
+        from scripts.quickstart import QuickstartRunner
+
+        return QuickstartRunner(
+            {
+                "db_path": str(tmp_path / "quickstart.db"),
+                "mode": "update",
+            }
+        )
+
+    @pytest.mark.parametrize(
+        "code,expected_fragment",
+        [
+            ("-101", "sid パラメータが設定されていません"),
+            ("-102", "sid パラメータが64byteを超えています"),
+            ("-103", "sid パラメータが不正です"),
+        ],
+    )
+    def test_jvinit_sid_errors_are_labeled_as_internal_not_service_key(
+        self, runner, code, expected_fragment
+    ):
+        error_type, message = runner._analyze_error(
+            f"JVInit failed with code {code}", returncode=1
+        )
+        assert error_type == "auth"
+        assert expected_fragment in message
+        # Must not resurrect the fabricated pre-fix framing of these codes as
+        # a service-key state (that's what -301/-302/-303 mean, not -101/-102/-103).
+        assert "サービスキー" not in message
+
+    @pytest.mark.parametrize(
+        "code,expected_fragment",
+        [
+            ("-301", "認証エラー"),
+            ("-302", "有効期限"),
+            ("-303", "設定されていません"),
+        ],
+    )
+    def test_jvopen_service_key_errors_are_distinct_from_jvinit(
+        self, runner, code, expected_fragment
+    ):
+        error_type, message = runner._analyze_error(
+            f"JVOpen failed with code {code}", returncode=1
+        )
+        assert error_type == "auth"
+        assert "サービスキー" in message
+        assert expected_fragment in message


### PR DESCRIPTION
## 背景

「エラー修正がJRA全体に波及していないか」を確認する中で、PR #144が修正した戻り値コード表の誤りと**同種の誤解が、constants.pyとは独立して他ファイルに複製されていた**ことが判明しました。centralな`ERROR_MESSAGES`辞書を参照せず、各ファイルが独自に(古い/誤った理解で)コードを解釈していたためです。

公式JV-Linkインターフェース仕様書(JV-Link4901.pdf「3. コード表」)と照合して確認・修正しました。

## 修正内容

### scripts/quickstart.py
`_check_jvlink_service_key()`・`_analyze_error()`が、`JVInit`の戻り値`-100`/`-101`/`-102`/`-103`を「サービスキー未設定/無効/期限切れ/利用不可」と誤って解釈していました。

実際は:
- `JVInit`は`-101`/`-102`/`-103`のみを返し(`-100`はJVInitの戻り値ではなく`JVSetUIProperties`/`JVSetServiceKey`等の戻り値)、いずれも**sidパラメータの形式エラー**(未設定/64byte超過/不正)であり、サービスキー(利用キー)自体の状態とは無関係
- サービスキーの未設定・無効・期限切れは`JVOpen`/`JVRTOpen`が返す`-301`/`-302`/`-303`の話

`_analyze_error()`に`-301`/`-302`/`-303`の正しい判定を追加。また、`JVLinkError`の文字列表現に例外クラス名(`JVLinkError`)が含まれ得るため、`'jvlink'`という緩い部分文字列一致だと`JVOpen`由来のサービスキーエラーも`JVInit`分岐に誤って落ちてしまう問題があったため、コード番号チェックの優先順位を先に変更しました。

### src/fetcher/base.py, src/fetcher/historical.py
`-201`/`-202`/`-203`を「データベースビジー」「ファイルビジー」「セットアップ未完了」とするコメント(third-party の kmy-keiba C# 実装由来)を、正しい意味に修正:
- `-201`: JVInitが行われていない
- `-202`: 前回のOpenがJVCloseされていない
- `-203`: JVOpenが行われていない

**リトライ対象コードの集合自体は変更していません。** `-201`/`-203`は実際には「JVInit/JVOpenが呼ばれていない」という呼び出し順序のバグを意味し、再試行では解決しませんが、これをリトライ対象から外すかどうかは本番のリトライ挙動に関わる判断のため、本PRのスコープ外としてコメントで明記するに留めています。

## テスト

- `tests/test_quickstart_cli.py::TestAnalyzeErrorJVInitCodes`(新規): JVInit(`-101`/`-102`/`-103`) vs JVOpen/JVRTOpen(`-301`/`-302`/`-303`)の判定と、部分文字列優先順位の修正を検証
- 全体: `1465 passed`(ローカルPostgreSQL接続時、test_cli.pyの2件は既知のオーダー依存flakeで無関係)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved JV-Link authentication error classification to distinguish invalid, expired, or missing service keys from initialization parameter errors.
  - Updated error messages to provide clearer guidance when service-key settings or connection parameters are incorrect.
  - Refined recoverable JV-Link read-error messages for clearer troubleshooting of temporary, file-related, and download-related issues.
  - Unknown initialization errors now receive a consistent generic error message with the returned code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->