### PR TITLE
Honor JV-Data cancellation state semantics

### DIFF
--- a/specs/operations/20260816_datakubun9_contract_worklog.md
+++ b/specs/operations/20260816_datakubun9_contract_worklog.md
@@ -1,0 +1,58 @@
+# DataKubun=9 cancellation contract worklog
+
+## Iteration identity
+
+- Started: 2026-08-16 JST.
+- Objective: reconcile cancellation/deletion handling with the current official
+  JV-Data `DataKubun=9` contract at every historical and realtime import path.
+- Minimum scope: identify which record types define `9` as cancellation,
+  distinguish state records that must remain queryable from child/expanded
+  records that must be deleted, verify primary-key and rollback behavior, add
+  one minimal red-first regression contract, implement the shared policy, run
+  focused and necessary broader tests, and complete one reviewed PR/merge.
+- Repository: `miyamamoto/jrvltsql`.
+- Worktree: dedicated worktree for the branch below; its local absolute path is
+  intentionally omitted from this tracked public record.
+- Branch: `agent/datakubun9-contract-20260816`.
+- Base/initial HEAD/origin master full SHA:
+  `d2935dff76a96a1b9e4045f48ea07257663651c0` (PR #187 merge).
+- Dependency order: JVOpen dataspec contract PR #187 is merged. Parser framing,
+  release versioning/publication, NAR follow-up, and MCP-server follow-up remain
+  later iterations.
+- Production/release version at start: tag and project version `v1.6.10` /
+  `1.6.10`. This iteration does not release.
+- Agent/model: Codex only. No Claude session or external coding agent is used.
+
+## Plan and gates
+
+- Re-read the current SDK archive's record-specific DataKubun definitions and
+  change history; do not infer one universal meaning from the shared header.
+- Recheck current official notices and community/staff discussions for later
+  cancellation-semantic changes. Official record definitions remain controlling.
+- Inventory parser output, table mappings, primary keys, historical import,
+  optimized/native import, realtime upsert/delete, and expanded child-row paths.
+- Before changing a check/policy, extend the smallest existing regression test
+  and run it against the current production code to prove the fail-open behavior.
+  Pair every rejection/deletion case with a retained-state or normal-data case.
+- Freeze one candidate, run affected SQLite/PostgreSQL/importer/realtime tests,
+  workflow-equivalent checks as warranted, and a bounded actual-acquisition
+  proof if this change can alter stored provider data.
+- Request one GitHub-native Copilot review, use Codex review, aggregate findings,
+  require unresolved threads zero, successful CI, exact local/remote head
+  equality, and a clean worktree before merge.
+- STOP on conflicting official record definitions, missing keys that make a
+  delete ambiguous, partial expanded-row deletion, rollback failure, provider
+  cleanup failure, base drift, or any unresolved actionable review finding.
+
+## Starting question
+
+- The repository already has partial realtime tests for `DataKubun=9`, but the
+  prior official compatibility audit identified payout/vote/odds families as a
+  remaining area requiring record-specific verification. No finding is accepted
+  until the current official definitions and every importer path are rechecked.
+
+## Next safe command
+
+- Read the prior audit finding and current import/realtime policies, then extract
+  the official `DataKubun` definitions for the implicated record types from the
+  cached current SDK materials without changing code.

--- a/specs/operations/20260816_datakubun9_contract_worklog.md
+++ b/specs/operations/20260816_datakubun9_contract_worklog.md
@@ -150,6 +150,14 @@
   passed on the implementation tree. Exact-SHA workflow, PostgreSQL, and actual
   snapshot replay evidence will be attached to the PR after the candidate is
   committed.
+- GitHub-native Copilot reviewed all eight changed files at candidate
+  `451a4ae67df0afa3a97905c001a087e66135f03c` and found one actionable boundary:
+  the ordered time-series mutation fallback did not propagate the one
+  batch-level `CollectedAt`. The new focused test first failed with inserted
+  values `['row-one', 'row-two']` instead of two `batch-capture` values. The
+  ordered path now stamps every validated row with the precomputed capture time
+  before single-row dispatch; the test passed, and the affected set then passed
+  92 tests, 7 skips, and 12 subtests. No other Copilot finding was reported.
 
 ## Boundary discovered for a later iteration
 
@@ -165,6 +173,7 @@
 
 ## Next safe command
 
-- Freeze and commit the reviewed implementation tree, then run the required
-  focused/workflow-equivalent, PostgreSQL, and bounded acquired-snapshot checks
-  against that full candidate SHA before opening or merging the PR.
+- Commit the aggregated review repair, push it to PR #188, then rerun the
+  necessary focused/workflow-equivalent and PostgreSQL checks against the new
+  full candidate SHA. Reply to and resolve the one review thread only after its
+  exact-SHA evidence passes.

--- a/specs/operations/20260816_datakubun9_contract_worklog.md
+++ b/specs/operations/20260816_datakubun9_contract_worklog.md
@@ -6,8 +6,8 @@
 - Objective: reconcile cancellation/deletion handling with the current official
   JV-Data `DataKubun=9` contract at every historical and realtime import path.
 - Minimum scope: identify which record types define `9` as cancellation,
-  distinguish state records that must remain queryable from child/expanded
-  records that must be deleted, verify primary-key and rollback behavior, add
+  distinguish state values that must remain queryable from explicit physical
+  erases, verify primary-key and rollback behavior, add
   one minimal red-first regression contract, implement the shared policy, run
   focused and necessary broader tests, and complete one reviewed PR/merge.
 - Repository: `miyamamoto/jrvltsql`.
@@ -51,8 +51,120 @@
   remaining area requiring record-specific verification. No finding is accepted
   until the current official definitions and every importer path are rechecked.
 
+## Official and observed evidence
+
+- The current SDK-bundled JV-Data specification Ver.4.9.0.1 defines
+  `9:レース中止` and `0:該当レコード削除(提供ミスなどの理由による)` separately
+  for HR, H1, H6, and O1 through O6. The immediately prior Ver.4.8.0.2 contains
+  the same definitions, so this is not a newly introduced meaning.
+- The current specification's cancellation-operation note says that H1/H6 are
+  provided with DataKubun 9 after prior vote-count publication and O1-O6 are
+  provided with DataKubun 9 after prior odds publication. It separately says
+  that HR is not normally provided for a cancelled meeting, while the HR record
+  format still reserves 9 for race cancellation. The format-specific definition
+  remains authoritative if such a record is received.
+- A current official web copy of Ver.4.9.0.1 corroborates the SDK material. A
+  search of the official developer community and public implementation
+  discussions found no later notice redefining 9 as physical deletion; the
+  relevant community material instead continues to direct implementers to the
+  JV-Data specification for record semantics.
+- A read-only aggregate check of the available historical JRA database found
+  DataKubun 9 rows in H1, H6, and every O1-O6 table. Across those rows, every
+  normalized child primary-key component was populated (zero blank child keys).
+  HR had no DataKubun 9 row, consistent with the cancellation-operation note.
+  No race identity or provider payload was recorded here.
+- Current historical importers naturally retain DataKubun 9 when a normalized
+  row has a complete key. The realtime single-row dispatcher instead treats 9
+  as deletion outside RA/SE/WF, and its batch path bypasses mutation dispatch.
+  Historical DataKubun 0 is also not applied uniformly: an exact-key row can be
+  upserted with status 0, while a header-only expanded-record erase can be
+  skipped for an incomplete child key, leaving stale rows.
+- `headDataKubun` is a legacy flattened name for the same record-header field,
+  not a separate provider mutation channel. Current parsers emit `DataKubun`;
+  both names must resolve to the same record-specific meaning for compatibility.
+
+## Implementation decision before tests
+
+- Define one shared set of record families whose DataKubun is domain state:
+  RA, SE, HR, H1, H6, O1-O6, and WF. For those families, 9 is retained by
+  upsert and only 0 requests physical erase.
+- Expanded H1/H6/O1-O6 erases use the six-part race key because one physical
+  JV-Data record is normalized into multiple child rows. RA/HR use the same
+  race key, SE adds Umaban, and WF uses Year/MonthDay.
+- Preserve provider order around erases by flushing a pending table batch before
+  deletion. If a realtime bulk call contains an erase, use ordered single-row
+  dispatch for that call; ordinary odds batches retain the optimized path.
+- Reject conflicting simultaneous `DataKubun` and legacy `headDataKubun` values
+  rather than guessing which status controls a destructive mutation.
+- Red-first coverage will exercise current and legacy cancellation names,
+  realtime single and batch paths, and historical exact/expanded erase behavior
+  through both importer implementations. Positive cancellation retention and
+  zero-only deletion are paired in the same contract.
+
+## Red-first evidence and implementation
+
+- Before changing production code, the focused contract run failed as intended:
+  legacy RA `headDataKubun=9` dispatched delete; HR/H1/H6/O1-O6
+  `DataKubun=9` dispatched delete; conflicting current/legacy values were not
+  rejected; realtime batch erase was rejected as an incomplete child row; and
+  historical expanded erase was skipped, leaving the prior snapshot. The
+  substantive result was 14 failed assertions with the pre-fix implementation
+  (plus passing RA/SE/WF controls). One optimized-statistics exact-dict mismatch
+  was a test-only assertion issue and was narrowed to the three contract fields
+  before implementation.
+- Implemented one record-specific policy for RA/SE/HR/H1/H6/O1-O6/WF. Current
+  and legacy header names now resolve identically and conflicting simultaneous
+  values fail closed. DataKubun 9 takes the insert/upsert path for these record
+  families; DataKubun 0 takes the physical-record erase path.
+- Historical ordinary and optimized import loops flush the target table before
+  a zero erase, apply the correct physical key, preserve provider order, and
+  count the erase as one processed physical record. Realtime bulk processing
+  falls back to ordered dispatch only when destructive mutation is present;
+  ordinary bulk odds ingestion remains batched.
+- A final Codex diff review found that the legacy alias selected the correct
+  realtime operation but was dropped before persistence. Tightening the
+  existing legacy test first reproduced `KeyError: 'DataKubun'`; the shared
+  metadata normalizer is now also used by realtime writes, and the same test
+  passes while proving that only canonical `DataKubun=9` reaches storage.
+- First post-fix focused run: 6 passed with 12 subtests. This covers both
+  historical importer implementations, realtime single/bulk paths, current and
+  legacy names, cancellation retention, zero erase, and alias conflict rejection.
+- Provider-order coverage then ran ordinary -> zero erase -> cancellation in one
+  call and confirmed the final cancellation state for both importer
+  implementations and realtime batch processing. A later zero erase removed the
+  exact RA row and every normalized O1 child row.
+- Backend coverage on a fresh isolated PostgreSQL 16 instance passed all 17
+  expanded-storage tests, including ordinary/optimized importers, realtime bulk,
+  native normalized tables, and the standard-name RACE table. SQLite affected
+  coverage passed 91 tests with 7 environment-gated skips and 12 subtests.
+- An acquired historical cancellation snapshot was replayed without recording
+  its race identity: all 54 actual normalized O1 rows had complete keys, both
+  historical and realtime paths retained all 54 with DataKubun 9, and a
+  header-only zero erase removed all rows from both targets.
+- Full local suite on the candidate worktree passed: 2,342 tests, 72
+  environment-gated skips, 15 subtests, and three pre-existing pytest warnings.
+  No test failed.
+- After the legacy-persistence repair, the affected SQLite set passed again:
+  91 tests, 7 environment-gated skips, and 12 subtests. Syntax compilation,
+  diff whitespace validation, and the workflow's fatal flake8 selector also
+  passed on the implementation tree. Exact-SHA workflow, PostgreSQL, and actual
+  snapshot replay evidence will be attached to the PR after the candidate is
+  committed.
+
+## Boundary discovered for a later iteration
+
+- `use_jravan_schema=True` has legacy split child tables for expanded vote/odds
+  records. Several child schemas intentionally omit the record-header
+  DataKubun, and the current mapping does not materialize their separate header
+  tables. Native NL/RT storage, realtime storage, and standard-name RACE are
+  covered here, but this iteration does not claim that the legacy split
+  H1/H6/O1-O6 representation can expose cancellation status.
+- That pre-existing structural mismatch is broader than mutation dispatch and
+  will be handled as a separate standard-schema storage iteration before
+  release. Until then it remains a release blocker, not an accepted omission.
+
 ## Next safe command
 
-- Read the prior audit finding and current import/realtime policies, then extract
-  the official `DataKubun` definitions for the implicated record types from the
-  cached current SDK materials without changing code.
+- Freeze and commit the reviewed implementation tree, then run the required
+  focused/workflow-equivalent, PostgreSQL, and bounded acquired-snapshot checks
+  against that full candidate SHA before opening or merging the PR.

--- a/src/database/schema_metadata.py
+++ b/src/database/schema_metadata.py
@@ -82,7 +82,10 @@ TABLE_METADATA: Dict[str, TableMetadata] = {
             {
                 "name": "データ区分",
                 "type": "TEXT",
-                "description": "データ区分（1=通常、2=訂正、3=削除、9=レコード削除）",
+                "description": (
+                    "レース詳細のデータ区分（1～7=提供段階、A=地方、B=海外、"
+                    "9=レース中止、0=提供ミス等による該当レコード削除）"
+                ),
                 "example": "1",
                 "nullable": False
             },

--- a/src/importer/importer.py
+++ b/src/importer/importer.py
@@ -594,6 +594,113 @@ def _record_type_from_record(record: dict) -> Any:
     return record.get("レコード種別ID") or record.get("RecordSpec") or record.get("headRecordSpec")
 
 
+CANCELLATION_STATE_RECORD_TYPES = frozenset(
+    {"RA", "SE", "HR", "H1", "H6", "O1", "O2", "O3", "O4", "O5", "O6", "WF"}
+)
+
+_OFFICIAL_ERASE_KEY_COLUMNS = {
+    "RA": _MINING_RACE_KEY_COLUMNS,
+    "SE": (*_MINING_RACE_KEY_COLUMNS, "Umaban"),
+    "HR": _MINING_RACE_KEY_COLUMNS,
+    # One physical H1/H6/O1-O6 record expands into multiple child rows.
+    "H1": _MINING_RACE_KEY_COLUMNS,
+    "H6": _MINING_RACE_KEY_COLUMNS,
+    "O1": _MINING_RACE_KEY_COLUMNS,
+    "O2": _MINING_RACE_KEY_COLUMNS,
+    "O3": _MINING_RACE_KEY_COLUMNS,
+    "O4": _MINING_RACE_KEY_COLUMNS,
+    "O5": _MINING_RACE_KEY_COLUMNS,
+    "O6": _MINING_RACE_KEY_COLUMNS,
+    "WF": ("Year", "MonthDay"),
+}
+
+_OFFICIAL_ERASE_STORAGE_TABLES = {
+    "RA": {"NL_RA", "RT_RA", "RACE"},
+    "SE": {"NL_SE", "RT_SE", "UMA_RACE"},
+    "HR": {"NL_HR", "RT_HR", "HARAI"},
+    "H1": {"NL_H1", "RT_H1", "HYO_TANPUKU"},
+    "H6": {"NL_H6", "RT_H6", "HYO_SANRENTAN"},
+    "O1": {"NL_O1", "RT_O1", "ODDS_TANPUKU"},
+    "O2": {"NL_O2", "RT_O2", "ODDS_UMAREN"},
+    "O3": {"NL_O3", "RT_O3", "ODDS_WIDE"},
+    "O4": {"NL_O4", "RT_O4", "ODDS_UMATAN"},
+    "O5": {"NL_O5", "RT_O5", "ODDS_SANRENPUKU"},
+    "O6": {"NL_O6", "RT_O6", "ODDS_SANRENTAN"},
+    "WF": {"NL_WF", "RT_WF", "WIN5"},
+}
+
+
+def resolve_record_data_kubun(record: dict) -> str:
+    """Resolve current and legacy names for the same JV-Data header field."""
+    current = record.get("DataKubun")
+    legacy = record.get("headDataKubun")
+    current = None if current in (None, "") else str(current)
+    legacy = None if legacy in (None, "") else str(legacy)
+    if current is not None and legacy is not None and current != legacy:
+        raise ValueError(
+            "record has conflicting DataKubun and headDataKubun values: "
+            f"{current!r} != {legacy!r}"
+        )
+    return current or legacy or "1"
+
+
+def clean_record_metadata(record: dict) -> dict:
+    """Drop parser metadata and normalize legacy JV-Data header aliases."""
+    metadata_fields = {
+        "headRecordSpec",
+        "レコード種別ID",
+        "_raw_data",
+        "_parse_errors",
+        "RecordDelimiter",
+        "RecordSeparator",
+    }
+    cleaned = {
+        key: value
+        for key, value in record.items()
+        if key not in metadata_fields and not key.startswith("_")
+    }
+    if record.get("DataKubun") not in (None, "") or record.get("headDataKubun") not in (
+        None,
+        "",
+    ):
+        cleaned["DataKubun"] = resolve_record_data_kubun(record)
+    cleaned.pop("headDataKubun", None)
+    return cleaned
+
+
+def _is_official_record_erase(record: dict, table_name: str) -> bool:
+    """Return whether a cancellation-capable physical record requests erase."""
+    record_type = _record_type_from_record(record)
+    return (
+        record_type in CANCELLATION_STATE_RECORD_TYPES
+        and table_name in _OFFICIAL_ERASE_STORAGE_TABLES[record_type]
+        and resolve_record_data_kubun(record) == "0"
+    )
+
+
+def _delete_official_record(database: BaseDatabase, record: dict, table_name: str) -> int:
+    """Apply DataKubun=0 at the physical-record boundary after key validation."""
+    record_type = _record_type_from_record(record)
+    if not _is_official_record_erase(record, table_name):
+        raise ValueError(f"{table_name} is not erase storage for record {record_type!r}")
+
+    key_columns = _OFFICIAL_ERASE_KEY_COLUMNS[record_type]
+    converted = convert_record_types(record, table_name)
+    # Some legacy standard schemas omit type metadata for an otherwise valid
+    # race key. Preserve the raw key only for those columns.
+    key_values = {
+        column: converted.get(column, record.get(column))
+        for column in key_columns
+    }
+    missing = [column for column, value in key_values.items() if value in (None, "")]
+    if missing:
+        raise ValueError(f"{record_type} record erase has incomplete key: {missing}")
+
+    where = " AND ".join(f"{column} = ?" for column in key_columns)
+    values = tuple(key_values[column] for column in key_columns)
+    return database.execute(f"DELETE FROM {table_name} WHERE {where}", values)
+
+
 def _mining_storage_config(record: dict, table_name: str) -> tuple[str, dict[str, Any]] | None:
     """Return the DM/TM storage contract that owns this parsed record and table."""
     record_type = _record_type_from_record(record)
@@ -1493,19 +1600,7 @@ class DataImporter:
         Returns:
             Cleaned record without metadata fields
         """
-        # Fields used for routing/metadata that shouldn't be in database tables
-        metadata_fields = {
-            "headRecordSpec",
-            "レコード種別ID",
-            "_raw_data",
-            "_parse_errors",
-            "RecordDelimiter",
-            "RecordSeparator",
-        }
-
-        return {
-            k: v for k, v in record.items() if k not in metadata_fields and not k.startswith("_")
-        }
+        return clean_record_metadata(record)
 
     def _record_for_table(self, record: dict, table_name: str) -> dict:
         """Return the parser representation required by the target schema."""
@@ -1600,6 +1695,19 @@ class DataImporter:
                 if table_name not in self._verified_mining_native_tables:
                     if verify_mining_native_schema(self.database, record, table_name):
                         self._verified_mining_native_tables.add(table_name)
+
+                if _is_official_record_erase(record, table_name):
+                    pending = batch_buffers.setdefault(table_name, [])
+                    if pending:
+                        self._flush_batch(table_name, pending, auto_commit)
+                        batch_buffers[table_name] = []
+                    _delete_official_record(self.database, record, table_name)
+                    self._records_imported += 1
+                    self._batches_processed += 1
+                    if auto_commit:
+                        self.database.commit()
+                    last_expanded_record_fingerprint = None
+                    continue
 
                 if _is_mining_race_delete(record, table_name):
                     pending = batch_buffers.setdefault(table_name, [])
@@ -2024,6 +2132,13 @@ class DataImporter:
             if table_name not in self._verified_mining_native_tables:
                 if verify_mining_native_schema(self.database, record, table_name):
                     self._verified_mining_native_tables.add(table_name)
+            if _is_official_record_erase(record, table_name):
+                _delete_official_record(self.database, record, table_name)
+                self._records_imported += 1
+                self._batches_processed += 1
+                if auto_commit:
+                    self.database.commit()
+                return True
             if _is_mining_race_delete(record, table_name):
                 _delete_mining_race_rows(self.database, record, table_name)
                 self._records_imported += 1

--- a/src/importer/importer_optimized.py
+++ b/src/importer/importer_optimized.py
@@ -19,13 +19,16 @@ from src.importer.importer import (
     _TK_CHILD_STORAGE_TABLES,
     _YS_STORAGE_TABLES,
     _delete_mining_race_rows,
+    _delete_official_record,
     _expanded_record_fingerprint,
     _is_mining_race_delete,
     _is_mining_snapshot_follower,
+    _is_official_record_erase,
     _mining_native_snapshot_rows,
     _record_type_from_record,
     apply_rc_batch,
     apply_ys_batch,
+    clean_record_metadata,
     insert_ch_coupled_batch,
     insert_ks_coupled_batch,
     insert_tk_coupled_batch,
@@ -192,19 +195,7 @@ class OptimizedDataImporter:
 
     @staticmethod
     def _clean_record(record: dict) -> dict:
-        metadata_fields = {
-            "headRecordSpec",
-            "レコード種別ID",
-            "_raw_data",
-            "_parse_errors",
-            "RecordDelimiter",
-            "RecordSeparator",
-        }
-        return {
-            key: value
-            for key, value in record.items()
-            if key not in metadata_fields and not key.startswith("_")
-        }
+        return clean_record_metadata(record)
 
     @classmethod
     def _record_for_table(cls, record: dict, table_name: str) -> dict:
@@ -298,6 +289,23 @@ class OptimizedDataImporter:
                 if table_name not in self._verified_mining_native_tables:
                     if verify_mining_native_schema(self.database, record, table_name):
                         self._verified_mining_native_tables.add(table_name)
+
+                if _is_official_record_erase(record, table_name):
+                    pending = batch_buffers.setdefault(table_name, [])
+                    if pending:
+                        self._flush_batch_optimized(
+                            table_name,
+                            pending,
+                            commit_batch=auto_commit,
+                        )
+                        batch_buffers[table_name] = []
+                    _delete_official_record(self.database, record, table_name)
+                    self._records_imported += 1
+                    self._batches_processed += 1
+                    if auto_commit:
+                        self.database.commit()
+                    last_expanded_record_fingerprint = None
+                    continue
 
                 if _is_mining_race_delete(record, table_name):
                     pending = batch_buffers.setdefault(table_name, [])

--- a/src/jvlink/constants.py
+++ b/src/jvlink/constants.py
@@ -531,8 +531,12 @@ DATA_KUBUN_NEW = "1"  # 新規
 DATA_KUBUN_UPDATE = "2"  # 変更
 DATA_KUBUN_REREGISTER = "3"  # 再登録
 DATA_KUBUN_REFRESH = "4"  # 更新
-DATA_KUBUN_DELETE = "9"  # 抹消
-DATA_KUBUN_ERASE = "0"  # 削除
+# Legacy public names. JV-Data assigns record-specific domain meanings to 9
+# (for example race cancellation or master-data deregistration); it is not a
+# universal physical-delete command. Value 0 is the explicit erroneous-record
+# erase for record families that define it.
+DATA_KUBUN_DELETE = "9"
+DATA_KUBUN_ERASE = "0"
 
 # JVOpen Options
 # IMPORTANT: Option values start from 1, NOT 0

--- a/src/realtime/updater.py
+++ b/src/realtime/updater.py
@@ -366,6 +366,9 @@ class RealtimeUpdater:
             validated_records.append(record)
 
         if ordered_mutation_required:
+            if timeseries and batch_collected_at:
+                for record in validated_records:
+                    record.setdefault("CollectedAt", batch_collected_at)
             results = [
                 self._process_single_record(record, timeseries=timeseries)
                 for record in validated_records

--- a/src/realtime/updater.py
+++ b/src/realtime/updater.py
@@ -8,13 +8,18 @@ from typing import Dict, List, Optional, Union
 
 from src.database.base import BaseDatabase
 from src.database.schema_types import get_table_primary_key_columns
+from src.importer.importer import (
+    CANCELLATION_STATE_RECORD_TYPES,
+    clean_record_metadata,
+    resolve_record_data_kubun,
+)
 from src.jvlink.constants import (
-    DATA_KUBUN_NEW,
-    DATA_KUBUN_UPDATE,
     DATA_KUBUN_DELETE,
+    DATA_KUBUN_ERASE,
+    DATA_KUBUN_NEW,
     DATA_KUBUN_REFRESH,
     DATA_KUBUN_REREGISTER,
-    DATA_KUBUN_ERASE,
+    DATA_KUBUN_UPDATE,
 )
 from src.parser.factory import ParserFactory
 from src.utils.logger import get_logger
@@ -342,7 +347,46 @@ class RealtimeUpdater:
         grouped: dict[str, list[Dict]] = {}
         errors = 0
         batch_collected_at = self._current_collected_at() if timeseries else None
+        validated_records: list[Dict] = []
+        ordered_mutation_required = False
+
         for record in records:
+            try:
+                data_kubun = resolve_record_data_kubun(record)
+            except ValueError as exc:
+                logger.warning(f"Skipping record with conflicting DataKubun aliases: {exc}")
+                errors += 1
+                continue
+            record_type = record.get("RecordSpec")
+            if data_kubun == DATA_KUBUN_ERASE or (
+                data_kubun == DATA_KUBUN_DELETE
+                and record_type not in CANCELLATION_STATE_RECORD_TYPES
+            ):
+                ordered_mutation_required = True
+            validated_records.append(record)
+
+        if ordered_mutation_required:
+            results = [
+                self._process_single_record(record, timeseries=timeseries)
+                for record in validated_records
+            ]
+            successful, rejected = summarize_update_result(results)
+            tables = sorted(
+                {
+                    item["table"]
+                    for item in successful
+                    if item.get("table")
+                }
+            )
+            return {
+                "operation": "batch_insert",
+                "success": errors + rejected == 0,
+                "inserted": len(successful),
+                "errors": errors + rejected,
+                "tables": tables,
+            }
+
+        for record in validated_records:
             if timeseries and batch_collected_at:
                 record.setdefault("CollectedAt", batch_collected_at)
             record_type = record.get("RecordSpec")
@@ -492,21 +536,26 @@ class RealtimeUpdater:
                 if verify_mining_native_schema(self.database, parsed_data, table_name):
                     self._verified_mining_native_tables.add(table_name)
 
-            # headDataKubun is an explicit mutation instruction. RA/SE/WF use
-            # record-level DataKubun for domain state (including finalized 7
-            # and cancelled 9). Only 0 is an erase instruction for these rows.
-            explicit_operation = parsed_data.get("headDataKubun")
-            if explicit_operation:
-                head_data_kubun = explicit_operation
-            elif (
-                record_type in {"RA", "SE", "WF"}
-                and parsed_data.get("DataKubun") != DATA_KUBUN_ERASE
+            # DataKubun is record-specific domain state. The legacy flattened
+            # name headDataKubun is the same header field, not a second command.
+            # For cancellation-capable records, 9 must remain queryable and
+            # only the official 0 value requests physical erase.
+            record_data_kubun = resolve_record_data_kubun(parsed_data)
+            if (
+                record_type in CANCELLATION_STATE_RECORD_TYPES
+                and record_data_kubun not in {
+                    DATA_KUBUN_ERASE,
+                    DATA_KUBUN_NEW,
+                    DATA_KUBUN_UPDATE,
+                    DATA_KUBUN_REREGISTER,
+                    DATA_KUBUN_REFRESH,
+                }
             ):
                 head_data_kubun = DATA_KUBUN_NEW
             else:
-                head_data_kubun = parsed_data.get("DataKubun") or DATA_KUBUN_NEW
+                head_data_kubun = record_data_kubun
 
-            # Process based on headDataKubun
+            # Process the resolved record-specific DataKubun.
             # Note: Per-record debug logging removed to reduce verbosity
             if head_data_kubun == DATA_KUBUN_NEW:
                 return self._handle_new_record(table_name, parsed_data)
@@ -521,9 +570,12 @@ class RealtimeUpdater:
                 # ERASE(0) is treated same as DELETE
                 return self._handle_delete_record(table_name, parsed_data)
             else:
-                logger.warning(f"Unknown headDataKubun: {head_data_kubun}")
+                logger.warning(f"Unknown DataKubun: {head_data_kubun}")
                 return None
 
+        except ValueError as e:
+            logger.error(f"Rejected realtime record: {e}")
+            raise
         except Exception as e:
             logger.error(f"Error processing single record: {e}", exc_info=True)
             raise
@@ -538,7 +590,7 @@ class RealtimeUpdater:
         """
         from src.importer.importer import convert_record_types
 
-        clean_data = {k: v for k, v in data.items() if not k.startswith("_")}
+        clean_data = clean_record_metadata(data)
         if table_name.startswith("TS_"):
             clean_data.setdefault("CollectedAt", self._current_collected_at())
         if table_name in {"TS_O1", "TS_SOKUHO_O1"}:
@@ -732,8 +784,12 @@ class RealtimeUpdater:
     @staticmethod
     def _expanded_record_delete_keys(table_name: str, data: Dict) -> list:
         """Return record-level delete keys for expanded array tables."""
-        data_kubun = data.get("headDataKubun") or data.get("DataKubun")
-        if data_kubun not in {DATA_KUBUN_DELETE, DATA_KUBUN_ERASE}:
+        data_kubun = resolve_record_data_kubun(data)
+        record_type = data.get("RecordSpec")
+        if data_kubun != DATA_KUBUN_ERASE and not (
+            data_kubun == DATA_KUBUN_DELETE
+            and record_type not in CANCELLATION_STATE_RECORD_TYPES
+        ):
             return []
 
         base_keys = ["Year", "MonthDay", "JyoCD", "Kaiji", "Nichiji", "RaceNum"]

--- a/tests/test_expanded_record_storage.py
+++ b/tests/test_expanded_record_storage.py
@@ -10,8 +10,10 @@ from uuid import uuid4
 import pytest
 
 from src.database.schema import SCHEMAS
+from src.database.schema_jravan import JRAVAN_SCHEMAS
 from src.database.sqlite_handler import SQLiteDatabase
 from src.importer.importer import DataImporter
+from src.importer.importer_optimized import OptimizedDataImporter
 from src.parser.av_parser import AVParser
 from src.parser.o1_parser import O1Parser
 from src.parser.o2_parser import O2Parser
@@ -50,6 +52,13 @@ def _make_o1_record(data_kubun: str = "4") -> bytes:
     return raw
 
 
+def _make_o1_erase_record() -> bytes:
+    header = _odds_header("O1", data_kubun="0") + b"0000"
+    raw = header + b" " * (O1Parser.RECORD_LENGTH - len(header) - 2) + b"\r\n"
+    assert len(raw) == O1Parser.RECORD_LENGTH
+    return raw
+
+
 def _make_empty_o2_record() -> bytes:
     raw = _odds_header("O2") + b"7" + b"0" * (153 * 13) + b"00000000999\r\n"
     assert len(raw) == O2Parser.RECORD_LENGTH
@@ -84,6 +93,12 @@ def _flatten(parsed):
 def _create_tables(db, table_names):
     for table_name in table_names:
         db.execute(SCHEMAS[table_name])
+    db.commit()
+
+
+def _create_jravan_tables(db, table_names):
+    for table_name in table_names:
+        db.execute(JRAVAN_SCHEMAS[table_name])
     db.commit()
 
 
@@ -196,6 +211,152 @@ def test_sqlite_realtime_delete_removes_expanded_o1_record(sqlite_db):
     assert result["success"] is True
     count = sqlite_db.fetch_one("SELECT COUNT(*) AS cnt FROM RT_O1")
     assert count["cnt"] == 0
+
+
+def _assert_realtime_batch_retains_cancellation_then_applies_zero_erase(db):
+    _create_tables(db, ["RT_O1"])
+    updater = RealtimeUpdater(db)
+
+    initial = _flatten(O1Parser().parse(_make_o1_record(data_kubun="4")))
+    erase = _flatten(O1Parser().parse(_make_o1_erase_record()))
+    cancelled = _flatten(O1Parser().parse(_make_o1_record(data_kubun="9")))
+    result = updater.process_parsed_records_batch([*initial, *erase, *cancelled])
+    assert result["success"] is True
+    assert result["inserted"] == 9
+    statuses = db.fetch_all("SELECT DISTINCT DataKubun AS status FROM RT_O1")
+    assert statuses == [{"status": "9"}]
+
+    result = updater.process_parsed_records_batch(erase)
+    assert result["success"] is True
+    count = db.fetch_one("SELECT COUNT(*) AS cnt FROM RT_O1")
+    assert count["cnt"] == 0
+
+
+def test_sqlite_realtime_batch_retains_cancellation_then_applies_zero_erase(sqlite_db):
+    _assert_realtime_batch_retains_cancellation_then_applies_zero_erase(sqlite_db)
+
+
+def _assert_historical_importer_retains_cancellation_then_applies_zero_erase(
+    db,
+    importer_class,
+):
+    _create_tables(db, ["NL_RA", "NL_O1"])
+    importer = importer_class(db, batch_size=100)
+    race_key = {
+        "RecordSpec": "RA",
+        "MakeDate": "20260419",
+        "Year": "2026",
+        "MonthDay": "0419",
+        "JyoCD": "06",
+        "Kaiji": "03",
+        "Nichiji": "08",
+        "RaceNum": "11",
+    }
+
+    stats = importer.import_records(
+        iter(
+            [
+                {**race_key, "DataKubun": "1"},
+                {**race_key, "DataKubun": "0"},
+                {**race_key, "headDataKubun": "9"},
+            ]
+        )
+    )
+    assert stats["records_imported"] == 3
+    assert stats["records_failed"] == 0
+    assert stats["batches_processed"] == 3
+    race = db.fetch_one("SELECT DataKubun AS status FROM NL_RA")
+    assert race == {"status": "9"}
+
+    initial_odds = _flatten(O1Parser().parse(_make_o1_record(data_kubun="4")))
+    erase = _flatten(O1Parser().parse(_make_o1_erase_record()))
+    cancelled_odds = _flatten(O1Parser().parse(_make_o1_record(data_kubun="9")))
+    stats = importer.import_records(iter([*initial_odds, *erase, *cancelled_odds]))
+    assert stats["records_imported"] == 9
+    assert stats["records_failed"] == 0
+    assert stats["batches_processed"] == 3
+    statuses = db.fetch_all("SELECT DISTINCT DataKubun AS status FROM NL_O1")
+    assert statuses == [{"status": "9"}]
+
+    stats = importer.import_records(
+        iter([{**race_key, "headDataKubun": "0"}, *erase])
+    )
+    assert stats["records_imported"] == 2
+    assert stats["records_failed"] == 0
+    assert db.fetch_one("SELECT COUNT(*) AS cnt FROM NL_RA")["cnt"] == 0
+    assert db.fetch_one("SELECT COUNT(*) AS cnt FROM NL_O1")["cnt"] == 0
+
+
+@pytest.mark.parametrize("importer_class", (DataImporter, OptimizedDataImporter))
+def test_sqlite_historical_importers_retain_cancellation_then_apply_zero_erase(
+    sqlite_db,
+    importer_class,
+):
+    _assert_historical_importer_retains_cancellation_then_applies_zero_erase(
+        sqlite_db,
+        importer_class,
+    )
+
+
+def test_postgresql_realtime_batch_retains_cancellation_then_applies_zero_erase(
+    postgresql_db,
+):
+    _assert_realtime_batch_retains_cancellation_then_applies_zero_erase(postgresql_db)
+
+
+@pytest.mark.parametrize("importer_class", (DataImporter, OptimizedDataImporter))
+def test_postgresql_historical_importers_retain_cancellation_then_apply_zero_erase(
+    postgresql_db,
+    importer_class,
+):
+    _assert_historical_importer_retains_cancellation_then_applies_zero_erase(
+        postgresql_db,
+        importer_class,
+    )
+
+
+def _assert_standard_race_retains_legacy_cancellation_then_applies_current_erase(
+    db,
+    importer_class,
+):
+    _create_jravan_tables(db, ["RACE"])
+    importer = importer_class(db, use_jravan_schema=True)
+    race_key = {
+        "RecordSpec": "RA",
+        "MakeDate": "20260419",
+        "Year": "2026",
+        "MonthDay": "0419",
+        "JyoCD": "06",
+        "Kaiji": "03",
+        "Nichiji": "08",
+        "RaceNum": "11",
+    }
+
+    stats = importer.import_records(iter([{**race_key, "headDataKubun": "9"}]))
+    assert stats["records_imported"] == 1
+    assert stats["records_failed"] == 0
+    assert db.fetch_one("SELECT DataKubun AS status FROM RACE") == {"status": "9"}
+
+    stats = importer.import_records(iter([{**race_key, "DataKubun": "0"}]))
+    assert stats["records_imported"] == 1
+    assert stats["records_failed"] == 0
+    assert db.fetch_one("SELECT COUNT(*) AS cnt FROM RACE")["cnt"] == 0
+
+
+@pytest.mark.parametrize("importer_class", (DataImporter, OptimizedDataImporter))
+def test_sqlite_standard_race_cancellation_and_erase(sqlite_db, importer_class):
+    _assert_standard_race_retains_legacy_cancellation_then_applies_current_erase(
+        sqlite_db,
+        importer_class,
+    )
+
+
+@pytest.mark.parametrize("importer_class", (DataImporter, OptimizedDataImporter))
+def test_postgresql_standard_race_cancellation_and_erase(postgresql_db, importer_class):
+    _assert_standard_race_retains_legacy_cancellation_then_applies_current_erase(
+        postgresql_db,
+        importer_class,
+    )
 
 
 def test_sqlite_importer_stores_official_av_record(sqlite_db):

--- a/tests/test_realtime.py
+++ b/tests/test_realtime.py
@@ -2,25 +2,25 @@
 # -*- coding: utf-8 -*-
 """Tests for realtime data fetching and monitoring."""
 
-import unittest
-from unittest.mock import Mock, MagicMock, patch, call, ANY
 import threading
 import time
+import unittest
+from unittest.mock import ANY, MagicMock, Mock, call, patch
 
 import pytest
 
 from src.fetcher.base import FetcherError
 from src.fetcher.realtime import RealtimeFetcher, materialize_complete_records
-from src.services.realtime_monitor import RealtimeMonitor, MonitorStatus
-from src.realtime.updater import RealtimeUpdater, summarize_update_result
 from src.jvlink.constants import (
-    JV_RT_SUCCESS,
-    JV_READ_SUCCESS,
-    DATA_KUBUN_NEW,
-    DATA_KUBUN_UPDATE,
     DATA_KUBUN_DELETE,
     DATA_KUBUN_ERASE,
+    DATA_KUBUN_NEW,
+    DATA_KUBUN_UPDATE,
+    JV_READ_SUCCESS,
+    JV_RT_SUCCESS,
 )
+from src.realtime.updater import RealtimeUpdater, summarize_update_result
+from src.services.realtime_monitor import MonitorStatus, RealtimeMonitor
 
 
 class TestRealtimeFetcher(unittest.TestCase):
@@ -763,7 +763,7 @@ class TestRealtimeUpdater(unittest.TestCase):
 
     @patch('src.realtime.updater.ParserFactory')
     def test_process_record_delete(self, mock_factory_class):
-        """Test processing delete record (headDataKubun=9)."""
+        """Legacy headDataKubun=9 keeps the official cancelled-race state."""
         # Setup mock parser
         mock_parser = MagicMock()
         mock_parser.parse.return_value = {
@@ -787,16 +787,18 @@ class TestRealtimeUpdater(unittest.TestCase):
         # Process record
         result = updater.process_record("RA20240101...")
 
-        # Verify result
+        # The legacy flattened field name has the same record-specific meaning
+        # as current DataKubun; 9 is not a physical-delete instruction for RA.
         self.assertIsNotNone(result)
-        self.assertEqual(result["operation"], "delete")
+        self.assertEqual(result["operation"], "insert")
         self.assertEqual(result["table"], "RT_RA")
         self.assertTrue(result["success"])
 
-        # Verify database execute was called for DELETE
-        self.mock_db.execute.assert_called_once()
-        call_args = self.mock_db.execute.call_args
-        self.assertIn("DELETE FROM RT_RA", call_args[0][0])
+        self.mock_db.insert.assert_called_once()
+        inserted = self.mock_db.insert.call_args.args[1]
+        self.assertEqual(inserted["DataKubun"], DATA_KUBUN_DELETE)
+        self.assertNotIn("headDataKubun", inserted)
+        self.mock_db.execute.assert_not_called()
 
     def test_record_data_kubun_zero_physically_deletes(self):
         updater = RealtimeUpdater(self.mock_db)
@@ -1197,9 +1199,22 @@ class TestRealtimeUpdater(unittest.TestCase):
     def test_cancellation_status_is_upserted_for_realtime_state_records(self):
         updater = RealtimeUpdater(self.mock_db)
 
-        for record_type in ("RA", "SE", "WF"):
+        for record_type in (
+            "RA", "SE", "HR", "H1", "H6",
+            "O1", "O2", "O3", "O4", "O5", "O6", "WF",
+        ):
             with self.subTest(record_type=record_type):
                 self.mock_db.reset_mock()
+                expanded_keys = {
+                    "H1": {"BetType": "Tansyo", "Kumi": "01"},
+                    "H6": {"SanrentanKumi": "010203"},
+                    "O1": {"Kumi": "00"},
+                    "O2": {"Kumi": "0102"},
+                    "O3": {"Kumi": "0102"},
+                    "O4": {"Kumi": "0102"},
+                    "O5": {"Kumi": "010203"},
+                    "O6": {"Kumi": "010203"},
+                }.get(record_type, {})
                 result = updater.process_parsed_record(
                     {
                         "RecordSpec": record_type,
@@ -1211,6 +1226,7 @@ class TestRealtimeUpdater(unittest.TestCase):
                         "Nichiji": "1",
                         "RaceNum": "1",
                         "Umaban": "1",
+                        **expanded_keys,
                     }
                 )
 
@@ -1219,25 +1235,25 @@ class TestRealtimeUpdater(unittest.TestCase):
                 self.mock_db.insert.assert_called_once()
                 self.mock_db.execute.assert_not_called()
 
-    def test_data_kubun_9_deletes_non_state_expanded_records(self):
+    def test_conflicting_current_and_legacy_data_kubun_is_rejected(self):
         updater = RealtimeUpdater(self.mock_db)
 
-        result = updater.process_parsed_record(
-            {
-                "RecordSpec": "O1",
-                "DataKubun": DATA_KUBUN_DELETE,
-                "Year": "2026",
-                "MonthDay": "0715",
-                "JyoCD": "05",
-                "Kaiji": "1",
-                "Nichiji": "1",
-                "RaceNum": "1",
-            }
-        )
+        with self.assertRaisesRegex(ValueError, "conflicting DataKubun"):
+            updater.process_parsed_record(
+                {
+                    "RecordSpec": "RA",
+                    "DataKubun": DATA_KUBUN_DELETE,
+                    "headDataKubun": DATA_KUBUN_ERASE,
+                    "Year": "2026",
+                    "MonthDay": "0715",
+                    "JyoCD": "05",
+                    "Kaiji": "1",
+                    "Nichiji": "1",
+                    "RaceNum": "1",
+                }
+            )
 
-        self.assertEqual(result["operation"], "delete")
-        self.assertTrue(result["success"])
-        self.mock_db.execute.assert_called_once()
+        self.mock_db.execute.assert_not_called()
         self.mock_db.insert.assert_not_called()
 
     def test_finalized_ra_data_kubun_is_stored_as_state(self):

--- a/tests/test_realtime.py
+++ b/tests/test_realtime.py
@@ -669,6 +669,38 @@ class TestRealtimeUpdater(unittest.TestCase):
         self.assertEqual(inserted_by_table["TS_SOKUHO_O1"][0]["SourceSpec"], "0B30")
         self.assertIn("CollectedAt", inserted_by_table["TS_SOKUHO_O1"][0])
 
+    def test_ordered_timeseries_batch_uses_one_collected_at(self):
+        """A destructive mutation must not split one capture into different timestamps."""
+        base = {
+            "RecordSpec": "O1",
+            "SourceSpec": "0B41",
+            "Year": 2026,
+            "MonthDay": 503,
+            "JyoCD": "05",
+            "Kaiji": 1,
+            "Nichiji": 2,
+            "RaceNum": 11,
+            "HassoTime": "1540",
+        }
+        records = [
+            {**base, "DataKubun": "1", "Umaban": 1, "Kumi": "00"},
+            {**base, "DataKubun": "0"},
+            {**base, "DataKubun": "9", "Umaban": 2, "Kumi": "00"},
+        ]
+        self.updater._current_collected_at = MagicMock(
+            side_effect=("batch-capture", "row-one", "erase", "row-two")
+        )
+
+        result = self.updater.process_parsed_records_batch(records, timeseries=True)
+
+        self.assertTrue(result["success"])
+        inserted = [call.args[1] for call in self.mock_db.insert.call_args_list]
+        self.assertEqual(len(inserted), 2)
+        self.assertEqual(
+            [row["CollectedAt"] for row in inserted],
+            ["batch-capture", "batch-capture"],
+        )
+
     def test_ts_o1_primary_key_fields_are_not_blank(self):
         """O1 horse rows keep a non-null Kumi sentinel for PostgreSQL keys."""
         data = self.updater._prepare_data_for_db(


### PR DESCRIPTION
## Summary

- preserve `DataKubun=9` as a queryable cancellation state for RA/SE/HR/H1/H6/O1-O6/WF
- apply only official `DataKubun=0` as the physical erase for those record families
- preserve provider order around expanded-record erases in ordinary, optimized, and realtime batch paths
- normalize legacy `headDataKubun` to canonical `DataKubun` and reject conflicting aliases
- preserve one batch-level `CollectedAt` when an ordered time-series mutation fallback is required

Official basis: current JV-Data Ver.4.9.0.1 and immediately prior Ver.4.8.0.2 define cancellation (`9`) separately from erroneous-record erase (`0`) for the affected families.

## Red-first evidence

Before production changes, the focused contract produced 14 substantive failures: cancellation records were deleted, conflicting aliases were accepted, and header-only expanded erases left stale rows. Later review assertions separately reproduced the legacy persistence defect as `KeyError: 'DataKubun'` and the ordered time-series timestamp defect as `['row-one', 'row-two']` rather than one batch capture time.

## Final candidate evidence

Candidate full SHA: `9a9e0bd107eea870da617a2482ce3caeb58913b9`

- affected SQLite/importer/realtime: 92 passed, 7 skipped, 12 subtests
- isolated PostgreSQL 16 expanded-storage contract: 17 passed
- exact-SHA acquired cancellation snapshot replay: 54 normalized O1 rows retained as status 9, then all 54 removed by the header-level status 0 erase, in historical and realtime paths
- GitHub Actions Python 3.12 test and distribution-content job: passed
- GitHub Actions lint job plus local compileall, fatal flake8 selector, import ordering, and diff whitespace: passed
- GitHub-native Copilot and Codex each reported the same `CollectedAt` boundary; it was repaired once, verified, replied to, and both threads are resolved
- local/remote candidate head equality and clean worktree: verified

The legacy split standard-schema representation for expanded H1/H6/O1-O6 remains a separately documented release blocker and is not claimed as solved by this mutation-dispatch PR.
