### PR TITLE
docs: audit JV-Data official specification compatibility

### DIFF
--- a/specs/operations/20260815_jvdata_official_spec_compatibility_audit.md
+++ b/specs/operations/20260815_jvdata_official_spec_compatibility_audit.md
@@ -1,0 +1,463 @@
+# JV-Data / JV-Link 公式仕様・新旧互換性監査
+
+## 結論
+
+対象 `master` は、公式仕様準拠を根拠に追加のコード変更をマージ、または
+リリースできる状態ではない。判定は **RED / DO NOT RELEASE** とする。
+
+2023年8月8日の仕様変更に対して「旧 dataspec を拒否し、N 付き dataspec で
+全件再セットアップする」という方針は、JRA-VAN スタッフの推奨と整合する。
+しかし、その入口検査は連結 dataspec を防げず、変更対象7レコードの現行形式も
+安全に処理できていない。加えて、変更時期とは独立した次の重大な矛盾がある。
+
+- native pywin32 経路の `JVOpen` / `JVGets` 呼出しが公式 COM シグネチャと異なる。
+- 共通パーサが Shift-JIS を全文デコードしてからバイト位置でスライスし、全角文字
+  より後ろの項目を破壊する。
+- 速報馬体重 `WH` を、別レコードである天候・馬場変更相当の40バイト構造として
+  読み、公式847バイトの馬体重18頭配列を保存できない。
+- 12レコードの公開長または終端位置が公式現行長より短く、多くは公式配列の1件目
+  だけを保存して途中に偽のレコード区切りを置いている。
+
+したがって、今回の監査報告そのものは保存してよいが、下記 blocker を直して
+実 Windows/JV-Link を含む検証を終えるまで、コードの「仕様準拠」マージ判定には
+使えない。
+
+## 対象と証跡
+
+- Repository: `miyamamoto/jrvltsql`
+- Branch: `codex/jvdata-official-spec-audit-20260815`
+- 監査対象 full SHA:
+  `d6f8f70e4976e053f636dc1d136a3214fa6996ad`
+- 監査開始時の `origin/master`: 同じ SHA
+- SDK 本体の公式最新版: 4.9.0.2（2024-08-07）
+- JV-Data / JV-Link 公式文書: 4.9.0.1（2024-08-07）
+- 直前比較対象 JV-Data: 4.8.0.2
+- product source、schema、test fixture は変更していない。
+
+取得した公式資料の SHA-256 は次の通り。
+
+| 資料 | SHA-256 |
+|---|---|
+| `JV-Data4901.xlsx` | `23bafd375f704acbdd696b5032ac1619f17d47e882587d6e7954b610527a8234` |
+| `JV-Data4901.pdf` | `b6c21aae4ccbba6a71c5e8065609c4fbb1ccee826c16e7d99ca6ecf7a4101522` |
+| `JV-Link4901.pdf` | `dfd1c425a62304bb464f15c25106e030ffccbf99c7c777972d6bb6b6d27ef1d7` |
+| `JV-Data4802.xlsx` | `6a567f10b601115eca350571f36d27d9d28bd2d3835ea72b5bc057711155d4a7` |
+
+主な一次資料:
+
+- SDK 配布ページ: <https://jra-van.jp/dlb/sdv/sdk.html>
+- JV-Data 4.9.0.1: <https://jra-van.jp/dlb/sdv/sdk/JV-Data4901.pdf>
+- JV-Link 4.9.0.1: <https://jra-van.jp/dlb/sdv/sdk/JV-Link4901.pdf>
+- 2023年仕様変更予告: <https://jra-van.jp/dlb/sdv/ml/20230315a.html>
+- 2023年8月8日リリース: <https://jra-van.jp/dlb/sdv/ml/20230808a.html>
+
+## 公式文書の扱い
+
+公式資料内にも矛盾があるため、単一表の機械転記だけでは判定していない。
+
+- JV-Data Excel の option 1 は `COMM` と `MING` を含み、変更履歴にも追加が
+  明記されている。一方、JV-Link PDF の option 1 表からは両者が欠けている。
+  本監査ではデータ仕様書の一覧と変更履歴を優先し、コードの `COMM` / `MING`
+  option 1 対応を正しいと判定した。
+- 公式開発者コミュニティで JRA-VAN スタッフは、暗黙の仕様変更ではなく文書の
+  記載漏れだったこと、TCVN/RCVN を setup に載せた履歴は誤記だったことを認めて
+  いる: <https://developer.jra-van.jp/t/topic/457>。
+- よって、文書間で食い違う箇所は「コードが誤り」と即断せず、変更履歴、データ
+  種別一覧、スタッフ回答、実行可能な境界テストの順で照合した。
+
+## Blocker / high findings
+
+### B-01 native `JVOpen` と `JVGets` の COM 呼出しが不一致
+
+公式 `JVOpen` は6引数
+`(dataspec, fromtime, option, readcount, downloadcount, lastfiletimestamp)` である。
+`src/jvlink/wrapper.py` は3引数だけで呼ぶ。戻り値だけは4要素 tuple を期待しており、
+入力側と出力側の前提が噛み合っていない。公式コミュニティ上の現行 pywin32 実例も
+`JVOpen("RACE", ..., 2, 0, 0, "")` と6引数を渡している:
+<https://developer.jra-van.jp/t/topic/632>。
+
+`JVGets` も公式は `(Byte Array buff, size, filename)` の3引数だが、コードは
+`JVGets("", size)` の2引数で、結果を文字列として扱う。JVGets は内部 fetcher では
+未使用だが、公開 API としては壊れている。
+
+既存テストの COM mock は誤った3引数呼出しを期待するため緑になる。リポジトリには
+bridge 実行本体の source/binary がなく、通常 fallback である native wrapper を実際の
+32-bit Windows COM に接続した証跡もない。このため、実 Windows smoke が終わるまで
+historical fetch 自体を release-ready と判定できない。
+
+### B-02 `BaseParser` がバイト位置を文字位置として使う
+
+公式の開始位置と長さはバイト単位で、Shift-JIS の全角文字は2バイトである。
+`BaseParser.parse()` はレコード全体を Unicode へデコードした後、`FieldDef.start` と
+`length` で文字列を切る。`errors='replace'` では位置を保存できない。
+
+公式現行長6870の CK 合成レコードで、byte 38 に `テスト`、byte 74 に
+`123456789` を置いた実測結果:
+
+```text
+Bamei                  'テスト                              123'
+HeichiHonsyokinTotal   '456789'
+RecordDelimiter        None
+```
+
+CK の賞金が桁落ちし、馬名には後続数値が混入した。BT は系統名より後ろの系統説明、
+JC は馬名・騎手名より後ろの負担重量・コード類が同じ理由で壊れる。CS は説明本文が
+実質最後の項目なので主要本文への影響は限定的だが、区切り検証はできない。
+
+### B-03 `WH` は馬体重レコードではない構造になっている
+
+公式 `WH` は847バイトで、レース番号、発表時刻、18頭分の
+`馬番 + 馬名 + 馬体重 + 増減符号 + 増減差`（45バイト×18）を持つ。
+`WHParser` は40バイトで、`HenkoID`、天候、芝・ダート馬場状態の前後値を読む。
+これは `WE` 系の内容であり、単なる末尾省略ではない。
+
+`NL_WH` と `RT_WH` schema も同じ40バイト前提なので、0B11 の入力を正しく
+分解できず、後から復元する raw field もない。速報馬体重経路全体の blocker である。
+
+### B-04 現行38種のうち複数が公式配列を途中で切る
+
+明らかに短い公開契約は次の12種である。
+
+```text
+BN 387/477    BR 455/545    CH 592/3862   DM 48/303
+KS 772/4173   RA 856/1272   RC 241/501    SK 78/208
+TK 727/21657  TM 39/141     WH 40/847     YS 146/382
+```
+
+左が実装上の公開長または終端、右が公式現行長。BN/BR/CH/KS の成績配列、DM/TM の
+18頭配列、TK の300頭配列、RC の3頭分記録、SK の14頭血統、YS の3競走案内などを
+1件または一部だけ取り、公式レコード内部に `RecordDelimiter` を置くものがある。
+これは「不要列を捨てる」だけではなく、繰返し要素のデータ損失と key collision を
+固定する schema になっている。
+
+RA には1272バイト分岐が追加されているが、公開定数と fixture は856バイトのままで、
+ラップタイム全配列、本賞金・付加賞金全配列などを保持しない。856は直前の4.8.0.2も
+1272バイトだったため、「旧公式レイアウト」とする根拠はない。
+
+### B-05 2023年変更対象7種は新旧両対応ではない
+
+4.8.0.2 から 4.9.0.1 への物理長変化は次の7種だけである。
+
+| ID | 旧長 | 現行長 | 現行実装 | 旧実装 | 判定 |
+|---|---:|---:|---|---|---|
+| UM | 1577 | 1609 | 現行位置・厳密長/CRLF | 拒否 | 現行のみ可 |
+| BR | 537 | 545 | 新幅だが455まで | version dispatchなし | 両方不可 |
+| HN | 245 | 251 | 長さだけ251、3つの番号は旧8byte位置 | 末尾も不一致 | 両方不可 |
+| SK | 178 | 208 | 78byte、血統14件中1件 | version dispatchなし | 両方不可 |
+| CK | 6864 | 6870 | 現行offsetだが B-02 で破壊 | version dispatchなし | 両方不可 |
+| HS | 196 | 200 | 現行10byte番号に対応 | version dispatchなし | 現行のみ可 |
+| BT | 6887 | 6889 | 現行offsetだが B-02 で破壊 | version dispatchなし | 両方不可 |
+
+「長い方を受け入れる」「警告後も読む」は version 対応ではない。幅が2バイト増えると
+後続キー・名前・区切りがすべてずれるため、layout を識別して別 offset を使うか、旧物理
+record を確実に拒否しなければならない。
+
+## 2023年8月8日境界の正しい読み方
+
+公式スタッフ回答から、次の3経路を区別する必要がある。
+
+| 取得経路 | dataspec | 対象時点 | 返る物理構造 |
+|---|---|---|---|
+| 旧通常更新 | `DIFF/BLOD/SNAP/HOSE/TCOV/RCOV` | 2023-08-07まで | 旧幅 |
+| 新通常更新 | `DIFN/BLDN/SNPN/HOSN/TCVN/RCVN` | 2023-08-08以後 | 拡張幅 |
+| 新 setup | N付き | 過去分を含むsetup | 過去も拡張幅へ変換 |
+
+スタッフは旧新を同じ store に混ぜず、新 dataspec で再 setup するよう案内している:
+
+- 新 setup と旧データの扱い: <https://developer.jra-van.jp/t/topic/215>
+- 旧通常更新と新通常更新の境界: <https://developer.jra-van.jp/t/topic/221>
+- 2026年の公式再案内（8月8日以後は DIFN）:
+  <https://developer.jra-van.jp/t/topic/898>
+
+したがって、jrvltsql が新世代だけを採用する方針は妥当であり、必ずしも一つの
+process で旧新両方を parse する必要はない。ただしその場合でも、旧 byte が COM、cache、
+保存済み raw fixture のどの入口からも入らないことと、現行7種が正しく parse できることが
+必要である。現在はどちらも満たさない。
+
+### 連結 dataspec による旧形式ガード回避
+
+公式 `JVOpen` は4文字固定 ID を連結して指定できる。コードの
+`is_retired_data_spec()` は文字列全体の完全一致しか見ない。
+
+```text
+DIFF      retired=True
+DIFFRACE  retired=False
+RACEDIFF  retired=False
+```
+
+direct wrapper は option/dataspec matrix も検査しないため、`DIFFRACE` を COM へ渡せる。
+この場合は旧幅と現行 RACE が同じ stream に入り得る。PR #161 の fail-closed 境界は単一
+ID にしか成立していない。
+
+## JVOpen dataspec / option 監査
+
+現行 JV-Data Excel の行を正本とした場合の official matrix は次の通り。
+
+- option 1: `TOKU,RACE,DIFF,BLOD,SNAP,SLOP,WOOD,YSCH,HOSE,HOYU,COMM,MING,DIFN,BLDN,SNPN,HOSN`
+- option 2: `TOKU,RACE,TCOV,RCOV,SNAP,TCVN,RCVN,SNPN`
+- option 3/4: option 1 と同じ
+
+判定:
+
+- `SNPN + option 2`、`COMM/MING + option 1` は現行コードどおりでよい。
+- `O1`～`O6` は RACE 等から返る record ID であり JVOpen dataspec ではない。コードが
+  option 1/3/4 に追加しているため、実サービスでは `-111` または `-116` となる。
+- 公式は複数ID連結を許すが、validator は単一完全一致しか受けない。CLI が明示的に単一
+  IDだけを製品契約にするならよいが、public wrapper も同じ制約を検査・文書化すべきである。
+- validator は current dataspec の大小文字を正規化せず、retired guard だけが大小文字を
+  無視する。重要度は低いが、public API 契約が非対称である。
+
+## JV-Link 状態・戻り値監査
+
+### High: `-2` を no-data success に変えている
+
+公式で `JVOpen/JVRTOpen = -2` は「setup dialog でキャンセル」であり、no data は `-1`
+だけである。wrapper/bridge は `-1` と `-2` を同じ no-data とし、stream open 状態にする。
+ユーザー取消とデータなしを区別できない。
+
+### High: native `JVRead/JVGets = -3` を回復不能例外にする
+
+公式 `-3` は「対象ファイルをダウンロード中。少し待って再開」である。bridge は返すが、
+native wrapper は例外にする。公式コミュニティの動作例も `-3` を sleep/retry している:
+<https://developer.jra-van.jp/t/topic/632>。
+
+### High: bridge の download 完了条件が逆
+
+公式 `JVStatus` はダウンロード済みファイル数を返し、`downloadcount` と一致した後も
+`JVClose` までその値を返す。`HistoricalFetcher._wait_for_download()` は正しいが、bridge の
+public `wait_for_download()` は「正数になった後0へ戻る」まで待つため、実サービスでは timeout
+する。公式コミュニティ教材も `status == downloadcount` を完了条件にする:
+<https://developer.jra-van.jp/t/topic/606>。
+
+### High: decode failure を plausible data に変える
+
+native `jv_read()` / `jv_gets()` は U+FFFD を ASCII `0`、その他の encode 不能文字を `?`
+へ置換する。壊れた transport byte が数値 `0` に変わると schema validation を通る可能性が
+あり、fail-open である。raw byte を復元できなければ record 全体を不合格にすべきである。
+
+### Medium: setup resume を実装していない
+
+公式は setup 読込の中断再開に `JVRead/JVGets` が返した filename と `JVSkip` を使う。
+コードに `JVSkip` はなく、setup の file-level resume を提供しない。全件を読むだけなら必須
+ではないが、大規模 setup の再開機能としては未対応である。コミュニティでも filename/
+skip の扱いに関する実運用上の質問が繰り返されている:
+<https://developer.jra-van.jp/t/topic/732>、
+<https://developer.jra-van.jp/t/topic/860>。
+
+## 全38レコード current-format matrix
+
+凡例:
+
+- `current-shape`: 現行長の主要 offset/配列分解が実装されている。ただし実 Windows raw
+  record での完全一致を証明するものではなく、弱い length/delimiter 検査は別 risk。
+- `partial`: 現行レコードの繰返しまたは末尾を捨てる。
+- `byte-bug`: 公式 offset 自体は現行寄りだが B-02 の文字/バイト混同で破壊される。
+- `wrong`: 別構造または旧 offset を current として扱う。
+- `undocumented fallback`: current branch に加え、公式根拠のない短い形も受理する。
+
+| ID | 公式長 | 実装判定 | 主要根拠 |
+|---|---:|---|---|
+| TK | 21657 | partial | 300頭配列の先頭付近、公開長727 |
+| RA | 1272 | partial + undocumented fallback | 1272分岐あり、配列不足、公開長856 |
+| SE | 555 | current-shape | byte slice、現行長とCRLFを厳密検査 |
+| HR | 719 | current-shape / weak gate | 払戻全配列を展開するが100byte以上を受理 |
+| H1 | 28955 | current-shape + undocumented fallback | full配列に加え317byteを受理 |
+| H6 | 102890 | current-shape + undocumented fallback | full配列に加え78byteを受理 |
+| O1 | 962 | current-shape / weak gate | full配列、短い record も続行 |
+| O2 | 2042 | current-shape / weak gate | 同上 |
+| O3 | 2654 | current-shape / weak gate | 同上 |
+| O4 | 4031 | current-shape / weak gate | 同上 |
+| O5 | 12293 | current-shape / weak gate | 同上 |
+| O6 | 83285 | current-shape / weak gate | 同上 |
+| UM | 1609 | current-shape | currentのみ、厳密長/CRLF |
+| KS | 4173 | partial | 成績配列を途中で終了、公開長772 |
+| CH | 3862 | partial | 表彰/成績配列を途中で終了、公開長592 |
+| BR | 545 | partial | 新幅の基本部のみ、公開長455 |
+| BN | 477 | partial | 成績配列の一部のみ、公開長387 |
+| HN | 251 | wrong | current長を宣言するが登録番号3項目は旧8byte offset |
+| SK | 208 | partial | 14件血統の1件のみ、公開長78 |
+| CK | 6870 | byte-bug | current offsetだが馬名後の全項目がずれる |
+| RC | 501 | partial | 3頭ブロックを途中で終了、公開長241 |
+| HC | 60 | current-shape / weak gate | 現行末尾まで |
+| HS | 200 | current-shape / weak gate | 2023 current幅 |
+| HY | 123 | current-shape / weak gate | 現行末尾まで |
+| YS | 382 | partial | 競走案内3件の一部、公開長146 |
+| BT | 6889 | byte-bug | current offsetだが系統名後の説明がずれる |
+| CS | 6829 | current-shape / delimiter caveat | 説明が実質末尾、BaseParserでCRLF検査不能 |
+| DM | 303 | partial | 18頭中1頭、公開長48 |
+| TM | 141 | partial | 18頭中1頭、公開長39 |
+| WF | 7215 | current-shape | full配列を展開 |
+| JG | 80 | current-shape / weak gate | 現行末尾まで |
+| WC | 105 | current-shape / delimiter caveat | numeric中心、現行末尾まで |
+| WH | 847 | wrong | 40byteの天候・馬場変更構造 |
+| WE | 42 | current-shape / delimiter caveat | 現行末尾まで |
+| AV | 78 | current-shape | byte slice override |
+| JC | 161 | byte-bug | 馬名/騎手名後の項目がずれる |
+| TC | 45 | current-shape / delimiter caveat | CRLF以外の43byteを定義 |
+| CC | 50 | current-shape / delimiter caveat | CRLF以外の48byteを定義 |
+
+`scripts/validate_schema_parser.py` は動的に生成する配列 key を静的に認識できず、HR/WF
+等に false positive を含む。この表は validator 出力をそのまま採用せず、公式 offset、
+parser の loop、schema、合成 record の実測を個別に照合した結果である。
+
+## DataKubun と realtime 更新
+
+公式で `DataKubun=9` は RA/SE/HR/H1/H6/O1～O6/WF などにおけるレース・重勝式の
+中止状態であり、汎用の「行を物理削除」ではない。updater は RA/SE/WF だけを例外扱い
+し、HR/H1/H6/O1～O6 の `9` を delete dispatch へ送る。schema には DataKubun があるのに
+中止 record を消すため、状態の意味を失う。
+
+AV の `1=出走取消`, `2=競走除外` は汎用 new/update と同じ数値だが、update handler は
+upsert なので両方とも行自体は残る。ここは値の意味を schema に保持しており、今回の
+blocking data loss とはしない。
+
+0B14 の snapshot replacement は、background updater では全 response を materialize して
+から transaction 内で置換し、daily updater も例外時 rollback する。今回確認した範囲では
+この新しい一括置換契約は fail-closed である。
+
+## それ以前・それ以後の仕様変更
+
+### 物理長が変わった古い record
+
+- 2003年: SE `547→555`、BR `467→537`、BN `413→477` 等。
+- これらを layout version / dataspec / record length で dispatch する共通機構はない。
+- 現行 setup が現行形へ正規化する経路だけを製品契約にするなら、古い raw cache/fixture を
+  明示拒否する必要がある。現在、多くの parser は短い record を warning 後も parse する。
+
+### 同じ長さで意味が変わった UM（2006年）
+
+馬名欧字80byteが60byteへ縮小し、20byte reserve の先頭が JRA施設在厩flag になった。
+現行 parser は60byte + flag + reserve を読むため、新 setup で正規化された record には対応
+する。一方、旧物理 record の80byte英字名を直接入れると末尾20byteを flag/reserve と誤認し、
+同じ record 長なので長さ検査だけでは発見できない。cache provenance または generation
+metadata が必要である。
+
+### code/初期値だけが変わったもの
+
+- 2019年 Grade `L`、騎手見習コードの説明・記号追加は TEXT として保存し、enum 拒否を
+  していないため対応できる。
+- 2021年 AV 事由区分の初期値 `0→space` も文字列として受け、両方で field shift は起きない。
+- 2024年の RA/SE 外国・地方レースにおける「設定される/されない」表修正は物理 offset の
+  変更ではない。code は値を hard reject しないため、今回確認した箇所に矛盾はない。
+
+公式は将来 dataspec 内に未知 record type が増えた場合に読み飛ばせるよう求めている。
+Factory は未知 type を `None` にするが、fetcher は parser failure と数えて response/cache を
+不完全扱いする。データ破壊を避ける fail-closed ではあるが、公式の forward-compatibility
+推奨どおりの「skipして既知recordを継続」にはなっていない。
+
+## Realtime / 時系列仕様で整合している点
+
+次は current master と公式仕様が整合するため、今回の finding にはしない。
+
+- `0B11`～`0B17`, `0B20`, `0B30`～`0B36`, `0B41`, `0B42`, `0B51` の ID 対応。
+- `0B41/0B42` は1年保持の時系列、`0B30`～`0B36` は1週間保持の速報として分離。
+- レース key は公式の12桁 `YYYYMMDDJJRR` と16桁 `YYYYMMDDJJKKHHRR` の双方が有効。
+  production helper が12桁を使うこと自体は誤りではない。
+- 0B14 を追加差分ではなく最新 snapshot として置換する方針。
+- JVRead buffer 262144 byte は最大 H6 102890 byte + NULL を十分収容する。
+
+競馬場 helper が01～10だけを列挙することと海外発売レースの realtime key については、
+一次資料から product の intended scope を確定できなかった。欠陥と推測せず evidence gap とする。
+
+## コミュニティ掲示板照合
+
+掲示板は一次仕様の代用にせず、スタッフ回答または再現例として用いた。
+
+- スタッフ回答: 新 setup は過去分も新構造へ変換し、旧新 store を混ぜない:
+  <https://developer.jra-van.jp/t/topic/215>
+- スタッフ回答: 2023-08-07以前の通常更新は旧構造、以後はN付き新構造:
+  <https://developer.jra-van.jp/t/topic/221>
+- スタッフ回答: UM の登録番号/生産者 code/name の幅変更を明示:
+  <https://developer.jra-van.jp/t/topic/214>
+- 2026年公式アナウンス: 2023-08-08以後の蓄積情報は DIFN:
+  <https://developer.jra-van.jp/t/topic/898>
+- スタッフ回答: 現行仕様書にも履歴漏れ・TCVN/RCVN setup誤記がある:
+  <https://developer.jra-van.jp/t/topic/457>
+- コミュニティ実行例: pywin32 の6引数 JVOpen と JVRead `-3` retry:
+  <https://developer.jra-van.jp/t/topic/632>
+- コミュニティ事例: SNAP のままでは新しい出走別着度数が取れず SNPN が必要:
+  <https://developer.jra-van.jp/t/topic/148>
+
+掲示板で報告される「取れない」「古い構造が返る」は、旧ID、新ID、通常、setup を区別しない
+と互いに矛盾して見える。今回の code 判定では topic 215/221 の3経路を基準に整理した。
+
+## 実行した検証
+
+対象 full SHA:
+`d6f8f70e4976e053f636dc1d136a3214fa6996ad`
+
+```text
+python3 -m pytest -q \
+  tests/test_jvdata490_layouts.py \
+  tests/test_parser_compatibility.py \
+  tests/test_ra_parser_jravan.py \
+  tests/test_jvlink_constants.py \
+  tests/test_jvlink_wrapper.py \
+  tests/unit/test_jvlink_bridge.py \
+  tests/test_error_scenarios.py
+```
+
+結果: exit 0、22 skipped。Windows-only wrapper test が skip され、残る mock/fixture は現行の
+誤ったシグネチャと短い互換長を契約化しているため、この green は公式準拠の証拠にならない。
+
+```text
+python3 scripts/validate_schema_parser.py
+```
+
+結果: exit 1、7 mismatches、16 errors。動的配列 parser に false positive を含むため、上記
+findings はこの出力だけではなく個別に再現したものに限定した。
+
+追加の read-only counterexample:
+
+- current CK 6870byte に全角馬名と後続9桁賞金を配置し、賞金が6桁へ崩れることを確認。
+- `is_retired_data_spec('DIFFRACE') is False` を確認。
+- current/previous Excel を列比較し、2023年の長さ変更が7種であることを確認。
+- 全38種について official record length と parser/schema の終端・loop count を比較。
+
+実施できていない必須検証:
+
+- 32-bit Windows + インストール済み JV-Link COM による native wrapper smoke。
+- JRA-VAN から保存した provenance 付き raw record を使う全38種 end-to-end fixture。
+
+この2点は credential/Windows/JV-Link runtime が必要で、static audit で green に代替しない。
+
+## 推奨する修正イテレーション
+
+後戻りを抑えるため、次の順で別PRにする。
+
+1. **COM transport contract**
+   `JVOpen` 6引数、`JVGets` ByteArray/filename、`-2`、`-3`、JVStatus 完了条件、decode
+   failure を直す。シグネチャを強制する fake で修正前 red を確認し、実 Windows smoke を gate
+   にする。
+2. **byte-first parser core**
+   field ごとに raw byte slice してから cp932 decode する。CK/BT/JC に「全角文字より後ろの
+   numeric/text field」の最小 red/green test を置く。
+3. **0B11 / WH full expansion**
+   847byteと18頭配列を実装し、NL/RT schema を展開する。40byte record が受理される現状を
+   red-first で固定し、WE と WH を別契約にする。
+4. **全38種の現行 layout/schema 再生成**
+   12 partial record、HN、RA 配列を公式 Excel から再実装する。偽 delimiter とDB再構築 fixture
+   を公式raw扱いしない。
+5. **2023 generation boundary**
+   staff 推奨の new-only rebuild 方針を維持し、連結 token、cache、raw import の全入口で旧物理
+   record を拒否する。7種すべての current positive と old negative を置く。true dual parser を
+   選ぶ場合だけ、明示 version dispatcher を別設計する。
+6. **dataspec / updater semantics**
+   O1～O6を JVOpen matrix から除き、単一/連結 public API 契約を統一し、中止 `9` を物理削除
+   せず domain state として保存する。
+7. **fixture provenance / resume / forward compatibility**
+   provenance付き raw fixture、未知 record skip policy、JVSkip setup resume を独立して整備する。
+
+各検査・validator の修正では、不正 record/シグネチャが修正前に実際に赤になることを先に
+確認する。上記 blocker を一つずつ直してレビューを毎回再実行するのではなく、各PR内で
+関連 finding を集約して一括修正・focused test・最終レビューを行う。
+
+## 最終判定
+
+- 2023年の新 dataspec への移行方針: **妥当**。
+- 変更前と変更後の物理 layout の両対応: **未達**。
+- new-only 方針として旧 layout を全入口で拒否: **未達**。
+- 現行4.9.0.1の全38種 parse/schema対応: **未達**。
+- JV-Link public API/状態機械: **未達**。
+- realtime ID/時系列保持区分の定義: **概ね整合**（ただし WH 実体は blocker）。
+- コードを仕様準拠としてマージ/リリース: **不可**。

