### PR TITLE
fix: align JV-Link transport with official contracts

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,6 +38,7 @@ jobs:
           tests/test_batch_processor.py \
           tests/test_time_series.py \
           tests/test_retired_data_specs.py \
+          tests/test_jvlink_transport_contract.py \
           tests/unit/test_jvlink_bridge.py \
           -v --cov=src --cov-report=xml --cov-report=term
 

--- a/specs/operations/20260815_jvlink_com_transport_contract_worklog.md
+++ b/specs/operations/20260815_jvlink_com_transport_contract_worklog.md
@@ -162,6 +162,16 @@
   envelope (while still rejecting explicit nonzero codes and error envelopes);
   native COM continues to require exact zero. The close group produced
   `9 passed`, and the combined transport/bridge group produced `76 passed`.
+- Post-commit public-call-site review of candidate
+  `86a62c4d41b475ed5afbb0e17c8b256edf344901` found that making
+  `download_count` the first required `wait_for_download` argument broke the
+  released `wait_for_download(timeout, poll_interval)` API. Two tests first
+  produced `2 failed` with a missing-argument `TypeError`. The bridge now
+  stores the validated JVOpen count, keeps the historical positional order,
+  permits an explicit keyword override, and fails closed when neither source
+  supplies an expected count. The focused rerun produced `2 passed`; the
+  combined transport/bridge group produced `78 passed`. The cited candidate
+  SHA is superseded and must not be used as final evidence.
 - Positive counterparts cover JVOpen success/no-data/cancel state, JVRTOpen
   success/no-data, exact JVStatus equality, valid byte/memoryview recovery,
   valid bridge base64, and successful exact-zero close.
@@ -187,6 +197,9 @@
   - validates base64, byte length, declared size, explicit close results, and
     exact download-count completion, while retaining the current companion
     runtime's code-less successful close acknowledgment;
+  - preserves the released positional wait signature by retaining the latest
+    validated JVOpen download count and refuses to infer completion when no
+    expected count is available;
   - preserves pending-close state across malformed envelopes and failed close.
 - `src/fetcher/base.py` and `src/fetcher/historical.py`
   - bound `-3` wait/retry with monotonic elapsed time;
@@ -201,7 +214,7 @@
 ## Verification on the current uncommitted candidate
 
 - `pytest -q --no-cov tests/test_jvlink_transport_contract.py
-  tests/unit/test_jvlink_bridge.py --tb=short`: `76 passed`.
+  tests/unit/test_jvlink_bridge.py --tb=short`: `78 passed`.
 - `pytest -q --no-cov tests/test_jvd_self_repair.py
   tests/test_retired_data_specs.py --tb=short`: `170 passed`.
 - `pytest -q --no-cov tests/test_realtime.py --tb=short`:
@@ -219,6 +232,12 @@
   3 subtests passed`; it predates the final strict-state corrections and is
   chronological evidence only, not the final candidate gate. The full workflow
   command must be rerun after committing the final candidate SHA.
+- The first committed candidate
+  `86a62c4d41b475ed5afbb0e17c8b256edf344901` passed the updated
+  workflow-equivalent command with `842 passed, 2 skipped, 3 warnings, 3
+  subtests passed`, but public API review subsequently superseded it with the
+  wait-signature correction above. Those results are chronological evidence,
+  not the final candidate gate.
 - A parallel pytest attempt caused only a shared `.coverage.*` SQLite collision
   after the realtime tests themselves reported `63 passed, 3 subtests passed`.
   It is not counted as a product pass; all affected suites above were rerun

--- a/specs/operations/20260815_jvlink_com_transport_contract_worklog.md
+++ b/specs/operations/20260815_jvlink_com_transport_contract_worklog.md
@@ -1,0 +1,271 @@
+# JV-Link COM transport contract worklog
+
+## Iteration identity
+
+- Started: 2026-08-15 JST
+- Objective: make the native Python JV-Link transport and the public bridge
+  helpers conform to the official JV-Link 4.9.0.1 call/return/state contracts,
+  without changing parser layouts or database schemas in this iteration.
+- Minimum scope:
+  - native pywin32 `JVOpen` six-argument invocation and tuple handling;
+  - native `JVGets` byte-array/size/filename invocation;
+  - distinct JVOpen `-1` no-data and `-2` setup-cancel semantics;
+  - recoverable JVRead/JVGets `-3` propagation and bounded caller retry;
+  - bridge download completion at `JVStatus == downloadcount`;
+  - fail-closed COM-buffer reconstruction when bytes cannot be recovered;
+  - focused negative/positive tests, documentation evidence, review, PR, and
+    merge for this transport-only iteration.
+- Out of scope: BaseParser byte slicing, WH/schema expansion, the remaining 38
+  parser layouts, dataspec generation guards, updater DataKubun semantics, and
+  fixture provenance. Those remain separate follow-up iterations documented in
+  PR #162.
+- Repository: `miyamamoto/jrvltsql`
+- Worktree: `/home/keiba/scratch/20260815_jrvltsql_com_transport`
+- Branch: `agent/jvlink-com-transport-contract-20260815`
+- Base / initial HEAD / `origin/master` full SHA:
+  `c1fc891a5d17ff2982901867f4c4b6dc4af98464`
+- Dependency: documentation audit PR #162 merged as the base SHA above.
+- Related released version: `v1.6.10`; this is a new unreleased code candidate.
+- Reviewer policy: Codex performs the implementation review. Gather all
+  actionable correctness/data-integrity findings before a consolidated fix;
+  do not merge without exact-head tests, CI, unresolved threads zero, and a
+  clean worktree.
+
+## Official contracts
+
+- JV-Link interface specification 4.9.0.1:
+  `https://jra-van.jp/dlb/sdv/sdk/JV-Link4901.pdf`.
+- The official SDK community index was rechecked on 2026-08-15. It still
+  identifies interface specification 4.9.0.1 (2024-08-07) as current even
+  though the separate development guide link was updated on 2026-08-04:
+  `https://developer.jra-van.jp/t/topic/45`.
+- `JVOpen(dataspec, fromtime, option, readcount, downloadcount,
+  lastfiletimestamp)` has six parameters. The last three are output/ref values.
+- `downloadcount` is the subset of `readcount` requiring download, so both
+  counts are non-negative and `downloadcount <= readcount`.
+- `JVGets(Byte Array buff, size, filename)` has three parameters.
+- JVOpen `-1` means no matching data; `-2` means the setup dialog was cancelled.
+- JVRead/JVGets `-3` means the file is still downloading and reading must resume
+  after a wait.
+- `JVStatus` is a downloaded-file count. Completion is equality with the
+  `downloadcount` returned by JVOpen, and the completed value remains until
+  JVClose.
+- Official `JVRTOpen(dataspec, key)` has no read-count out parameter and
+  succeeds only with return code `0`; the Python API retains a zero-valued
+  second tuple item solely for backward interface compatibility.
+- The current official error-code community post confirms the meanings and
+  remedies for `-1`, `-3`, `-201/-202/-203`, `-402/-403`, and `-502/-503`:
+  `https://developer.jra-van.jp/t/topic/822`.
+
+## Start state and operations
+
+- Verified `gh` 2.76.0 and an authenticated `miyamamoto` GitHub session.
+- Fetched `origin/master`; created the clean dedicated worktree and branch from
+  full SHA `c1fc891a5d17ff2982901867f4c4b6dc4af98464`.
+- At the initial checkpoint, no production source or test had been edited yet.
+- Added platform-neutral, fixed-signature COM fakes and public state-machine
+  tests in `tests/test_jvlink_transport_contract.py`; these do not inherit the
+  Windows-only skip marker in `tests/test_jvlink_wrapper.py`.
+- Red-first command on unchanged production source:
+  `pytest -q tests/test_jvlink_transport_contract.py` exited `1` with
+  `13 failed`. The observed failures included three missing `JVOpen`
+  arguments, the missing `JVGets` filename argument, `-2` being accepted as
+  no-data/readable, `-3` raising immediately instead of waiting, U+FFFD being
+  silently changed to ASCII `0`, CP1252 byte `0x93` becoming CP932 `0x8167`,
+  bridge `wait_for_download` not accepting `download_count`, and JVStatus
+  overshoot being accepted as completion. These are the intended contract
+  failures, not fixture/setup failures.
+- Before production edits, expanded the same red suite with direct negative
+  cases for deterministic call-order/download failures, byte-count mismatch,
+  and bridge setup-cancel state. A second unchanged-source red run is required
+  below before implementation.
+- Expanded unchanged-source red command:
+  `pytest -q tests/test_jvlink_transport_contract.py` exited `1` with
+  `20 failed`. The added cases also observed that `-201/-202/-203/-502/-503`
+  were retried or deleted instead of failing once, a short native buffer was
+  not rejected by a byte-count contract, and bridge `-2` exposed a readable
+  state. Product edits begin only after this second red result.
+- Independent source re-check after the first green implementation found an
+  actionable pywin32 marshaling error in the candidate: the official interface
+  has three JVGets arguments, but a working pywin32 implementation returns
+  `(return_code, memoryview, filename)`, not the candidate's assumed four-item
+  tuple. The same field report changed JVRead/JVGets out-argument placeholders
+  from empty strings to `bytearray()` after intermittent JVLinkAgent crashes.
+  Evidence: `https://qiita.com/hraps/items/b7a4ba572ff52f4ff47d` (updated
+  2025-07-14), cross-checked against the official JVGets syntax. Tests are
+  changed first; a focused red result against the first candidate is required
+  before correcting production code.
+- Review also found that `.github/workflows/test.yml` enumerates test files and
+  did not include the new transport contract suite, so CI could be green while
+  every new negative test was absent. A workflow-membership test is added
+  before the workflow edit and must fail on the current workflow.
+
+## Red/green implementation evidence
+
+- First implementation corrected the six-argument JVOpen call, JVGets call
+  shape, `-1/-2/-3` handling, exact JVStatus completion, corrupt-file error
+  classification, and fail-closed buffer recovery. The expanded contract suite
+  turned green after those edits.
+- A source recheck against the working 64-bit Python/pywin32 field report
+  `https://qiita.com/hraps/items/b7a4ba572ff52f4ff47d` found that JVGets
+  actually returns three values `(code, memoryview, filename)` and that empty
+  string dummy arguments had caused intermittent JVLinkAgent failures. Two new
+  tests failed against the first candidate, then passed after both JVRead and
+  JVGets used `bytearray()` placeholders and JVGets accepted the three-value
+  return shape.
+- The CI-membership test failed once before
+  `tests/test_jvlink_transport_contract.py` was added to the enumerated workflow
+  command, then passed.
+- Additional state/protocol negative tests were run before each related fix:
+  bridge RT no-data/close exception (`2 failed`), malformed/short base64 payload
+  (`2 failed`), missing result codes and close error response (`5 failed`),
+  missing open outputs/RT compatibility count (`4 failed`), and undocumented
+  positive JVOpen (`1 failed`). Each corresponding focused rerun passed after
+  the implementation change.
+- The assumed mandatory bridge RT `readcount` was then checked against the
+  actual companion runtime. Read-only inspection of
+  `miyamamoto/jrvltsql-wine-runtime` `origin/main` full SHA
+  `be759ee5bdccd06dccb61f1c63f9799f136c0a39` proved that its valid
+  `JVRTOpen=-1` envelope omits `readcount`. A compatibility test for this exact
+  response, positive JVRTOpen rejection, and negative expected download count
+  produced `3 failed` before correction and `4 passed` after correction. The
+  earlier missing-RT-count hypothesis/test was withdrawn rather than encoding
+  a bridge-incompatible contract.
+- Strict state review found that a successful COM/bridge open followed by a
+  malformed output envelope lost the JVClose obligation, and that impossible
+  `downloadcount > readcount` plus a nonzero invented JVRTOpen count were still
+  accepted. The focused negative run produced `6 failed`; after preserving
+  pending-close state before output validation and validating the counts it
+  produced `6 passed`.
+- A close acknowledgment with a nonzero result was being treated as success
+  and clearing state. The new native/bridge negative test produced `1 failed`;
+  after exact-zero validation, the close-focused group produced `5 passed`.
+- Final native-state review found the same close-obligation leak for a
+  malformed successful one-item JVRTOpen tuple. Its focused test produced
+  `1 failed` before state capture was moved ahead of tuple validation and
+  `1 passed` afterward.
+- Final bridge-state review found that a protocol-level `status: ok` response
+  without a result code raised correctly but lost the remote JVClose
+  obligation for both JVOpen and JVRTOpen. The two-case negative test produced
+  `2 failed` with `_needs_close == False`; after capturing the obligation
+  before result-code validation it produced `2 passed`.
+- The complete fetch-loop reread found that `-402/-403` with no recovery
+  callback continued without deleting or reopening anything, allowing an
+  endless reread of the same corrupt file. The two-code negative test first
+  produced `2 failed` because no exception was raised, then `2 passed` after
+  the no-recovery branch was made fail-closed.
+- Companion-runtime compatibility review found that
+  `jrvltsql-wine-runtime@be759ee5bdccd06dccb61f1c63f9799f136c0a39`
+  acknowledges close as `{"status":"ok"}` without the official native Long
+  result code. A direct compatibility test produced `1 failed` against the
+  strict candidate. The bridge now accepts only this successful legacy
+  envelope (while still rejecting explicit nonzero codes and error envelopes);
+  native COM continues to require exact zero. The close group produced
+  `9 passed`, and the combined transport/bridge group produced `76 passed`.
+- Positive counterparts cover JVOpen success/no-data/cancel state, JVRTOpen
+  success/no-data, exact JVStatus equality, valid byte/memoryview recovery,
+  valid bridge base64, and successful exact-zero close.
+
+## Implemented scope
+
+- `src/jvlink/wrapper.py`
+  - invokes JVOpen with all six official arguments;
+  - invokes JVRead/JVGets with stable `bytearray()` out placeholders;
+  - accepts current three-value and compatible four-value marshaled read
+    responses without inventing missing fields;
+  - distinguishes readable state from the mandatory JVClose obligation;
+  - validates official result/count relationships and rejects malformed
+    successful envelopes without leaking close state;
+  - preserves `-3` for bounded caller retry;
+  - reconstructs exact transport bytes and rejects replacement/unencodable or
+    short buffers instead of manufacturing `0`/`?` data;
+  - clears state only after exact-zero JVClose.
+- `src/jvlink/bridge.py`
+  - validates result codes and required JVOpen fields fail-closed;
+  - remains compatible with the current runtime's count-less RT no-data
+    envelope while requiring any provided compatibility count to be zero;
+  - validates base64, byte length, declared size, explicit close results, and
+    exact download-count completion, while retaining the current companion
+    runtime's code-less successful close acknowledgment;
+  - preserves pending-close state across malformed envelopes and failed close.
+- `src/fetcher/base.py` and `src/fetcher/historical.py`
+  - bound `-3` wait/retry with monotonic elapsed time;
+  - allow targeted corrupt-file recovery only for official `-402/-403`;
+  - fail once without blind deletion for deterministic call-order, download,
+    and missing-file statuses;
+  - reject setup cancellation as no-data and reject negative/overshot download
+    counts immediately.
+- `.github/workflows/test.yml` executes the new platform-neutral transport
+  contract suite on every test job.
+
+## Verification on the current uncommitted candidate
+
+- `pytest -q --no-cov tests/test_jvlink_transport_contract.py
+  tests/unit/test_jvlink_bridge.py --tb=short`: `76 passed`.
+- `pytest -q --no-cov tests/test_jvd_self_repair.py
+  tests/test_retired_data_specs.py --tb=short`: `170 passed`.
+- `pytest -q --no-cov tests/test_realtime.py --tb=short`:
+  `63 passed, 3 subtests passed`.
+- `pytest -q --no-cov tests/test_error_scenarios.py --tb=short`:
+  `21 passed`.
+- `flake8 src tests --count --select=E9,F63,F7,F82 --show-source
+  --statistics`: exit `0`, count `0`.
+- `python3 -m compileall -q` on all changed source and the new test: exit `0`.
+- `black --check tests/test_jvlink_transport_contract.py`: pass. Existing
+  source files are not bulk-reformatted because repository formatting drift is
+  outside this iteration.
+- `git diff --check`: pass.
+- An earlier workflow-equivalent run passed `820 passed, 2 skipped, 3 warnings,
+  3 subtests passed`; it predates the final strict-state corrections and is
+  chronological evidence only, not the final candidate gate. The full workflow
+  command must be rerun after committing the final candidate SHA.
+- A parallel pytest attempt caused only a shared `.coverage.*` SQLite collision
+  after the realtime tests themselves reported `63 passed, 3 subtests passed`.
+  It is not counted as a product pass; all affected suites above were rerun
+  sequentially with `--no-cov` and exited zero.
+
+## Windows/JV-Link smoke status
+
+- Read-only host inspection on 2026-08-15 found Linux x86_64, no `wine`, no
+  `wine32`, no `powershell.exe`, no JV/JRA/WINE integration environment marker,
+  and no real JVLinkBridge executable. Located `.exe` files were zero-purpose
+  pytest fixtures under `.pytest-tmp`.
+- `tests/integration/test_jvlink_real.py` is opt-in through
+  `JLTSQL_RUN_REAL_INTEGRATION=1` and explicitly requires an authenticated
+  Windows JV-Link host. This host cannot meet that precondition.
+- GitHub `.github/workflows/test.yml` runs only on `ubuntu-latest`; it cannot
+  supply the missing native COM smoke.
+- Linux fixed-signature fakes prove argument/state logic but are not treated as
+  equivalent to real pywin32/COM marshaling. Per the iteration STOP condition,
+  this remains a merge blocker unless a direct authenticated Windows result is
+  supplied for the exact candidate SHA.
+
+## Red-first requirement
+
+- Add the minimum signature-enforcing fakes and state-boundary tests before
+  production edits.
+- Run them on the unchanged production code and record the exact failing
+  assertions/exit status here.
+- Positive counterparts must show official success/no-data paths still work.
+- A thrown exception is not a successful `-3` decision. Tests must observe a
+  recoverable status and a bounded retry/timeout decision at the caller.
+- Buffer reconstruction must have a negative test proving U+FFFD or an
+  unencodable character cannot become plausible `0`/`?` data.
+
+## Next safe command
+
+Review the complete diff once more, update this worklog if a finding changes
+the candidate, commit the candidate, and rerun the exact workflow-equivalent
+test/lint commands on that full SHA. Push a draft PR with the exact SHA and
+evidence. Do not merge until the real Windows/JV-Link smoke is attached to the
+same candidate or an explicitly accepted equally direct replacement exists.
+
+## STOP conditions
+
+- Stop before product edits until the focused new tests fail on unchanged
+  production code for the intended reason.
+- Stop before merge if the real Windows/JV-Link smoke required by the native
+  path cannot be executed or replaced by sufficiently direct evidence; mark it
+  as an explicit blocker rather than treating Linux mocks as equivalent.
+- Stop before merge on any focused/workflow-equivalent failure, actionable
+  review finding, unresolved thread, head/test SHA mismatch, or dirty worktree.

