### PR TITLE
release: jrvltsql v1.6.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,10 +16,11 @@
 - write-through cache への書き込みを parsed record 単位ではなく `jv_read` buffer
   単位に変更。full-struct parser（H1 は 28,955 byte の buffer から 1,485 行、
   H6 は 102,890 byte から 4,896 行）は 1 つの buffer を多数の行に展開し、各行が
-  同一の `_raw` を持つため、同じ blob が行数分だけ追記されていた。実測では
-  RACE/option=4 の約 10 分間で 21.8 GB（99.9% が重複、実データは約 80 MB）が
-  生成されていたものが、同一範囲の再実行で 4,230 MB/min → 10.17 MB/min、重複 0%
-  になった。`_raw` の契約と yield される record の形は変更なし
+  同一の `_raw` を持つため、同じ blob が行数分だけ追記されていた。実測（RACE/option=4）
+  では、約 10 分間で 21.8 GB・99.9% が重複（同一範囲の実データは約 80 MB）。
+  書き込みレートは別計測で 4,230 MB/min、修正後に同一範囲を再実行すると
+  10.17 MB/min・重複 0% になった（2 つは別々の計測で、一方から他方は導出できない）。
+  `_raw` の契約と yield される record の形は変更なし
 - `JVRead` の `-402`（0 byte の破損ファイル）を、`JVRead` が返した exact filename
   だけを `JVFiledelete` で削除し、同一の `JVOpen` context を再オープンして自己修復。
   再ダウンロード完了・file count・`last_file_timestamp` の一致を確認し、既に caller へ

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,50 @@
 
 現時点で未リリースの変更はありません。
 
+## [1.6.10] - 2026-08-11
+
+### Fixed
+
+- write-through cache への書き込みを parsed record 単位ではなく `jv_read` buffer
+  単位に変更。full-struct parser（H1 は 28,955 byte の buffer から 1,485 行、
+  H6 は 102,890 byte から 4,896 行）は 1 つの buffer を多数の行に展開し、各行が
+  同一の `_raw` を持つため、同じ blob が行数分だけ追記されていた。実測では
+  RACE/option=4 の約 10 分間で 21.8 GB（99.9% が重複、実データは約 80 MB）が
+  生成されていたものが、同一範囲の再実行で 4,230 MB/min → 10.17 MB/min、重複 0%
+  になった。`_raw` の契約と yield される record の形は変更なし
+- `JVRead` の `-402`（0 byte の破損ファイル）を、`JVRead` が返した exact filename
+  だけを `JVFiledelete` で削除し、同一の `JVOpen` context を再オープンして自己修復。
+  再ダウンロード完了・file count・`last_file_timestamp` の一致を確認し、既に caller へ
+  返した prefix を読み飛ばして重複なしで継続する。再試行は最大 2 回で、確認できない
+  条件はすべて fail closed。`-403` は同一ファイルの一部 record を既に返している
+  可能性があるため、best-effort 削除のうえ fail closed とし、危険な位置再開はしない
+- append-only の raw cache を fetch 開始前の byte checkpoint へ rollback するよう変更。
+  generator の途中放棄、replay 不完了、index 更新失敗でも半端な cache を残さない。
+  複数日 range の complete index は一時ファイルからの atomic replace で一括確定する
+- `--from/--to` と cache 完全性の意味を安全側へ統一。option=2 は `JVOpen` が
+  `--from` を取得範囲として扱わないため、既存 NL cache を含めて cache をバイパスし、
+  `cache build/rebuild --option 2` は誤った完全範囲を作る前に fail loud する
+- HC/WC を日付なし master として扱わず、時系列の `ChokyoDate` で `--to` filter と
+  cache 日付を判定。対応する event date を持たない master 行を検出した場合は完全
+  cache marker を付けず、同一取得の部分 cache append も rollback する
+- 旧 cache の完全性 marker を schema v2 で失効させ、legacy raw と active raw を分離
+
+### Changed
+
+- `fetch --option 2` の説明と `--from` の help を公式仕様に合わせて修正。`fromtime`
+  は任意の過去週を選択するものではなく、現在の開催サイクル内の継続性を管理する
+  ものであること、日曜・月曜は 2 つの開催サイクルにまたがりうることを明記
+  （ドキュメントと help のみの変更で、取得と cache の挙動は変更なし）
+- `config/config.yaml.example` の `databases.postgresql` に `connect_timeout` と
+  `sslmode` を built-in 既定と同じ値（10 / prefer）で追記
+
+### Added
+
+- `tests/test_historical_cache_write_through.py`（新規）: buffer 単位の cache 書き込み
+  回帰テスト。5 ケース中 4 ケースは本修正前には失敗する
+- `tests/test_jvd_self_repair.py`（新規）: `JVRead` `-402`/`-403` の自己修復と
+  fail-closed 条件の網羅テスト
+
 ## [1.6.9] - 2026-07-21
 
 ### Fixed
