### PR TITLE
一度も JV-Link に渡っていない jvlink.service_key 設定を削除

### DIFF
--- a/config/config.yaml.example
+++ b/config/config.yaml.example
@@ -2,10 +2,7 @@
 # Copy this file to config.yaml and edit as needed
 
 # JV-Link Settings
-jvlink:
-  # JRA-VAN Service Key (required)
-  # Get from https://jra-van.jp/dlb/
-  service_key: "${JVLINK_SERVICE_KEY}"
+jvlink: {}
 
 
 # Database Settings

--- a/scripts/daily_update.py
+++ b/scripts/daily_update.py
@@ -289,7 +289,6 @@ def main() -> int:
             database=database,
             sid=config.get("jvlink.sid", "JLTSQL"),
             batch_size=1000,
-            service_key=config.get("jvlink.service_key"),
             show_progress=False,
         )
         try:

--- a/scripts/fill_empty_postgresql_tables.py
+++ b/scripts/fill_empty_postgresql_tables.py
@@ -40,7 +40,6 @@ class EmptyTableFiller:
         config = load_config(str(config_path)) if config_path.exists() else None
         if config:
             self.db_config = config.get("databases.postgresql", {})
-            self.service_key = config.get("jvlink.service_key")
         else:
             self.db_config = {
                 "host": "localhost",
@@ -49,7 +48,6 @@ class EmptyTableFiller:
                 "user": "postgres",
                 "password": "",
             }
-            self.service_key = None
 
     def get_empty_tables(self, db):
         """空テーブルのリストを取得"""
@@ -85,7 +83,6 @@ class EmptyTableFiller:
         try:
             fetcher = HistoricalFetcher(
                 sid=f"FILL_{data_spec}",
-                service_key=self.service_key,
                 show_progress=False
             )
 

--- a/scripts/quickstart.py
+++ b/scripts/quickstart.py
@@ -3332,7 +3332,6 @@ class QuickstartRunner:
                     database=database,
                     sid=config.get("jvlink.sid", "JLTSQL"),
                     batch_size=1000,
-                    service_key=config.get("jvlink.service_key"),
                     show_progress=True,
                 )
 

--- a/src/cli/main.py
+++ b/src/cli/main.py
@@ -89,19 +89,6 @@ def _print_fetch_guardrail_notes(jv_option: int) -> None:
     err_console.print(f"[yellow]Note:[/yellow] {FETCH_NOTE_DATE_FIELDS}")
 
 
