### PR TITLE
fix(fetch): make date range and cache semantics fail-safe

### DIFF
--- a/src/cache/manager.py
+++ b/src/cache/manager.py
@@ -19,13 +19,14 @@ class CacheManager:
     Thread-safe for concurrent RT_ writes.
 
     Directory structure:
-        cache_dir/nl/{SPEC}/{YYYYMMDD}.bin  -- 蓄積系
+        cache_dir/nl/{SPEC}/{YYYYMMDD}.v2.bin  -- 蓄積系
         cache_dir/rt/{SPEC_CODE}/{YYYYMMDD}.bin  -- 速報系
 
     Binary format: [uint32-BE length][raw bytes] per record (length-prefixed)
     """
 
     HEADER = struct.Struct(">I")  # 4-byte big-endian uint32
+    NL_CACHE_SCHEMA_VERSION = 2
 
     def __init__(self, cache_dir: Path):
         self.cache_dir = Path(cache_dir)
@@ -45,7 +46,9 @@ class CacheManager:
         return d
 
     def _nl_path(self, spec: str, date_str: str) -> Path:
-        return self._nl_dir(spec) / f"{date_str}.bin"
+        return self._nl_dir(spec) / (
+            f"{date_str}.v{self.NL_CACHE_SCHEMA_VERSION}.bin"
+        )
 
     def _index_path(self, spec: str) -> Path:
         return self._nl_dir(spec) / ".index.json"
@@ -85,7 +88,8 @@ class CacheManager:
     # --- NL_ public API ---
     def has_nl(self, spec: str, date_str: str) -> bool:
         """Return True if complete NL cache exists for this spec+date."""
-        return self._load_index(self._index_path(spec)).get(date_str, {}).get("complete", False)
+        entry = self._load_index(self._index_path(spec)).get(date_str, {})
+        return self._nl_entry_is_complete(entry)
 
     def has_nl_range(self, spec: str, from_date: str, to_date: str) -> bool:
         """Return True if ALL dates in range are fully cached."""
@@ -93,10 +97,19 @@ class CacheManager:
         end = _parse_date(to_date)
         index = self._load_index(self._index_path(spec))
         while d <= end:
-            if not index.get(d.strftime("%Y%m%d"), {}).get("complete", False):
+            if not self._nl_entry_is_complete(
+                index.get(d.strftime("%Y%m%d"), {})
+            ):
                 return False
             d += timedelta(days=1)
         return True
+
+    def _nl_entry_is_complete(self, entry: object) -> bool:
+        return (
+            isinstance(entry, dict)
+            and entry.get("complete") is True
+            and entry.get("schema_version") == self.NL_CACHE_SCHEMA_VERSION
+        )
 
     def write_nl_record(self, spec: str, date_str: str, raw: bytes) -> None:
         """Append one raw record to NL cache (thread-safe)."""
@@ -146,6 +159,7 @@ class CacheManager:
                 count = self._count_records(bin_path) if bin_path.exists() else 0
                 index[date_str] = {
                     "complete": True,
+                    "schema_version": self.NL_CACHE_SCHEMA_VERSION,
                     "count": count,
                     "size": size,
                     "mtime": _now_iso(),
@@ -215,12 +229,16 @@ class CacheManager:
             for spec_dir in sorted(p for p in nl_base.iterdir() if p.is_dir()):
                 spec = spec_dir.name
                 idx = self._load_index(spec_dir / ".index.json")
-                dates = sorted(idx.keys())
+                dates = sorted(
+                    date_str
+                    for date_str, entry in idx.items()
+                    if self._nl_entry_is_complete(entry)
+                )
                 bins = list(spec_dir.glob("*.bin"))
                 sz = sum(b.stat().st_size for b in bins)
                 result["nl"][spec] = {
                     "cached_dates": len(dates),
-                    "complete_dates": sum(1 for v in idx.values() if v.get("complete")),
+                    "complete_dates": len(dates),
                     "date_range": f"{dates[0]}..{dates[-1]}" if dates else "(empty)",
                     "size_bytes": sz,
                 }
@@ -253,10 +271,14 @@ class CacheManager:
             if not d.is_dir():
                 continue
             if date_str:
-                f = d / f"{date_str}.bin"
-                if f.exists():
-                    f.unlink()
-                    deleted += 1
+                cache_files = [
+                    d / f"{date_str}.bin",
+                    d / f"{date_str}.v{self.NL_CACHE_SCHEMA_VERSION}.bin",
+                ]
+                for f in cache_files:
+                    if f.exists():
+                        f.unlink()
+                        deleted += 1
                 idx_path = d / ".index.json"
                 if idx_path.exists():
                     idx = self._load_index(idx_path)

--- a/src/cli/main.py
+++ b/src/cli/main.py
@@ -60,8 +60,8 @@ FETCH_NOTE_TO_SINGLE_OPEN = (
     "option=1/2/4 では --to を狭めてもサーバからのダウンロード量は減りません。"
 )
 FETCH_NOTE_TO_SETUP_CHUNKS = (
-    "option=3 の370日超の範囲は年単位の JVOpen に分割されるため、"
-    "--to を広げるほど呼び出し回数とダウンロード量が増えます。"
+    "option=3 の370日超の範囲は年単位の JVOpen に分割され、"
+    "--to の延長で年次チャンクが追加される場合に呼び出し回数とダウンロード量が増えます。"
 )
 FETCH_NOTE_DATE_FIELDS = (
     "--to は Year+MonthDay または ChokyoDate（HC/WC の調教日）で判定します。"
@@ -358,7 +358,8 @@ def update(ctx, force):
         "Client-side end date (YYYYMMDD), not a JVOpen end bound. Filters "
         "Year+MonthDay and HC/WC ChokyoDate; records without either date are "
         "kept and prevent a complete-cache marker. With option=3, ranges over "
-        "370 days are split yearly, so widening --to increases downloads."
+        "370 days are split into calendar-year chunks; extending --to increases "
+        "downloads only when it adds another chunk."
     ),
 )
 @click.option("--spec", "data_spec", required=True, help="Data specification (RACE, DIFF, etc.)")

--- a/src/cli/main.py
+++ b/src/cli/main.py
@@ -44,7 +44,45 @@ __version__ = _read_version()
 
 # Console for rich output (Windows cp932-safe)
 console = Console(legacy_windows=True)
+err_console = Console(stderr=True, legacy_windows=True)
 logger = get_logger(__name__)
+
+
+FETCH_NOTE_SETUP_MODE = "セットアップモード - 全データ取得（ダイアログが表示されます）"
+FETCH_NOTE_OPTION2_RANGE = (
+    "option=2（今週データ）では --from は JVOpen の取得範囲に効きません。"
+    "取得期間の完全性を保証できないため、NL キャッシュは使用・作成しません。"
+)
+FETCH_NOTE_TO_CLIENT_FILTER = (
+    "--to は JVOpen の終端ではなく、取得後のクライアント側フィルタです。"
+)
+FETCH_NOTE_TO_SINGLE_OPEN = (
+    "option=1/2/4 では --to を狭めてもサーバからのダウンロード量は減りません。"
+)
+FETCH_NOTE_TO_SETUP_CHUNKS = (
+    "option=3 の370日超の範囲は年単位の JVOpen に分割されるため、"
+    "--to を広げるほど呼び出し回数とダウンロード量が増えます。"
+)
+FETCH_NOTE_DATE_FIELDS = (
+    "--to は Year+MonthDay または ChokyoDate（HC/WC の調教日）で判定します。"
+    "対応する日付を持たないレコードは JV-Link 取得時に除外されず、"
+    "その取得範囲は完全キャッシュとして記録されません。"
+)
+
+
+def _print_fetch_guardrail_notes(jv_option: int) -> None:
+    """Emit option-dependent date-range caveats after input validation."""
+    if jv_option in (3, 4):
+        err_console.print(f"[yellow]Note:[/yellow] {FETCH_NOTE_SETUP_MODE}")
+    if jv_option == 2:
+        err_console.print(f"[yellow]Note:[/yellow] {FETCH_NOTE_OPTION2_RANGE}")
+
+    err_console.print(f"[yellow]Note:[/yellow] {FETCH_NOTE_TO_CLIENT_FILTER}")
+    if jv_option == 3:
+        err_console.print(f"[yellow]Note:[/yellow] {FETCH_NOTE_TO_SETUP_CHUNKS}")
+    else:
+        err_console.print(f"[yellow]Note:[/yellow] {FETCH_NOTE_TO_SINGLE_OPEN}")
+    err_console.print(f"[yellow]Note:[/yellow] {FETCH_NOTE_DATE_FIELDS}")
 
 
 def _normalize_service_key(value: str | None) -> str | None:
@@ -303,8 +341,26 @@ def update(ctx, force):
 
 
 @cli.command()
-@click.option("--from", "date_from", required=True, help="Start date (YYYYMMDD)")
-@click.option("--to", "date_to", required=True, help="End date (YYYYMMDD) - filters records up to this date")
+@click.option(
+    "--from",
+    "date_from",
+    required=True,
+    help=(
+        "Start date (YYYYMMDD). Passed as JVOpen fromtime for options 1/3/4; "
+        "option=2 ignores it server-side and bypasses NL cache."
+    ),
+)
+@click.option(
+    "--to",
+    "date_to",
+    required=True,
+    help=(
+        "Client-side end date (YYYYMMDD), not a JVOpen end bound. Filters "
+        "Year+MonthDay and HC/WC ChokyoDate; records without either date are "
+        "kept and prevent a complete-cache marker. With option=3, ranges over "
+        "370 days are split yearly, so widening --to increases downloads."
+    ),
+)
 @click.option("--spec", "data_spec", required=True, help="Data specification (RACE, DIFF, etc.)")
 @click.option(
     "--option",
@@ -355,11 +411,6 @@ def fetch(ctx, date_from, date_to, data_spec, jv_option, db, batch_size, progres
     console.print(f"  Option:     {jv_option} ({option_names.get(jv_option, '不明')})")
     console.print(f"  Database:   {db_type}")
 
-    # Warn if setup mode (3 or 4) is used
-    if jv_option in (3, 4):
-        console.print()
-        console.print("[yellow]Note:[/yellow] セットアップモード - 全データ取得（ダイアログが表示されます）")
-
     # Validate data_spec and option combination
     from src.jvlink.constants import is_valid_jvopen_combination, JVOPEN_VALID_COMBINATIONS
     if not is_valid_jvopen_combination(data_spec, jv_option):
@@ -369,6 +420,7 @@ def fetch(ctx, date_from, date_to, data_spec, jv_option, db, batch_size, progres
         console.print(f"       option={jv_option} で取得可能: {', '.join(valid_specs)}")
         sys.exit(1)
 
+    _print_fetch_guardrail_notes(jv_option)
     console.print()
 
     try:
@@ -488,8 +540,16 @@ def cache_info(ctx, cache_dir):
 
 @cache.command("build")
 @click.option("--spec", "data_spec", required=True, help="Data spec (RACE, DIFF, DIFFU, etc.)")
-@click.option("--from", "date_from", required=True, help="Start date YYYYMMDD")
-@click.option("--to", "date_to", required=True, help="End date YYYYMMDD")
+@click.option("--from", "date_from", required=True, help="Start date YYYYMMDD (option=2 is not cacheable)")
+@click.option(
+    "--to",
+    "date_to",
+    required=True,
+    help=(
+        "Client-side end date YYYYMMDD. Records without Year+MonthDay or "
+        "ChokyoDate prevent the range from being marked complete."
+    ),
+)
 @click.option("--option", "jv_option", type=int, default=1, show_default=True,
               help="JVOpen option: 1=通常, 2=今週, 3=setup, 4=split-setup")
 @click.option("--also-import", is_flag=True, default=False,
@@ -509,6 +569,12 @@ def cache_build(ctx, data_spec, date_from, date_to, jv_option, also_import, db, 
     """
     from src.cache import CacheManager
     from src.fetcher.historical import HistoricalFetcher