--- a/specs/operations/20260815_jvdata_official_spec_compatibility_audit_worklog.md
+++ b/specs/operations/20260815_jvdata_official_spec_compatibility_audit_worklog.md
@@ -194,6 +194,16 @@
   exit 0 with 22 Windows-only skips. `git diff --check` also exits 0. These
   tests are recorded as repository-regression evidence, not official-format
   proof, for the fixture/mock reasons stated above.
+- Committed the documentation-only audit as
+  `2a25c85e27c236de00b7d5a03b2d88962580fed2`, pushed branch
+  `codex/jvdata-official-spec-audit-20260815`, and opened PR #162:
+  `https://github.com/miyamamoto/jrvltsql/pull/162`. The PR body records that
+  merging this documentation does not approve the audited product code and
+  that the product verdict remains RED / DO NOT RELEASE.
+- Re-ran the focused audit selection on full SHA
+  `2a25c85e27c236de00b7d5a03b2d88962580fed2`; exit 0 with the same 22
+  Windows-only skips. `git diff HEAD^ --check` exits 0 and the worktree was
+  clean before this required post-PR worklog update.
 
 ## Remaining evidence gaps
 
@@ -210,11 +220,11 @@
 
 ## Next safe commands
 
-- Inspect the documentation-only diff, commit it, and repeat the necessary
-  report/link checks on the resulting full SHA.
-- Publish the documentation-only PR, verify its head/threads/checks once, then
-  merge only the audit report iteration. Do not describe that merge as approval
-  of the product code; the report verdict remains RED.
+- Commit and push this post-PR evidence update, then record the final candidate
+  full SHA in the PR conversation (not in a self-referential commit).
+- Verify PR #162 head/checks/threads once against that SHA, then merge only the
+  documentation audit iteration. Do not describe that merge as approval of the
+  product code; the report verdict remains RED.
 
 ## STOP conditions
 

