### PR TITLE
票数データ取得時のデータサイズ過多

### DIFF
--- a/src/fetcher/historical.py
+++ b/src/fetcher/historical.py
@@ -323,7 +323,15 @@ class HistoricalFetcher(BaseFetcher):
                 )
                 self._fetch_task_id = fetch_task_id
 
-            # Fetch and parse records (with optional cache write-through)
+            # Fetch and parse records (with optional cache write-through).
+            # The cache stores raw jv_read buffers, so write once per buffer, not
+            # once per parsed record: full-struct parsers (H1/H6) expand one
+            # buffer into thousands of rows that all carry the same `_raw`. Rows
+            # from one buffer share a header, hence the same record date, so the
+            # first surviving row stands in for all of them. Identity is a safe
+            # "same buffer" test because each jv_read() returns a new bytes
+            # object and last_cached_raw keeps it alive.
+            last_cached_raw = None
             for data in self._fetch_and_parse(
                 fetch_task_id,
                 to_date=to_date,
@@ -331,7 +339,9 @@ class HistoricalFetcher(BaseFetcher):
                 consume_replayed_record=self._consume_replayed_record,
                 replay_pending=lambda: self._jvd_replay_records_remaining > 0,
             ):
-                if active_cache_manager and "_raw" in data:
+                raw = data.get("_raw") if active_cache_manager else None
+                if raw is not None and raw is not last_cached_raw:
+                    last_cached_raw = raw
                     rec_date = _extract_record_date(data)
                     if rec_date:
                         if rec_date not in cache_checkpoints:
@@ -339,7 +349,7 @@ class HistoricalFetcher(BaseFetcher):
                                 data_spec,
                                 rec_date,
                             )
-                        active_cache_manager.write_nl_record(data_spec, rec_date, data["_raw"])
+                        active_cache_manager.write_nl_record(data_spec, rec_date, raw)
                     else:
                         # The record is yielded/imported, but cannot be replayed
                         # from this date-keyed cache. Keep the range incomplete;

