### PR TITLE
docs(fetch): align option 2 range guidance with JV-Link

### DIFF
--- a/src/cli/main.py
+++ b/src/cli/main.py
@@ -50,8 +50,12 @@ logger = get_logger(__name__)
 
 FETCH_NOTE_SETUP_MODE = "セットアップモード - 全データ取得（ダイアログが表示されます）"
 FETCH_NOTE_OPTION2_RANGE = (
-    "option=2（今週データ）では --from は JVOpen の取得範囲に効きません。"
-    "取得期間の完全性を保証できないため、NL キャッシュは使用・作成しません。"
+    "option=2（今週データ）でも --from は JVOpen の fromtime に渡され、"
+    "今週データ内の連続性管理に使われます。ただし任意の過去週を選択するものではなく、"
+    "JV-Link が現在の開催サイクルに絞ったデータを返します。"
+    "日曜・月曜は2サイクル分になる場合があります。"
+    "任意の --from/--to 範囲の完全性を保証できないため、"
+    "NL キャッシュは使用・作成しません。"
 )
 FETCH_NOTE_TO_CLIENT_FILTER = (
     "--to は JVOpen の終端ではなく、取得後のクライアント側フィルタです。"
@@ -346,8 +350,10 @@ def update(ctx, force):
     "date_from",
     required=True,
     help=(
-        "Start date (YYYYMMDD). Passed as JVOpen fromtime for options 1/3/4; "
-        "option=2 ignores it server-side and bypasses NL cache."
+        "Start date (YYYYMMDD), passed as JVOpen fromtime for all options. "
+        "With option=2 it manages continuity within the current race-cycle "
+        "data; it does not select an arbitrary historical week, and Sunday "
+        "or Monday may cover two cycles. NL cache is bypassed."
     ),
 )
 @click.option(
@@ -573,8 +579,10 @@ def cache_build(ctx, data_spec, date_from, date_to, jv_option, also_import, db, 
 
     if jv_option == 2:
         raise click.UsageError(
-            "cache build does not support option=2: JVOpen ignores --from, "
-            "so the requested date range cannot be marked complete safely"
+            "cache build does not support option=2: JVOpen uses --from to "
+            "manage continuity within current race-cycle data, not to select "
+            "an arbitrary historical range, so the requested date range "
+            "cannot be marked complete safely"
         )
 
     config = ctx.obj.get("config", {}) if ctx.obj else {}
@@ -671,8 +679,10 @@ def cache_rebuild(ctx, data_spec, date_from, date_to, jv_option, cache_dir):
     """
     if jv_option == 2:
         raise click.UsageError(
-            "cache rebuild does not support option=2: JVOpen ignores --from, "
-            "so the requested date range cannot be marked complete safely"
+            "cache rebuild does not support option=2: JVOpen uses --from to "
+            "manage continuity within current race-cycle data, not to select "
+            "an arbitrary historical range, so the requested date range "
+            "cannot be marked complete safely"
         )
 
     from src.cache import CacheManager

--- a/src/fetcher/historical.py
+++ b/src/fetcher/historical.py
@@ -219,9 +219,10 @@ class HistoricalFetcher(BaseFetcher):
 
         download_task_id = None
         fetch_task_id = None
-        # option=2 ignores fromtime server-side, so a requested date range can
-        # never be proven complete. Bypass both existing NL cache markers and
-        # write-through caching for that mode.
+        # option=2 uses fromtime only for continuity within current race-cycle
+        # data; it cannot prove an arbitrary requested historical range
+        # complete. Bypass both existing NL cache markers and write-through
+        # caching for that mode.
         active_cache_manager = self.cache_manager if option != 2 else None
         cache_checkpoints: dict[str, Optional[int]] = {}
         cache_write_committed = active_cache_manager is None

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -278,10 +278,12 @@ class TestFetchCommand(unittest.TestCase):
             )
 
         self.assertEqual(result.exit_code, 0, result.output)
-        self.assertIn('option=2 ignores it server-side', result.output)
-        self.assertIn('ChokyoDate', result.output)
-        self.assertIn('calendar-year chunks', result.output)
-        self.assertIn('adds another chunk', result.output)
+        help_text = ' '.join(result.output.split())
+        self.assertIn('current race-cycle data', help_text)
+        self.assertIn('Sunday or Monday may cover two cycles', help_text)
+        self.assertIn('ChokyoDate', help_text)
+        self.assertIn('calendar-year chunks', help_text)
+        self.assertIn('adds another chunk', help_text)
 
     @patch('src.importer.batch.BatchProcessor')
     def test_fetch_with_all_args(self, mock_batch_processor):


### PR DESCRIPTION
## What changed

- Correct the `fetch --option 2` note and `--from` help to match the official JV-Link behavior.
- Explain that `fromtime` manages continuity within the current race-cycle data rather than selecting an arbitrary historical week.
- Document that Sunday and Monday can cover two race cycles.
- Correct the stale cache comment while retaining the existing fail-safe option-2 cache bypass.

## Why

The previous wording first claimed that option 2 ignored `fromtime`, then an intermediate correction implied that a caller could select an arbitrary retained week. Both descriptions were inconsistent with the official JV-Link specification and could mislead an operator attempting historical recovery.

This PR changes documentation and an existing help assertion only. Runtime fetching and cache behavior are unchanged.

Official references:

- https://jra-van.jp/dlb/sdv/sdk/JV-Link4901.pdf
- https://jra-van.jp/dlb/sdv/sdk/DataLab422.pdf

## Validation

- Final head SHA: `19453a5a33ef09837e7aea72ebc2701f92439c26`
- Squash merge SHA: `afb948bfccd151b66f86676812d0eeea98e1c8f4`
- `27 passed` for `tests/test_cli.py` and `tests/test_historical_cache_failures.py`
- `python3 -m py_compile src/cli/main.py src/fetcher/historical.py`
- `git diff --check`
- Independent exact-SHA review: P0/P1/P2 = 0
- GitHub Actions `test` and `lint`: success
- Native Copilot thread addressed; unresolved threads: 0