@@ -255,7 +299,8 @@
 - quickstart.py 対話形式セットアップウィザード
 - CLI コマンド（fetch, status, monitor, init）
 
-[Unreleased]: https://github.com/miyamamoto/jrvltsql/compare/v1.6.9...HEAD
+[Unreleased]: https://github.com/miyamamoto/jrvltsql/compare/v1.6.10...HEAD
+[1.6.10]: https://github.com/miyamamoto/jrvltsql/compare/v1.6.9...v1.6.10
 [1.6.9]: https://github.com/miyamamoto/jrvltsql/compare/v1.6.8...v1.6.9
 [1.6.8]: https://github.com/miyamamoto/jrvltsql/compare/v1.6.7...v1.6.8
 [1.6.7]: https://github.com/miyamamoto/jrvltsql/compare/v1.6.6...v1.6.7

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,54 @@
+# jrvltsql v1.6.10 Release Notes
+
+Everything merged since v1.6.9: PR #149, #150, #151, #152, and #153.
+
+## Highlights
+
+- Writes the raw write-through cache once per `jv_read` buffer instead of once
+  per parsed record. Full-struct parsers expand a single buffer into thousands
+  of rows (H1: 1,485 rows from 28,955 bytes; H6: 4,896 rows from 102,890
+  bytes), and every one of those rows carries the same `_raw`, so the identical
+  blob was appended once per row. A real RACE/option=4 run produced 21.8 GB of
+  cache in about ten minutes with 99.9% duplicate content where the actual data
+  for the range is roughly 80 MB. Re-running the same range after the fix
+  produced 10.17 MB/min instead of 4,230 MB/min with 0% duplicates. The `_raw`
+  contract and the shape of yielded records are unchanged, so cache replay is
+  unaffected.
+- Self-repairs `JVRead` `-402` (a zero-byte corrupt file) at the official error
+  boundary rather than by guessing physical Wine cache paths. Only the exact
+  filename returned by `JVRead` is deleted through `JVFiledelete`; the same
+  `JVOpen` context is reopened, re-download completion, file count, and
+  `last_file_timestamp` are all required to match, and the already-emitted
+  prefix is drained without re-parsing, re-yielding, or re-caching it. Retries
+  are bounded at two and every unprovable condition fails closed. `-403` may
+  have already emitted part of the same file, so it deletes the file
+  best-effort for the next run and fails closed instead of resuming at an
+  unsafe position.
+- Rolls the append-only raw cache back to a byte checkpoint taken before the
+  fetch. Abandoning the generator mid-stream, an incomplete replay, or a failed
+  index update no longer leaves a partial cache behind, and multi-day
+  completeness markers are committed together by atomic replace from a
+  temporary file.
+- Makes `--from/--to` and cache completeness fail-safe. Option 2 bypasses the
+  cache entirely — including existing NL cache — because `JVOpen` does not
+  treat `--from` as a fetch range under that option, and
+  `cache build/rebuild --option 2` now fails loudly before it can record a
+  bogus complete range.
+- Treats HC/WC as time-series rather than undated master data, using
+  `ChokyoDate` for the `--to` filter and the cache date key. A master row with
+  no corresponding event date suppresses the complete-cache marker and rolls
+  back the partial cache appended by the same fetch.
+- Invalidates legacy cache completeness markers under schema v2, separating
+  legacy raw from active raw.
+- Corrects the `fetch --option 2` note and `--from` help to match the official
+  JV-Link specification: `fromtime` manages continuity within the current race
+  cycle rather than selecting an arbitrary retained week, and Sunday/Monday can
+  span two race cycles. Documentation and help only; fetch and cache behavior
+  are unchanged.
+- Documents `connect_timeout` and `sslmode` in the `databases.postgresql` block
+  of `config/config.yaml.example` at the same values as the built-in defaults
+  (10 / prefer). The handler already read both keys.
+
 # jrvltsql v1.6.9 Release Notes
 
 ## Highlights

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -9,11 +9,12 @@ Everything merged since v1.6.9: PR #149, #150, #151, #152, and #153.
   of rows (H1: 1,485 rows from 28,955 bytes; H6: 4,896 rows from 102,890
   bytes), and every one of those rows carries the same `_raw`, so the identical
   blob was appended once per row. A real RACE/option=4 run produced 21.8 GB of
