### PR TITLE
Document resolved UM pedigree contract

### DIFF
--- a/specs/operations/20260815_um_bloodline_contract_worklog.md
+++ b/specs/operations/20260815_um_bloodline_contract_worklog.md
@@ -2,7 +2,7 @@
 
 ## Iteration identity
 
-- Started: 2026-08-15 JST.
+- Started: 2026-08-15 JST
 - Objective: resolve the remaining official-spec gap reported in issue #156 by
   proving whether the current `UM` parser reads all 14 three-generation
   pedigree slots and every following field at the official byte offsets, then
@@ -10,11 +10,11 @@
 - Minimum scope: `UM` parser/layout, directly coupled schema/import paths,
   focused byte-level regression tests, migration/reimport guidance if stored
   rows are affected, and directly affected documentation.
-- Repository: `miyamamoto/jrvltsql`.
-- Worktree: `/home/keiba/scratch/20260815_jrvltsql_um_bloodline`.
-- Branch: `agent/um-bloodline-contract-20260815`.
+- Repository: `miyamamoto/jrvltsql`
+- Worktree: `/home/keiba/scratch/20260815_jrvltsql_um_bloodline`
+- Branch: `agent/um-bloodline-contract-20260815`
 - Base / initial HEAD / `origin/master` full SHA:
-  `dec167b10426aa74284a4d3a1745638af98c2b96`.
+  `dec167b10426aa74284a4d3a1745638af98c2b96`
 - Related issue: #156.
 - Dependency: PR #169 is merged at the base SHA; this iteration is independent
   of the `HappyoTime` storage correction.

--- a/specs/operations/20260815_um_bloodline_contract_worklog.md
+++ b/specs/operations/20260815_um_bloodline_contract_worklog.md
@@ -111,9 +111,16 @@
 
 ## Current state and next safe commands
 
-1. Amend this audit-only worklog, run the focused proof on the resulting full
-   SHA, and publish a small PR so the read-only resolution has a tracked source.
-2. After merge, start a separate worktree from the new `origin/master` for the
+1. Published candidate `b9e42cfec5dba90ce1304dc4421752d381ee1a43`
+   on branch `agent/um-bloodline-contract-20260815` and opened ready PR #170:
+   `https://github.com/miyamamoto/jrvltsql/pull/170`. Requested the GitHub
+   native Copilot reviewer once at PR creation. The exact candidate proof was
+   308 passed plus critical flake8 and `git diff --check`, all exit 0.
+2. Commit this publication record, push the resulting final candidate, and
+   verify its focused tests, Actions, accumulated reviews, unresolved-thread
+   count, and clean worktree once as the final gate. Record the final full SHA
+   and gate evidence on PR #170 because a commit cannot self-record its SHA.
+3. After merge, start a separate worktree from the new `origin/master` for the
    next genuine compatibility gap. The audit matrix identifies `HN` current
    10-byte registration-number offsets as the smallest remaining byte-level
    corruption item; re-verify it against SDK 5.0.0 before implementation.

--- a/specs/operations/20260815_um_bloodline_contract_worklog.md
+++ b/specs/operations/20260815_um_bloodline_contract_worklog.md
@@ -108,6 +108,16 @@
   at 2026-08-15T10:05:39Z. Issue #156 remains closed as completed; the comment
   explicitly limits the resolution to the proven current contract and does not
   claim a reproducible historical producer.
+- GitHub Codex then identified a P2 proof weakness: several one-byte fields,
+  three earnings fields, and blank text fields shared decoded values, so a
+  swapped parser slice could pass the claimed exact-offset test. Strengthened
+  the fixture so every parsed field has a distinct decoded sentinel and added
+  an invariant that rejects future duplicate sentinels.
+- Red proof before committing the test fix: temporarily changed
+  `RuikeiHonsyoSyogai` to read the `RuikeiFukaSyogai` slice, then ran its one
+  parametrized case. It failed as intended with
+  `assert '000123404' == '000123402'`, exit 1. Restored the production parser
+  without change; the strengthened layout suite then passed 100 tests, exit 0.
 
 ## Current state and next safe commands
 
@@ -116,10 +126,11 @@
    `https://github.com/miyamamoto/jrvltsql/pull/170`. Requested the GitHub
    native Copilot reviewer once at PR creation. The exact candidate proof was
    308 passed plus critical flake8 and `git diff --check`, all exit 0.
