### PR TITLE
Fix headless JVOpen under Wine

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -37,9 +37,10 @@ headless 実行を停止させる場合があります。X display と `xdotool`
 環境では、クライアントは既知のダイアログだけを `Escape` で拒否します。
 更新を承諾する `Return` は送りません。この監視を無効にする場合は
 `JVLINK_AUTO_CLOSE_DIALOGS=0`、監視間隔を変える場合は
-`JVLINK_DIALOG_WATCH_INTERVAL_SECONDS` を指定します。未知のダイアログ、応答
-timeout、読めない bridge 応答は成功扱いせず、timeout 時は状態不明の bridge
-process を終了します。
+`JVLINK_DIALOG_WATCH_INTERVAL_SECONDS` を指定します。監視間隔の既定値は0.5秒、
+最小値は0.1秒で、非数・無限値・解釈不能値は安全側の既定値0.5秒に戻します。
+未知のダイアログ、応答timeout、読めない bridge 応答は成功扱いせず、timeout
+時は状態不明の bridge process を終了します。
 
 ## 主要コンポーネント
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -24,6 +24,23 @@ Windows 実行・検証・収集用の配備先として扱い、a6 上で直接
 `--db postgresql` で、収集した通常データは PostgreSQL に直接保存します。
 SQLite は単体検証や PostgreSQL がない環境のフォールバックです。
 
+### Wine bridge を使う配備
+
+公開 CLI の利用要件は Windows 10 / 11 ですが、`JVLinkBridge` クライアントは
+コンテナ化した collector から native Win32 bridge を Wine で起動する経路も
+持ちます。この経路では `JVLINK_BRIDGE_EXE` で bridge の Unix 側パス、
+必要に応じて `JVLINK_WINE`、`JVLINK_WINEPREFIX`、`JVLINK_WINEARCH` を指定します。
+Wine、JV-Link、X display の導入とサービスキー登録は配備環境の責務です。
+
+JV-Link は `JVOpen` / `JVRTOpen` 中にお知らせや DataLab 更新確認を表示し、
+headless 実行を停止させる場合があります。X display と `xdotool` がある Wine
+環境では、クライアントは既知のダイアログだけを `Escape` で拒否します。
+更新を承諾する `Return` は送りません。この監視を無効にする場合は
+`JVLINK_AUTO_CLOSE_DIALOGS=0`、監視間隔を変える場合は
+`JVLINK_DIALOG_WATCH_INTERVAL_SECONDS` を指定します。未知のダイアログ、応答
+timeout、読めない bridge 応答は成功扱いせず、timeout 時は状態不明の bridge
+process を終了します。
+
 ## 主要コンポーネント
 
 | コンポーネント | 役割 |