--- a/src/fetcher/base.py
+++ b/src/fetcher/base.py
@@ -16,6 +16,9 @@ from src.utils.progress import JVLinkProgressDisplay
 
 logger = get_logger(__name__)
 
+JV_READ_DOWNLOAD_TIMEOUT_SECONDS = 300.0
+JV_READ_DOWNLOAD_POLL_INTERVAL_SECONDS = 0.2
+
 
 class FetcherError(Exception):
     """Data fetcher error."""
@@ -95,7 +98,6 @@ class BaseFetcher(ABC):
         to_date: Optional[str] = None,
         recover_file_error: Optional[Callable[[int, str], None]] = None,
         consume_replayed_record: Optional[Callable[[], bool]] = None,
-        replay_pending: Optional[Callable[[], bool]] = None,
     ) -> Iterator[dict]:
         """Internal method to fetch and parse records.
 
@@ -106,8 +108,6 @@ class BaseFetcher(ABC):
                 corrupt downloaded files (-402/-403).
             consume_replayed_record: Optional callback that returns True when a
                 record replayed after recovery must be skipped.
-            replay_pending: Optional callback that returns True while a
-                historical recovery is still replaying an emitted prefix.
 
         Yields:
             Dictionary of parsed record data
@@ -119,11 +119,32 @@ class BaseFetcher(ABC):
         last_update_time = self._start_time
         update_interval = 2.0  # Update progress every 2 seconds
         last_gc_time = self._start_time  # Periodic GC to free COM buffers
+        download_wait_started: Optional[float] = None
 
         while True:
             try:
                 # Read next record
                 ret_code, buff, filename = self.jvlink.jv_read()
+
+                if ret_code == -3:
+                    now = time.monotonic()
+                    if download_wait_started is None:
+                        download_wait_started = now
+                    elapsed = now - download_wait_started
+                    if elapsed >= JV_READ_DOWNLOAD_TIMEOUT_SECONDS:
+                        raise FetcherError(
+                            "JVRead file-downloading wait timeout after "
+                            f"{elapsed:.1f} seconds"
+                        )
+                    logger.debug(
+                        "JVRead waiting for file download",
+                        filename=filename,
+                        elapsed_seconds=elapsed,
+                    )
+                    time.sleep(JV_READ_DOWNLOAD_POLL_INTERVAL_SECONDS)
+                    continue
+
+                download_wait_started = None
 
                 # Return code meanings:
                 # > 0: Success with data (value is data length)
@@ -251,71 +272,26 @@ class BaseFetcher(ABC):
                             )
                         last_update_time = current_time
 
-                elif ret_code in (-201, -202, -203, -402, -403, -502, -503):
-                    # Recoverable errors - delete corrupted file and continue
-                    #
-                    # Official meanings (JV-Link "3. コード表", JVRead/JVGets
-                    # section) differ from the original kmy-keiba-derived
-                    # labels below:
-                    # -201: JVInit not called (not "database busy")
-                    # -202: previous JVOpen/JVRTOpen/JVMVOpen not JVClose'd (not "file busy")
-                    # -203: JVOpen not called (not "setup not complete or file corruption")
-                    # -402, -403: downloaded file abnormal -- size 0 / bad content (file, not database)
-                    # -502: download failed (communication/disk error)
-                    # -503: file not found
-                    #
-                    # -201/-203 in particular indicate a call-order bug (JVInit/
-                    # JVOpen genuinely not called), which deleting a file and
-                    # retrying jv_read() cannot fix -- retrying will just hit
-                    # the same code again. They remain in this recoverable set
-                    # unchanged pending a decision on whether that's still the
-                    # right classification; see the PR description.
-                    if (
-                        ret_code not in (-402, -403)
-                        and replay_pending is not None
-                        and replay_pending()
-                    ):
-                        raise FetcherError(
-                            "JVRead returned legacy recoverable error "
-                            f"{ret_code} while historical recovery replay was pending; "
-                            "cannot preserve stream position safely"
-                        )
-
-                    # Error-specific guidance
-                    error_messages = {
-                        -201: "JVInitが行なわれていません（内部エラー）。一時的なエラーとして続行します。",
-                        -202: "前回のOpenがJVCloseされていません（オープン中）。一時的なエラーとして続行します。",
-                        -203: "JVOpenが行なわれていません（内部エラー）。ファイルを削除して続行します。",
-                        -402: "ダウンロードしたファイルが異常です（サイズ0）。破損ファイルを削除して続行します。",
-                        -403: "ダウンロードしたファイルが異常です（データ内容）。破損ファイルを削除して続行します。",
-                        -502: "ダウンロードに失敗しました（通信エラーやディスクエラーなど）。破損ファイルを削除して続行します。",
-                        -503: "読み出すべきファイルが見つかりません。ファイルを削除して続行します。",
-                    }
-
-                    error_msg = error_messages.get(ret_code, "リカバリー可能なエラーが発生しました。")
+                elif ret_code in (-402, -403):
+                    # Only the two official corrupt-downloaded-file statuses
+                    # enter targeted file recovery. Call-order errors
+                    # (-201/-202/-203), download failure (-502), and missing
+                    # file (-503) cannot be repaired by repeating JVRead or by
+                    # deleting the returned path.
                     logger.warning(
-                        f"Recoverable JVRead error: {error_msg}",
+                        "JVRead returned a corrupt downloaded file",
                         ret_code=ret_code,
                         filename=filename,
-                        recommended_action="Deleting corrupted file and continuing",
                     )
-                    if ret_code in (-203, -402, -403, -502, -503):
-                        if recover_file_error is not None and ret_code in (-402, -403):
-                            recover_file_error(ret_code, filename or "")
-                            self._repaired_read_errors += 1
-                        elif filename and hasattr(self.jvlink, 'jv_file_delete'):
-                            # Continuing lets non-snapshot imports drain later
-                            # files, but this response is no longer complete.
-                            self._recoverable_read_errors += 1
-                            try:
-                                self.jvlink.jv_file_delete(filename)
-                                logger.info(f"Deleted corrupted file: {filename}")
-                            except Exception as e:
-                                logger.warning(f"Failed to delete file {filename}: {e}")
-                        else:
-                            self._recoverable_read_errors += 1
+                    if recover_file_error is not None:
+                        recover_file_error(ret_code, filename or "")
+                        self._repaired_read_errors += 1
                     else:
                         self._recoverable_read_errors += 1
+                        raise FetcherError(
+                            "JVRead corrupt-file recovery is unavailable for "
+                            f"error code {ret_code} ({filename or 'unknown file'})"
+                        )
                     continue
 
                 else:

--- a/src/fetcher/historical.py
+++ b/src/fetcher/historical.py
@@ -293,6 +293,8 @@ class HistoricalFetcher(BaseFetcher):
             )
 
             # Check if data is empty
+            if result == -2:
+                raise FetcherError("JVOpen setup dialog was cancelled")
             if result == -1 or (read_count == 0 and download_count == 0):
                 logger.info(
                     "No data available from specified timestamp",
@@ -304,6 +306,8 @@ class HistoricalFetcher(BaseFetcher):
                         f"{data_spec}: サーバーにデータなし"
                     )
                 return  # No data to fetch
+            if result != 0:
+                raise FetcherError(f"JVOpen returned unexpected result code: {result}")
 
             # Wait for download to complete if needed
             if download_count > 0:
@@ -343,7 +347,6 @@ class HistoricalFetcher(BaseFetcher):
                 to_date=to_date,
                 recover_file_error=self._recover_historical_read_error,
                 consume_replayed_record=self._consume_replayed_record,
-                replay_pending=lambda: self._jvd_replay_records_remaining > 0,
             ):
                 raw = data.get("_raw") if active_cache_manager else None
                 if raw is not None and raw is not last_cached_raw:
@@ -582,32 +585,13 @@ class HistoricalFetcher(BaseFetcher):
         """
         start_time = time.time()
         last_status = None