--- a/tests/test_historical_cache_write_through.py
+++ b/tests/test_historical_cache_write_through.py
@@ -1,0 +1,108 @@
+"""write-through キャッシュは jv_read バッファ 1 個につき 1 回だけ書くこと.
+
+フルストラクト系パーサは 1 バッファを多数の行へ展開し（H1: 28,955B → 1,485 行、
+H6: 102,890B → 4,896 行）、その全行が同じ `_raw` を持つ。行ごとに書くと同じ
+blob が行数ぶん重複する。
+"""
+
+from unittest.mock import MagicMock
+
+from src.fetcher.historical import HistoricalFetcher
+
+H1_BYTES, H1_ROWS = 28_955, 1_485
+H6_BYTES, H6_ROWS = 102_890, 4_896
+JV_READ_COMPLETE = 0
+
+
+def _fetcher(cache, jv_read_results) -> HistoricalFetcher:
+    """JV-Link を持たない HistoricalFetcher を組み立てる."""
+    f = HistoricalFetcher.__new__(HistoricalFetcher)
+    f.parser_factory = MagicMock()
+    f.cache_manager = cache
+    f.show_progress = False
+    f.progress_display = None
+    f._service_key = None
+    f._records_fetched = f._records_parsed = f._records_failed = 0
+    f._files_processed = f._total_files = 0
+    f._start_time = 0.0
+    f._jvd_self_repair_attempts = f._jvd_replay_records_remaining = 0
+    f._recoverable_read_errors = 0
+    f._jv_open_context = f._jv_open_last_file_timestamp = f._fetch_task_id = None
+
+    f.jvlink = MagicMock()
+    f.jvlink.jv_init.return_value = None
+    # (result, read_count, download_count, last_file_timestamp)
+    f.jvlink.jv_open.return_value = (0, len(jv_read_results), 0, "20220110000000")
+    f.jvlink.jv_read.side_effect = jv_read_results
+    return f
+
+
+def _row(n: int) -> dict:
+    """同一バッファから展開された行（ヘッダ由来の日付は全行共通）."""
+    return {"Year": "2022", "MonthDay": "0110", "SanrentanKumi": f"{n:06d}"}
+
+
+def _run(fetcher) -> list:
+    return list(fetcher.fetch("RACE", "20220101", "20221231", option=4))
+
+
+def _written(cache) -> list:
+    return [c.args[2] for c in cache.write_nl_record.call_args_list]
+
+
+def _assert_cached_once(rows: int, size: int) -> None:
+    buff = b"X" * size
+    cache = MagicMock()
+    f = _fetcher(cache, [(size, buff, "f1"), (JV_READ_COMPLETE, None, None)])
+    f.parser_factory.parse.return_value = [_row(i) for i in range(rows)]
+
+    assert len(_run(f)) == rows, "全行が呼び出し元へ渡ること"
+    assert _written(cache) == [buff], (
+        f"バッファ 1 個につき書き込みは 1 回（実際 {cache.write_nl_record.call_count} 回）"
+    )
+    assert cache.write_nl_record.call_args_list[0].args[:2] == ("RACE", "20220110")
+
+
+def test_h1_full_struct_buffer_is_cached_once():
+    _assert_cached_once(H1_ROWS, H1_BYTES)
+
+
+def test_h6_full_struct_buffer_is_cached_once():
+    _assert_cached_once(H6_ROWS, H6_BYTES)
+
+
+def test_each_jv_read_buffer_is_cached_separately():
+    """別バッファは別々に書かれること（重複排除しすぎていないこと）."""
+    a, b = b"A" * 1000, b"B" * 1000
+    cache = MagicMock()
+    f = _fetcher(cache, [(1000, a, "f1"), (1000, b, "f2"), (JV_READ_COMPLETE, None, None)])
+    f.parser_factory.parse.side_effect = [[_row(0), _row(1), _row(2)], [_row(3), _row(4)]]
+
+    assert len(_run(f)) == 5
+    assert _written(cache) == [a, b]
+
+
+def test_single_record_parser_is_unaffected():
+    """RA/SE のような 1 バッファ = 1 レコードのパーサは従来どおり."""
+    buff = b"R" * 1300
+    cache = MagicMock()
+    f = _fetcher(cache, [(1300, buff, "f1"), (JV_READ_COMPLETE, None, None)])
+    f.parser_factory.parse.return_value = _row(0)  # list ではなく単一 dict
+
+    assert len(_run(f)) == 1
+    assert _written(cache) == [buff]
+
+
+def test_rows_filtered_out_by_to_date_do_not_lose_the_buffer():
+    """先頭行が to_date で除外されても、そのバッファはキャッシュされること."""
+    buff = b"F" * 2000
+    cache = MagicMock()
+    f = _fetcher(cache, [(2000, buff, "f1"), (JV_READ_COMPLETE, None, None)])
+    f.parser_factory.parse.return_value = [
+        {"Year": "2023", "MonthDay": "0105"},  # to_date(20221231) より後 -> 除外
+        _row(1),
+        _row(2),
+    ]
+
+    assert len(_run(f)) == 2, "範囲外の 1 行だけが除外されること"
+    assert _written(cache) == [buff], "先頭行が除外されてもバッファは残ること"


### PR DESCRIPTION
ローカルキャッシュが JV-Data ストリームを忠実に保存できていない。キャッシュの目的は「一度取得したデータを再ダウンロードせずに再投入する」ことなので、保存されたものが元のストリームと一致しないのは機能の前提が崩れている状態にあたる。

コミット1つ、`src/fetcher/historical.py` の16行と回帰テスト1ファイルのみ。

---

## 期待される動作

`jv_read()` が1回返したバッファは、キャッシュに**1レコードとして**書かれる。`read_nl()` で読み戻すと**1件**返る。

| 取得したもの | キャッシュに入る数 | 
|---|---|---|
| H6 バッファ 1個（102,890 B） | 1 | 
| H1 バッファ 1個（28,955 B） | 1 | 
| RA バッファ 1個 | 1 | 

## 実際に起きること

| 取得したもの | キャッシュに入る数 | 
|---|---|---|
| H6 バッファ 1個（102,890 B） | **4,896** |
| H1 バッファ 1個（28,955 B） | **1,485** | 
| RA バッファ 1個 | 1 | 

いずれも中身は完全に同一のコピー。

---

## 影響

データ量が多くなり、ディスクがパンクする

---

## 再現方法

### 1. 増幅そのものを見る（JV-Link も DB も不要・数秒）

```python
from src.parser.h1_parser import H1Parser
from tests.fixtures.record_factory import make_h1_record_full

buff = make_h1_record_full()          # 28,955 バイトの H1 フルストラクト
rows = H1Parser().parse(buff)         # -> List[Dict]
print(len(buff), len(rows), len(buff) * len(rows))
# 28955 1485 42998175   ← 29KB のバッファが 41MB 書き込まれる
```

H6 も同様（`src/parser/h6_parser.py` の `_parse_full` が `for i in range(4896)`）。

### 2. 書き込み経路ごと再現する（このPRの回帰テスト）