+
+    if jv_option == 2:
+        raise click.UsageError(
+            "cache build does not support option=2: JVOpen ignores --from, "
+            "so the requested date range cannot be marked complete safely"
+        )
 
     config = ctx.obj.get("config", {}) if ctx.obj else {}
     service_key = config.get("jvlink", {}).get("service_key") or os.environ.get("JVLINK_SERVICE_KEY")
@@ -602,6 +668,12 @@ def cache_rebuild(ctx, data_spec, date_from, date_to, jv_option, cache_dir):
     Example:
       jltsql cache rebuild --spec RACE --from 20260301 --to 20260328
     """
+    if jv_option == 2:
+        raise click.UsageError(
+            "cache rebuild does not support option=2: JVOpen ignores --from, "
+            "so the requested date range cannot be marked complete safely"
+        )
+
     from src.cache import CacheManager
     mgr = CacheManager(Path(cache_dir))
 

--- a/src/fetcher/base.py
+++ b/src/fetcher/base.py
@@ -397,20 +397,23 @@ class BaseFetcher(ABC):
         Returns:
             True if record date <= to_date, False otherwise
         """
-        # Extract date from record
-        # Most JV-Data records have Year and MonthDay fields
+        # Most JV-Data records have Year and MonthDay fields. HC/WC training
+        # records instead carry their event date in ChokyoDate.
         year = data.get("Year")
         month_day = data.get("MonthDay")
 