-def _normalize_service_key(value: str | None) -> str | None:
-    """Normalize service key values from config/env."""
-    if not value:
-        return None
-    v = str(value).strip()
-    if not v:
-        return None
-    # Unresolved env placeholders should be treated as missing.
-    if v.startswith("${") and v.endswith("}"):
-        return None
-    return v
-
-
 @click.group()
 @click.option(
     "--config",
@@ -445,7 +432,6 @@ def fetch(ctx, date_from, date_to, data_spec, jv_option, db, batch_size, progres
             create_all_tables(database)
 
             sid = config.get("jvlink.sid", "JLTSQL") if config else "JLTSQL"
-            service_key = config.get("jvlink.service_key") if config else None
 
             cache_mgr = None
             if use_cache:
@@ -457,7 +443,6 @@ def fetch(ctx, date_from, date_to, data_spec, jv_option, db, batch_size, progres
                 database=database,
                 sid=sid,
                 batch_size=batch_size,
-                service_key=service_key,
                 show_progress=progress,
                 cache_manager=cache_mgr,
             )
@@ -586,7 +571,6 @@ def cache_build(ctx, data_spec, date_from, date_to, jv_option, also_import, db, 
         )
 
     config = ctx.obj.get("config", {}) if ctx.obj else {}
-    service_key = config.get("jvlink", {}).get("service_key") or os.environ.get("JVLINK_SERVICE_KEY")
 
     mgr = CacheManager(Path(cache_dir))
 
@@ -598,7 +582,7 @@ def cache_build(ctx, data_spec, date_from, date_to, jv_option, also_import, db, 
 
     click.echo(f"Building cache: {data_spec} {date_from}..{date_to} (option={jv_option})")
 
-    fetcher = HistoricalFetcher(sid="UNKNOWN", service_key=service_key, show_progress=True)
+    fetcher = HistoricalFetcher(sid="UNKNOWN", show_progress=True)
     fetcher.cache_manager = mgr
 
     if also_import:
@@ -620,7 +604,6 @@ def cache_build(ctx, data_spec, date_from, date_to, jv_option, also_import, db, 
         with database:
             processor = BatchProcessor(
                 database=database,
-                service_key=service_key,
                 show_progress=True,
                 cache_manager=mgr,
             )
@@ -1331,7 +1314,6 @@ def config(ctx, show, set_value, get_key):
         jvlink_tree = tree.add("JV-Link")
         jvlink_config = config_dict.get("jvlink", {})
         jvlink_tree.add(f"SID: {jvlink_config.get('sid', 'N/A')}")
-        jvlink_tree.add(f"Service Key: {'*' * 20 if jvlink_config.get('service_key') else 'Not set'}")
 
         # Database section
         db_tree = tree.add("Database")

--- a/src/fetcher/base.py
+++ b/src/fetcher/base.py
@@ -41,17 +41,12 @@ class BaseFetcher(ABC):
     def __init__(
         self,
         sid: str = "UNKNOWN",
-        service_key: Optional[str] = None,
         show_progress: bool = True,
     ):
         """Initialize base fetcher.
 
         Args:
             sid: Session ID for JV-Link API (default: "UNKNOWN")
-            service_key: Optional JV-Link service key. If provided, it will be set
-                        programmatically without requiring registry configuration.
-                        If not provided, the service key must be configured in
-                        JRA-VAN DataLab application or registry.
             show_progress: Show stylish progress display (default: True)
         """
         # Prefer C# JVLinkBridge over Python win32com for JRA operations.
@@ -73,13 +68,11 @@ class BaseFetcher(ABC):
         self._repaired_read_errors = 0
         self._files_processed = 0
         self._total_files = 0
-        self._service_key = service_key
         self.show_progress = show_progress
         self.progress_display: Optional[JVLinkProgressDisplay] = None
         self._start_time = None
 
-        logger.info(f"{self.__class__.__name__} initialized", sid=sid,
-                   has_service_key=service_key is not None)
+        logger.info(f"{self.__class__.__name__} initialized", sid=sid)
 
     @abstractmethod
     def fetch(self, **kwargs) -> Iterator[dict]:

--- a/src/fetcher/historical.py
+++ b/src/fetcher/historical.py
@@ -49,8 +49,8 @@ class HistoricalFetcher(BaseFetcher):
 
     JVD_SELF_REPAIR_MAX_RETRIES = 2
 
-    def __init__(self, sid: str = "UNKNOWN", service_key: Optional[str] = None, show_progress: bool = True):
-        super().__init__(sid, service_key=service_key, show_progress=show_progress)
+    def __init__(self, sid: str = "UNKNOWN", show_progress: bool = True):
+        super().__init__(sid, show_progress=show_progress)
         self.cache_manager = None
         self._jvd_self_repair_attempts = 0
         self._jvd_replay_records_remaining = 0
@@ -237,7 +237,7 @@ class HistoricalFetcher(BaseFetcher):
                 )
 
             # Initialize JV-Link
-            logger.info("Initializing JV-Link", has_service_key=self._service_key is not None)
+            logger.info("Initializing JV-Link")
             if self.progress_display:
                 # スペックヘッダーを表示（日付範囲付き）
                 self.progress_display.print_spec_header(data_spec, from_date, to_date)

--- a/src/fetcher/realtime.py
+++ b/src/fetcher/realtime.py
@@ -144,7 +144,7 @@ class RealtimeFetcher(BaseFetcher):
 
         try:
             # Initialize JV-Link
-            logger.info("Initializing JV-Link", has_service_key=self._service_key is not None)
+            logger.info("Initializing JV-Link")
             ret = self.jvlink.jv_init()
             if ret != JV_RT_SUCCESS:
                 raise FetcherError(f"JV-Link initialization failed: {ret}")

--- a/src/importer/batch.py
+++ b/src/importer/batch.py
@@ -44,7 +44,6 @@ class BatchProcessor:
         database: BaseDatabase,
         batch_size: int = 1000,
         sid: str = "UNKNOWN",
-        service_key: Optional[str] = None,
         show_progress: bool = True,
         cache_manager=None,
     ):
@@ -54,14 +53,11 @@ class BatchProcessor:
             database: Database handler instance
             batch_size: Records per batch
             sid: Session ID for JV-Link API (default: "UNKNOWN")
-            service_key: Optional service key. If provided, it will be set
-                        programmatically without requiring registry configuration.
             show_progress: Show stylish progress display (default: True)
             cache_manager: Optional CacheManager for local file cache read/write
         """
         self.fetcher = HistoricalFetcher(
             sid,
-            service_key=service_key,
             show_progress=show_progress,
         )
         self.importer = DataImporter(database, batch_size)
@@ -71,7 +67,6 @@ class BatchProcessor:
         logger.info(
             "BatchProcessor initialized",
             sid=sid,
-            has_service_key=service_key is not None,
             show_progress=show_progress,
         )
 

--- a/src/utils/config.py
+++ b/src/utils/config.py
@@ -29,15 +29,13 @@ class Config:
         """Get configuration value by dot-separated key.
 
         Args:
-            key: Dot-separated key (e.g., "jvlink.service_key")
+            key: Dot-separated key
             default: Default value if key not found
 
         Returns:
             Configuration value
 
         Examples:
-            >>> config.get("jvlink.service_key")
-            "YOUR_KEY"
             >>> config.get("databases.sqlite.enabled")
             True
         """
@@ -93,7 +91,6 @@ def _expand_env_vars(config: Any) -> Any:
         Configuration with expanded environment variables
 
     Examples:
-        ${JVLINK_SERVICE_KEY} -> value of JVLINK_SERVICE_KEY
         ${POSTGRES_HOST:localhost} -> value of POSTGRES_HOST or "localhost"
     """
     if isinstance(config, dict):
@@ -139,16 +136,6 @@ def _validate_config(config: Dict[str, Any]) -> None:
     if not enabled_dbs:
         raise ConfigError("At least one database must be enabled")
 
-    # Validate JV-Link service key (if not using env var)
-    service_key = config.get("jvlink", {}).get("service_key", "")
-    if not service_key or service_key.startswith("${"):
-        # Will be expanded from environment variable
-        pass
-    elif len(service_key) < 10:
-        # Assume valid keys are at least 10 characters
-        raise ConfigError("Invalid JV-Link service key")
-
-
 
 def load_config(config_path: Optional[Union[str, Path]] = None) -> Config:
     """Load configuration from YAML file.
@@ -165,7 +152,6 @@ def load_config(config_path: Optional[Union[str, Path]] = None) -> Config:
 
     Examples:
         >>> config = load_config()
-        >>> service_key = config.get("jvlink.service_key")
     """
     resolved_path: Path
     if config_path is None:
@@ -203,9 +189,7 @@ def get_default_config() -> Dict[str, Any]:
         Default configuration dictionary
     """
     return {
-        "jvlink": {
-            "service_key": "",
-        },
+        "jvlink": {},
         "databases": {
             "sqlite": {
                 "enabled": True,

--- a/tests/test_batch_processor.py
+++ b/tests/test_batch_processor.py
@@ -29,7 +29,6 @@ def test_historical_no_data_resets_statistics_from_previous_spec():
     fetcher.show_progress = False
     fetcher.progress_display = None
     fetcher.cache_manager = None
-    fetcher._service_key = None
     fetcher._records_fetched = 9
     fetcher._records_parsed = 8
     fetcher._records_failed = 1

--- a/tests/test_utils_config.py
+++ b/tests/test_utils_config.py
@@ -129,22 +129,6 @@ class TestValidateConfig:
         with pytest.raises(ConfigError, match="At least one"):
             _validate_config(cfg)
 
-    def test_short_service_key_raises(self):
-        cfg = self._valid()
-        cfg["jvlink"]["service_key"] = "short"
-        with pytest.raises(ConfigError, match="service key"):
-            _validate_config(cfg)
-
-    def test_env_var_service_key_skips_length_check(self):
-        cfg = self._valid()
-        cfg["jvlink"]["service_key"] = "${JVLINK_KEY}"
-        _validate_config(cfg)  # should not raise
-
-    def test_empty_service_key_skips_check(self):
-        cfg = self._valid()
-        cfg["jvlink"]["service_key"] = ""
-        _validate_config(cfg)  # empty is allowed (env var path)
-
 
 # ---------------------------------------------------------------------------
 # load_config
@@ -218,4 +202,4 @@ class TestGetDefaultConfig:
         d1 = get_default_config()
         d2 = get_default_config()
         d1["jvlink"]["service_key"] = "MODIFIED"
-        assert d2["jvlink"]["service_key"] == ""
+        assert d2["jvlink"] == {}


### PR DESCRIPTION
## 背景

`config.yaml` の `jvlink.service_key` と `JVLINK_SERVICE_KEY` 環境変数は、JV-Link に一度も渡っていません。

```
config.yaml → config.get("jvlink.service_key")   # cli/main.py
           → HistoricalFetcher(service_key=...)
           → BaseFetcher.__init__
           → self._service_key = service_key     ← ここで終わり
```

`_service_key` の読み手はログ出力だけです。キーを登録する `jv_set_service_key()` は `wrapper.py` と `bridge.py` に定義がありますが、**`src/` `scripts/` のどこからも呼ばれていません**（呼び出しは `tests/unit/test_jvlink_bridge.py` のスタブテストのみ）。

実際に認証を成立させているのは JV-Link 自身の registry エントリで、これは JV-Link 設定ダイアログ / JRA-VAN DataLab が書き込みます。新規キーはそこでの一度きりのオンライン有効化（ライセンスのマシン紐付け）も必要です。

service_keyという記述がソースコード上あることにより、使われていると誤解するため、削除を提案します。

### 互換性

既存 `config.yaml` に `jvlink.service_key` が残っていても**無視されるだけでエラーにはなりません**。
マイグレーション不要で、JV-Link 側のキー設定手順にも変更はありません。

## テスト

```
$ python -m pytest tests/ --ignore=tests/e2e --ignore=tests/integration
1516 passed, 38 skipped
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration**
  * Simplified JV-Link configuration by removing service-key settings and validation requirements.
  * Configuration displays no longer show service-key information.

* **Maintenance**
  * Updated data-fetching and batch-processing workflows to operate without service-key parameters.
  * Initialization logs no longer report service-key status.
  * Updated related tests and configuration examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->