--- a/specs/operations/20260815_jvopen_runtime_gap_worklog.md
+++ b/specs/operations/20260815_jvopen_runtime_gap_worklog.md
@@ -1,0 +1,204 @@
+# JVOpen runtime gap remediation worklog
+
+## Iteration identity
+
+- Started: 2026-08-15 JST
+- Objective: diagnose the authenticated `JVOpen(RACE)` 120-second timeout,
+  re-audit the merged public client against current and legacy official JV-Link
+  contracts plus the deployed Wine runtime, implement only proven gaps, run
+  focused and real-environment tests, obtain strict Codex review, and merge a
+  complete PR.
+- Minimum scope: JV-Link process launch and JSON transport, `JVInit`, `JVOpen`,
+  `JVStatus`, `JVRead`, `JVClose`, compatibility envelopes, timeout cleanup,
+  and the smallest directly affected fetcher paths.
+- Repository: `miyamamoto/jrvltsql`
+- Worktree:
+  `/home/keiba/scratch/20260815_jrvltsql_jvopen_runtime_gap`
+- Branch: `agent/jvopen-runtime-gap-20260815`
+- Base / initial HEAD / `origin/master` full SHA:
+  `1fbcb09c049b4fa0ad09c350cc74dd2093a855cb`
+- Related release: `v1.6.10`; PRs #161-#164 are merged and unreleased.
+- Dependency order: official/community contract audit, local contract tests,
+  isolated authenticated development-collector smoke, then PR review/merge.
+- Reviewer: Codex. Claude Code and external coding agents are not used.
+
+## Initial state
+
+- KPS read-only status was checked with
+  `python3 scripts/system_status.py --json --skip-remote --sections git`.
+  KPS was clean and current; the unrelated jrvltsql-nar checkout warning is
+  outside this public jrvltsql iteration.
+- `origin/master` was fetched before worktree creation and matched the base SHA
+  above.
+- PR #164 proved a real authenticated
+  `JVInit -> JVRTOpen(0B30) -> JVRead(962 bytes) -> JVClose` path and the
+  `JVOpen(MING)=-1 -> JVClose=0` obligation. Successful-data
+  `JVOpen(RACE) -> JVStatus -> JVRead` remained unproven because both the exact
+  merge-SHA harness and deployed Wine-aware client timed out at 120 seconds.
+
+## Official and community recheck
+
+- The current official SDK page still publishes JV-Link SDK `4.9.0.2`
+  (2024-08-07) and JV-Link/JV-Data specifications `4.9.0.1`:
+  <https://jra-van.jp/dlb/sdv/sdk.html>.
+- The cached official `JV-Link4901.pdf` was re-read for `JVOpen`, `JVStatus`,
+  `JVRead`, and `JVClose`. `JVOpen` validates the request, obtains the server
+  file list, compares local files, starts the download thread, and then returns
+  to the application. Therefore a 120-second silence before the JSON bridge
+  emits an open response is not a successful large-download wait; download
+  progress belongs to `JVStatus` after `JVOpen` returns.
+- The official 2023 change notice and the July 2026 developer announcement were
+  checked again. They confirm the 2023 format boundary and that DIFF after
+  2023-08-08 is exposed as `DIFN`; this runtime iteration does not alter those
+  parser contracts:
+  <https://jra-van.jp/dlb/sdv/ml/20230808a.html>,
+  <https://developer.jra-van.jp/t/topic/898>.
+- Current community/staff reports were checked for `JVOpen` ordering and
+  dialogs. Reports cover invalid FromTime `-112`, RACE retrieval behavior,
+  missed records when reading before `JVStatus` completes, and a blocking
+  `JRA-VANからのお知らせ` dialog. Staff recommends disabling the notice in
+  JV-Link settings:
+  <https://developer.jra-van.jp/t/topic/807>,
+  <https://developer.jra-van.jp/t/topic/832>,
+  <https://developer.jra-van.jp/t/topic/773>,
+  <https://developer.jra-van.jp/t/topic/342>.
+
+## Reproduction and root cause
+
+- The public `src/jvlink/bridge.py` launched a Windows `.exe` directly and had
+  no Wine command/environment path. The deployed collector client had a
+  separate Wine-aware implementation, but its dialog watcher matched only
+  `JRA-VANからのお知らせ` and activated the default button with `Return`.
+- Under the development collector's non-blocking service lock, the deployed
+  bridge reproduced `JVInit=0` followed by no `JVOpen(RACE)` response. During
+  the blocked COM invocation, an X11 window owned by `JVLinkBridge.exe` was
+  observed with exact title `JRA-VAN DataLab.`, geometry `476x120`, and a
+  prompt asking whether to download the new version. Its default focused
+  button was affirmative. No secret, record payload, filename, race key, or
+  registry value was captured or retained.
+- The first bounded diagnostic intentionally timed out after 45 seconds and
+  cleaned up. A second call installed a test-only exact-title watcher that
+  sent `Escape`, not `Return`. It rejected one prompt, after which the same
+  `JVOpen(RACE, 20260808000000, option=1)` returned in about 0.8 seconds with
+  `code=0`, `readcount=30`, and `downloadcount=30`. This isolates the root
+  cause to a missed blocking update prompt rather than download volume or
+  `JVStatus` ordering.
+
+## Red-first contract evidence
+
+- Before changing production code, six focused tests were added and run
+  against base SHA `1fbcb09c049b4fa0ad09c350cc74dd2093a855cb`:
+  `pytest -q tests/unit/test_jvlink_bridge.py -k 'environment_override or
+  builds_a_wine_command or fails_closed_when_wine_is_missing or
+  known_update_dialog or wine_preamble or timeout_aborts' --no-cov`.
+- Result: **6 failed**. The failures showed that the environment bridge path
+  was ignored, no Wine command/fail-closed check existed, no safe dialog
+  rejection existed, Wine preamble/BOM output was rejected, and a response
+  timeout left the stuck process running.
+- A paired normal case was retained or added for every changed boundary: Wine
+  present/missing, known dialog/default-disabled watcher, valid JSON after
+  runtime preamble, normal response/timeout abort.
+- Strict Codex boundary review then identified five additional fail-closed
+  requirements before candidate freeze: scope X11 operations to the bridge PID,
+  reject non-finite watcher intervals, require the official `JVInit` result
+  code, close the temporary stderr stream on abort, and abort after a broken
+  stdin pipe. Eight focused cases covering those branches were run before the
+  repair and **8 failed** (four interval values plus four distinct contracts).
+  After one repair batch the same command selection passed **8/8**.
+
+## Implementation and current validation
+
+- `src/jvlink/bridge.py` now discovers the bridge through the deployed
+  environment contract, launches it through Wine on non-Windows platforms,
+  passes the existing Wine prefix/architecture contract, drains stderr to a
+  temporary file, tolerates non-JSON Wine preamble plus UTF-8 BOM, and aborts a
+  process when the response stream is timed out or no longer trustworthy.
+- The Wine watcher uses exact known title patterns and sends only `Escape`.
+  It does not press the affirmative default button. It is limited to Wine with
+  an X display and `xdotool`, and can be disabled with
+  `JVLINK_AUTO_CLOSE_DIALOGS=0`.
+- Focused unit and official transport-contract validation passed:
+  `pytest -q tests/unit/test_jvlink_bridge.py
+  tests/test_jvlink_transport_contract.py --no-cov` -> **84 passed**.
+- The exact modified public `src/` tree (bridge content SHA-256
+  `c8ab955195deacb668a285eca3c810c5907f254771440d80b14b92260ea700a6`)
+  was staged in the running development collector and executed as UID/GID
+  `1001:1001` under its non-blocking service lock. Sanitized result:
+  `JVInit=0`; one known update prompt rejected; `JVOpen=0`, `readcount=30`,
+  `downloadcount=29`; `JVStatus=29`; first `JVRead=80` with an 80-byte payload;
+  legacy runtime `JVClose` acknowledgement accepted as `0`; total about 2.2
+  seconds.
+- After the smoke, the lock was available, no bridge/agent process remained,
+  the collector was healthy, and disposable staged source plus the diagnostic
+  screenshot were deleted.
+- A second exact modified-source smoke after PID scoping and strict `JVInit`
+  validation used bridge content SHA-256
+  `f5f0ca40692eeaf71ce1ed27fcac88945909222c8e3395e3bcee99e41f84c032`.
+  It rejected one prompt owned by that bridge PID and completed
+  `JVInit=0 -> JVOpen=0/readcount=30/downloadcount=0 -> JVRead=80 bytes ->
+  JVClose=0` in about 0.81 seconds. The zero download count was expected after
+  the earlier bounded call populated the local JV-Link cache; it was not used
+  as substitute evidence for the earlier positive-count `JVStatus=29` pass.
+- Final pre-commit focused validation:
+  `pytest -q tests/unit/test_jvlink_bridge.py
+  tests/test_jvlink_transport_contract.py --no-cov` -> **91 passed**;
+  `mypy src/jvlink/bridge.py --follow-imports=skip --ignore-missing-imports
+  --no-strict-optional` -> **success**; flake8 syntax/undefined-name selection,
+  compileall, and `git diff --check` -> **success**.
+- The README-prescribed local suite was run alone after an initially invalid
+  parallel run exposed the repository's shared `.pytest-tmp` collision. The
+  valid isolated command
+  `pytest tests/ -q --ignore=tests/integration/ --ignore=tests/e2e/` passed
+  **1824 tests**, skipped 38 environment-specific tests, passed 5 subtests, and
+  emitted only three pre-existing `PytestReturnNotNoneWarning` warnings.
+
+## Codex review verdict before candidate freeze
+
+- P0: none. This change does not alter race data contents, parser offsets,
+  labels, odds timing, or model inputs.
+- P1 findings found and fixed in one batch: unsafe default-button activation;
+  title-only X11 scope; non-finite watcher interval; timeout/broken-pipe process
+  leakage; missing `JVInit` result-code acceptance.
+- P2: public Windows support remains the primary documented user contract;
+  the separately required Wine provisioning boundary and opt-out setting are
+  now documented without exposing deployment secrets.
+- Residual compatibility note: the deployed native bridge still acknowledges
+  `JVClose` without its official Long result field. The already-merged client
+  compatibility envelope accepts that exact legacy acknowledgement with a
+  warning. This PR neither broadens nor reports that legacy envelope as an
+  official response.
+- Verdict: **GREEN for candidate freeze**, subject to tests, authenticated smoke,
+  GitHub checks, Copilot review, and unresolved-thread count on the exact
+  committed full SHA.
+
+## Safety and evidence rules
+
+- Never expose service keys, database URLs, registry contents, machine
+  identity, race keys, filenames, or record payloads.
+- Use the development collector's own non-blocking service lock for every
+  authenticated call; do not overlap a scheduled collection.
+- Do not restart the collector, mutate Wine/JV-Link identity, perform setup
+  downloads, or request an unbounded historical interval merely to obtain a
+  passing result.
+- Distinguish exact public-repository code, a test-only Wine launcher adapter,
+  the separately deployed runtime client, and the native bridge binary.
+- A timeout, missing response, unreadable value, or cleanup failure is not a
+  pass. Any new or changed validator must first be shown failing on the
+  pre-fix code and must retain a paired passing case.
+
+## Next safe command
+
+Commit the reviewed diff, run focused and full tests plus the authenticated
+smoke on that exact full SHA without changing tracked files, publish the PR,
+record SHA-bound evidence in PR metadata, resolve every actionable review
+thread, and merge only after the final gate is green.
+
+## STOP conditions
+
+- Stop authenticated calls if the service lock is busy, the target is not the
+  development collector, or another bridge/agent owns the stream.
+- Stop implementation if the suspected gap is not supported by official
+  documentation, current runtime behavior, a reproducible test, or a narrowly
+  justified compatibility contract.
+- Do not merge with a failing required test, unresolved actionable thread,
+  dirty worktree, moved base, or an unrecorded final full SHA.

--- a/specs/operations/20260815_jvopen_runtime_gap_worklog.md
+++ b/specs/operations/20260815_jvopen_runtime_gap_worklog.md
@@ -205,6 +205,40 @@
   three pre-existing `PytestReturnNotNoneWarning` warnings. Authenticated
   runtime evidence must still be repeated after this repair is committed;
   results bound only to `5267950...` cannot gate the new candidate.