-        if not year or not month_day:
+        if year and month_day:
+            record_date = f"{year}{month_day}"
+        else:
+            chokyo_date = data.get("ChokyoDate")
+            record_date = str(chokyo_date) if chokyo_date else None
+
+        if not record_date:
             # If date fields are not present, include the record
             # (don't filter records that don't have date information)
             return True
 
         try:
-            # Construct record date as YYYYMMDD
-            record_date = f"{year}{month_day}"
-
             # Compare as strings (YYYYMMDD format allows string comparison)
             return record_date <= to_date
         except Exception as e:
@@ -418,6 +421,7 @@ class BaseFetcher(ABC):
                 "Failed to extract date from record",
                 year=year,
                 month_day=month_day,
+                chokyo_date=data.get("ChokyoDate"),
                 error=str(e),
             )
             # If we can't determine the date, include the record

--- a/src/fetcher/historical.py
+++ b/src/fetcher/historical.py
@@ -20,6 +20,9 @@ def _extract_record_date(record: dict) -> Optional[str]:
     monthday = record.get("MonthDay") or record.get("headMonthDay") or record.get("KaisaiTsukihi")
     if year and monthday and len(str(year)) == 4 and len(str(monthday)) == 4:
         return str(year) + str(monthday)
+    chokyo_date = record.get("ChokyoDate")
+    if chokyo_date and len(str(chokyo_date)) == 8:
+        return str(chokyo_date)
     return None
 
 