-        retry_count = 0
-        max_retries = 2  # Maximum retries for temporary errors
-        if download_count <= 0:
+        if download_count < 0:
+            raise FetcherError("download_count must not be negative")
+        if download_count == 0:
             return
 
         last_progress_time = start_time  # Track when downloaded-file count last changed.
         stall_timeout = 300.0  # 5 minutes before stall abort
-
-        # Retryable error codes (temporary errors that may resolve)
-        #
-        # Official meanings (JV-Link "3. コード表", JVStatus section) differ
-        # from the labels below:
-        # -201: JVInit not called (not "database busy")
-        # -202: previous JVOpen/JVRTOpen/JVMVOpen not JVClose'd (not "file busy")
-        # -203: JVOpen not called (not "incomplete setup/cache issue")
-        # -502: download failed (communication/disk error)
-        # -503: (JVStatus doesn't define -503; kept here for the bounded
-        #        max_retries=2 safety net below in case JVRead's -503,
-        #        file not found, surfaces through this status poll)
-        #
-        # -201/-203 indicate a call-order bug (JVInit/JVOpen genuinely not
-        # called), which polling jv_status() again cannot fix -- it will keep
-        # returning the same code. They remain in this retryable set
-        # unchanged (bounded by max_retries=2 below) pending a decision on
-        # whether that's still the right classification.
-        retryable_errors = {-201, -202, -203, -502, -503}
 
         while True:
             # Check if timeout exceeded
@@ -618,11 +602,11 @@ class HistoricalFetcher(BaseFetcher):
             try:
                 # Get download status
                 # JVStatus returns the number of downloaded files, not a
-                # percentage.  Download is complete when the count reaches the
-                # JVOpen download_count value.
+                # percentage. Download is complete only when the count equals
+                # the JVOpen download_count value retained until JVClose.
                 status = self.jvlink.jv_status()
 
-                if status >= download_count:
+                if status == download_count:
                     logger.info(
                         "Download completed",
                         elapsed_seconds=int(elapsed),
@@ -642,6 +626,17 @@ class HistoricalFetcher(BaseFetcher):
                     logger.info("File write wait completed")
                     return
 
+                if status > download_count:
+                    raise FetcherError(
+                        "JVStatus downloaded-file count exceeded JVOpen "
+                        f"download_count: {status} > {download_count}"
+                    )
+
+                if status < 0:
+                    raise FetcherError(
+                        f"Download failed with JVStatus code: {status}"
+                    )
+
                 if status != last_status:
                     last_progress_time = time.time()  # Reset stall timer on any change
                     if status >= 0:
@@ -660,8 +655,6 @@ class HistoricalFetcher(BaseFetcher):
                                 completed=status,
                                 status=f"{status}/{download_count} - {int(elapsed)}秒経過",
                             )
-                        # Reset retry count on progress
-                        retry_count = 0
                     last_status = status
                 else:
                     # Stall detection: abort if downloaded-file count does not
@@ -678,25 +671,6 @@ class HistoricalFetcher(BaseFetcher):
                             raise FetcherError(
                                 f"Download stalled at {status}/{download_count} files for {stall_elapsed:.0f}s"
                             )
-
-                if status < 0:
-                    if status in retryable_errors:
-                        retry_count += 1
-                        if retry_count <= max_retries:
-                            logger.warning(
-                                "Retryable download error, will retry",
-                                status_code=status,
-                                retry_count=retry_count,
-                                max_retries=max_retries,
-                            )
-                            time.sleep(interval * 2)  # Wait longer before retry
-                            continue
-                        else:
-                            raise FetcherError(
-                                f"Download failed after {max_retries} retries with status code: {status}"
-                            )
-                    else:
-                        raise FetcherError(f"Download failed with status code: {status}")
 
                 # Wait before next status check
                 time.sleep(interval)

--- a/src/jvlink/bridge.py
+++ b/src/jvlink/bridge.py
@@ -8,6 +8,7 @@ This replaces the Python win32com-based JVLinkWrapper, eliminating:
 """
 
 import base64
+import binascii
 import json
 import subprocess
 import sys
@@ -25,6 +26,40 @@ from src.jvlink.constants import (
 from src.utils.logger import get_logger
 
 logger = get_logger(__name__)
+
+
+def _require_response_code(response: dict, command: str) -> int:
+    if "code" not in response:
+        raise JVLinkBridgeError(f"{command} response has no result code")
+    code = response["code"]
+    if type(code) is not int:
+        raise JVLinkBridgeError(
+            f"{command} response result code is not an integer: {code!r}"
+        )
+    return code
+
+
+def _require_nonnegative_count(response: dict, field: str, command: str) -> int:
+    if field not in response:
+        raise JVLinkBridgeError(f"{command} response has no {field}")
+    value = response[field]
+    if type(value) is not int or value < 0:
+        raise JVLinkBridgeError(
+            f"{command} response {field} is not a non-negative integer: {value!r}"
+        )
+    return value
+
+
+def _require_string(response: dict, field: str, command: str) -> str:
+    if field not in response:
+        raise JVLinkBridgeError(f"{command} response has no {field}")
+    value = response[field]
+    if not isinstance(value, str):
+        raise JVLinkBridgeError(
+            f"{command} response {field} is not a string: {value!r}"
+        )
+    return value
+
 
 # Default bridge executable locations (searched in order)
 _BRIDGE_SEARCH_PATHS = [
@@ -99,6 +134,7 @@ class JVLinkBridge:
         self._timeout = timeout
         self._process: Optional[subprocess.Popen] = None
         self._is_open = False
+        self._needs_close = False
 
         if bridge_path:
             self._bridge_path = Path(bridge_path)
@@ -233,15 +269,35 @@ class JVLinkBridge:
             timeout=120.0,
         )
 
-        code = response.get("code", -1)
-        read_count = response.get("readcount", 0)
-        download_count = response.get("downloadcount", 0)
-        last_ts = response.get("lastfiletimestamp", "")
+        # A protocol-level success means the remote COM call has already
+        # opened state even if a malformed response omits its result code.
+        # Preserve the close obligation before validating response fields.
+        if response.get("status") == "ok":
+            self._needs_close = True
+        code = _require_response_code(response, "JVOpen")
 
-        if code < -2:
+        # The remote COM call has already changed state before its JSON out
+        # fields are validated. A malformed success/no-data/cancel response
+        # must still be closed instead of leaking into a later -202.
+        if code in (0, -1, -2, -202):
+            self._needs_close = True
+            if code != -202:
+                self._is_open = code == 0
+
+        read_count = _require_nonnegative_count(response, "readcount", "JVOpen")
+        download_count = _require_nonnegative_count(
+            response, "downloadcount", "JVOpen"
+        )
+        last_ts = _require_string(response, "lastfiletimestamp", "JVOpen")
+
+        if code not in (0, -1, -2):
             raise JVLinkBridgeError("JVOpen failed", error_code=code)
+        if download_count > read_count:
+            raise JVLinkBridgeError(
+                "JVOpen response downloadcount exceeds readcount: "
+                f"{download_count} > {read_count}"
+            )
 
-        self._is_open = True
         logger.info("JVOpen via bridge", data_spec=data_spec, read_count=read_count, download_count=download_count)
         return code, read_count, download_count, last_ts
 
@@ -251,13 +307,30 @@ class JVLinkBridge:
             timeout=30.0,
         )
 
-        code = response.get("code", -1)
-        read_count = response.get("readcount", 0)
+        if response.get("status") == "ok":
+            self._needs_close = True
+        code = _require_response_code(response, "JVRTOpen")
+        # JVRTOpen officially has no read-count output. Older bridge builds
+        # include a compatibility field on success but omit it for -1.
+        read_count = 0
+        if "readcount" in response:
+            read_count = _require_nonnegative_count(
+                response, "readcount", "JVRTOpen"
+            )
 
-        if code < -2:
+        if code in (0, -1, -2, -202):
+            self._needs_close = True
+            if code != -202:
+                self._is_open = code == 0
+
+        if code not in (0, -1):
             raise JVLinkBridgeError("JVRTOpen failed", error_code=code)
+        if read_count != 0:
+            raise JVLinkBridgeError(
+                "JVRTOpen compatibility readcount must be 0, "
+                f"got {read_count}"
+            )
 
-        self._is_open = True
         return code, read_count
 
     def jv_read(self) -> Tuple[int, Optional[bytes], Optional[str]]:
@@ -269,13 +342,29 @@ class JVLinkBridge:
             timeout=60.0,
         )
 
-        code = response.get("code", 0)
+        code = _require_response_code(response, "JVRead")
 
         if code > 0:
             data_b64 = response.get("data", "")
-            data_bytes = base64.b64decode(data_b64) if data_b64 else b""
+            try:
+                data_bytes = base64.b64decode(data_b64, validate=True)
+            except (binascii.Error, TypeError, ValueError) as exc:
+                raise JVLinkBridgeError(
+                    "JVRead bridge payload is not valid base64"
+                ) from exc
+            if len(data_bytes) < code:
+                raise JVLinkBridgeError(
+                    "JVRead bridge payload is shorter than its return byte "
+                    f"count: {len(data_bytes)} < {code}"
+                )
+            declared_size = response.get("size")
+            if declared_size is not None and declared_size != code:
+                raise JVLinkBridgeError(
+                    "JVRead bridge size does not match its return byte count: "
+                    f"{declared_size} != {code}"
+                )
             filename = response.get("filename", "")
-            return code, data_bytes, filename
+            return code, data_bytes[:code], filename
         elif code == JV_READ_SUCCESS:  # 0
             return code, None, None
         elif code == JV_READ_NO_MORE_DATA:  # -1
@@ -289,22 +378,41 @@ class JVLinkBridge:
             return code, None, response.get("filename")
 
     def jv_gets(self) -> Tuple[int, Optional[bytes]]:
-        """JV-Link doesn't have JVGets; delegates to jv_read."""
+        """Expose the bridge's byte payload through the JVGets-shaped API.
+
+        JV-Link has a native JVGets method, but the JSON bridge has only one
+        read command and already returns CP932 bytes, so it delegates here.
+        """
         code, buff, filename = self.jv_read()
         return code, buff
 
     def jv_close(self) -> int:
-        try:
-            self._send_command({"cmd": "close"}, timeout=10.0)
-        except JVLinkBridgeError:
-            pass
+        response = self._send_command({"cmd": "close"}, timeout=10.0)
+        if response.get("status") != "ok":
+            raise JVLinkBridgeError(
+                response.get("error", "JVClose returned an invalid response")
+            )
+        if "code" in response:
+            code = _require_response_code(response, "JVClose")
+            if code != 0:
+                raise JVLinkBridgeError("JVClose failed", error_code=code)
+        else:
+            # jrvltsql-wine-runtime through be759ee acknowledges close with
+            # only {"status":"ok"}. Preserve compatibility until that
+            # adapter propagates JVClose's official Long result code.
+            logger.warning(
+                "JVClose bridge response omitted the native result code; "
+                "accepting the legacy runtime acknowledgment"
+            )
+            code = 0
         self._is_open = False