+- Review-repair commit `df7f9a3a64b5cd8ef4bd34da1c6e0934867d8f1e`
+  repeated the 94 focused tests and the isolated 1827-test suite successfully.
+  The repository-wide mypy command still reports the pre-existing 76 errors in
+  20 files and is advisory in the current workflow; targeted mypy on the
+  changed bridge remains clean, and fatal flake8/compile/diff checks passed.
+
+## Exact repair-candidate authenticated smoke
+
+- A first staging attempt added the disposable source directory only through
+  `PYTHONPATH` while leaving the container working directory at `/app`. Python
+  correctly prioritized the current directory and imported the older deployed
+  client. That excluded run reproduced the old client's 120-second `JVOpen`
+  timeout. A diagnostic retry found one exact-title update dialog whose X11 PID
+  matched the bridge PID; a production-equivalent `Escape` action immediately
+  released `JVOpen`. The old deployed method then rejected a keyword supported
+  by the candidate, which further proved the import was not the candidate.
+  This was a test-harness binding failure and is not candidate evidence.
+- The harness was corrected by setting the container working directory to the
+  disposable exact-source root and by hashing the file resolved through
+  `src.jvlink.bridge.__file__` before any authenticated call. The imported
+  bridge SHA-256 was
+  `d57d1cb89f8fd329191d9596199cce9dbffb7c747384915b978b10a3f7507610`,
+  matching repair commit `df7f9a3a64b5cd8ef4bd34da1c6e0934867d8f1e`.
+- Under UID/GID `1001:1001` and the development collector's non-blocking
+  service lock, the corrected exact-source smoke completed in about 0.92
+  seconds: `JVInit=0`; `JVOpen=0`, read count 30, download count 0;
+  download/status-ready true; first `JVRead=80` with an 80-byte payload; and
+  `JVClose=0`. The zero download count is expected from the populated local
+  cache and does not replace the earlier same-implementation positive-count
+  `JVStatus=29` evidence.
+- The disposable staged source was deleted. No bridge/agent process remained,
+  the service lock was available, and the development collector stayed
+  healthy. No service key, environment value, record payload, race key,
+  filename, or registry content was emitted.
 
 ## Safety and evidence rules
 

--- a/specs/operations/20260815_jvopen_runtime_gap_worklog.md
+++ b/specs/operations/20260815_jvopen_runtime_gap_worklog.md
@@ -171,6 +171,41 @@
   GitHub checks, Copilot review, and unresolved-thread count on the exact
   committed full SHA.
 
+## PR #165 review repair batch
+
+- The first published candidate was
+  `5267950419c22c7d4e90b81c59f3ddad4f81a4d5`. Its exact-SHA GitHub `test`
+  and `lint` jobs passed, but it is no longer an acceptable merge candidate
+  because the post-publication reviews found concrete boundary defects.
+- Codex/CodeRabbit independently found that using `select.select()` on a
+  `TextIOWrapper` could report a false timeout when `readline()` had already
+  buffered the JSON line behind a non-JSON Wine preamble. Copilot/CodeRabbit
+  also found that an explicitly configured missing bridge silently fell back,
+  directories were accepted as executables, and the Wine error incorrectly
+  named only Linux even though the branch is all non-Windows platforms.
+  Duplicate findings were clustered into one repair batch; none was dismissed
+  because the reviewer or automation source was optional.
+- Before production repair, the focused selection
+  `pytest -q tests/unit/test_jvlink_bridge.py -k 'explicit_bridge_override or
+  consumes_buffered_json or fails_closed_when_wine_is_missing' --no-cov`
+  failed **4 tests**: both missing/directory environment overrides fell
+  through, the second buffered line timed out, and the message lacked the
+  non-Windows contract. A separate direct-constructor directory test was then
+  added and failed **1 test** because `Path.exists()` accepted the directory.
+- The repair makes every explicit bridge path fail closed unless it is a
+  regular file, uses `Path.is_file()` for all discovery candidates, keeps one
+  deadline while performing bounded threaded `readline()` calls on every
+  platform, and documents the dialog-watcher default (0.5 seconds), floor
+  (0.1 seconds), and invalid/non-finite fallback (0.5 seconds).
+- The repaired boundary selection passed **6 tests**. The combined bridge and
+  official transport-contract suite passed **94 tests**; targeted mypy,
+  flake8 syntax/undefined-name checks, compileall, and `git diff --check` also
+  passed. The isolated local suite passed **1827 tests**, skipped 38
+  environment-specific tests, passed 5 subtests, and emitted only the same
+  three pre-existing `PytestReturnNotNoneWarning` warnings. Authenticated
+  runtime evidence must still be repeated after this repair is committed;
+  results bound only to `5267950...` cannot gate the new candidate.
+
 ## Safety and evidence rules
 
 - Never expose service keys, database URLs, registry contents, machine
@@ -188,10 +223,10 @@
 
 ## Next safe command
 
-Commit the reviewed diff, run focused and full tests plus the authenticated
-smoke on that exact full SHA without changing tracked files, publish the PR,
-record SHA-bound evidence in PR metadata, resolve every actionable review
-thread, and merge only after the final gate is green.
+Commit the batched review repair, run focused and full tests plus the
+authenticated smoke on that new exact full SHA without changing tracked files,
+update PR evidence, reply to and resolve every actionable review thread, and
+merge only after the final gate is green.
 
 ## STOP conditions
 

--- a/src/jvlink/bridge.py
+++ b/src/jvlink/bridge.py
@@ -5,21 +5,30 @@ This replaces the Python win32com-based JVLinkWrapper, eliminating:
 - 32-bit Python requirement
 - COM threading/marshaling issues
 - win32com dependency
+
+Platform support:
+- Windows: runs JVLinkBridge.exe directly
+- Linux: runs the native Win32 bridge through Wine
 """
 
 import base64
 import binascii
 import json
+import math
+import os
+import shutil
 import subprocess
 import sys
+import tempfile
+import threading
 import time
 from pathlib import Path
-from typing import Optional, Tuple
+from typing import Optional, TextIO, Tuple
 
 from src.jvlink.constants import (
+    BUFFER_SIZE_JVREAD,
     JV_READ_NO_MORE_DATA,
     JV_READ_SUCCESS,
-    BUFFER_SIZE_JVREAD,
     is_retired_data_spec,
     retired_data_spec_message,
 )
@@ -63,15 +72,51 @@ def _require_string(response: dict, field: str, command: str) -> str:
 
 # Default bridge executable locations (searched in order)
 _BRIDGE_SEARCH_PATHS = [
+    # Native Win32 bridge (preferred for Wine; no .NET runtime dependency)
+    Path("tools/jvlink-bridge/bin/native/JVLinkBridge.exe"),
     # Relative to jrvltsql repo root (build output)
     Path("tools/jvlink-bridge/bin/x86/Release/net8.0-windows/JVLinkBridge.exe"),
     Path("tools/jvlink-bridge/bin/Release/net8.0-windows/JVLinkBridge.exe"),
+    Path("tools/jvlink-bridge/bin/x86/Release/net48/JVLinkBridge.exe"),
+    Path("tools/jvlink-bridge/bin/Release/net48/JVLinkBridge.exe"),
     # Relative to jrvltsql repo root (flat copy)
     Path("tools/jvlink-bridge/JVLinkBridge.exe"),
     # Generic Windows locations
     Path(r"C:\Program Files\JVLinkBridge\JVLinkBridge.exe"),
     Path(r"C:\Program Files (x86)\JVLinkBridge\JVLinkBridge.exe"),
 ]
+
+_BRIDGE_SEARCH_PATHS_LINUX = [
+    Path("/opt/jvlink-bridge/JVLinkBridge.exe"),
+    Path.home() / "jvlink-bridge" / "JVLinkBridge.exe",
+    Path("tools/jvlink-bridge/bin/native/JVLinkBridge.exe"),
+    Path("tools/jvlink-bridge/bin/x86/Release/net48/JVLinkBridge.exe"),
+    Path("tools/jvlink-bridge/bin/x86/Release/net8.0-windows/JVLinkBridge.exe"),
+    Path("tools/jvlink-bridge/JVLinkBridge.exe"),
+]
+
+# These are exact X11 title regular expressions for JV-Link dialogs proven to
+# block a headless JVOpen/JVRTOpen call.  Escape selects the non-affirmative
+# path; Return is deliberately not used because the DataLab update prompt
+# focuses its "yes" button by default.
+_DISMISSIBLE_DIALOG_TITLE_PATTERNS = (
+    r"^JRA-VAN DataLab\.$",
+    r"^JRA-VANからのお知らせ$",
+)
+_ENABLED_VALUES = {"1", "true", "yes", "on"}
+_DISABLED_VALUES = {"0", "false", "no", "off"}
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[2]
+
+
+def _wine_executable() -> str:
+    return os.environ.get("JVLINK_WINE", "wine")
+
+
+def _is_wine_available(wine: Optional[str] = None) -> bool:
+    return shutil.which(wine or _wine_executable()) is not None
 
 
 def find_bridge_executable() -> Optional[Path]:
@@ -80,14 +125,26 @@ def find_bridge_executable() -> Optional[Path]:
     Returns:
         Path to JVLinkBridge.exe, or None if not found.
     """