`tests/test_historical_cache_write_through.py` が、モックした `jv_read` に1バッファを返させ、パーサがそれを N 行へ展開する状況を作って `write_nl_record` の**呼び出し回数**を数える。修正前:

```
FAIL test_h1_full_struct_buffer_is_cached_once
     バッファ 1 個につき書き込みは 1 回（実際 1485 回）
FAIL test_h6_full_struct_buffer_is_cached_once
     バッファ 1 個につき書き込みは 1 回（実際 4896 回）
FAIL test_each_jv_read_buffer_is_cached_separately
FAIL test_rows_filtered_out_by_to_date_do_not_lose_the_buffer
PASS test_single_record_parser_is_unaffected

1 passed, 4 failed
```

### 3. 実データで再現する

```bash
jltsql fetch --data-spec RACE --from 20220101 --to 20221231 --jv-option 4
```

`data/cache/nl/RACE/*.bin` が数分で GB 単位に育つ。中身の重複は次で確認できる（PowerShell）:

```powershell
$lines = Get-Content .\data\cache\nl\RACE\20220108.bin -TotalCount 2000 -Encoding Default
$set = New-Object 'System.Collections.Generic.HashSet[string]'
foreach ($l in $lines) { [void]$set.Add($l) }
"行数=$($lines.Count) ユニーク=$($set.Count)"    # 修正前: 行数=2000 ユニーク=2
```

## 再現条件

**すべて満たすときだけ発生する。**

| 条件 | 理由 |
|---|---|
| **write-through キャッシュが有効** | `jltsql fetch` の `--use-cache`（**既定で有効**）。内部的には `HistoricalFetcher.fetch_with_cache()` 経由で `cache_manager` が設定されている状態 |
| **H1 または H6 を含む spec** | RACE が該当。これらだけがフルストラクトで多数行に展開される |
| **フルストラクト長のレコードが実際に流れてくる** | H1 は 28,955 B 以上、H6 は 102,890 B 以上。短いフラットレコードは単一 dict を返すので発生しない |
| **キャッシュミス（新規取得）であること** | 書き込みが起きるのは取得経路のみ。ただし一度汚染されたキャッシュは、以後のキャッシュヒット時に二乗の再生を引き起こす |


---

## 原因

実装不具合

`_fetch_and_parse()`（`src/fetcher/base.py`）が、フルストラクト系パーサの返す**全サブレコード**に元バッファ全体を貼り付けて yield する。

```python
data = self.parser_factory.parse(buff)
# Full-struct parsers (H1, H6) return List[Dict]
records_list = data if isinstance(data, list) else [data]

for record_item in records_list:
    ...
    record_item["_raw"] = buff   # 4,896 個すべてに、同じ 102,890 バイト
    yield record_item
```

`historical.py` はその dict ごとにキャッシュへ書く。

```python
for data in self._fetch_and_parse(...):
    if active_cache_manager and "_raw" in data:
        ...
        active_cache_manager.write_nl_record(data_spec, rec_date, data["_raw"])
```

**保存の単位（`jv_read` のバッファ）と、書き込みを駆動する単位（パース済みレコード）が食い違っている。** この2つが一致するのは「1バッファ = 1レコード」のパーサだけで、H1/H6 では最初から一致していない。`_raw` を全行に配ったことで、コードの見た目からは単位の違いが分からなくなっていた（`data["_raw"]` は「この行の生データ」に見えるが、実体は隣の行と共有している同じオブジェクト）。

## 修正

バッファを**最初に生き残った行**で1回だけキャッシュする。

- 1つのバッファから展開された行はすべて同じヘッダを持つため**記録日付も同じ**。どの行で処理しても等価で、`cache_range_complete = False` の分岐も含めて成り立つ
- **`base.py` で先頭行にだけ `_raw` を付ける案は採らなかった。** `to_date` フィルタでその行が落ちるとバッファ全体がキャッシュから欠落する。回帰テストでこのケースを固定している
- 同一性判定に `is` を使えるのは、連続する `jv_read()` が必ず別オブジェクトを返すため（`wrapper.py` が `.encode('latin-1')` で毎回生成する）。参照を保持しているので `id()` の再利用による誤判定も起きない
- **`_raw` の契約と yield されるレコードの形は変えていない。** キャッシュ再生経路とその既存テストは影響を受けない。`yield data` は条件の外にあるので、呼び出し元に渡る行は1件も減らない


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate historical cache entries when a single data buffer produces multiple records.
  * Preserved date checkpoints and correctly handles buffers with records lacking extractable dates.
  * Maintained separate caching for distinct data buffers.

* **Tests**
  * Added coverage for large buffers, filtered records, single-record parsing, and multiple-buffer caching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->