+        self._needs_close = False
         logger.info("JV-Link stream closed via bridge")
-        return 0
+        return code
 
     def jv_status(self) -> int:
         response = self._send_command({"cmd": "status"}, timeout=10.0)
-        return response.get("code", 0)
+        return _require_response_code(response, "JVStatus")
 
     def jv_file_delete(self, filename: str) -> int:
         response = self._send_command(
@@ -320,24 +428,39 @@ class JVLinkBridge:
         # The production jrvltsql-wine-runtime bridge serializes the COM
         # JVFiledelete return value as ``code``. A missing value is a protocol
         # violation, not an implicit success.
-        if "code" not in response:
-            raise JVLinkBridgeError(
-                f"JVFiledelete response has no result code for {filename}"
-            )
-        return response["code"]
+        return _require_response_code(response, f"JVFiledelete for {filename}")
 
-    def wait_for_download(self, timeout: float = 300.0, poll_interval: float = 0.5) -> bool:
+    def wait_for_download(
+        self,
+        download_count: int,
+        timeout: float = 300.0,
+        poll_interval: float = 0.5,
+    ) -> bool:
+        """Wait until JVStatus exactly matches JVOpen's download count."""
+        if download_count < 0:
+            raise ValueError("download_count must not be negative")
+        if download_count == 0:
+            return True
+
         start = time.time()
-        download_started = False
 
         while time.time() - start < timeout:
             status = self.jv_status()
-            if status > 0:
-                download_started = True
-            elif status == 0 and download_started:
-                logger.info("Download completed via bridge")
+            if status == download_count:
+                logger.info(
+                    "Download completed via bridge",
+                    downloaded_files=status,
+                    download_count=download_count,
+                )
                 return True
-            elif status < 0:
+            if status > download_count:
+                logger.error(
+                    "JVStatus count exceeded JVOpen download count",
+                    status=status,
+                    download_count=download_count,
+                )
+                return False
+            if status < 0:
                 logger.error("Download error via bridge", status=status)
                 return False
             time.sleep(poll_interval)
@@ -345,8 +468,13 @@ class JVLinkBridge:
         logger.warning("Download timeout via bridge", timeout=timeout)
         return False
 
-    def jv_wait_for_download(self, timeout: float = 300.0, poll_interval: float = 0.5) -> bool:
-        return self.wait_for_download(timeout, poll_interval)
+    def jv_wait_for_download(
+        self,
+        download_count: int,
+        timeout: float = 300.0,
+        poll_interval: float = 0.5,
+    ) -> bool:
+        return self.wait_for_download(download_count, timeout, poll_interval)
 
     def is_open(self) -> bool:
         return self._is_open
@@ -367,13 +495,14 @@ class JVLinkBridge:
                     pass
         self._process = None
         self._is_open = False
+        self._needs_close = False
 
     def __enter__(self):
         self.jv_init()
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
-        if self._is_open:
+        if self._is_open or getattr(self, "_needs_close", False):
             self.jv_close()
         self.cleanup()
 

--- a/src/jvlink/bridge.py
+++ b/src/jvlink/bridge.py
@@ -135,6 +135,7 @@ class JVLinkBridge:
         self._process: Optional[subprocess.Popen] = None
         self._is_open = False
         self._needs_close = False
+        self._download_count: Optional[int] = None
 
         if bridge_path:
             self._bridge_path = Path(bridge_path)
@@ -298,6 +299,7 @@ class JVLinkBridge:
                 f"{download_count} > {read_count}"
             )
 
+        self._download_count = download_count
         logger.info("JVOpen via bridge", data_spec=data_spec, read_count=read_count, download_count=download_count)
         return code, read_count, download_count, last_ts
 
@@ -331,6 +333,7 @@ class JVLinkBridge:
                 f"got {read_count}"
             )
 
+        self._download_count = 0
         return code, read_count
 
     def jv_read(self) -> Tuple[int, Optional[bytes], Optional[str]]:
@@ -407,6 +410,7 @@ class JVLinkBridge:
             code = 0
         self._is_open = False
         self._needs_close = False
+        self._download_count = None
         logger.info("JV-Link stream closed via bridge")
         return code
 
@@ -432,11 +436,22 @@ class JVLinkBridge:
 
     def wait_for_download(
         self,
-        download_count: int,
         timeout: float = 300.0,
         poll_interval: float = 0.5,
+        download_count: Optional[int] = None,
     ) -> bool:
-        """Wait until JVStatus exactly matches JVOpen's download count."""
+        """Wait until JVStatus exactly matches JVOpen's download count.
+
+        ``timeout`` and ``poll_interval`` retain their historical positional
+        order. Callers may supply ``download_count`` explicitly as a keyword;
+        otherwise the validated value from the latest JVOpen is used.
+        """
+        if download_count is None:
+            download_count = getattr(self, "_download_count", None)
+        if download_count is None:
+            raise ValueError(
+                "download_count is unavailable; call JVOpen first or pass it explicitly"
+            )
         if download_count < 0:
             raise ValueError("download_count must not be negative")
         if download_count == 0:
@@ -470,11 +485,15 @@ class JVLinkBridge:
 
     def jv_wait_for_download(
         self,
-        download_count: int,
         timeout: float = 300.0,
         poll_interval: float = 0.5,
+        download_count: Optional[int] = None,
     ) -> bool:
-        return self.wait_for_download(download_count, timeout, poll_interval)
+        return self.wait_for_download(
+            timeout=timeout,
+            poll_interval=poll_interval,
+            download_count=download_count,
+        )
 
     def is_open(self) -> bool:
         return self._is_open
@@ -496,6 +515,7 @@ class JVLinkBridge:
         self._process = None
         self._is_open = False
         self._needs_close = False
+        self._download_count = None
 
     def __enter__(self):
         self.jv_init()

--- a/src/jvlink/wrapper.py
+++ b/src/jvlink/wrapper.py
@@ -55,6 +55,64 @@ CP1252_TO_BYTE = {
 }
 
 
+def _recover_com_buffer(value, expected_size: int, method_name: str) -> bytes:
+    """Recover the exact JV-Data bytes from a pywin32 out buffer.
+
+    Depending on the COM marshaling path, pywin32 can expose the buffer as a
+    byte array, a BSTR containing one Unicode code point per byte, or decoded
+    CP932 text.  Recovery must be lossless: replacement characters and unknown
+    code points are protocol failures, never plausible ``0``/``?`` data.
+    """
+    if isinstance(value, (bytes, bytearray, memoryview)):
+        recovered = bytes(value)
+    elif isinstance(value, str):
+        if "\ufffd" in value:
+            raise JVLinkError(
+                f"{method_name} buffer contains an irreversible Unicode replacement character"
+            )
+
+        try:
+            recovered = value.encode("latin-1")
+        except UnicodeEncodeError:
+            if any(ord(char) in CP1252_TO_BYTE for char in value):
+                result = bytearray()
+                for char in value:
+                    codepoint = ord(char)
+                    if codepoint <= 0xFF:
+                        result.append(codepoint)
+                    elif codepoint in CP1252_TO_BYTE:
+                        result.append(CP1252_TO_BYTE[codepoint])
+                    else:
+                        try:
+                            result.extend(char.encode("cp932"))
+                        except UnicodeEncodeError as exc:
+                            raise JVLinkError(
+                                f"{method_name} buffer contains an unrecoverable "
+                                f"character U+{codepoint:04X}"
+                            ) from exc
+                recovered = bytes(result)
+            else:
+                try:
+                    recovered = value.encode("cp932")
+                except UnicodeEncodeError as exc:
+                    bad = exc.object[exc.start]
+                    raise JVLinkError(
+                        f"{method_name} buffer contains an unrecoverable "
+                        f"character U+{ord(bad):04X}"
+                    ) from exc
+    else:
+        raise JVLinkError(
+            f"{method_name} returned unsupported buffer type {type(value).__name__}"
+        )
+
+    if len(recovered) < expected_size:
+        raise JVLinkError(
+            f"{method_name} buffer is shorter than its return byte count: "
+            f"{len(recovered)} < {expected_size}"
+        )
+    return recovered[:expected_size]
+
+
 class JVLinkError(Exception):
     """JV-Link related error."""
 
@@ -110,6 +168,7 @@ class JVLinkWrapper:
         self.sid = sid
         self._jvlink = None
         self._is_open = False
+        self._needs_close = False
         self._com_initialized = False
 
         try:
@@ -259,9 +318,33 @@ class JVLinkWrapper:
 
         try:
             # JVOpen signature: (dataspec, fromtime, option, ref readCount, ref downloadCount, out lastFileTimestamp)
-            # pywin32: COM methods with ref/out parameters return them as tuple
-            # Call with only IN parameters (dataspec, fromtime, option)
-            jv_result = self._jvlink.JVOpen(data_spec, fromtime, option)
+            # Dynamic pywin32 dispatch still requires placeholders for all
+            # official ref/out parameters and returns their values as a tuple.
+            jv_result = self._jvlink.JVOpen(
+                data_spec,
+                fromtime,
+                option,
+                0,
+                0,
+                "",
+            )
+
+            # JVOpen has already changed COM state before pywin32 marshals its
+            # out values. Preserve the close obligation even when that
+            # marshaled response is malformed and cannot be returned.
+            possible_result = (
+                jv_result[0]
+                if isinstance(jv_result, tuple) and jv_result
+                else jv_result
+            )
+            if type(possible_result) is int and possible_result in (
+                0,
+                -1,
+                -2,
+                -202,
+            ):
+                self._needs_close = True
+                self._is_open = possible_result == 0
 
             # Handle return value
             if isinstance(jv_result, tuple):
@@ -273,16 +356,20 @@ class JVLinkWrapper:
                 # Unexpected single value
                 raise ValueError(f"Unexpected JVOpen return type: {type(jv_result)}, expected tuple")
 
+            if type(result) is not int:
+                raise JVLinkError(
+                    f"JVOpen returned a non-integer result code: {result!r}"
+                )
+
             # Handle result codes for JVOpen (per official spec "3. コード表",
             # JVOpen/JVRTOpen never returns -100/-101/-102/-103 -- those are
             # JVSetUIProperties/JVSetServiceKey/JVInit codes; JVOpen's actual
             # errors start at -111):
             # 0 (JV_RT_SUCCESS): Success with data
             # -1: No data available (NOT an error - normal when no new data)
-            # -2: No data available (alternative code)
+            # -2: Setup dialog cancelled by the user
             # <= -111: Actual errors (e.g., -111=dataspec invalid, -301=auth error, etc.)
-            if result < -2:
-                # Real errors are -111 or below (see comment above)
+            if result not in (0, -1, -2):
                 logger.error(
                     "JVOpen failed",
                     data_spec=data_spec,
@@ -291,16 +378,46 @@ class JVLinkWrapper:
                     error_code=result,
                 )
                 raise JVLinkError("JVOpen failed", error_code=result)
-            elif result in (-1, -2):
-                # -1 and -2 both mean "no data available" - NOT an error
+            elif result == -1:
                 logger.info(
                     "JVOpen: No data available",
                     data_spec=data_spec,
                     fromtime=fromtime,
                     result_code=result,
                 )
+            elif result == -2:
+                logger.warning(
+                    "JVOpen: setup dialog cancelled",
+                    data_spec=data_spec,
+                    fromtime=fromtime,
+                    result_code=result,
+                )
 