-    for p in _BRIDGE_SEARCH_PATHS:
+    env_path = os.environ.get("JVLINK_BRIDGE_EXE")
+    if env_path:
+        candidate = Path(env_path).expanduser()
+        if candidate.exists():
+            return candidate
+
+    search_paths = (
+        _BRIDGE_SEARCH_PATHS_LINUX
+        if sys.platform != "win32"
+        else _BRIDGE_SEARCH_PATHS
+    )
+    for p in search_paths:
+        p = p.expanduser()
         if p.is_absolute() and p.exists():
             return p
-        # Try relative to current working directory
         if not p.is_absolute():
-            abs_p = Path.cwd() / p
-            if abs_p.exists():
-                return abs_p
+            for base in (Path.cwd(), _repo_root()):
+                candidate = base / p
+                if candidate.exists():
+                    return candidate
     return None
 
 
@@ -136,6 +193,11 @@ class JVLinkBridge:
         self._is_open = False
         self._needs_close = False
         self._download_count: Optional[int] = None
+        self._use_wine = sys.platform != "win32"
+        self._wine = _wine_executable()
+        self._stderr_file: Optional[TextIO] = None
+        self._dialog_watcher_stop: Optional[threading.Event] = None
+        self._dialog_watcher_thread: Optional[threading.Thread] = None
 
         if bridge_path:
             self._bridge_path = Path(bridge_path)
@@ -148,41 +210,274 @@ class JVLinkBridge:
                 "tools/jvlink-bridge/ にビルド済みバイナリを配置してください。"
             )
 
-        logger.info("JVLinkBridge initialized", bridge_path=str(self._bridge_path), sid=sid)
+        logger.info(
+            "JVLinkBridge initialized",
+            bridge_path=str(self._bridge_path),
+            sid=sid,
+            use_wine=self._use_wine,
+            wine=self._wine if self._use_wine else None,
+        )
+
+    @property
+    def uses_wine(self) -> bool:
+        return self._use_wine
+
+    def _build_command(self) -> list[str]:
+        if not self._use_wine:
+            return [str(self._bridge_path)]
+        if not _is_wine_available(self._wine):
+            raise JVLinkBridgeError(
+                "Linux環境ではWineが必要です。wine32/wine をインストールし、"
+                "必要なら JVLINK_WINE に実行ファイルを指定してください。"
+            )
+        return [self._wine, str(self._bridge_path)]
+
+    def _build_env(self) -> dict[str, str]:
+        env = os.environ.copy()
+        if self._use_wine:
+            env.setdefault("WINEDEBUG", "-all")
+        wineprefix = env.get("JVLINK_WINEPREFIX")
+        if wineprefix:
+            env["WINEPREFIX"] = wineprefix
+        winearch = env.get("JVLINK_WINEARCH")
+        if winearch:
+            env["WINEARCH"] = winearch
+        return env
+
+    def _dialog_watcher_enabled(self) -> bool:
+        if not self._use_wine:
+            return False
+        value = os.environ.get("JVLINK_AUTO_CLOSE_DIALOGS", "1").lower()
+        if value in _DISABLED_VALUES:
+            return False
+        if value not in _ENABLED_VALUES and value != "":
+            logger.warning(
+                "Ignoring invalid JVLINK_AUTO_CLOSE_DIALOGS value",
+                value=value,
+            )
+            return False
+        return bool(os.environ.get("DISPLAY")) and shutil.which("xdotool") is not None
+
+    def _dismiss_known_dialogs_once(self) -> int:
+        """Reject only known blocking JV-Link dialogs visible on this X display."""
+        if not self._use_wine or not os.environ.get("DISPLAY"):
+            return 0
+        if shutil.which("xdotool") is None:
+            return 0
+        process = self._process
+        if process is None or process.poll() is not None:
+            return 0
+
+        dismissed = 0
+        env = self._build_env()
+        for pattern in _DISMISSIBLE_DIALOG_TITLE_PATTERNS:
+            try:
+                result = subprocess.run(
+                    [
+                        "xdotool",
+                        "search",
+                        "--onlyvisible",
+                        "--pid",
+                        str(process.pid),
+                        "--name",
+                        pattern,
+                    ],
+                    capture_output=True,
+                    text=True,
+                    timeout=1.0,
+                    check=False,
+                    env=env,
+                )
+            except (OSError, subprocess.SubprocessError):
+                continue
+            if result.returncode != 0:
+                continue
+            for window_id in result.stdout.split():
+                try:
+                    action = subprocess.run(
+                        [
+                            "xdotool",
+                            "windowactivate",
+                            window_id,
+                            "key",
+                            "Escape",
+                        ],
+                        stdout=subprocess.DEVNULL,
+                        stderr=subprocess.DEVNULL,
+                        timeout=1.0,
+                        check=False,
+                        env=env,
+                    )
+                except (OSError, subprocess.SubprocessError):
+                    continue
+                if action.returncode == 0:
+                    dismissed += 1
+                    logger.info(
+                        "Rejected blocking JV-Link dialog",
+                        title_pattern=pattern,
+                    )
+        return dismissed
+
+    def _dialog_watch_interval(self) -> float:
+        raw_value = os.environ.get(
+            "JVLINK_DIALOG_WATCH_INTERVAL_SECONDS", "0.5"
+        )
+        try:
+            interval = float(raw_value)
+        except ValueError:
+            interval = math.nan
+        if not math.isfinite(interval):
+            logger.warning(
+                "Invalid JVLINK_DIALOG_WATCH_INTERVAL_SECONDS; using 0.5"
+            )
+            return 0.5
+        return max(interval, 0.1)
+
+    def _ensure_dialog_watcher(self) -> None:
+        if not self._dialog_watcher_enabled():
+            return
+        if (
+            self._dialog_watcher_thread is not None
+            and self._dialog_watcher_thread.is_alive()
+        ):
+            return
+
+        interval = self._dialog_watch_interval()
+        stop = threading.Event()
+
+        def _watch() -> None:
+            while not stop.wait(interval):
+                self._dismiss_known_dialogs_once()
+
+        self._dialog_watcher_stop = stop
+        self._dialog_watcher_thread = threading.Thread(
+            target=_watch,
+            name="jvlink-dialog-watcher",
+            daemon=True,
+        )
+        self._dialog_watcher_thread.start()
+
+    def _stop_dialog_watcher(self) -> None:
+        if self._dialog_watcher_stop is not None:
+            self._dialog_watcher_stop.set()
+        if (
+            self._dialog_watcher_thread is not None
+            and self._dialog_watcher_thread.is_alive()
+        ):
+            self._dialog_watcher_thread.join(timeout=2.0)
+        self._dialog_watcher_stop = None
+        self._dialog_watcher_thread = None
+
+    def _open_stderr_file(self) -> TextIO:
+        if self._stderr_file is not None:
+            try:
+                self._stderr_file.close()
+            except OSError:
+                pass
+        self._stderr_file = tempfile.TemporaryFile(
+            mode="w+t", encoding="utf-8", errors="replace"
+        )
+        return self._stderr_file
+
+    def _stderr_tail(self, limit: int = 4000) -> str:
+        if self._stderr_file is None:
+            return ""
+        try:
+            self._stderr_file.flush()
+            self._stderr_file.seek(0)
+            return self._stderr_file.read()[-limit:]
+        except (OSError, ValueError):
+            return ""
+
+    def _close_stderr_file(self) -> None:
+        if self._stderr_file is not None:
+            try:
+                self._stderr_file.close()
+            except OSError:
+                pass
+            self._stderr_file = None
+
+    def _abort_process(self) -> None:
+        """Terminate a bridge whose protocol state can no longer be trusted."""
+        process = self._process
+        self._process = None
+        if process is not None and process.poll() is None:
+            try:
+                process.terminate()
+                process.wait(timeout=5.0)
+            except Exception:
+                try:
+                    process.kill()
+                    process.wait(timeout=5.0)
+                except Exception:
+                    pass
+        self._is_open = False
+        self._needs_close = False
+        self._download_count = None
+        self._stop_dialog_watcher()
+        self._close_stderr_file()
+
+    def _response_timeout(self, timeout: float) -> JVLinkBridgeError:
+        stderr_tail = self._stderr_tail()
+        self._abort_process()
+        suffix = f". stderr: {stderr_tail}" if stderr_tail else ""
+        return JVLinkBridgeError(f"Bridge response timeout ({timeout}s){suffix}")
 
     def _start_process(self):
         if self._process is not None and self._process.poll() is None:
             return
 