@@ -216,9 +219,13 @@ class HistoricalFetcher(BaseFetcher):
 
         download_task_id = None
         fetch_task_id = None
-        active_cache_manager = self.cache_manager
+        # option=2 ignores fromtime server-side, so a requested date range can
+        # never be proven complete. Bypass both existing NL cache markers and
+        # write-through caching for that mode.
+        active_cache_manager = self.cache_manager if option != 2 else None
         cache_checkpoints: dict[str, Optional[int]] = {}
         cache_write_committed = active_cache_manager is None
+        cache_range_complete = True
 
         try:
             # Info for setup mode (option 3 or 4) - ログのみ、画面表示はしない
@@ -332,6 +339,11 @@ class HistoricalFetcher(BaseFetcher):
                                 rec_date,
                             )
                         active_cache_manager.write_nl_record(data_spec, rec_date, data["_raw"])
+                    else:
+                        # The record is yielded/imported, but cannot be replayed
+                        # from this date-keyed cache. Keep the range incomplete;
+                        # the finally block rolls back any partial appends.
+                        cache_range_complete = False
                 yield data
 
             if self._jvd_replay_records_remaining > 0:
@@ -347,7 +359,7 @@ class HistoricalFetcher(BaseFetcher):
                 )
 
             # Mark cached dates as complete