-  cache in about ten minutes with 99.9% duplicate content where the actual data
-  for the range is roughly 80 MB. Re-running the same range after the fix
-  produced 10.17 MB/min instead of 4,230 MB/min with 0% duplicates. The `_raw`
-  contract and the shape of yielded records are unchanged, so cache replay is
-  unaffected.
+  cache in about ten minutes with 99.9% duplicate content, where the actual data
+  for the range is roughly 80 MB. Separately, the observed write rate was
+  4,230 MB/min before the fix and 10.17 MB/min with 0% duplicates when the same
+  range was re-run after it. The volume and the rate are two independent
+  measurements; neither is derived from the other. The `_raw` contract and the
+  shape of yielded records are unchanged, so cache replay is unaffected.
 - Self-repairs `JVRead` `-402` (a zero-byte corrupt file) at the official error
   boundary rather than by guessing physical Wine cache paths. Only the exact
   filename returned by `JVRead` is deleted through `JVFiledelete`; the same

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "jltsql"
-version = "1.6.9"
+version = "1.6.10"
 description = "JRA-VAN DataLab の競馬データをSQLite・PostgreSQLにインポートするツール"
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,3 +1,3 @@
 """jrvltsql - JRA-VAN データ取得・管理ツール"""
 
-__version__ = "1.6.9"
+__version__ = "1.6.10"


### PR DESCRIPTION
v1.6.10 リリース。v1.6.9 以降に merge された PR #149 / #150 / #151 / #152 / #153 をまとめたリリースです。詳細は CHANGELOG.md / RELEASE_NOTES.md 参照。

## 中心となる修正 (#153)

write-through cache は raw `jv_read` buffer を保存する一方、書き込みは parsed record 単位で駆動されていました。full-struct parser は 1 つの buffer を多数の行へ展開し（H1: 28,955 byte → 1,485 行、H6: 102,890 byte → 4,896 行）、その全行が同一の `_raw` を持つため、同じ blob が行数分だけ追記されていました。

実測（RACE/option=4）: 約 10 分で 21.8 GB、うち 99.9% が重複、同一範囲の実データは約 80 MB。修正後に同じ範囲を再実行すると 4,230 MB/min → 10.17 MB/min、重複 0%。

## 同梱する他の修正

| PR | 内容 |
|---|---|
| #149 | `config.yaml.example` の `databases.postgresql` に `connect_timeout` / `sslmode` を built-in 既定値で明記 |
| #150 | `JVRead` `-402` を公式の read 境界で自己修復（exact filename のみ `JVFiledelete` → 同一 `JVOpen` context 再オープン → prefix 読み飛ばし）。再試行は最大 2 回、確認できない条件は fail closed。`-403` は fail closed。raw cache は fetch 前の byte checkpoint へ rollback |
| #151 | `--from/--to` と cache 完全性を安全側へ統一。option=2 は cache バイパス、`cache build/rebuild --option 2` は fail loud、HC/WC は `ChokyoDate` で日付判定、旧 cache marker を schema v2 で失効 |
| #152 | option 2 の `fromtime` 説明と `--from` help を公式仕様に整合（docs / help のみ、挙動変更なし） |
| #153 | 上記の cache 書き込み修正 |

## テスト

- `1517 passed, 44 skipped`（`pytest -q -o addopts=''`、PostgreSQL driver / python-dotenv 導入済み環境）
- `tests/test_cli.py::TestCLIBasic::test_status_command` と `::test_version_command` の 2 件が失敗しますが、**未変更の master (`0c4814d`) でも同一件数・同一テストが失敗**します。単体実行では両方 pass するため、本リリースとは無関係の既存の test isolation 問題です。

## 変更ファイル

`CHANGELOG.md` / `RELEASE_NOTES.md` / `pyproject.toml` / `src/__init__.py` のみ。コード変更はありません。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cache consistency, rollback behavior, and recovery from incomplete or corrupted cached data.
  * Corrected range handling and date processing for HC/WC time-series queries.
  * Added safer handling for legacy cache markers and invalid states.
* **Documentation**
  * Updated help and PostgreSQL configuration guidance.
  * Added release documentation and regression test coverage details.
* **Release**
  * Updated the package to version 1.6.10.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->