-            self._is_open = True
+            malformed_fields = []
+            if type(read_count) is not int or read_count < 0:
+                malformed_fields.append(f"invalid read_count={read_count!r}")
+            if type(download_count) is not int or download_count < 0:
+                malformed_fields.append(
+                    f"invalid download_count={download_count!r}"
+                )
+            if (
+                type(read_count) is int
+                and type(download_count) is int
+                and download_count > read_count
+            ):
+                malformed_fields.append(
+                    "download_count exceeds read_count: "
+                    f"{download_count} > {read_count}"
+                )
+            if not isinstance(last_file_timestamp, str):
+                malformed_fields.append(
+                    "invalid last_file_timestamp="
+                    f"{last_file_timestamp!r}"
+                )
+            if malformed_fields:
+                raise JVLinkError(
+                    "Malformed JVOpen response: " + ", ".join(malformed_fields)
+                )
 
             logger.info(
                 "JVOpen successful",
@@ -338,29 +455,65 @@ class JVLinkWrapper:
             >>> result, count = wrapper.jv_rt_open("0B12")  # Race results
         """
         try:
-            # JVRTOpen returns (return_code, read_count) as a tuple in pywin32
+            # The official JVRTOpen return value is the result code only. Keep
+            # accepting the historical two-item wrapper shape for API
+            # compatibility, but never reinterpret a positive result code as
+            # a read count.
             jv_result = self._jvlink.JVRTOpen(data_spec, key)
 
-            # Handle both tuple and single value returns
+            possible_result = (
+                jv_result[0]
+                if isinstance(jv_result, tuple) and jv_result
+                else jv_result
+            )
+            if type(possible_result) is int and possible_result in (
+                0,
+                -1,
+                -2,
+                -202,
+            ):
+                self._needs_close = True
+                if possible_result != -202:
+                    self._is_open = possible_result == 0
+
             if isinstance(jv_result, tuple):
+                if len(jv_result) != 2:
+                    raise JVLinkError(
+                        "Unexpected JVRTOpen return tuple length: "
+                        f"{len(jv_result)}, expected 2"
+                    )
                 result, read_count = jv_result
             else:
-                # Single value: if negative, it's an error code; if positive/zero, it's read_count
-                if jv_result < 0:
-                    result = jv_result
-                    read_count = 0
-                else:
-                    result = JV_RT_SUCCESS
-                    read_count = jv_result
+                result = jv_result
+                read_count = 0
 
-            if result < 0:
+            if type(result) is not int:
+                raise JVLinkError(
+                    f"Unexpected JVRTOpen result code: {result!r}"
+                )
+            if type(read_count) is not int or read_count < 0:
+                raise JVLinkError(
+                    f"Unexpected JVRTOpen compatibility read count: {read_count!r}"
+                )
+
+            if result in (0, -1) and read_count != 0:
+                raise JVLinkError(
+                    "JVRTOpen compatibility read count must be 0, "
+                    f"got {read_count}"
+                )
+
+            if result != JV_RT_SUCCESS:
                 # -1: 該当データなし（正常系 - 指定キーにデータが存在しない）
                 if result == -1:
                     logger.debug("JVRTOpen: no data available", data_spec=data_spec, key=key, error_code=result)
                     # データなしは例外にせず、結果をそのまま返す
                     return result, read_count
+                if result in (-2, -202):
+                    # The shared official return-code table requires JVClose
+                    # after setup cancellation or an already-open result.
+                    self._needs_close = True
                 # -114: 契約外データ種別（警告レベル、ユーザーには問題なし）
-                elif result == -114:
+                if result == -114:
                     logger.debug("JVRTOpen: data spec not subscribed", data_spec=data_spec, error_code=result)
                     raise JVLinkError("JVRTOpen failed", error_code=result)
                 else:
@@ -368,6 +521,7 @@ class JVLinkWrapper:
                     raise JVLinkError("JVRTOpen failed", error_code=result)
 
             self._is_open = True
+            self._needs_close = True
 
             logger.info(
                 "JVRTOpen successful",
@@ -416,20 +570,34 @@ class JVLinkWrapper:
             raise JVLinkError("JV-Link stream not open. Call jv_open() or jv_rt_open() first.")
 
         try:
-            # JVRead signature: JVRead(String buff, Long size, String filename)
-            # Call with empty strings and buffer size
-            # pywin32 returns 4-tuple: (return_code, buff_str, size_int, filename_str)
-            jv_result = self._jvlink.JVRead("", BUFFER_SIZE_JVREAD, "")
+            # Official signature: JVRead(String buff, Long size, String
+            # filename). bytearray placeholders avoid unstable pywin32 out-
+            # parameter marshaling observed with empty strings.
+            jv_result = self._jvlink.JVRead(
+                bytearray(),
+                BUFFER_SIZE_JVREAD,
+                bytearray(),
+            )
 
             # Handle result - pywin32 returns (return_code, buff_str, size, filename_str)
-            if isinstance(jv_result, tuple) and len(jv_result) >= 4:
+            if isinstance(jv_result, tuple) and len(jv_result) == 4:
                 result = jv_result[0]
                 buff_str = jv_result[1]
                 # jv_result[2] is size (int) - not needed
                 filename_str = jv_result[3]
+            elif isinstance(jv_result, tuple) and len(jv_result) == 3:
+                # Some pywin32 dispatch paths omit the input-only size from
+                # the returned out-parameter tuple.
+                result, buff_str, filename_str = jv_result
             else:
                 # Unexpected return format
-                raise JVLinkError(f"Unexpected JVRead return format: {type(jv_result)}, length={len(jv_result) if isinstance(jv_result, tuple) else 'N/A'}")
+                result_length = (
+                    len(jv_result) if isinstance(jv_result, tuple) else "N/A"
+                )
+                raise JVLinkError(
+                    "Unexpected JVRead return format: "
+                    f"{type(jv_result)}, length={result_length}"
+                )
 
             # Return code meanings:
             # > 0: Success, value is data length in bytes
@@ -456,52 +624,7 @@ class JVLinkWrapper:
                 # - Bytes 0x80-0x9F are C1 control characters in Unicode
                 # - These cannot be encoded as Shift-JIS, causing 'replace' to fail
                 # - This caused 99.7% of Japanese text data to be corrupted with '?'
-                if buff_str:
-                    # JV-Link COM returns Shift-JIS encoded data.
-                    # pywin32 may handle this in different ways:
-                    #
-                    # 1. Raw bytes as code points (0x00-0xFF) - ideal case
-                    #    -> Use latin-1 to extract bytes directly
-                    #
-                    # 2. Some bytes interpreted as CP1252 by Windows/pywin32
-                    #    -> Bytes 0x80-0x9F become Unicode chars like U+201C
-                    #    -> Need to convert these back to original bytes
-                    #    -> Use module-level CP1252_TO_BYTE mapping
-                    #
-                    # 3. Proper Unicode (Japanese chars as U+3000+)
-                    #    -> Encode to cp932 for parsers
-
-                    # 高速変換: 3段階のエンコード戦略
-                    # 1. Latin-1（ASCII + 拡張ASCII）- 最速
-                    # 2. CP932（日本語）- 高速
-                    # 3. 個別処理（CP1252変換が必要な場合）- 低速だが稀
-                    try:
-                        data_bytes = buff_str.encode('latin-1')
-                    except UnicodeEncodeError:
-                        try:
-                            # 日本語を含む場合はcp932で一括変換
-                            data_bytes = buff_str.encode('cp932')
-                        except UnicodeEncodeError:
-                            # CP1252変換が必要な文字が含まれる場合のみ個別処理
-                            result_bytes = bytearray()
-                            for c in buff_str:
-                                cp = ord(c)
-                                if cp <= 0xFF:
-                                    result_bytes.append(cp)
-                                elif cp in CP1252_TO_BYTE:
-                                    result_bytes.append(CP1252_TO_BYTE[cp])
-                                elif cp == 0xFFFD:
-                                    # Unicode replacement character - データ破損
-                                    # 数値フィールドでエラーを避けるため'0'に置換
-                                    result_bytes.append(0x30)  # '0'
-                                else:
-                                    try:
-                                        result_bytes.extend(c.encode('cp932'))
-                                    except UnicodeEncodeError:
-                                        result_bytes.append(0x3F)  # '?'
-                            data_bytes = bytes(result_bytes)
-                else:
-                    data_bytes = b""
+                data_bytes = _recover_com_buffer(buff_str, result, "JVRead")
 
                 # Note: Per-record debug logging removed to reduce verbosity
                 return result, data_bytes, filename_str
@@ -515,6 +638,13 @@ class JVLinkWrapper:
                 # File switch (-1)
                 # Note: Debug log removed - this is very frequent during data fetching
                 return result, None, None
+
+            elif result == -3:
+                logger.debug(
+                    "JVRead waiting for file download",
+                    filename=filename_str,
+                )
+                return result, None, filename_str
 
             elif result in (-402, -403):
                 # Preserve the filename returned by JVRead so the fetcher can
@@ -573,19 +703,29 @@ class JVLinkWrapper:
             raise JVLinkError("JV-Link stream not open. Call jv_open() or jv_rt_open() first.")
 
         try:
-            # JVGets signature: JVGets(String buff, Long buffsize)
-            # Call with empty string and buffer size
-            # pywin32 returns tuple: (return_code, buff_str, buffsize)
-            jv_result = self._jvlink.JVGets("", BUFFER_SIZE_JVREAD)
+            # Official signature: JVGets(Byte Array buff, Long size,
+            # String filename). Dynamic dispatch requires all placeholders.
+            jv_result = self._jvlink.JVGets(
+                bytearray(),
+                BUFFER_SIZE_JVREAD,
+                bytearray(),
+            )
 
-            # Handle result - pywin32 returns (return_code, buff_str, buffsize)
-            if isinstance(jv_result, tuple) and len(jv_result) >= 2:
+            # Working dynamic-dispatch paths return (return_code, memoryview,
+            # filename). Accept a four-item variant as well for compatibility
+            # with type libraries that echo the input size.
+            if isinstance(jv_result, tuple) and len(jv_result) in (3, 4):
                 result = jv_result[0]
                 buff_str = jv_result[1]
-                # jv_result[2] is buffsize (int) - not needed
             else:
                 # Unexpected return format
-                raise JVLinkError(f"Unexpected JVGets return format: {type(jv_result)}, length={len(jv_result) if isinstance(jv_result, tuple) else 'N/A'}")
+                result_length = (
+                    len(jv_result) if isinstance(jv_result, tuple) else "N/A"
+                )
+                raise JVLinkError(
+                    "Unexpected JVGets return format: "
+                    f"{type(jv_result)}, length={result_length}"
+                )
 
             # Return code meanings:
             # > 0: Success, value is data length in bytes
@@ -593,46 +733,7 @@ class JVLinkWrapper:
             # -1: File switch (continue reading)
             # < -1: Error
             if result > 0:
-                # Successfully read data (result is data length)
-                # JVGets returns Shift-JIS encoded byte array directly
-                # pywin32 may represent this as a string where each byte is a character
-                if buff_str:
-                    # Convert string to Shift-JIS bytes
-                    # JVGets stores Shift-JIS bytes in a BSTR, similar to JVRead
-                    # Use latin-1 encoding to extract raw bytes (1:1 mapping for 0x00-0xFF)
-                    # 高速変換: 3段階のエンコード戦略
-                    # 1. Latin-1（ASCII + 拡張ASCII）- 最速
-                    # 2. CP932（日本語）- 高速
-                    # 3. 個別処理（CP1252変換が必要な場合）- 低速だが稀
-                    try:
-                        data_bytes = buff_str.encode('latin-1')
-                    except UnicodeEncodeError:
-                        # If latin-1 fails, try cp932 encoding
-                        try:
-                            data_bytes = buff_str.encode('cp932')
-                        except UnicodeEncodeError:
-                            # Fallback: character-by-character conversion with CP1252 handling
-                            result_bytes = bytearray()
-                            for c in buff_str:
-                                cp = ord(c)
-                                if cp <= 0xFF:
-                                    result_bytes.append(cp)
-                                elif cp in CP1252_TO_BYTE:
-                                    result_bytes.append(CP1252_TO_BYTE[cp])
-                                elif cp == 0xFFFD:
-                                    # Unicode replacement character - データ破損
-                                    # 数値フィールドでエラーを避けるため'0'に置換
-                                    result_bytes.append(0x30)  # '0'
-                                else:
-                                    try:
-                                        result_bytes.extend(c.encode('cp932'))
-                                    except UnicodeEncodeError:
-                                        result_bytes.append(0x3F)  # '?'
-                            data_bytes = bytes(result_bytes)
-                else:
-                    data_bytes = b""
-
-                return result, data_bytes
+                return result, _recover_com_buffer(buff_str, result, "JVGets")
 
             elif result == JV_READ_SUCCESS:
                 # Read complete (0)
@@ -640,6 +741,10 @@ class JVLinkWrapper:
 
             elif result == JV_READ_NO_MORE_DATA:
                 # File switch (-1)
+                return result, None
+
+            elif result == -3:
+                logger.debug("JVGets waiting for file download")
                 return result, None
 
             else:
@@ -669,20 +774,27 @@ class JVLinkWrapper:
         """
         try:
             result = self._jvlink.JVClose()
+            if type(result) is not int or result != 0:
+                raise JVLinkError(
+                    f"JVClose returned an invalid result code: {result!r}",
+                    error_code=result if type(result) is int else None,
+                )
             self._is_open = False
+            self._needs_close = False
             logger.info("JV-Link stream closed")
             return result
         except Exception as e:
+            if isinstance(e, JVLinkError):
+                raise
             raise JVLinkError(f"JVClose failed: {e}")
 
     def jv_file_delete(self, filename: str) -> int:
         """Delete a cached file from JV-Link cache.
 
-        This method is used to handle recoverable errors (-203, -402, -403, -502, -503)
-        during data reading. When these errors occur, the corrupted file should be
-        deleted and the read operation retried.
-
-        Based on kmy-keiba's JVLinkReader.cs error handling pattern.
+        This method is used for the official corrupt-downloaded-file errors
+        (-402 and -403). After deleting the exact filename returned by
+        JVRead/JVGets, callers must restart from JVOpen. Other call-order,
+        download, or missing-file errors are not repaired by blind deletion.
 
         Args:
             filename: The filename to delete (as returned by JVRead)
@@ -733,7 +845,7 @@ class JVLinkWrapper:
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         """Context manager exit."""
-        if self._is_open:
+        if self._is_open or getattr(self, "_needs_close", False):
             self.jv_close()
 
     def reinitialize_com(self):
@@ -763,7 +875,7 @@ class JVLinkWrapper:
             logger.warning("Reinitializing COM component due to error...")
 
             # Close any open streams
-            if self._is_open:
+            if self._is_open or getattr(self, "_needs_close", False):
                 try:
                     self.jv_close()
                 except Exception:
@@ -796,6 +908,7 @@ class JVLinkWrapper:
                 raise
 
             self._is_open = False
+            self._needs_close = False
 
             logger.info("COM component reinitialized successfully", sid=self.sid)
 
@@ -830,7 +943,9 @@ class JVLinkWrapper:
             gc = None
 
         # Close stream if still open
-        if hasattr(self, '_is_open') and self._is_open:
+        if hasattr(self, '_is_open') and (
+            self._is_open or getattr(self, '_needs_close', False)
+        ):
             try:
                 self.jv_close()
             except Exception:

--- a/tests/test_jvd_self_repair.py
+++ b/tests/test_jvd_self_repair.py
@@ -449,18 +449,17 @@ def test_replay_skip_still_runs_periodic_com_buffer_gc():
     )
 
 
-def test_legacy_read_error_during_replay_fails_closed():
+def test_file_not_found_during_replay_fails_closed():
     fetcher = _fetcher()
     fetcher._jvd_replay_records_remaining = 1
     fetcher.jvlink.jv_read.side_effect = [
         (-503, None, "missing.jvd"),
     ]
 
-    with pytest.raises(FetcherError, match="while historical recovery replay was pending"):
+    with pytest.raises(FetcherError, match="-503"):
         list(
             fetcher._fetch_and_parse(
                 consume_replayed_record=fetcher._consume_replayed_record,
-                replay_pending=lambda: fetcher._jvd_replay_records_remaining > 0,
             )
         )
 
@@ -564,20 +563,22 @@ def test_read_recovery_rejects_nonzero_delete_result():
 
 
 @pytest.mark.parametrize("error_code", [-203, -502, -503])
-def test_other_recoverable_error_uses_legacy_delete_without_stream_restart(error_code):
+def test_non_corruption_error_fails_without_delete_or_stream_restart(error_code):
     fetcher = _fetcher()
     fetcher.jvlink.jv_read.side_effect = [
         (error_code, None, "other.jvd"),
         (0, None, None),
     ]
 
-    assert list(
-        fetcher._fetch_and_parse(
-            recover_file_error=fetcher._recover_historical_read_error,
+    with pytest.raises(FetcherError, match=str(error_code)):
+        list(
+            fetcher._fetch_and_parse(
+                recover_file_error=fetcher._recover_historical_read_error,
+            )
         )
-    ) == []
 
-    fetcher.jvlink.jv_file_delete.assert_called_once_with("other.jvd")
+    fetcher.jvlink.jv_read.assert_called_once()
+    fetcher.jvlink.jv_file_delete.assert_not_called()
     fetcher.jvlink.jv_close.assert_not_called()
     fetcher.jvlink.jv_open.assert_not_called()
 

--- a/tests/test_jvlink_transport_contract.py
+++ b/tests/test_jvlink_transport_contract.py
@@ -534,6 +534,38 @@ def test_bridge_wait_for_download_completes_at_exact_open_count():
     assert bridge.jv_status.call_count == 3
 
 
+def test_bridge_wait_for_download_preserves_legacy_signature_with_open_count():
+    bridge = JVLinkBridge.__new__(JVLinkBridge)
+    bridge._is_open = False
+    bridge._needs_close = False
+    bridge._download_count = None
+    bridge._send_command = MagicMock(
+        return_value={
+            "status": "ok",
+            "code": 0,
+            "readcount": 4,
+            "downloadcount": 2,
+            "lastfiletimestamp": "20260815000000",
+        }
+    )
+    bridge.jv_open("RACE", "20260815000000", 1)
+    bridge.jv_status = MagicMock(side_effect=[1, 2])
+
+    with patch("src.jvlink.bridge.time.sleep"):
+        assert bridge.wait_for_download(timeout=1.0, poll_interval=0.01) is True
+
+
+def test_bridge_wait_for_download_without_expected_count_fails_closed():
+    bridge = JVLinkBridge.__new__(JVLinkBridge)
+    bridge._download_count = None
+    bridge.jv_status = MagicMock(return_value=0)
+
+    with pytest.raises(ValueError, match="download|count|JVOpen"):
+        bridge.wait_for_download(timeout=1.0, poll_interval=0.01)
+
+    bridge.jv_status.assert_not_called()
+
+
 def test_bridge_wait_for_download_rejects_count_overshoot():
     bridge = JVLinkBridge.__new__(JVLinkBridge)
     bridge.jv_status = MagicMock(return_value=3)

--- a/tests/test_jvlink_transport_contract.py
+++ b/tests/test_jvlink_transport_contract.py
@@ -1,0 +1,579 @@
+"""Platform-neutral tests for the official JV-Link transport contract.
+
+These tests deliberately bypass ``JVLinkWrapper.__init__`` so that the COM
+call shape and state machine are checked on Linux as well as Windows.  The
+fakes use fixed Python signatures: omitting an official in/out argument is a
+test failure instead of being hidden by ``MagicMock``.
+"""
+
+import base64
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from src.fetcher.base import FetcherError
+from src.fetcher.historical import HistoricalFetcher
+from src.jvlink.bridge import JVLinkBridge, JVLinkBridgeError
+from src.jvlink.wrapper import JVLinkError, JVLinkWrapper
+
+
+def test_github_actions_executes_transport_contract_suite():
+    workflow = Path(".github/workflows/test.yml").read_text(encoding="utf-8")
+    assert "tests/test_jvlink_transport_contract.py" in workflow
+
+
+def _wrapper(com, *, is_open=False):
+    wrapper = JVLinkWrapper.__new__(JVLinkWrapper)
+    wrapper.sid = "TEST"
+    wrapper._jvlink = com
+    wrapper._is_open = is_open
+    wrapper._com_initialized = False
+    return wrapper
+
+
+def _historical_fetcher(jvlink):
+    with (
+        patch("src.jvlink.bridge.find_bridge_executable", return_value=None),
+        patch("src.fetcher.base.JVLinkWrapper", return_value=jvlink),
+    ):
+        return HistoricalFetcher(sid="TEST", show_progress=False)
+
+
+class SixArgumentOpenCom:
+    def __init__(self, result=(0, 7, 3, "20260815000000")):
+        self.result = result
+        self.calls = []
+
+    def JVOpen(
+        self,
+        data_spec,
+        fromtime,
+        option,
+        read_count,
+        download_count,
+        last_file_timestamp,
+    ):
+        self.calls.append(
+            (
+                data_spec,
+                fromtime,
+                option,
+                read_count,
+                download_count,
+                last_file_timestamp,
+            )
+        )
+        return self.result
+
+
+class ThreeArgumentGetsCom:
+    def __init__(self, result):
+        self.result = result
+        self.calls = []
+
+    def JVGets(self, buff, size, filename):
+        self.calls.append((buff, size, filename))
+        return self.result
+
+
+def test_native_jvopen_supplies_all_six_official_arguments():
+    com = SixArgumentOpenCom()
+    wrapper = _wrapper(com)
+
+    assert wrapper.jv_open("RACE", "20260815000000", 1) == com.result
+    assert com.calls == [
+        ("RACE", "20260815000000", 1, 0, 0, ""),
+    ]
+    assert wrapper.is_open() is True
+
+
+def test_open_rejects_an_undefined_positive_result_code():
+    wrapper = _wrapper(SixArgumentOpenCom((1, 7, 0, "20260815000000")))
+    with pytest.raises(JVLinkError, match="JVOpen"):
+        wrapper.jv_open("RACE", "20260815000000", 1)
+
+    bridge = JVLinkBridge.__new__(JVLinkBridge)
+    bridge._is_open = False
+    bridge._needs_close = False
+    bridge._send_command = MagicMock(
+        return_value={
+            "status": "ok",
+            "code": 1,
+            "readcount": 7,
+            "downloadcount": 0,
+            "lastfiletimestamp": "20260815000000",
+        }
+    )
+    with pytest.raises(JVLinkBridgeError, match="JVOpen"):
+        bridge.jv_open("RACE", "20260815000000", 1)
+
+
+def test_open_rejects_impossible_counts_and_keeps_close_pending():
+    wrapper = _wrapper(SixArgumentOpenCom((0, 1, 2, "20260815000000")))
+    with pytest.raises(JVLinkError, match="download|count"):
+        wrapper.jv_open("RACE", "20260815000000", 1)
+    assert wrapper._needs_close is True
+
+    bridge = JVLinkBridge.__new__(JVLinkBridge)
+    bridge._is_open = False
+    bridge._needs_close = False
+    bridge._send_command = MagicMock(
+        return_value={
+            "status": "ok",
+            "code": 0,
+            "readcount": 1,
+            "downloadcount": 2,
+            "lastfiletimestamp": "20260815000000",
+        }
+    )
+    with pytest.raises(JVLinkBridgeError, match="download|count"):
+        bridge.jv_open("RACE", "20260815000000", 1)
+    assert bridge._needs_close is True
+
+
+def test_native_malformed_success_response_keeps_close_pending():
+    wrapper = _wrapper(SixArgumentOpenCom((0, 1, 0)))
+
+    with pytest.raises(JVLinkError, match="tuple length|return"):
+        wrapper.jv_open("RACE", "20260815000000", 1)
+
+    assert wrapper._needs_close is True
+
+
+@pytest.mark.parametrize("result_code", [-1, -2])
+def test_native_jvopen_non_success_does_not_expose_a_readable_stream(result_code):
+    com = SixArgumentOpenCom((result_code, 0, 0, ""))
+    wrapper = _wrapper(com)
+
+    assert wrapper.jv_open("RACE", "20260815000000", 3)[0] == result_code
+    assert wrapper.is_open() is False
+    assert wrapper._needs_close is True
+
+
+def test_historical_fetcher_reports_setup_cancel_instead_of_no_data():
+    jvlink = MagicMock()
+    jvlink.jv_init.return_value = 0
+    jvlink.jv_open.return_value = (-2, 0, 0, "")
+    fetcher = _historical_fetcher(jvlink)
+
+    with pytest.raises(FetcherError, match="cancel"):
+        list(fetcher.fetch("RACE", "20260815", "20260815", option=3))
+
+    jvlink.jv_close.assert_called_once()
+
+
+def test_native_jvgets_uses_byte_array_size_and_filename_arguments():
+    com = ThreeArgumentGetsCom((4, memoryview(b"ABCD"), "RACE.jvd"))
+    wrapper = _wrapper(com, is_open=True)
+
+    assert wrapper.jv_gets() == (4, b"ABCD")
+    assert len(com.calls) == 1
+    buff, size, filename = com.calls[0]
+    assert isinstance(buff, bytearray)
+    assert size > 4
+    assert isinstance(filename, bytearray)
+
+
+def test_native_jvread_uses_stable_pywin32_dummy_buffers():
+    com = MagicMock()
+    com.JVRead.return_value = (0, "", 0, "")
+    wrapper = _wrapper(com, is_open=True)
+
+    assert wrapper.jv_read() == (0, None, None)
+    buff, size, filename = com.JVRead.call_args.args
+    assert isinstance(buff, bytearray)
+    assert size > 0
+    assert isinstance(filename, bytearray)
+
+
+def test_native_jvread_and_jvgets_propagate_downloading_status():
+    read_com = MagicMock()
+    read_com.JVRead.return_value = (-3, "", 0, "RACE.jvd")
+    assert _wrapper(read_com, is_open=True).jv_read() == (-3, None, "RACE.jvd")
+
+    gets_com = ThreeArgumentGetsCom((-3, memoryview(b""), "RACE.jvd"))
+    assert _wrapper(gets_com, is_open=True).jv_gets() == (-3, None)
+
+
+def test_fetcher_waits_and_resumes_after_downloading_status():
+    jvlink = MagicMock()
+    jvlink.jv_read.side_effect = [(-3, None, "RACE.jvd"), (0, None, None)]
+    fetcher = _historical_fetcher(jvlink)
+
+    with patch("src.fetcher.base.time.sleep") as sleep:
+        assert list(fetcher._fetch_and_parse()) == []
+
+    sleep.assert_called_once()
+    assert jvlink.jv_read.call_count == 2
+
+
+def test_fetcher_downloading_retry_has_a_hard_timeout():
+    jvlink = MagicMock()
+    jvlink.jv_read.return_value = (-3, None, "RACE.jvd")
+    fetcher = _historical_fetcher(jvlink)
+
+    with (
+        patch("src.fetcher.base.JV_READ_DOWNLOAD_TIMEOUT_SECONDS", 1.0, create=True),
+        patch("src.fetcher.base.time.monotonic", side_effect=[0.0, 0.5, 1.1]),
+        patch("src.fetcher.base.time.sleep") as sleep,
+        pytest.raises(FetcherError, match="downloading.*timeout"),
+    ):
+        list(fetcher._fetch_and_parse())
+
+    assert jvlink.jv_read.call_count == 3
+    assert sleep.call_count == 2
+
+
+@pytest.mark.parametrize("error_code", [-201, -202, -203, -502, -503])
+def test_fetcher_does_not_retry_deterministic_or_download_failures(error_code):
+    jvlink = MagicMock()
+    jvlink.jv_read.side_effect = [
+        (error_code, None, "RACE.jvd"),
+        (0, None, None),
+    ]
+    fetcher = _historical_fetcher(jvlink)
+
+    with pytest.raises(FetcherError, match=str(error_code)):
+        list(fetcher._fetch_and_parse())
+
+    jvlink.jv_read.assert_called_once()
+    jvlink.jv_file_delete.assert_not_called()
+
+
+@pytest.mark.parametrize("error_code", [-402, -403])
+def test_fetcher_corrupt_file_without_recovery_callback_fails_once(error_code):
+    jvlink = MagicMock()
+    jvlink.jv_read.side_effect = [
+        (error_code, None, "RACE.jvd"),
+        (0, None, None),
+    ]
+    fetcher = _historical_fetcher(jvlink)
+
+    with pytest.raises(FetcherError, match=f"{error_code}|recovery"):
+        list(fetcher._fetch_and_parse())
+
+    jvlink.jv_read.assert_called_once()
+    jvlink.jv_file_delete.assert_not_called()
+
+
+def test_native_jvread_rejects_irrecoverable_replacement_character():
+    com = MagicMock()
+    com.JVRead.return_value = (1, "\ufffd", 1, "RACE.jvd")
+    wrapper = _wrapper(com, is_open=True)
+
+    with pytest.raises(JVLinkError, match="recover|buffer|replacement"):
+        wrapper.jv_read()
+
+
+def test_native_jvread_preserves_cp1252_mapped_raw_byte():
+    com = MagicMock()
+    com.JVRead.return_value = (1, "\u201c", 1, "RACE.jvd")
+    wrapper = _wrapper(com, is_open=True)
+
+    assert wrapper.jv_read() == (1, b"\x93", "RACE.jvd")
+
+
+def test_native_jvread_rejects_a_buffer_shorter_than_returned_byte_count():
+    com = MagicMock()
+    com.JVRead.return_value = (4, b"ABC", 3, "RACE.jvd")
+    wrapper = _wrapper(com, is_open=True)
+
+    with pytest.raises(JVLinkError, match="short|length|buffer"):
+        wrapper.jv_read()
+
+
+def test_bridge_setup_cancel_does_not_expose_a_readable_stream():
+    bridge = JVLinkBridge.__new__(JVLinkBridge)
+    bridge._is_open = False
+    bridge._send_command = MagicMock(
+        return_value={
+            "status": "ok",
+            "code": -2,
+            "readcount": 0,
+            "downloadcount": 0,
+            "lastfiletimestamp": "",
+        }
+    )
+
+    assert bridge.jv_open("RACE", "20260815000000", 3)[0] == -2
+    assert bridge.is_open() is False
+    assert bridge._needs_close is True
+
+
+def test_bridge_realtime_no_data_does_not_expose_a_readable_stream():
+    bridge = JVLinkBridge.__new__(JVLinkBridge)
+    bridge._is_open = False
+    bridge._needs_close = False
+    bridge._send_command = MagicMock(return_value={"status": "ok", "code": -1, "readcount": 0})
+
+    assert bridge.jv_rt_open("0B12", "2026081501010101") == (-1, 0)
+    assert bridge.is_open() is False
+    assert bridge._needs_close is True
+
+
+def test_bridge_realtime_no_data_accepts_current_runtime_response_without_count():
+    bridge = JVLinkBridge.__new__(JVLinkBridge)
+    bridge._is_open = False
+    bridge._needs_close = False
+    bridge._send_command = MagicMock(
+        return_value={"status": "error", "code": -1, "error": "JVRTOpen failed"}
+    )
+
+    assert bridge.jv_rt_open("0B12", "2026081501010101") == (-1, 0)
+    assert bridge.is_open() is False
+    assert bridge._needs_close is True
+
+
+def test_realtime_open_rejects_undefined_positive_result_code():
+    native_com = MagicMock()
+    native_com.JVRTOpen.return_value = (1, 0)
+    with pytest.raises(JVLinkError, match="JVRTOpen"):
+        _wrapper(native_com).jv_rt_open("0B12", "2026081501010101")
+
+    bridge = JVLinkBridge.__new__(JVLinkBridge)
+    bridge._is_open = False
+    bridge._needs_close = False
+    bridge._send_command = MagicMock(return_value={"status": "ok", "code": 1, "readcount": 0})
+    with pytest.raises(JVLinkBridgeError, match="JVRTOpen"):
+        bridge.jv_rt_open("0B12", "2026081501010101")
+
+
+def test_realtime_open_rejects_nonzero_compatibility_read_count():
+    native_com = MagicMock()
+    native_com.JVRTOpen.return_value = (0, 1)
+    with pytest.raises(JVLinkError, match="read count|read_count"):
+        _wrapper(native_com).jv_rt_open("0B12", "2026081501010101")
+
+    bridge = JVLinkBridge.__new__(JVLinkBridge)
+    bridge._is_open = False
+    bridge._needs_close = False
+    bridge._send_command = MagicMock(return_value={"status": "ok", "code": 0, "readcount": 1})
+    with pytest.raises(JVLinkBridgeError, match="readcount|read count"):
+        bridge.jv_rt_open("0B12", "2026081501010101")
+
+
+def test_native_realtime_malformed_success_keeps_close_pending():
+    native_com = MagicMock()
+    native_com.JVRTOpen.return_value = (0,)
+    wrapper = _wrapper(native_com)
+
+    with pytest.raises(JVLinkError, match="tuple length|JVRTOpen"):
+        wrapper.jv_rt_open("0B12", "2026081501010101")
+
+    assert wrapper._needs_close is True
+
+
+def test_bridge_close_failure_keeps_pending_close_state_and_is_reported():
+    bridge = JVLinkBridge.__new__(JVLinkBridge)
+    bridge._is_open = True
+    bridge._needs_close = True
+    bridge._send_command = MagicMock(side_effect=JVLinkBridgeError("close transport failed"))
+
+    with pytest.raises(JVLinkBridgeError, match="close transport failed"):
+        bridge.jv_close()
+
+    assert bridge.is_open() is True
+    assert bridge._needs_close is True
+
+
+def test_bridge_close_error_response_keeps_pending_close_state_and_is_reported():
+    bridge = JVLinkBridge.__new__(JVLinkBridge)
+    bridge._is_open = True
+    bridge._needs_close = True
+    bridge._send_command = MagicMock(return_value={"status": "error", "error": "JVClose failed"})
+
+    with pytest.raises(JVLinkBridgeError, match="JVClose failed"):
+        bridge.jv_close()
+
+    assert bridge.is_open() is True
+    assert bridge._needs_close is True
+
+
+def test_bridge_close_accepts_current_runtime_ack_without_code():
+    bridge = JVLinkBridge.__new__(JVLinkBridge)
+    bridge._is_open = True
+    bridge._needs_close = True
+    bridge._send_command = MagicMock(return_value={"status": "ok"})
+
+    assert bridge.jv_close() == 0
+    assert bridge.is_open() is False
+    assert bridge._needs_close is False
+
+
+def test_close_rejects_nonzero_result_and_preserves_pending_state():
+    native_com = MagicMock()
+    native_com.JVClose.return_value = -1
+    wrapper = _wrapper(native_com, is_open=True)
+    wrapper._needs_close = True
+    with pytest.raises(JVLinkError, match="JVClose"):
+        wrapper.jv_close()
+    assert wrapper.is_open() is True
+    assert wrapper._needs_close is True
+
+    bridge = JVLinkBridge.__new__(JVLinkBridge)
+    bridge._is_open = True
+    bridge._needs_close = True
+    bridge._send_command = MagicMock(return_value={"status": "ok", "code": -1})
+    with pytest.raises(JVLinkBridgeError, match="JVClose"):
+        bridge.jv_close()
+    assert bridge.is_open() is True
+    assert bridge._needs_close is True
+
+
+@pytest.mark.parametrize("method_name", ["jv_open", "jv_rt_open", "jv_read", "jv_status"])
+def test_bridge_missing_result_code_is_a_protocol_error(method_name):
+    bridge = JVLinkBridge.__new__(JVLinkBridge)
+    bridge._is_open = True
+    bridge._needs_close = True
+    bridge._send_command = MagicMock(return_value={"status": "ok"})
+
+    method = getattr(bridge, method_name)
+    args = {
+        "jv_open": ("RACE", "20260815000000", 1),
+        "jv_rt_open": ("0B12", "2026081501010101"),
+        "jv_read": (),
+        "jv_status": (),
+    }[method_name]
+
+    with pytest.raises(JVLinkBridgeError, match="code|result"):
+        method(*args)
+
+
+@pytest.mark.parametrize(
+    ("method_name", "args", "response"),
+    [
+        (
+            "jv_open",
+            ("RACE", "20260815000000", 1),
+            {
+                "status": "ok",
+                "readcount": 4,
+                "downloadcount": 2,
+                "lastfiletimestamp": "20260815000000",
+            },
+        ),
+        (
+            "jv_rt_open",
+            ("0B12", "2026081501010101"),
+            {"status": "ok"},
+        ),
+    ],
+)
+def test_bridge_malformed_success_without_code_keeps_close_pending(method_name, args, response):
+    bridge = JVLinkBridge.__new__(JVLinkBridge)
+    bridge._is_open = False
+    bridge._needs_close = False
+    bridge._send_command = MagicMock(return_value=response)
+
+    with pytest.raises(JVLinkBridgeError, match="code|result"):
+        getattr(bridge, method_name)(*args)
+
+    assert bridge.is_open() is False
+    assert bridge._needs_close is True
+
+
+@pytest.mark.parametrize("missing_field", ["readcount", "downloadcount", "lastfiletimestamp"])
+def test_bridge_open_missing_output_field_is_a_protocol_error(missing_field):
+    response = {
+        "status": "ok",
+        "code": 0,
+        "readcount": 4,
+        "downloadcount": 2,
+        "lastfiletimestamp": "20260815000000",
+    }
+    del response[missing_field]
+    bridge = JVLinkBridge.__new__(JVLinkBridge)
+    bridge._is_open = False
+    bridge._needs_close = False
+    bridge._send_command = MagicMock(return_value=response)
+
+    with pytest.raises(JVLinkBridgeError, match=missing_field):
+        bridge.jv_open("RACE", "20260815000000", 1)
+    assert bridge._needs_close is True
+
+
+@pytest.mark.parametrize(
+    "encoded",
+    [
+        base64.b64encode(b"ABC").decode("ascii"),
+        "not-valid-base64!",
+    ],
+)
+def test_bridge_read_rejects_malformed_or_short_payload(encoded):
+    bridge = JVLinkBridge.__new__(JVLinkBridge)
+    bridge._is_open = True
+    bridge._send_command = MagicMock(
+        return_value={
+            "status": "ok",
+            "code": 4,
+            "data": encoded,
+            "filename": "RACE.jvd",
+            "size": 4,
+        }
+    )
+
+    with pytest.raises(JVLinkBridgeError, match="base64|short|length|payload"):
+        bridge.jv_read()
+
+
+def test_bridge_wait_for_download_completes_at_exact_open_count():
+    bridge = JVLinkBridge.__new__(JVLinkBridge)
+    bridge.jv_status = MagicMock(side_effect=[0, 1, 2])
+
+    with patch("src.jvlink.bridge.time.sleep"):
+        assert (
+            bridge.wait_for_download(
+                download_count=2,
+                timeout=1.0,
+                poll_interval=0.01,
+            )
+            is True
+        )
+
+    assert bridge.jv_status.call_count == 3
+
+
+def test_bridge_wait_for_download_rejects_count_overshoot():
+    bridge = JVLinkBridge.__new__(JVLinkBridge)
+    bridge.jv_status = MagicMock(return_value=3)
+
+    with patch("src.jvlink.bridge.time.sleep"):
+        assert (
+            bridge.wait_for_download(
+                download_count=2,
+                timeout=1.0,
+                poll_interval=0.01,
+            )
+            is False
+        )
+
+    bridge.jv_status.assert_called_once()
+
+
+def test_download_wait_rejects_negative_expected_count():
+    bridge = JVLinkBridge.__new__(JVLinkBridge)
+    bridge.jv_status = MagicMock()
+    with pytest.raises(ValueError, match="download_count"):
+        bridge.wait_for_download(download_count=-1)
+    bridge.jv_status.assert_not_called()
+
+    fetcher = _historical_fetcher(MagicMock())
+    with pytest.raises(FetcherError, match="download_count"):
+        fetcher._wait_for_download(download_count=-1)
+
+
+def test_historical_wait_rejects_count_overshoot_and_status_error_immediately():
+    jvlink = MagicMock()
+    fetcher = _historical_fetcher(jvlink)
+
+    for status in (3, -502):
+        jvlink.reset_mock()
+        jvlink.jv_status.return_value = status
+        with pytest.raises(FetcherError):
+            fetcher._wait_for_download(
+                download_count=2,
+                timeout=1,
+                interval=0.01,
+            )
+        jvlink.jv_status.assert_called_once()

--- a/tests/test_jvlink_wrapper.py
+++ b/tests/test_jvlink_wrapper.py
@@ -94,7 +94,9 @@ class TestJVLinkWrapper:
         assert download_count == 0
         assert last_file_timestamp == "20241231235959"
         assert wrapper.is_open()
-        mock_com.JVOpen.assert_called_once_with("RACE", "20240101000000", 1)
+        mock_com.JVOpen.assert_called_once_with(
+            "RACE", "20240101000000", 1, 0, 0, ""
+        )
 
     @patch("win32com.client.Dispatch")
     def test_jv_open_with_option(self, mock_dispatch):
@@ -113,13 +115,15 @@ class TestJVLinkWrapper:
         assert read_count == 500
         assert download_count == 100
         assert last_file_timestamp == "20241231235959"
-        mock_com.JVOpen.assert_called_once_with("SNPN", "20240101000000", 2)
+        mock_com.JVOpen.assert_called_once_with(
+            "SNPN", "20240101000000", 2, 0, 0, ""
+        )
 
     @patch("win32com.client.Dispatch")
     def test_jv_open_failure(self, mock_dispatch):
         """Test JVOpen failure with actual error code (<-2)."""
         mock_com = MagicMock()
-        # JVOpen: -1/-2 are "no data" (not errors), -100 is setup required (real error)
+        # JVOpen: -1 is no data, -2 is setup cancel, and -100 is an error.
         mock_com.JVOpen.return_value = (-100, 0, 0, "")
         mock_dispatch.return_value = mock_com
 
@@ -140,20 +144,22 @@ class TestJVLinkWrapper:
         wrapper = JVLinkWrapper(sid="TEST")
         # Should NOT raise - -1 means no data, not an error
         wrapper.jv_open("RACE", "20240101000000")
+        assert not wrapper.is_open()
 
     @patch("win32com.client.Dispatch")
     def test_jv_rt_open_success(self, mock_dispatch):
         """Test JVRTOpen success."""
         mock_com = MagicMock()
-        # JVRTOpen can return either (result, read_count) or single value
-        mock_com.JVRTOpen.return_value = (0, 10)
+        # JVRTOpen officially returns only a result code. The wrapper keeps a
+        # zero compatibility count in its public tuple.
+        mock_com.JVRTOpen.return_value = (0, 0)
         mock_dispatch.return_value = mock_com
 
         wrapper = JVLinkWrapper(sid="TEST")
         result, count = wrapper.jv_rt_open("0B12")
 
         assert result == JV_RT_SUCCESS
-        assert count == 10
+        assert count == 0
         assert wrapper.is_open()
         mock_com.JVRTOpen.assert_called_once_with("0B12", "")
 
@@ -183,6 +189,7 @@ class TestJVLinkWrapper:
         result, count = wrapper.jv_rt_open("0B12")
         assert result == -1
         assert count == 0
+        assert not wrapper.is_open()
 
     @patch("win32com.client.Dispatch")
     def test_jv_rt_open_with_new_specs(self, mock_dispatch):
@@ -193,16 +200,16 @@ class TestJVLinkWrapper:
         wrapper = JVLinkWrapper(sid="TEST")
 
         # Test 0B41 (時系列オッズ 単複枠)
-        mock_com.JVRTOpen.return_value = (0, 5)
+        mock_com.JVRTOpen.return_value = (0, 0)
         result, count = wrapper.jv_rt_open("0B41")
         assert result == JV_RT_SUCCESS
-        assert count == 5
+        assert count == 0
 
         # Test 0B42 (時系列オッズ 馬連)
-        mock_com.JVRTOpen.return_value = (0, 3)
+        mock_com.JVRTOpen.return_value = (0, 0)
         result, count = wrapper.jv_rt_open("0B42")
         assert result == JV_RT_SUCCESS
-        assert count == 3
+        assert count == 0
 
     @patch("win32com.client.Dispatch")
     def test_jv_read_success(self, mock_dispatch):

--- a/tests/test_realtime.py
+++ b/tests/test_realtime.py
@@ -210,7 +210,7 @@ def test_materialize_complete_records_rejects_recoverable_read_loss():
         )
 
 
-def test_realtime_fetcher_tracks_recoverable_read_loss():
+def test_realtime_fetcher_fails_on_jvopen_not_called():
     fetcher = RealtimeFetcher.__new__(RealtimeFetcher)
     fetcher.reset_statistics()
     fetcher._files_processed = 0
@@ -223,9 +223,12 @@ def test_realtime_fetcher_tracks_recoverable_read_loss():
         (0, None, None),
     ]
 
-    assert list(fetcher._fetch_and_parse()) == []
-    assert fetcher.get_statistics()["recoverable_read_errors"] == 1
-    fetcher.jvlink.jv_file_delete.assert_called_once_with("corrupt.jvd")
+    with pytest.raises(FetcherError, match="-203"):
+        list(fetcher._fetch_and_parse())
+
+    fetcher.jvlink.jv_read.assert_called_once()
+    assert fetcher.get_statistics()["recoverable_read_errors"] == 0
+    fetcher.jvlink.jv_file_delete.assert_not_called()
 
 
 @pytest.mark.parametrize("error_code", [-402, -403])

--- a/tests/test_retired_data_specs.py
+++ b/tests/test_retired_data_specs.py
@@ -282,7 +282,7 @@ class TestWrapperRejectsBeforeCOM:
 
         assert (result, read_count) == (0, 100)
         wrapper._jvlink.JVOpen.assert_called_once_with(
-            data_spec, "20240101000000", option
+            data_spec, "20240101000000", option, 0, 0, ""
         )
 
 

--- a/tests/unit/test_jvlink_bridge.py
+++ b/tests/unit/test_jvlink_bridge.py
@@ -168,7 +168,7 @@ class TestJVLinkBridgeAPI:
 
     def test_jv_close(self, bridge):
         bridge._is_open = True
-        _patch_responses(bridge, {"status": "ok"})
+        _patch_responses(bridge, {"status": "ok", "code": 0})
         assert bridge.jv_close() == 0
         assert not bridge._is_open
 
@@ -181,9 +181,10 @@ class TestJVLinkBridgeAPI:
         assert bridge.jv_file_delete("test.jvd") == 0
 
     def test_jv_rt_open(self, bridge):
-        _patch_responses(bridge, {"status": "ok", "code": 0, "readcount": 5})
+        _patch_responses(bridge, {"status": "ok", "code": 0, "readcount": 0})
         code, rc = bridge.jv_rt_open("0B12")
         assert code == 0
+        assert rc == 0
 
     def test_jv_set_service_key_stub(self, bridge):
         """Service key setting is a stub in bridge mode."""
@@ -202,7 +203,7 @@ class TestJVLinkBridgeLifecycle:
         _patch_responses(
             bridge,
             {"status": "ok", "hwnd": 1, "linkType": "jra"},  # init
-            {"status": "ok"},  # close
+            {"status": "ok", "code": 0},  # close
             {"status": "ok", "message": "bye"},  # quit
         )
         with bridge:
@@ -220,10 +221,14 @@ class TestJVLinkBridgeLifecycle:
 
     def test_wait_for_download(self, bridge):
         call_count = [0]
-        statuses = [0, 50, 100, 0]
+        statuses = [0, 50, 100]
         def fake_response(timeout=30.0):
             idx = min(call_count[0], len(statuses) - 1)
             call_count[0] += 1
             return {"status": "ok", "code": statuses[idx]}
         bridge._read_response = fake_response
-        assert bridge.wait_for_download(timeout=5.0, poll_interval=0.01) is True
+        assert bridge.wait_for_download(
+            download_count=100,
+            timeout=5.0,
+            poll_interval=0.01,
+        ) is True


### PR DESCRIPTION
## Summary

Align the native pywin32 and JSON bridge transport boundaries with the current official JV-Link 4.9.0.1 contract while retaining the released bridge API and the current companion runtime envelope.

- call JVOpen and JVGets with their official argument shapes
- distinguish JVOpen no-data and setup-cancel state and retain mandatory JVClose obligations
- propagate JVRead/JVGets downloading status with a bounded caller wait
- reject lossy or short COM buffers, malformed bridge payloads, impossible counts, and undefined result codes
- restrict corrupt-file recovery to -402/-403 and fail closed when recovery is unavailable
- require exact JVStatus completion while preserving the released wait_for_download(timeout, poll_interval) signature
- retain compatibility with jrvltsql-wine-runtime be759ee5bdccd06dccb61f1c63f9799f136c0a39, including its count-less RT no-data and code-less successful close envelopes

## Candidate

Full SHA: `37cfb714a091ad667d132c8dd46f7aef5d87b991`
Base SHA: `c1fc891a5d17ff2982901867f4c4b6dc4af98464`
Reviewer: Codex; no Claude review used for this candidate.

## Evidence

- workflow-equivalent pytest on the exact candidate: `844 passed, 2 skipped, 3 warnings, 3 subtests passed`
- focused transport plus bridge tests: `78 passed`
- self-repair plus retired-spec tests: `170 passed`
- realtime tests: `63 passed, 3 subtests passed`
- error scenarios: `21 passed`
- critical flake8 E9/F63/F7/F82: `0`
- compileall, Black check for the new suite, and git diff check: pass
- workflow mypy remains continue-on-error and reports existing baseline errors; no new error points at the added wait compatibility code

Red-first evidence and every superseded candidate are recorded in `specs/operations/20260815_jvlink_com_transport_contract_worklog.md`.

## Sources

- Official interface specification 4.9.0.1: https://jra-van.jp/dlb/sdv/sdk/JV-Link4901.pdf
- Current SDK index: https://developer.jra-van.jp/t/topic/45
- Current official error-code community post: https://developer.jra-van.jp/t/topic/822
- Current pywin32 field report: https://qiita.com/hraps/items/b7a4ba572ff52f4ff47d

## Merge blocker

Do not merge yet. This host and the GitHub workflow are Linux-only and cannot run authenticated JV-Link COM. The platform-neutral fixed-signature tests are not equivalent to a real Windows/pywin32 smoke. Attach a passing native Windows/JV-Link result for this exact full SHA before merge. The current companion runtime also cannot propagate the native JVClose result code, so its legacy success acknowledgment is intentionally retained and documented.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved JV-Link download handling with polling, timeouts, and accurate completion checks.
  - Added stricter validation for responses, counts, payloads, and encoded data to prevent corrupted or inconsistent results.
  - Improved cleanup and recovery when connections close unexpectedly or setup is cancelled.
  - Non-corruption errors now fail immediately without deleting files or restarting streams.
- **Documentation**
  - Added comprehensive documentation covering JV-Link transport behavior, verification results, platform limitations, and required smoke testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->