-        logger.info("Starting JVLinkBridge subprocess", path=str(self._bridge_path))
-
-        self._process = subprocess.Popen(
-            [str(self._bridge_path)],
-            stdin=subprocess.PIPE,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            text=True,
-            encoding="utf-8",
-            bufsize=1,
+        logger.info(
+            "Starting JVLinkBridge subprocess",
+            path=str(self._bridge_path),
+            wine=self._use_wine,
         )
 
-        response = self._read_response(timeout=10.0)
-        if response.get("status") != "ready":
-            raise JVLinkBridgeError(f"Bridge failed to start: {response.get('error', 'unknown')}")
-        logger.info("JVLinkBridge subprocess ready", version=response.get("version"))
+        command = self._build_command()
+        stderr_file = self._open_stderr_file()
+        try:
+            self._process = subprocess.Popen(
+                command,
+                stdin=subprocess.PIPE,
+                stdout=subprocess.PIPE,
+                stderr=stderr_file,
+                text=True,
+                encoding="utf-8",
+                errors="replace",
+                bufsize=1,
+                env=self._build_env(),
+            )
+
+            response = self._read_response(timeout=10.0)
+            if response.get("status") != "ready":
+                raise JVLinkBridgeError(
+                    "Bridge failed to start: "
+                    f"{response.get('error', 'unknown')}. stderr: {self._stderr_tail()}"
+                )
+            logger.info(
+                "JVLinkBridge subprocess ready", version=response.get("version")
+            )
+        except Exception:
+            self._abort_process()
+            raise
 
     def _send_command(self, cmd: dict, timeout: Optional[float] = None) -> dict:
         if self._process is None or self._process.poll() is not None:
             raise JVLinkBridgeError("Bridge process is not running")
 
-        timeout = timeout or self._timeout
+        if self._process.stdin is None:
+            raise JVLinkBridgeError("Bridge stdin is not available")
+
+        timeout = self._timeout if timeout is None else timeout
         cmd_json = json.dumps(cmd, ensure_ascii=False)
+        self._ensure_dialog_watcher()
 
         try:
             self._process.stdin.write(cmd_json + "\n")
             self._process.stdin.flush()
-        except (BrokenPipeError, OSError) as e:
-            raise JVLinkBridgeError(f"Failed to send command: {e}")
+        except (BrokenPipeError, OSError) as exc:
+            self._abort_process()
+            raise JVLinkBridgeError(f"Failed to send command: {exc}") from exc
 
         return self._read_response(timeout=timeout)
 
@@ -190,46 +485,77 @@ class JVLinkBridge:
         if self._process is None:
             raise JVLinkBridgeError("Bridge process is not running")
 
-        if sys.platform == "win32":
-            import threading
-            result = [None]
-            error = [None]
+        deadline = time.monotonic() + timeout
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                raise self._response_timeout(timeout)
 
-            def _read():
-                try:
-                    result[0] = self._process.stdout.readline()
-                except Exception as e:
-                    error[0] = e
+            process = self._process
+            if process is None or process.stdout is None:
+                raise JVLinkBridgeError("Bridge stdout is not available")
 
-            thread = threading.Thread(target=_read, daemon=True)
-            thread.start()
-            thread.join(timeout=timeout)
+            if sys.platform == "win32":
+                result = [None]
+                error = [None]
 
-            if thread.is_alive():
-                raise JVLinkBridgeError(f"Bridge response timeout ({timeout}s)")
-            if error[0]:
-                raise JVLinkBridgeError(f"Bridge read error: {error[0]}")
-            line = result[0]
-        else:
-            import select
-            ready, _, _ = select.select([self._process.stdout], [], [], timeout)
-            if not ready:
-                raise JVLinkBridgeError(f"Bridge response timeout ({timeout}s)")
-            line = self._process.stdout.readline()
+                def _read(
+                    process=process,
+                    result=result,
+                    error=error,
+                ):
+                    try:
+                        result[0] = process.stdout.readline()
+                    except Exception as exc:
+                        error[0] = exc
 
-        if not line:
-            stderr_output = ""
-            if self._process.stderr:
-                try:
-                    stderr_output = self._process.stderr.read()
-                except Exception:
-                    pass
-            raise JVLinkBridgeError(f"Bridge terminated unexpectedly. stderr: {stderr_output}")
+                thread = threading.Thread(target=_read, daemon=True)
+                thread.start()
+                thread.join(timeout=remaining)
 
-        try:
-            return json.loads(line.strip())
-        except json.JSONDecodeError as e:
-            raise JVLinkBridgeError(f"Invalid JSON from bridge: {line.strip()!r}: {e}")
+                if thread.is_alive():
+                    raise self._response_timeout(timeout)
+                if error[0]:
+                    self._abort_process()
+                    raise JVLinkBridgeError(f"Bridge read error: {error[0]}")
+                line = result[0]
+            else:
+                import select
+
+                ready, _, _ = select.select([process.stdout], [], [], remaining)
+                if not ready:
+                    raise self._response_timeout(timeout)
+                line = process.stdout.readline()
+
+            if not line:
+                stderr_output = self._stderr_tail()
+                self._abort_process()
+                raise JVLinkBridgeError(
+                    f"Bridge terminated unexpectedly. stderr: {stderr_output}"
+                )
+
+            raw = line.strip().lstrip("\ufeff")
+            if not raw:
+                continue
+
+            try:
+                response = json.loads(raw)
+            except json.JSONDecodeError as exc:
+                if not raw.startswith("{"):
+                    logger.warning("Ignoring non-JSON bridge output", line=raw[:200])
+                    continue
+                stderr_output = self._stderr_tail()
+                self._abort_process()
+                raise JVLinkBridgeError(
+                    f"Invalid JSON from bridge: {raw!r}: {exc}. "
+                    f"stderr: {stderr_output}"
+                ) from exc
+            if not isinstance(response, dict):
+                self._abort_process()
+                raise JVLinkBridgeError(
+                    "Invalid JSON from bridge: response is not an object"
+                )
+            return response
 
     # =========================================================================
     # JV-Link API Methods
@@ -239,12 +565,14 @@ class JVLinkBridge:
         self._start_process()
         response = self._send_command({"cmd": "init", "type": "jra", "key": self.sid})
 
-        if response.get("status") == "error":
-            code = response.get("code", -1)
-            raise JVLinkBridgeError(response.get("error", "JVInit failed"), error_code=code)
+        code = _require_response_code(response, "JVInit")
+        if code != 0:
+            raise JVLinkBridgeError(
+                response.get("error", "JVInit failed"), error_code=code
+            )
 
-        logger.info("JV-Link initialized via bridge", hwnd=response.get("hwnd"))
-        return 0
+        logger.info("JV-Link initialized via bridge", code=code)
+        return code
 
     def jv_set_service_key(self, service_key: str) -> int:
         """Set service key. Note: Bridge doesn't directly support this yet.
@@ -516,6 +844,8 @@ class JVLinkBridge:
         self._is_open = False
         self._needs_close = False
         self._download_count = None
+        self._close_stderr_file()
+        self._stop_dialog_watcher()
 
     def __enter__(self):
         self.jv_init()

--- a/src/jvlink/bridge.py
+++ b/src/jvlink/bridge.py
@@ -8,7 +8,7 @@ This replaces the Python win32com-based JVLinkWrapper, eliminating:
 
 Platform support:
 - Windows: runs JVLinkBridge.exe directly
-- Linux: runs the native Win32 bridge through Wine
+- Non-Windows: runs the native Win32 bridge through Wine
 """
 
 import base64
@@ -35,6 +35,16 @@ from src.jvlink.constants import (
 from src.utils.logger import get_logger
 
 logger = get_logger(__name__)
+
+
+class JVLinkBridgeError(Exception):
+    """JV-Link Bridge related error."""
+
+    def __init__(self, message: str, error_code: Optional[int] = None):
+        self.error_code = error_code
+        if error_code is not None:
+            message = f"{message} (code: {error_code})"
+        super().__init__(message)
 
 
 def _require_response_code(response: dict, command: str) -> int:
@@ -128,8 +138,12 @@ def find_bridge_executable() -> Optional[Path]:
     env_path = os.environ.get("JVLINK_BRIDGE_EXE")
     if env_path:
         candidate = Path(env_path).expanduser()
-        if candidate.exists():
-            return candidate
+        if not candidate.is_file():
+            raise JVLinkBridgeError(
+                "JVLINK_BRIDGE_EXE must point to a JVLinkBridge.exe file: "
+                f"{candidate}"
+            )
+        return candidate
 
     search_paths = (
         _BRIDGE_SEARCH_PATHS_LINUX
@@ -138,24 +152,14 @@ def find_bridge_executable() -> Optional[Path]:
     )
     for p in search_paths:
         p = p.expanduser()
-        if p.is_absolute() and p.exists():
+        if p.is_absolute() and p.is_file():
             return p
         if not p.is_absolute():
             for base in (Path.cwd(), _repo_root()):
                 candidate = base / p
-                if candidate.exists():
+                if candidate.is_file():
                     return candidate
     return None
-
-
-class JVLinkBridgeError(Exception):
-    """JV-Link Bridge related error."""
-
-    def __init__(self, message: str, error_code: Optional[int] = None):
-        self.error_code = error_code
-        if error_code is not None:
-            message = f"{message} (code: {error_code})"
-        super().__init__(message)
 
 
 class JVLinkBridge:
@@ -199,12 +203,12 @@ class JVLinkBridge:
         self._dialog_watcher_stop: Optional[threading.Event] = None
         self._dialog_watcher_thread: Optional[threading.Thread] = None
 
-        if bridge_path:
+        if bridge_path is not None:
             self._bridge_path = Path(bridge_path)
         else:
             self._bridge_path = find_bridge_executable()
 
-        if self._bridge_path is None or not self._bridge_path.exists():
+        if self._bridge_path is None or not self._bridge_path.is_file():
             raise JVLinkBridgeError(
                 "JVLinkBridge.exe が見つかりません。"
                 "tools/jvlink-bridge/ にビルド済みバイナリを配置してください。"
@@ -227,7 +231,7 @@ class JVLinkBridge:
             return [str(self._bridge_path)]
         if not _is_wine_available(self._wine):
             raise JVLinkBridgeError(
-                "Linux環境ではWineが必要です。wine32/wine をインストールし、"
+                "非Windows環境ではWineが必要です。wine32/wine をインストールし、"
                 "必要なら JVLINK_WINE に実行ファイルを指定してください。"
             )
         return [self._wine, str(self._bridge_path)]
@@ -495,37 +499,29 @@ class JVLinkBridge:
             if process is None or process.stdout is None:
                 raise JVLinkBridgeError("Bridge stdout is not available")
 
-            if sys.platform == "win32":
-                result = [None]
-                error = [None]
+            result = [None]
+            error = [None]
 
-                def _read(
-                    process=process,
-                    result=result,
-                    error=error,
-                ):
-                    try:
-                        result[0] = process.stdout.readline()
-                    except Exception as exc:
-                        error[0] = exc
+            def _read(
+                process=process,
+                result=result,
+                error=error,
+            ):
+                try:
+                    result[0] = process.stdout.readline()
+                except Exception as exc:
+                    error[0] = exc
 
-                thread = threading.Thread(target=_read, daemon=True)
-                thread.start()
-                thread.join(timeout=remaining)
+            thread = threading.Thread(target=_read, daemon=True)
+            thread.start()
+            thread.join(timeout=remaining)
 
-                if thread.is_alive():
-                    raise self._response_timeout(timeout)
-                if error[0]:
-                    self._abort_process()
-                    raise JVLinkBridgeError(f"Bridge read error: {error[0]}")
-                line = result[0]
-            else:
-                import select
-
-                ready, _, _ = select.select([process.stdout], [], [], remaining)
-                if not ready:
-                    raise self._response_timeout(timeout)
-                line = process.stdout.readline()
+            if thread.is_alive():
+                raise self._response_timeout(timeout)
+            if error[0]:
+                self._abort_process()
+                raise JVLinkBridgeError(f"Bridge read error: {error[0]}")
+            line = result[0]
 
             if not line:
                 stderr_output = self._stderr_tail()

--- a/tests/unit/test_jvlink_bridge.py
+++ b/tests/unit/test_jvlink_bridge.py
@@ -3,6 +3,7 @@
 import base64
 import subprocess
 import tempfile
+import threading
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -48,6 +49,10 @@ class TestJVLinkBridgeInit:
         b = JVLinkBridge(bridge_path=exe)
         assert b._bridge_path == exe
 
+    def test_explicit_bridge_path_rejects_directory(self, tmp_path):
+        with pytest.raises(JVLinkBridgeError, match="JVLinkBridge.exe"):
+            JVLinkBridge(bridge_path=tmp_path)
+
     def test_find_bridge_executable_honors_environment_override(
         self, tmp_path, monkeypatch
     ):
@@ -58,24 +63,38 @@ class TestJVLinkBridgeInit:
 
         assert find_bridge_executable() == exe
 
-    def test_linux_bridge_builds_a_wine_command(self, tmp_path):
+    @pytest.mark.parametrize("kind", ["missing", "directory"])
+    def test_explicit_bridge_override_fails_closed(
+        self, tmp_path, monkeypatch, kind
+    ):
+        override = tmp_path / "JVLinkBridge.exe"
+        if kind == "directory":
+            override.mkdir()
+        monkeypatch.setenv("JVLINK_BRIDGE_EXE", str(override))
+
+        with pytest.raises(JVLinkBridgeError, match="JVLINK_BRIDGE_EXE"):
+            find_bridge_executable()
+
+    def test_non_windows_bridge_builds_a_wine_command(self, tmp_path):
         exe = tmp_path / "JVLinkBridge.exe"
         exe.touch()
         bridge = JVLinkBridge(bridge_path=exe)
+        bridge._use_wine = True
 
         with patch("src.jvlink.bridge.shutil.which", return_value="/usr/bin/wine"):
             assert bridge._build_command() == ["wine", str(exe)]
 
-    def test_linux_bridge_fails_closed_when_wine_is_missing(self, tmp_path):
+    def test_non_windows_bridge_fails_closed_when_wine_is_missing(self, tmp_path):
         exe = tmp_path / "JVLinkBridge.exe"
         exe.touch()
         bridge = JVLinkBridge(bridge_path=exe)
+        bridge._use_wine = True
 
-        with (
-            patch("src.jvlink.bridge.shutil.which", return_value=None),
-            pytest.raises(JVLinkBridgeError, match="Wine"),
-        ):
-            bridge._build_command()
+        with patch("src.jvlink.bridge.shutil.which", return_value=None):
+            with pytest.raises(JVLinkBridgeError, match="Wine") as exc_info:
+                bridge._build_command()
+
+        assert "非Windows" in str(exc_info.value)
 
     def test_known_update_dialog_is_rejected_instead_of_accepted(
         self, tmp_path, monkeypatch
@@ -83,6 +102,7 @@ class TestJVLinkBridgeInit:
         exe = tmp_path / "JVLinkBridge.exe"
         exe.touch()
         bridge = JVLinkBridge(bridge_path=exe)
+        bridge._use_wine = True
         bridge._process = MagicMock(pid=777)
         bridge._process.poll.return_value = None
         monkeypatch.setenv("DISPLAY", ":1")
@@ -127,6 +147,7 @@ class TestJVLinkBridgeInit:
         exe = tmp_path / "JVLinkBridge.exe"
         exe.touch()
         bridge = JVLinkBridge(bridge_path=exe)
+        bridge._use_wine = True
         monkeypatch.setenv("DISPLAY", ":1")
         monkeypatch.setenv("JVLINK_AUTO_CLOSE_DIALOGS", "0")
 
@@ -144,7 +165,7 @@ class TestJVLinkBridgeInit:
         ):
             assert bridge._dialog_watch_interval() == 0.5
 
-    def test_bridge_response_ignores_wine_preamble_and_utf8_bom(self, bridge):
+    def test_bridge_response_consumes_buffered_json_after_wine_preamble(self, bridge):
         bridge._process.stdout.readline.side_effect = [
             "wine runtime preamble\n",
             '\ufeff{"status":"ready","version":"test"}\n',
@@ -153,7 +174,7 @@ class TestJVLinkBridgeInit:
             "select.select",
             side_effect=[
                 ([bridge._process.stdout], [], []),
-                ([bridge._process.stdout], [], []),
+                ([], [], []),
             ],
         ):
             assert bridge._read_response(timeout=1.0) == {
@@ -165,11 +186,15 @@ class TestJVLinkBridgeInit:
         process = bridge._process
         bridge._stderr_file = tempfile.TemporaryFile(mode="w+t")
         stderr_file = bridge._stderr_file
-        with (
-            patch("select.select", return_value=([], [], [])),
-            pytest.raises(JVLinkBridgeError, match="timeout"),
-        ):
-            bridge._read_response(timeout=0.01)
+        release_reader = threading.Event()
+        process.stdout.readline.side_effect = lambda: (
+            release_reader.wait(timeout=1.0) or ""
+        )
+        try:
+            with pytest.raises(JVLinkBridgeError, match="timeout"):
+                bridge._read_response(timeout=0.01)
+        finally:
+            release_reader.set()
 
         process.terminate.assert_called_once()
         assert bridge._process is None

--- a/tests/unit/test_jvlink_bridge.py
+++ b/tests/unit/test_jvlink_bridge.py
@@ -1,8 +1,8 @@
 """Tests for JVLinkBridge client (JRA/中央競馬)."""
 
-import json
 import base64
-from pathlib import Path
+import subprocess
+import tempfile
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -10,6 +10,7 @@ import pytest
 from src.jvlink.bridge import (
     JVLinkBridge,
     JVLinkBridgeError,
+    find_bridge_executable,
 )
 from src.parser.se_parser import SEParser
 from tests.fixtures.record_factory import make_se_record
@@ -47,10 +48,150 @@ class TestJVLinkBridgeInit:
         b = JVLinkBridge(bridge_path=exe)
         assert b._bridge_path == exe
 
+    def test_find_bridge_executable_honors_environment_override(
+        self, tmp_path, monkeypatch
+    ):
+        exe = tmp_path / "native" / "JVLinkBridge.exe"
+        exe.parent.mkdir()
+        exe.touch()
+        monkeypatch.setenv("JVLINK_BRIDGE_EXE", str(exe))
+
+        assert find_bridge_executable() == exe
+
+    def test_linux_bridge_builds_a_wine_command(self, tmp_path):
+        exe = tmp_path / "JVLinkBridge.exe"
+        exe.touch()
+        bridge = JVLinkBridge(bridge_path=exe)
+
+        with patch("src.jvlink.bridge.shutil.which", return_value="/usr/bin/wine"):
+            assert bridge._build_command() == ["wine", str(exe)]
+
+    def test_linux_bridge_fails_closed_when_wine_is_missing(self, tmp_path):
+        exe = tmp_path / "JVLinkBridge.exe"
+        exe.touch()
+        bridge = JVLinkBridge(bridge_path=exe)
+
+        with (
+            patch("src.jvlink.bridge.shutil.which", return_value=None),
+            pytest.raises(JVLinkBridgeError, match="Wine"),
+        ):
+            bridge._build_command()
+
+    def test_known_update_dialog_is_rejected_instead_of_accepted(
+        self, tmp_path, monkeypatch
+    ):
+        exe = tmp_path / "JVLinkBridge.exe"
+        exe.touch()
+        bridge = JVLinkBridge(bridge_path=exe)
+        bridge._process = MagicMock(pid=777)
+        bridge._process.poll.return_value = None
+        monkeypatch.setenv("DISPLAY", ":1")
+
+        search = subprocess.CompletedProcess(
+            args=[], returncode=0, stdout="42\n", stderr=""
+        )
+        dismissed = subprocess.CompletedProcess(
+            args=[], returncode=0, stdout="", stderr=""
+        )
+        with (
+            patch("src.jvlink.bridge.shutil.which", return_value="/usr/bin/xdotool"),
+            patch(
+                "src.jvlink.bridge.subprocess.run",
+                side_effect=[
+                    search,
+                    dismissed,
+                    subprocess.CompletedProcess([], 1, "", ""),
+                ],
+            ) as run,
+        ):
+            assert bridge._dismiss_known_dialogs_once() == 1
+
+        assert run.call_args_list[0].args[0] == [
+            "xdotool",
+            "search",
+            "--onlyvisible",
+            "--pid",
+            "777",
+            "--name",
+            r"^JRA-VAN DataLab\.$",
+        ]
+        assert run.call_args_list[1].args[0] == [
+            "xdotool",
+            "windowactivate",
+            "42",
+            "key",
+            "Escape",
+        ]
+
+    def test_dialog_watcher_can_be_disabled(self, tmp_path, monkeypatch):
+        exe = tmp_path / "JVLinkBridge.exe"
+        exe.touch()
+        bridge = JVLinkBridge(bridge_path=exe)
+        monkeypatch.setenv("DISPLAY", ":1")
+        monkeypatch.setenv("JVLINK_AUTO_CLOSE_DIALOGS", "0")
+
+        with patch(
+            "src.jvlink.bridge.shutil.which", return_value="/usr/bin/xdotool"
+        ):
+            bridge._ensure_dialog_watcher()
+
+        assert bridge._dialog_watcher_thread is None
+
+    @pytest.mark.parametrize("value", ["nan", "inf", "-inf", "invalid"])
+    def test_invalid_dialog_watch_interval_falls_back(self, bridge, value):
+        with patch.dict(
+            "os.environ", {"JVLINK_DIALOG_WATCH_INTERVAL_SECONDS": value}
+        ):
+            assert bridge._dialog_watch_interval() == 0.5
+
+    def test_bridge_response_ignores_wine_preamble_and_utf8_bom(self, bridge):
+        bridge._process.stdout.readline.side_effect = [
+            "wine runtime preamble\n",
+            '\ufeff{"status":"ready","version":"test"}\n',
+        ]
+        with patch(
+            "select.select",
+            side_effect=[
+                ([bridge._process.stdout], [], []),
+                ([bridge._process.stdout], [], []),
+            ],
+        ):
+            assert bridge._read_response(timeout=1.0) == {
+                "status": "ready",
+                "version": "test",
+            }
+
+    def test_bridge_response_timeout_aborts_the_stuck_process(self, bridge):
+        process = bridge._process
+        bridge._stderr_file = tempfile.TemporaryFile(mode="w+t")
+        stderr_file = bridge._stderr_file
+        with (
+            patch("select.select", return_value=([], [], [])),
+            pytest.raises(JVLinkBridgeError, match="timeout"),
+        ):
+            bridge._read_response(timeout=0.01)
+
+        process.terminate.assert_called_once()
+        assert bridge._process is None
+        assert stderr_file.closed
+
+    def test_bridge_send_failure_aborts_the_stuck_process(self, bridge):
+        process = bridge._process
+        process.stdin.write.side_effect = BrokenPipeError("closed")
+
+        with pytest.raises(JVLinkBridgeError, match="Failed to send"):
+            bridge._send_command({"cmd": "status"})
+
+        process.terminate.assert_called_once()
+        assert bridge._process is None
+
 
 class TestJVLinkBridgeAPI:
     def test_jv_init_success(self, bridge):
-        _patch_responses(bridge, {"status": "ok", "hwnd": 12345, "linkType": "jra"})
+        _patch_responses(
+            bridge,
+            {"status": "ok", "code": 0, "hwnd": 12345, "linkType": "jra"},
+        )
         assert bridge.jv_init() == 0
 
     def test_jv_init_error(self, bridge):
@@ -58,14 +199,19 @@ class TestJVLinkBridgeAPI:
         with pytest.raises(JVLinkBridgeError):
             bridge.jv_init()
 
+    def test_jv_init_requires_an_official_result_code(self, bridge):
+        _patch_responses(bridge, {"status": "ok"})
+
+        with pytest.raises(JVLinkBridgeError, match="no result code"):
+            bridge.jv_init()
+
     def test_jv_init_sends_type_jra(self, bridge):
         """Verify init command includes type=jra."""
         sent_cmds = []
-        original_send = bridge._send_command
 
         def capture_send(cmd, **kwargs):
             sent_cmds.append(cmd)
-            return {"status": "ok", "hwnd": 1, "linkType": "jra"}
+            return {"status": "ok", "code": 0, "hwnd": 1, "linkType": "jra"}
 
         bridge._send_command = capture_send
         bridge.jv_init()
@@ -202,7 +348,7 @@ class TestJVLinkBridgeLifecycle:
     def test_context_manager(self, bridge):
         _patch_responses(
             bridge,
-            {"status": "ok", "hwnd": 1, "linkType": "jra"},  # init
+            {"status": "ok", "code": 0, "hwnd": 1, "linkType": "jra"},  # init
             {"status": "ok", "code": 0},  # close
             {"status": "ok", "message": "bye"},  # quit
         )


### PR DESCRIPTION
## Summary

- launch the native JVLinkBridge through Wine on non-Windows deployments using the existing runtime environment contract
- reject only the two known blocking JV-Link dialog titles with `Escape`, scoped to the bridge PID
- fail closed on missing Wine, non-finite watcher settings, malformed/missing JVInit result codes, broken pipes, unreadable protocol state, and response timeouts
- document the advanced Wine bridge boundary and opt-out

## Root cause

The authenticated development collector reproduced `JVInit=0` followed by a 45-second `JVOpen(RACE)` silence. While the COM call was blocked, `JVLinkBridge.exe` owned a visible `JRA-VAN DataLab.` update prompt whose affirmative button was focused. The deployed watcher only recognized `JRA-VANからのお知らせ` and used `Return`, which would be unsafe for this prompt.

Rejecting the exact update prompt with `Escape` made the same call return in about 0.8 seconds. The official JV-Link 4.9.0.1 contract says `JVOpen` returns after starting its download thread; download completion is then observed through `JVStatus`, so a pre-response 120-second wait is not normal download progress.

## Validation

Candidate full SHA: `5267950419c22c7d4e90b81c59f3ddad4f81a4d5`

- red-first base evidence: 6/6 new Wine/transport cases failed before implementation
- red-first review batch: 8/8 PID, non-finite interval, JVInit result, stderr cleanup, and broken-pipe cases failed before the repair batch
- `pytest -q tests/unit/test_jvlink_bridge.py tests/test_jvlink_transport_contract.py --no-cov`: 91 passed
- `pytest tests/ -q --ignore=tests/integration/ --ignore=tests/e2e/`: 1824 passed, 38 skipped, 5 subtests passed; only 3 pre-existing return-not-none warnings
- flake8 syntax/undefined-name selection: passed
- `mypy src/jvlink/bridge.py --follow-imports=skip --ignore-missing-imports --no-strict-optional`: passed
- `git diff --check`: passed
- exact-SHA authenticated smoke under the development collector service lock: `JVInit=0 -> JVOpen=0/readcount=30/downloadcount=0 -> JVRead=80 bytes -> JVClose=0` in about 0.78 seconds; one exact-title/PID-scoped update prompt was rejected
- preceding exact modified-source smoke with uncached files: `JVOpen=0/readcount=30/downloadcount=29 -> JVStatus=29 -> JVRead=80 bytes -> JVClose=0`
- after each smoke: lock available, no bridge/agent process remaining, collector healthy

No service key, registry value, record payload, filename, race key, or connection string was printed or retained.

## Review

Codex performed a strict pre-freeze review. P1 findings were fixed in one batch: affirmative default-button risk, title-only X11 scope, non-finite watcher interval, timeout/broken-pipe cleanup, and missing JVInit result-code acceptance. Verdict: GREEN for candidate freeze.

Official/current references and the complete sanitized audit trail are recorded in `specs/operations/20260815_jvopen_runtime_gap_worklog.md`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Linux/Wine support for running JV-Link through a containerized bridge.
  * Added configurable Wine settings and automatic dismissal of known blocking dialogs.
  * Improved handling of startup failures, timeouts, malformed responses, and process cleanup.

* **Bug Fixes**
  * JV-Link initialization now validates and returns the bridge result code reliably.

* **Documentation**
  * Added deployment guidance, configuration requirements, dialog handling, and operational safeguards.

* **Tests**
  * Expanded coverage for Wine execution, error handling, response validation, and initialization behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->