### PR TITLE
docs(postgres): connect_timeout / sslmode を config example に明記

### DIFF
--- a/config/config.yaml.example
+++ b/config/config.yaml.example
@@ -41,6 +41,10 @@ databases:
     password: "${POSTGRES_PASSWORD}"
     pool_size: 5
     max_overflow: 10
+    # SSL mode: disable, allow, prefer (default), require, verify-ca, verify-full
+    sslmode: "prefer"
+    # Connection timeout in seconds
+    connect_timeout: 10
 
 # Data Fetch Settings
 data_fetch:


### PR DESCRIPTION
## 事象

`config.yaml.example` を見ても、PostgreSQL の接続タイムアウト（`connect_timeout`）や SSL モード（`sslmode`）の設定箇所が無く、これらのキーを設定できることに気づけません。

## 原因

- ハンドラ `PostgreSQLDatabase` は `connect_timeout` / `sslmode` を **`databases.postgresql` ブロックから読みます**（`src/database/postgresql_handler.py:68-69`。docstring にも記載あり）。
- しかし `config/config.yaml.example` の `databases.postgresql` にその 2 キーが例示されておらず、`host` / `port` / `database` / `user` / `password` / `pool_size` / `max_overflow` しかありません。→ 利用者が設定可能なことを知る手がかりが無い状態です。

## 修正

- `config/config.yaml.example` の `databases.postgresql` に `sslmode` と `connect_timeout` を追記しました。
- 値は **built-in 既定と同じ（`prefer` / `10`）** で、**挙動は変わりません**。キーの存在を example で示すだけの変更です（ハンドラ等コードの変更はありません）。

    # SSL mode: disable, allow, prefer (default), require, verify-ca, verify-full
    sslmode: "prefer"
    # Connection timeout in seconds
    connect_timeout: 10

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the example PostgreSQL configuration with explicit SSL mode and connection timeout settings.
  * Helps users configure database connections with sensible defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->