-2. Commit this publication record, push the resulting final candidate, and
-   verify its focused tests, Actions, accumulated reviews, unresolved-thread
-   count, and clean worktree once as the final gate. Record the final full SHA
-   and gate evidence on PR #170 because a commit cannot self-record its SHA.
+2. Commit the review-driven sentinel-test correction, push the resulting final
+   candidate, and verify its focused tests, Actions, accumulated reviews,
+   unresolved-thread count, and clean worktree once as the final gate. Record
+   the final full SHA and gate evidence on PR #170 because a commit cannot
+   self-record its SHA.
 3. After merge, start a separate worktree from the new `origin/master` for the
    next genuine compatibility gap. The audit matrix identifies `HN` current
    10-byte registration-number offsets as the smallest remaining byte-level

--- a/specs/operations/20260815_um_bloodline_contract_worklog.md
+++ b/specs/operations/20260815_um_bloodline_contract_worklog.md
@@ -1,0 +1,128 @@
+# UM three-generation pedigree contract worklog
+
+## Iteration identity
+
+- Started: 2026-08-15 JST.
+- Objective: resolve the remaining official-spec gap reported in issue #156 by
+  proving whether the current `UM` parser reads all 14 three-generation
+  pedigree slots and every following field at the official byte offsets, then
+  apply the smallest correction if the current contract is still wrong.
+- Minimum scope: `UM` parser/layout, directly coupled schema/import paths,
+  focused byte-level regression tests, migration/reimport guidance if stored
+  rows are affected, and directly affected documentation.
+- Repository: `miyamamoto/jrvltsql`.
+- Worktree: `/home/keiba/scratch/20260815_jrvltsql_um_bloodline`.
+- Branch: `agent/um-bloodline-contract-20260815`.
+- Base / initial HEAD / `origin/master` full SHA:
+  `dec167b10426aa74284a4d3a1745638af98c2b96`.
+- Related issue: #156.
+- Dependency: PR #169 is merged at the base SHA; this iteration is independent
+  of the `HappyoTime` storage correction.
+- Implementer and reviewer: Codex. Claude Code is not used.
+
+## Initial evidence and decision boundary
+
+- Issue #156 reports an observed model of `block start + 2` and 48 bytes per
+  slot versus the official 46-byte slot (`HansyokuNum` 10 bytes + `Bamei` 36
+  bytes), corrupting all 14 pedigree entries and the fields after the block.
+- PR/commit history includes later `UM` 1609-byte layout corrections, so the
+  report may already be fixed. The issue will not be closed from code reading
+  alone: current and historical official definitions, parser field offsets,
+  a synthetic sentinel record, and relevant existing tests must agree.
+- If a new or modified validator is required, its negative case must be run
+  against the pre-fix implementation first and fail for the intended reason.
+- If current production already passes the official byte-level contract, do
+  not manufacture a code change. Record the proof on #156 and close it only if
+  every reported affected field class is covered.
+
+## Official and community verification
+
+- Current official artifact: JRA-VAN Data Lab SDK 5.0.0 64-bit,
+  `https://jra-van.jp/dlb/sdv/sdk/JVDTLABSDK500_64bit.zip`.
+- Archive SHA-256:
+  `21f4d54706ff050e383f21f3571f59ffe8de38ed46a01be3e5b7756ee957f9d7`.
+- Official `JVData_Struct.py` SHA-256:
+  `8994f985fce846f1b4fcbc3ddf2a5c6394c586a458478346891222b3b61e4ee3`.
+- `JV_UM_UMA.SetDataB` reads the 14 pedigree entries as
+  `MidB2B(b, 205 + 46 * i, 46)`. Each `KETTO3_INFO` is a 10-byte
+  `HansyokuNum` followed by a 36-byte `Bamei`; the following official
+  positions are `TozaiCD=849`, `ChokyosiCode=850`, `BreederCode=883`, and
+  `BanusiCode=983`.
+- The official 2023 upgrade notice records the 4.8.0.2 to 4.9.0 format change.
+  JRA-VAN support further states in the developer community thread
+  `https://developer.jra-van.jp/t/topic/215` that a new setup with the new
+  dataspec returns pre-2023 data in the new physical shape, and that old and
+  new stores must not be mixed. The current parser's exact-1609-byte-only
+  policy is therefore deliberate compatibility with the supported DIFN setup
+  path, not an omission of a required mixed-layout dispatch.
+- The issue's reporter, `hayato1980`, also authored PR #160. Its real DIFN
+  validation imported 4,034 `NL_UM` rows, reached pedigree slot 14, and found
+  every populated breeding number to be ten digits. PR #160 merged as
+  `e55b1f93f4661cf83cc7d890ebe6ee7399f354ab`.
+- A follow-up history audit found that the reachable pre-PR-160 parser already
+  used the current 46-byte pedigree stride. PR #160 extended the parser through
+  the 1,609-byte record tail, made length/CRLF validation strict, and added the
+  exhaustive byte-level proof; it did not introduce the stride itself. The
+  exact producer/version that created the reporter's previously corrupted
+  stored rows is therefore not reproducible from reachable `um_parser.py`
+  history and must not be attributed to that PR's parent revision.
+
+## Base-SHA verification
+
+- Verified production base:
+  `dec167b10426aa74284a4d3a1745638af98c2b96`.
+- The current parser uses zero-based `ketto_pos=204`, increments by exactly
+  46 bytes, and reads ten plus 36 bytes for every slot. Its following offsets
+  are the official one-based positions minus one.
+- `tests/test_um_parser_layout.py` builds a gap-free 1,609-byte CP932 sentinel
+  record with unique values for all 14 slots and all subsequent trainer,
+  breeder, birthplace, owner, earnings, result-count, running-style, race-count,
+  and terminal-CRLF fields. It also rejects legacy 1,577-byte, short, long, and
+  malformed-delimiter inputs before field extraction.
+- Command: `python3 -m pytest -q tests/test_um_parser_layout.py
+  tests/test_parser_compatibility.py
+  --basetemp=/tmp/jrvltsql-um156-base-dec167b`.
+- Result: **308 passed**, exit 0.
+- Conclusion: the corruption described in issue #156 is not present in the
+  current base, and the current supported DIFN import path is covered by an
+  exact official-layout sentinel. Its historical producer is not reproducible
+  from reachable parser history. No production or test change is justified;
+  any rows known to have been produced by the corrupt path still require
+  reimport with a current parser and current-format Data Lab setup.
+
+## GitHub resolution
+
+- Added an evidence comment to issue #156 identifying PR #160, current and
+  official offsets, the 308-test result, the DIFN setup contract, and the need
+  to reimport any already-corrupted stored rows.
+- Closed issue #156 as `completed` at 2026-08-15T09:59:49Z. This was a GitHub
+  metadata change only; no repository code was changed by the closure.
+- Codex review of candidate
+  `5d8cdf051e52ad691de470f14535fea05d3f8312` found no runtime or test issue,
+  while its history investigation exposed the attribution nuance above. A
+  transparent correction to #156 was therefore required before publishing
+  this audit, so the closed issue distinguishes the proven current contract
+  from the unknown historical producer.
+- Added that correction at
+  `https://github.com/miyamamoto/jrvltsql/issues/156#issuecomment-5301737803`
+  at 2026-08-15T10:05:39Z. Issue #156 remains closed as completed; the comment
+  explicitly limits the resolution to the proven current contract and does not
+  claim a reproducible historical producer.
+
+## Current state and next safe commands
+
+1. Amend this audit-only worklog, run the focused proof on the resulting full
+   SHA, and publish a small PR so the read-only resolution has a tracked source.
+2. After merge, start a separate worktree from the new `origin/master` for the
+   next genuine compatibility gap. The audit matrix identifies `HN` current
+   10-byte registration-number offsets as the smallest remaining byte-level
+   corruption item; re-verify it against SDK 5.0.0 before implementation.
+
+## STOP conditions
+
+- Do not infer character positions from decoded Unicode; JV-Data offsets are
+  byte-based CP932 offsets.
+- Do not close #156 solely because a later commit mentions `UM`; prove the 14
+  slot stride and at least the first fields after the block.
+- Do not merge if any current/historical supported layout, storage path, exact
+  candidate test, review finding, or PR thread remains unresolved.