--- a/specs/operations/20260815_jvdata_official_spec_compatibility_audit_worklog.md
+++ b/specs/operations/20260815_jvdata_official_spec_compatibility_audit_worklog.md
@@ -1,0 +1,228 @@
+# JV-Data official-spec and compatibility audit worklog
+
+## Audit identity
+
+- Started: 2026-08-15 JST
+- Objective: compare jrvltsql exhaustively against the current official
+  JV-Data/JV-Link contracts, their published change history, and relevant
+  JRA-VAN developer-community reports; determine whether changed formats are
+  handled correctly before and after each boundary.
+- Minimum scope: dataspec/option matrix, JV-Link calls and return handling,
+  record IDs and lengths, field offsets/types/encodings, parser dispatch,
+  SQLite/PostgreSQL schemas, realtime/time-series records, and known versioned
+  layout transitions. Community posts are corroboration, never a replacement
+  for an official contract.
+- Repository: `miyamamoto/jrvltsql`
+- Worktree: `/home/keiba/scratch/20260815_jrvltsql_official_spec_audit`
+- Branch: `codex/jvdata-official-spec-audit-20260815`
+- Base / initial HEAD / `origin/master`:
+  `d6f8f70e4976e053f636dc1d136a3214fa6996ad`
+- Related production/release version: none identified; this is a read-only
+  source-contract audit of current `master`.
+- Dependencies: none. No production runtime or credential-bearing data source
+  is required for the initial static audit.
+
+## Evidence policy
+
+- Official JRA-VAN SDK documents and announcements are primary evidence.
+- JRA-VAN Data Lab developer-community staff answers and archived board posts
+  are secondary evidence and will be labelled as such.
+- Current source behavior, repository history, fixtures, and tests are observed
+  independently. A passing test is not treated as proof if it does not reach a
+  failure boundary.
+- “Supports both versions” means the implementation can identify the applicable
+  layout and parse each without silent field shift, truncation, key corruption,
+  or schema coercion. Merely keeping an old dataspec constant importable does
+  not count as old-layout parsing support.
+
+## Initial sources discovered
+
+- Official SDK index: `https://jra-van.jp/dlb/sdv/sdk.html`
+- Current official JV-Data specification 4.9.0.1:
+  `https://jra-van.jp/dlb/sdv/sdk/JV-Data4901.pdf`
+- Official 2023-08-08 SDK/JV-Link update notice:
+  `https://jra-van.jp/dlb/sdv/ml/20230808a.html`
+- Official support notice requiring the 2023-08-08 client update:
+  `https://support.jra-van.jp/jravan/detail?category=2&id=332&site=SVKNEGBV`
+- Official developer community: `https://developer.jra-van.jp/`
+- Community topics initially relevant to change history and option behavior:
+  `/t/topic/457`, `/t/topic/459`, `/t/topic/622`, `/t/topic/732`.
+
+## Operations and observations
+
+- Fetched `origin/master`, verified full SHA
+  `d6f8f70e4976e053f636dc1d136a3214fa6996ad`, and created the clean dedicated
+  worktree/branch above.
+- Initial official-source search confirms the current published SDK is 4.9.0.2
+  while both the JV-Link and JV-Data reference documents are 4.9.0.1 dated
+  2024-08-07. The current JV-Data table lists legacy and N-suffixed dataspecs in
+  parallel; the exact semantics and date/layout selection still require
+  section-level verification and must not be inferred from the table alone.
+- Downloaded the current official JV-Data/JV-Link documents and the immediately
+  preceding JV-Data 4.8.0.2 PDF/XLSX into
+  `/home/keiba/scratch/20260815_jvdata_official_materials/`. Relevant SHA-256
+  values are:
+  - `JV-Data4901.xlsx`:
+    `23bafd375f704acbdd696b5032ac1619f17d47e882587d6e7954b610527a8234`
+  - `JV-Data4901.pdf`:
+    `b6c21aae4ccbba6a71c5e8065609c4fbb1ccee826c16e7d99ca6ecf7a4101522`
+  - `JV-Link4901.pdf`:
+    `dfd1c425a62304bb464f15c25106e030ffccbf99c7c777972d6bb6b6d27ef1d7`
+  - `JV-Data4802.xlsx`:
+    `6a567f10b601115eca350571f36d27d9d28bd2d3835ea72b5bc057711155d4a7`
+- Official JRA-VAN staff answers in developer-community topics 215 and 221
+  establish three distinct cases at the 2023-08-08 boundary: old normal data
+  through 2023-08-07 is requested with the old dataspec and old structure;
+  normal data registered on/after 2023-08-08 uses the N-suffixed dataspec and
+  expanded structure; a fresh N-suffixed setup returns older history converted
+  to the expanded structure. Staff explicitly advises rebuilding with the new
+  setup instead of mixing old and new structures in one store.
+- Comparing the official 4.8.0.2 and 4.9.0.1 workbooks found exactly seven
+  record-length transitions: `UM 1577->1609`, `BR 537->545`, `HN 245->251`,
+  `SK 178->208`, `CK 6864->6870`, `HS 196->200`, and `BT 6887->6889`.
+  The changes are breeder code/name and breeding-registration-number width
+  expansions, including all consequent byte-offset shifts.
+- Instantiated all 38 current parser classes and compared their declared or
+  effective terminal offsets to the current official record lengths. Twelve
+  have an obviously truncated or wrong public current-format contract:
+  `BN 387/477`, `BR 455/545`, `CH 592/3862`, `DM 48/303`, `KS 772/4173`,
+  `RA 856/1272`, `RC 241/501`, `SK 78/208`, `TK 727/21657`, `TM 39/141`,
+  `WH 40/847`, and `YS 146/382` (`implementation/official`). `CC`, `JC`, and
+  `TC` end two bytes before the official length only because their BaseParser
+  field lists omit CRLF; that is not itself truncation. RA contains a separate
+  1272-byte branch despite its incorrect public length constant, so it is
+  classified separately: its current branch reaches late fields but still
+  stores only a subset of official repeated arrays.
+- `BaseParser.parse()` decodes the entire Shift-JIS byte record before slicing
+  fields by official byte offsets. The workbook states positions in bytes and
+  full-width characters occupy two bytes. Therefore its claim that
+  `errors='replace'` preserves field positions is false: any multibyte text
+  before a later field shifts that field's Unicode-string index. AV overrides
+  the method with byte slicing; other BaseParser descendants require a
+  per-record reachability test.
+- The code's JVOpen matrix contradicts the current official matrix by accepting
+  record IDs `O1`-`O6` as dataspecs; those are records returned inside `RACE`,
+  not valid JVOpen data-specification IDs. `MING` and `COMM` with option 1 are
+  accepted by the current JV-Data Excel matrix and its change history, so the
+  code is correct on those two entries. The current JV-Link PDF omits both from
+  option 1 while listing them for setup, which is an official-document conflict
+  rather than a code defect; the Excel data contract and explicit history are
+  treated as controlling evidence. Its rejection of all six old dataspecs is a
+  deliberate single-generation migration policy, not direct support for both
+  official old-normal and new-normal retrieval paths.
+- JVOpen officially accepts a concatenation of fixed four-character dataspecs.
+  `is_retired_data_spec()` checks only exact whole-string equality, so mixed
+  requests such as `DIFFRACE` and `RACEDIFF` bypass the old-layout guard. The
+  direct wrapper does not enforce the option matrix, and can therefore pass
+  such a stream to COM, mixing legacy and current bytes. This defeats the
+  safety boundary introduced by the retired-dataspec gate.
+- The native pywin32 wrapper invokes `JVOpen(data_spec, fromtime, option)` with
+  three arguments. The official interface has six arguments, and current
+  working pywin32 examples pass three placeholder out/ref arguments and receive
+  `(rc, readcount, downloadcount, lastfiletimestamp)` as the result tuple. No
+  in-repository bridge executable/source is shipped, so the native fallback is
+  a production-reachable path. Existing mocks assert the three-argument call
+  and therefore hide this real COM contract mismatch.
+- `jv_gets()` similarly calls `JVGets("", size)` with two arguments and treats
+  the result buffer as a string. The official method takes a byte array, size,
+  and filename. This public method is not used by the fetchers, but is not a
+  compliant JV-Link implementation.
+- Official positions are byte offsets in Shift-JIS. A synthetic current CK
+  record with `Bamei=テスト` at byte 38 and prize `123456789` at byte 74
+  produced `Bamei='テスト ... 123'`, prize `456789`, and no delimiter. This
+  executable counterexample proves BaseParser corrupts fields after multibyte
+  text. CK, BT, and JC are directly affected; every BaseParser descendant was
+  classified by whether meaningful fields follow multibyte content.
+- The realtime `WH` implementation is not a truncated bodyweight parser: its
+  40-byte fields are the weather/track-change `WE` layout. Official `WH` is 847
+  bytes and contains the race number, announcement time, and 18 repeated
+  45-byte bodyweight blocks. `NL_WH`/`RT_WH` mirror the wrong 40-byte schema, so
+  0B11 cannot be represented or recovered after import.
+- H1/H6/O1-O6/HR use `DataKubun=9` to represent race cancellation. The updater
+  preserves this domain state only for RA, SE, and WF; for the other official
+  record types it dispatches `9` to physical deletion. This discards the
+  cancellation state even though the schemas retain a DataKubun column.
+- `H1Parser` and `H6Parser` accept undocumented 317-byte and 78-byte “flat”
+  fallback layouts, and `RAParser` accepts an undocumented 856-byte branch.
+  Neither the immediately prior 4.8.0.2 specification nor the published change
+  history identifies these as old official layouts. Tests and generated fixture
+  files label these reconstructed shapes as compatibility/real data, so invalid
+  lengths are currently normalized by the test contract.
+- The direct wrapper and bridge treat JVOpen return `-2` as no-data success and
+  mark the stream open. The official code table defines `-2` exclusively as
+  user cancellation of the setup dialog. This loses the cancellation state.
+- `HistoricalFetcher._wait_for_download()` correctly waits until `JVStatus`
+  reaches JVOpen's `downloadcount`. The bridge's public `wait_for_download()`
+  instead waits for progress to become positive and then return to zero; the
+  official contract says the completed count remains equal to `downloadcount`
+  until JVClose, so that bridge helper times out after a real download.
+- The wrapper raises immediately for JVRead/JVGets `-3` even though the official
+  contract identifies it as “file still downloading; wait and resume”. The
+  bridge preserves `-3`. The two public implementations therefore expose
+  incompatible behavior for an official recoverable state.
+- `JVLinkWrapper.jv_read()` replaces U+FFFD with ASCII `0` and otherwise
+  unencodable text with `?`. A transport-decoding failure can therefore mutate
+  a field into plausible numeric data rather than failing closed.
+- A focused regression run against the candidate full SHA
+  `d6f8f70e4976e053f636dc1d136a3214fa6996ad` passed:
+  `python3 -m pytest -q tests/test_jvdata490_layouts.py
+  tests/test_parser_compatibility.py tests/test_ra_parser_jravan.py
+  tests/test_jvlink_constants.py tests/test_jvlink_wrapper.py
+  tests/unit/test_jvlink_bridge.py tests/test_error_scenarios.py` (22 skipped).
+  The green result is negative evidence for test adequacy because signature
+  mocks, reconstructed short fixtures, and flat-layout assertions encode the
+  mismatched implementation contract. `python3 scripts/validate_schema_parser.py`
+  exited 1 with 7 reported mismatches and 16 errors; several are false positives
+  for dynamically expanded parsers, so only independently confirmed findings
+  are used in the audit conclusion.
+- A second synthetic current HN record independently confirmed the 2023
+  transition defect. With official current positions populated, the parser
+  returned the ten-byte breeding number as only its first eight bytes, shifted
+  the following fields (`DelKubun='J'`, horse name prefixed by `2`), lost both
+  parent breeding numbers, and returned an empty delimiter.
+- Wrote the tracked all-38 audit report at
+  `specs/operations/20260815_jvdata_official_spec_compatibility_audit.md`.
+  It separates current-layout coverage, historical/undocumented fallback
+  shapes, the 2023 three-path retrieval contract, state-machine/API findings,
+  community corroboration, and evidence gaps. No product code, schema, test,
+  or fixture was edited.
+- Re-fetched `origin/master` after the report draft. Local HEAD and
+  `origin/master` remain
+  `d6f8f70e4976e053f636dc1d136a3214fa6996ad`; GitHub has no open pull request
+  for `miyamamoto/jrvltsql` at this observation point.
+- Re-ran the focused audit test selection against the unchanged target SHA;
+  exit 0 with 22 Windows-only skips. `git diff --check` also exits 0. These
+  tests are recorded as repository-regression evidence, not official-format
+  proof, for the fixture/mock reasons stated above.
+
+## Remaining evidence gaps
+
+- A real 32-bit Windows/JV-Link smoke test is still required to convert the
+  native pywin32 signature finding from primary-contract plus independent
+  working examples into an end-to-end observation on this package.
+- The official materials define current and published historical layouts, but
+  the repository's short fixture records were reconstructed from database rows
+  and are not preserved raw JV-Link records. Their provenance cannot establish
+  an undocumented official compatibility format.
+- Overseas/foreign-sale realtime-key coverage cannot be classified safely from
+  the available key examples alone and is left as an explicit coverage gap,
+  not reported as a defect.
+
+## Next safe commands
+
+- Inspect the documentation-only diff, commit it, and repeat the necessary
+  report/link checks on the resulting full SHA.
+- Publish the documentation-only PR, verify its head/threads/checks once, then
+  merge only the audit report iteration. Do not describe that merge as approval
+  of the product code; the report verdict remains RED.
+
+## STOP conditions
+
+- Stop before changing production code: this iteration is an audit unless the
+  user separately authorizes fixes after findings are presented.
+- Stop before treating a community claim as fact unless corroborated by an
+  official document, staff answer, executable behavior, or a clearly labelled
+  uncertainty.
+- Stop and report an evidence gap where an old official specification or
+  representative record cannot be obtained; do not infer dual-version support
+  from current-format tests.