-            if active_cache_manager:
+            if active_cache_manager and cache_range_complete:
                 from datetime import timedelta
                 d = datetime.strptime(from_date, "%Y%m%d").date()
                 end = datetime.strptime(to_date, "%Y%m%d").date()
@@ -360,6 +372,13 @@ class HistoricalFetcher(BaseFetcher):
                     completed_dates,
                 )
                 cache_write_committed = True
+            elif active_cache_manager:
+                logger.warning(
+                    "NL cache range left incomplete because records lacked a supported event date",
+                    data_spec=data_spec,
+                    from_date=from_date,
+                    to_date=to_date,
+                )
 
             # Log summary
             stats = self.get_statistics()
@@ -473,7 +492,11 @@ class HistoricalFetcher(BaseFetcher):
         Yields:
             Dictionary of parsed record data
         """
-        if cache_manager.has_nl_range(data_spec, from_date, to_date):
+        if option == 2:
+            # Do not trust old false-complete markers created by earlier
+            # versions, and do not attach a manager that could create new ones.
+            yield from self.fetch(data_spec, from_date, to_date, option)
+        elif cache_manager.has_nl_range(data_spec, from_date, to_date):
             # Full cache hit: yield from cache
             self.reset_statistics()
             for raw in cache_manager.read_nl(data_spec, from_date, to_date):

--- a/tests/test_cache_manager.py
+++ b/tests/test_cache_manager.py
@@ -120,6 +120,30 @@ class TestNlIndex:
         idx = cm._load_index(cm._index_path("RACE"))
         assert idx["20260401"]["count"] == 3
         assert idx["20260401"]["complete"] is True
+        assert (
+            idx["20260401"]["schema_version"]
+            == CacheManager.NL_CACHE_SCHEMA_VERSION
+        )
+
+    def test_legacy_complete_cache_is_not_reused_or_appended(self, tmp_path):
+        cm = _make_cache(tmp_path)
+        legacy_path = cm._nl_dir("RACE") / "20260401.bin"
+        legacy_path.write_bytes(cm.HEADER.pack(6) + b"legacy")
+        cm._save_index(
+            cm._index_path("RACE"),
+            {"20260401": {"complete": True, "count": 1}},
+        )
+
+        assert cm.has_nl_range("RACE", "20260401", "20260401") is False
+        assert list(cm.read_nl("RACE", "20260401", "20260401")) == []
+
+        cm.write_nl_record("RACE", "20260401", _raw("fresh"))
+        cm.mark_nl_complete("RACE", "20260401")
+
+        assert list(cm.read_nl("RACE", "20260401", "20260401")) == [
+            _raw("fresh")
+        ]
+        assert legacy_path.exists()
 
     def test_mark_nl_complete_empty_date(self, tmp_path):
         cm = _make_cache(tmp_path)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -262,6 +262,14 @@ class TestFetchCommand(unittest.TestCase):
             result.exception is not None
         )
 
+    def test_fetch_help_explains_option_dependent_date_semantics(self):
+        result = self.runner.invoke(cli, ['fetch', '--help'])
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertIn('option=2 ignores it server-side', result.output)
+        self.assertIn('ChokyoDate', result.output)
+        self.assertIn('split yearly', result.output)
+
     @patch('src.importer.batch.BatchProcessor')
     def test_fetch_with_all_args(self, mock_batch_processor):
         """Test fetch command with all arguments."""

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -268,7 +268,8 @@ class TestFetchCommand(unittest.TestCase):
         self.assertEqual(result.exit_code, 0, result.output)
         self.assertIn('option=2 ignores it server-side', result.output)
         self.assertIn('ChokyoDate', result.output)
-        self.assertIn('split yearly', result.output)
+        self.assertIn('calendar-year chunks', result.output)
+        self.assertIn('adds another chunk', result.output)
 
     @patch('src.importer.batch.BatchProcessor')
     def test_fetch_with_all_args(self, mock_batch_processor):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -263,7 +263,19 @@ class TestFetchCommand(unittest.TestCase):
         )
 
     def test_fetch_help_explains_option_dependent_date_semantics(self):
-        result = self.runner.invoke(cli, ['fetch', '--help'])
+        example_config = (
+            Path(__file__).resolve().parents[1] / 'config' / 'config.yaml.example'
+        )
+        with self.runner.isolated_filesystem():
+            config_path = Path('config.yaml')
+            config_path.write_text(
+                example_config.read_text(encoding='utf-8'),
+                encoding='utf-8',
+            )
+            result = self.runner.invoke(
+                cli,
+                ['--config', str(config_path), 'fetch', '--help'],
+            )
 
         self.assertEqual(result.exit_code, 0, result.output)
         self.assertIn('option=2 ignores it server-side', result.output)

--- a/tests/test_date_filtering.py
+++ b/tests/test_date_filtering.py
@@ -52,6 +52,16 @@ class TestDateFiltering:
         record3 = {"Year": "2025", "MonthDay": "0101"}
         assert fetcher._is_within_date_range(record3, "20241231") is False
 
+        # HC/WC training records carry the event date in ChokyoDate.
+        assert fetcher._is_within_date_range(
+            {"RecordSpec": "HC", "ChokyoDate": "20240701"},
+            "20240630",
+        ) is False
+        assert fetcher._is_within_date_range(
+            {"RecordSpec": "WC", "ChokyoDate": "20240630"},
+            "20240630",
+        ) is True
+
     def test_is_within_date_range_missing_fields(self, fetcher):
         """Test that records missing date fields are included."""
         # Record with no date fields

--- a/tests/test_historical_cache_failures.py
+++ b/tests/test_historical_cache_failures.py
@@ -56,3 +56,29 @@ def test_cache_replay_counts_each_parsed_list_item():
     assert stats["records_fetched"] == 1
     assert stats["records_parsed"] == 2
     assert stats["records_failed"] == 0
+
+
+def test_option2_bypasses_even_an_existing_complete_cache_marker():
+    cache = MagicMock()
+    fetcher = _fetcher_without_jvlink()
+    fetcher.fetch = MagicMock(return_value=iter([{"RecordSpec": "RA"}]))
+
+    records = list(
+        fetcher.fetch_with_cache(
+            cache,
+            "RACE",
+            "20200101",
+            "20261231",
+            option=2,
+        )
+    )
+
+    assert records == [{"RecordSpec": "RA"}]
+    cache.has_nl_range.assert_not_called()
+    cache.read_nl.assert_not_called()
+    fetcher.fetch.assert_called_once_with(
+        "RACE",
+        "20200101",
+        "20261231",
+        2,
+    )

--- a/tests/test_jvd_self_repair.py
+++ b/tests/test_jvd_self_repair.py
@@ -370,6 +370,56 @@ def test_abandoned_fetch_with_cache_clears_attached_manager(tmp_path):
     assert not cache_manager.has_nl("RACE", "20260101")
 
 
+def test_undated_record_rolls_back_partial_cache_and_leaves_range_incomplete(tmp_path):
+    fetcher = _fetcher()
+    fetcher.show_progress = False
+    fetcher._service_key = None
+    fetcher.cache_manager = CacheManager(tmp_path / "cache")
+    fetcher.jvlink.jv_init.return_value = 0
+    fetcher.jvlink.jv_open.return_value = (0, 2, 0, "ts")
+    fetcher.jvlink.jv_read.side_effect = [
+        (1, b"dated", "dated.jvd"),
+        (1, b"master", "master.jvd"),
+        (0, None, None),
+    ]
+    fetcher.parser_factory.parse.side_effect = lambda raw: (
+        {"RecordSpec": "RA", "Year": "2026", "MonthDay": "0101"}
+        if raw == b"dated"
+        else {"RecordSpec": "UM"}
+    )
+
+    records = list(fetcher.fetch("DIFF", "20260101", "20260101"))
+
+    assert [record["RecordSpec"] for record in records] == ["RA", "UM"]
+    assert not fetcher.cache_manager.has_nl("DIFF", "20260101")
+    assert list(fetcher.cache_manager.read_nl("DIFF", "20260101", "20260101")) == []
+
+
+def test_chokyo_date_is_used_for_cache_coverage(tmp_path):
+    fetcher = _fetcher()
+    fetcher.show_progress = False
+    fetcher._service_key = None
+    fetcher.cache_manager = CacheManager(tmp_path / "cache")
+    fetcher.jvlink.jv_init.return_value = 0
+    fetcher.jvlink.jv_open.return_value = (0, 1, 0, "ts")
+    fetcher.jvlink.jv_read.side_effect = [
+        (1, b"training", "training.jvd"),
+        (0, None, None),
+    ]
+    fetcher.parser_factory.parse.return_value = {
+        "RecordSpec": "HC",
+        "ChokyoDate": "20260101",
+    }
+
+    records = list(fetcher.fetch("SLOP", "20260101", "20260101"))
+
+    assert records[0]["ChokyoDate"] == "20260101"
+    assert fetcher.cache_manager.has_nl("SLOP", "20260101")
+    assert list(
+        fetcher.cache_manager.read_nl("SLOP", "20260101", "20260101")
+    ) == [b"training"]
+
+
 def test_replay_skip_still_runs_periodic_com_buffer_gc():
     fetcher = _fetcher()
     fetcher._jvd_replay_records_remaining = 1


### PR DESCRIPTION
## 背景

hayato1980/jrvltsql#7 で報告された `fetch --from/--to` の option 依存挙動を、miyamamoto/jrvltsql の最新 `master` に安全側で反映します。

元のローカル作業は contributor fork の履歴を基点としており、別件の変更を含んでいたため、その履歴は持ち込まず最新 `origin/master` 上へ必要な修正だけを実装しました。

## 変更内容

- `fetch` 実行時と help に、`--from/--to` の option 依存挙動を明示
- option=2 は JVOpen が `--from` を取得範囲として扱わないため、既存NL cacheも含めてcacheをバイパス
- `cache build/rebuild --option 2` は、誤った完全範囲を作らないよう変更前に fail-loud
- HC/WC は日付なしmasterとして扱わず、時系列の `ChokyoDate` で `--to` filterとcache日付を判定
- 対応するevent dateを持たないmaster行を検出した場合、完全cache markerを付けず、同一取得の部分cache appendもrollback

## 原因

JVOpenのサーバ側範囲、取得後のclient filter、日付keyのNL cache coverageが同じ `--from/--to` で表現されていました。特にoption=2と日付なしrecordでは、要求範囲を完全取得した証拠がないままcache indexをcompleteにできる状態でした。

## 影響

CLI利用者はダウンロード量とfilterの実効範囲を実行前に判断できます。cacheは再利用性より完全性を優先し、証明できない範囲をcache hitとして扱いません。

## 検証

対象commit: `3a2b16694d5ce562b8db27a5511793fb2599c2fe`

- 変更周辺: `93 passed`
- GitHub Actions test job相当: `646 passed, 2 skipped`
- fatal flake8 (`E9,F63,F7,F82`): `0`
- `fetch --help`、`cache build/rebuild --option 2` のCLI smokeを確認
- 独立レビュー指摘の年次chunk表現を修正し、`tests/test_cli.py`: `23 passed`
- 旧cache markerをschema v2で失効し、legacy rawとactive rawを分離。cache/CLI focused: `64 passed`
- `fetch --help` testをisolated filesystem + tracked example configで実行。CLI: `23 passed`

Source report: https://github.com/hayato1980/jrvltsql/pull/7


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved fetch and cache command help with clearer date-filtering, range, completeness, and setup-mode guidance.
  * Added support for date filtering using `ChokyoDate` when standard date fields are unavailable.

* **Bug Fixes**
  * Prevented incomplete or undated results from being marked as complete cache ranges.
  * Cache bypass is now enforced for the JVOpen fetch option to ensure accurate results.
  * Added clearer validation and warnings for unsupported cache-building options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