--- a/tests/test_um_parser_layout.py
+++ b/tests/test_um_parser_layout.py
@@ -32,21 +32,21 @@ CHAKU = [f"{i:03d}" * 6 for i in range(1, 28)]
 
 FIELDS = [
     ("RecordSpec", 1, 2, b"UM"),
-    ("DataKubun", 3, 1, b"1"),
+    ("DataKubun", 3, 1, b"2"),
     ("MakeDate", 4, 8, b"20260801"),
     ("KettoNum", 12, 10, b"2019900001"),
-    ("DelKubun", 22, 1, b"0"),
+    ("DelKubun", 22, 1, b"3"),
     ("RegDate", 23, 8, b"20210401"),
     ("DelDate", 31, 8, b"00000000"),
     ("BirthDate", 39, 8, b"20190315"),
     ("Bamei", 47, 36, _pad("テストウマアルファ", 36, zenkaku=True)),
     ("BameiKana", 83, 36, _pad("ﾃｽﾄｳﾏｱﾙﾌｧ", 36)),
     ("BameiEng", 119, 60, _pad("Test Horse Alpha", 60)),
-    ("ZaikyuFlag", 179, 1, b"0"),
-    ("Reserved", 180, 19, b" " * 19),
+    ("ZaikyuFlag", 179, 1, b"4"),
+    ("Reserved", 180, 19, _pad("RESERVED-180", 19)),
     ("UmaKigoCD", 199, 2, b"00"),
-    ("SexCD", 201, 1, b"1"),
-    ("HinsyuCD", 202, 1, b"1"),
+    ("SexCD", 201, 1, b"5"),
+    ("HinsyuCD", 202, 1, b"6"),
     ("KeiroCD", 203, 2, b"01"),
 ]
 # 項番18 <3代血統情報> 位置205 繰返14 46バイト（繁殖登録番号10 + 馬名36）