### PR DESCRIPTION
## Summary

- audit current `master` against the official JV-Data/JV-Link 4.9.0.1 documents, the immediately preceding 4.8.0.2 layouts, the published change history, and relevant JRA-VAN developer-community staff answers
- record the all-38 current-format parser/schema matrix and the exact seven-record 2023-08-08 layout boundary
- distinguish official-document inconsistencies from source defects and provide ordered remediation iterations

This PR changes documentation only. It does **not** approve the audited product code. The audit verdict is **RED / DO NOT RELEASE** until the recorded blockers are corrected.

## Major blockers recorded

- native pywin32 `JVOpen`/`JVGets` calls do not match the official COM argument contracts
- `BaseParser` decodes Shift-JIS before applying official byte offsets, corrupting CK/BT/JC after multibyte text
- `WH` implements a 40-byte weather/track-change shape instead of the official 847-byte bodyweight record
- multiple official repeated records are truncated to their first element or an early subset
- the 2023 new-only migration policy is reasonable, but concatenated dataspecs bypass the retired-layout guard and the seven changed records are not all safe in the current layout

## Candidate evidence

- candidate full SHA: `2a25c85e27c236de00b7d5a03b2d88962580fed2`
- focused local regression selection: exit 0, 22 Windows-only skips
- `git diff HEAD^ --check`: exit 0
- worktree clean
- official materials and local SHA-256 values are recorded in the report/worklog

Focused command:

```text
python3 -m pytest -q \
  tests/test_jvdata490_layouts.py \
  tests/test_parser_compatibility.py \
  tests/test_ra_parser_jravan.py \
  tests/test_jvlink_constants.py \
  tests/test_jvlink_wrapper.py \
  tests/unit/test_jvlink_bridge.py \
  tests/test_error_scenarios.py
```

The passing repository tests are explicitly not presented as official-format proof: signature mocks, short reconstructed fixtures, and 22 Windows-only skips leave the blockers observable by primary-contract comparison and focused synthetic counterexamples.