@@ -55,21 +55,21 @@ for slot, (num, name) in enumerate(PEDIGREE, start=1):
     FIELDS.append((f"Ketto3InfoHansyokuNum{slot}", base, 10, num.encode("ascii")))
     FIELDS.append((f"Ketto3InfoBamei{slot}", base + 10, 36, _pad(name, 36, zenkaku=True)))
 FIELDS += [
-    ("TozaiCD", 849, 1, b"1"),
+    ("TozaiCD", 849, 1, b"7"),
     ("ChokyosiCode", 850, 5, b"99001"),
     ("ChokyosiRyakusyo", 855, 8, _pad("テスト師", 8, zenkaku=True)),
-    ("Syotai", 863, 20, b" " * 20),
+    ("Syotai", 863, 20, _pad("招待地域", 20, zenkaku=True)),
     ("BreederCode", 883, 8, b"99900001"),
     ("BreederName", 891, 72, _pad("テスト牧場", 72, zenkaku=True)),
     ("SanchiName", 963, 20, _pad("テスト町", 20, zenkaku=True)),
     ("BanusiCode", 983, 6, b"990001"),
     ("BanusiName", 989, 64, _pad("テスト馬主", 64, zenkaku=True)),
-    ("RuikeiHonsyoHeiti", 1053, 9, b"000123400"),
-    ("RuikeiHonsyoSyogai", 1062, 9, b"000000000"),
-    ("RuikeiFukaHeichi", 1071, 9, b"000005600"),
-    ("RuikeiFukaSyogai", 1080, 9, b"000000000"),
-    ("RuikeiSyutokuHeichi", 1089, 9, b"000078900"),
-    ("RuikeiSyutokuSyogai", 1098, 9, b"000000000"),
+    ("RuikeiHonsyoHeiti", 1053, 9, b"000123401"),
+    ("RuikeiHonsyoSyogai", 1062, 9, b"000123402"),
+    ("RuikeiFukaHeichi", 1071, 9, b"000123403"),
+    ("RuikeiFukaSyogai", 1080, 9, b"000123404"),
+    ("RuikeiSyutokuHeichi", 1089, 9, b"000123405"),
+    ("RuikeiSyutokuSyogai", 1098, 9, b"000123406"),
 ]
 CHAKU_NAMES = [
     "SogoChaku", "ChuoGokeiChaku",
@@ -120,6 +120,9 @@ class TestUMParserLayout:
     def test_record_delimiter_closes_the_layout(self):
         delimiter = self.record[UMParser.RECORD_DELIMITER_START:UMParser.RECORD_LENGTH]
         assert delimiter == b"\r\n"
+
+    def test_every_field_uses_a_distinct_decoded_sentinel(self):
+        assert len(set(EXPECTED.values())) == len(EXPECTED)
 
     @pytest.mark.parametrize("field_name", sorted(EXPECTED))
     def test_every_field_is_read_from_its_spec_position(self, field_name):


### PR DESCRIPTION
## Summary

- record the SDK 5.0.0 byte-level contract for all 14 `UM` three-generation pedigree entries and every field after the block
- document why the current 1,609-byte-only parser contract is compatible with the supported post-2023 DIFN setup
- preserve the evidence used to close #156, including the correction that the 46-byte stride predates PR #160
- strengthen the layout fixture so every parsed field has a distinct decoded sentinel and future duplicate sentinels fail explicitly

Runtime parser code is unchanged. Rows previously produced by an unidentified corrupt historical path still require reimport with the current parser and current-format Data Lab setup.

## Review finding and red proof

GitHub Codex found that equal fixture values could let swapped earnings/blank-field slices pass. Before committing the correction, `RuikeiHonsyoSyogai` was temporarily pointed at the `RuikeiFukaSyogai` slice; the focused case failed as intended with `assert '000123404' == '000123402'` (exit 1). The production parser was then restored without change.

## Validation

Final candidate: `fbaf4166ad97fd1a718caf40a012892b4e517f06`

- `python3 -m pytest -q tests/test_um_parser_layout.py tests/test_parser_compatibility.py --basetemp=/tmp/jrvltsql-um156-pr170-final-fbaf416` — **309 passed**
- `python3 -m flake8 src tests --select=E9,F63,F7,F82` — passed
- `git diff --check origin/master...HEAD` — passed
- Codex exact-SHA review — no additional actionable finding; it independently reran the 309-test focused suite
- both review threads were answered and resolved

Closes #156