### PR TITLE
Fix standard-schema H1/H6 snapshot storage

### DIFF
--- a/specs/operations/20260816_jravan_hyosu_state_worklog.md
+++ b/specs/operations/20260816_jravan_hyosu_state_worklog.md
@@ -226,9 +226,47 @@
   (4,896 source rows) through both importers and removed all owner/child rows on
   status 0, without exposing race identity.
 
+## PR #190 aggregated review repair
+
+- PR #190 was opened at final pre-review head
+  `f7c4155a63845fea256d56f9202813246dacbe69`. GitHub Actions lint and test
+  checks passed on that exact head. The configured Codex review and the single
+  requested GitHub-native Copilot review both examined that head; CodeRabbit
+  completed its configured review as well.
+- Codex found that two consecutive full parser results with the same public
+  header values had no explicit physical-record boundary when used directly,
+  outside the fetcher path. Both importers could therefore coalesce revisions
+  and retain a combination removed by the later complete snapshot.
+- Codex and Copilot independently found the same header replacement defect:
+  nullable owner columns were omitted from the conflict update. A later blank
+  refund flag or total consequently preserved the prior non-null value even
+  though H1/H6 are complete snapshots. The findings were accepted as one
+  duplicate correctness cluster.
+- One minimal regression combines both failure modes: it imports two direct
+  H6 parser results with identical public headers, where the later record has
+  no child combination and blanks its refund flags and totals. Before repair it
+  failed for both importers (`2 failed, 2 passed`), retaining refund flag `1`
+  and both old totals instead of `NULL`; the child-removal assertion was not
+  reached. The duplicate-key fail-closed test was also parametrized over both
+  importers as a review coverage improvement.
+- Full H1/H6 parser results now carry an internal per-parse physical-record ID.
+  The importer uses it only when raw-buffer identity is unavailable, and the
+  normal metadata cleaner excludes it from storage. Complete owner replacement
+  now writes supplied nullable columns as `NULL`; the compact compatibility
+  layout still updates only the columns it actually supplies. The shared
+  rollback helper was renamed from an odds-specific name to a neutral coupled-
+  snapshot name without changing behavior.
+- The pre-implementation regression is now green (`4 passed, 66 deselected`).
+  Expanded storage, table mapping, parser compatibility, current-layout, and
+  parser coverage tests pass `320 passed, 20 skipped` on the repaired working
+  tree. The general docstring percentage warning was classified non-blocking:
+  it is not a correctness finding, and the new public/contract helpers already
+  document their behavior.
+
 ## Next safe action
 
-- Commit this evidence-only worklog update, run the smallest focused contract
-  on that final documentation head, then push once and open the PR. Collect the
-  single GitHub-native Copilot review plus configured automated reviewers,
-  aggregate findings, and repair once if necessary.
+- Commit and push this single aggregated repair, run the required focused and
+  PostgreSQL checks against the repaired full SHA, reply to the three duplicate
+  or addressed review threads, resolve all threads, then confirm check success,
+  clean worktree, and merge PR #190. Do not run a second automated-review loop
+  solely for the renamed helper or the additional test.

--- a/specs/operations/20260816_jravan_hyosu_state_worklog.md
+++ b/specs/operations/20260816_jravan_hyosu_state_worklog.md
@@ -212,11 +212,23 @@
   passed `16 passed, 6 skipped`, and expanded storage/mapping/parser
   compatibility passed `257 passed, 20 skipped`. Because this repair changes
   source after the first freeze, SHA `941c783...` is not the PR candidate.
+- The repaired source candidate is
+  `bcb91bf51d96e0b8b1f515910f748cb9f7716832`, based directly on current
+  `origin/master` `dde898c3394c24c9b781024d959c770ee7add58e`.
+  On this exact source SHA, Python 3.12.11 expanded storage/mapping/parser
+  compatibility passed `257 passed, 20 skipped`; a second disposable fresh
+  PostgreSQL 16 run passed all 67 expanded-storage cases; blocking flake8 found
+  zero errors; and diff/status checks were clean.
+- Targeted mypy reported 31 pre-existing shared logger/database/type-annotation
+  findings and no finding in the new H1/H6 storage or positional-array blocks.
+  The workflow treats mypy as warning-only. A Python 3.12 registered-data replay
+  on the exact source SHA again stored status-9 H1 (1,501 source rows) and H6
+  (4,896 source rows) through both importers and removed all owner/child rows on
+  status 0, without exposing race identity.
 
 ## Next safe action
 
-- Commit the positional-array review repair and this evidence, freeze the new
-  full candidate SHA, and rerun the focused Python 3.12 and PostgreSQL gates
-  required by the source change. Then push once, open the PR, collect the
+- Commit this evidence-only worklog update, run the smallest focused contract
+  on that final documentation head, then push once and open the PR. Collect the
   single GitHub-native Copilot review plus configured automated reviewers,
   aggregate findings, and repair once if necessary.

--- a/specs/operations/20260816_jravan_hyosu_state_worklog.md
+++ b/specs/operations/20260816_jravan_hyosu_state_worklog.md
@@ -1,0 +1,60 @@
+# JRA-VAN H1/H6 standard-schema state worklog
+
+## Iteration identity
+
+- Started: 2026-08-16 JST
+- Objective: make H1/H6 vote-count records conform to the official current
+  and supported historical JV-Data layouts in both native and JRA-VAN
+  standard schemas, without changing existing public compatibility aliases.
+- Minimal scope: H1/H6 parser-to-standard storage routing, physical
+  header/child materialization, current-snapshot replacement, zero erase,
+  additive schema verification, ordinary/optimized importer parity, focused
+  contracts, and documentation needed to describe public behavior.
+- Repository: `miyamamoto/jrvltsql`
+- Dedicated worktree: scratch worktree `20260816_jrvltsql_hyosu`
+- Branch: `agent/jravan-hyosu-20260816`
+- Base and initial HEAD:
+  `dde898c3394c24c9b781024d959c770ee7add58e`
+- Base provenance: squash merge of PR #189, which completed O1-O6
+  standard-schema header/child storage.
+- Related released version: `v1.6.10`, targeting
+  `dbb299a756e01bad4c79efd76d934c64f3d8af69`. This iteration is not yet a
+  release candidate.
+- Agent/model: Codex only, per user instruction; no Claude Code session is
+  used for implementation or review.
+
+## Dependency order and boundaries
+
+1. Confirm current and immediately prior official H1/H6 physical layouts,
+   status semantics, table ownership, and documented historical changes.
+2. Compare parser rows, native schemas, standard schemas, table mappings, both
+   importers, erase behavior, and package/docs surface against those contracts.
+3. Add the smallest red-first regressions for the missing fail-closed/state
+   contracts, then implement one aggregated repair.
+4. Validate the frozen full SHA with affected Python 3.12 tests, fresh
+   PostgreSQL, static checks, and an acquired normalized snapshot replay when
+   source coverage exists.
+5. Open one PR, request the single GitHub-native Copilot review, aggregate all
+   findings, repair once if needed, prove unresolved threads are zero, and
+   merge before the next logical iteration.
+
+## Initial observations
+
+- PR #189 deliberately left H1/H6 as the next release blocker because their
+  standard schemas split one physical record into one header plus several
+  vote-count child tables, while the existing public mapping points to legacy
+  child aliases.
+- The O1-O6 coupled-storage implementation is a useful transaction and
+  verification pattern, but H1/H6 require their own official field transforms
+  and cannot be treated as odds rows by renaming record types.
+- A new provider acquisition remains a mandatory final release gate for the
+  repository as a whole. Historical snapshot replay in this iteration is
+  supporting storage evidence, not a substitute for that release gate.
+
+## Current state
+
+- Worktree is based on current `origin/master` and clean at iteration start.
+- No source or test changes have been made yet.
+- Next safe action: inspect repository H1/H6 layouts and standard schemas, then
+  verify the current and prior official specifications and relevant public
+  community reports before writing regressions.

--- a/specs/operations/20260816_jravan_hyosu_state_worklog.md
+++ b/specs/operations/20260816_jravan_hyosu_state_worklog.md
@@ -189,10 +189,34 @@
   replay. This is stored-data evidence only; a new provider acquisition remains
   a mandatory repository release gate.
 
+## Pre-PR Codex review repair
+
+- The first frozen implementation SHA was
+  `941c783fb90dcc36b6cbed314e1158895475dfa2`. Exact-SHA Python 3.12 affected
+  tests passed `796 passed, 22 skipped, 12 subtests`; the workflow test list
+  passed `893 passed, 2 skipped, 12 subtests`; fresh PostgreSQL 16 passed all
+  65 expanded-storage cases; distribution contents passed. The blocking
+  flake8 selection reported zero findings. The broader warning-only flake8 run
+  retained repository-wide legacy warnings and was non-blocking, matching the
+  workflow policy.
+- A subsequent Codex boundary review found one historical positional bug before
+  PR creation: full H1/H6 refund arrays used the generic trimmed decoder. If an
+  early one-byte flag was blank while a later flag was populated, trimming
+  shifted the later value into the wrong horse/bracket slot. A new pre-repair
+  regression failed twice with `assert 1 == 28` for the ordinary and optimized
+  standard paths.
+- H1 now preserves all 28 horse, eight bracket, and eight same-bracket bytes;
+  H6 preserves all 18 horse bytes. Standard conversion maps positional blanks
+  to nullable numbered columns, including pre-introduction refund totals,
+  without changing the flat compatibility layout. The focused repaired set
+  passed `16 passed, 6 skipped`, and expanded storage/mapping/parser
+  compatibility passed `257 passed, 20 skipped`. Because this repair changes
+  source after the first freeze, SHA `941c783...` is not the PR candidate.
+
 ## Next safe action
 
-- Review the complete uncommitted diff for correctness and minimize any
-  duplicated or over-broad surface. Replay one registered acquired H1 and H6
-  physical snapshot through both standard importers without recording race
-  identity, then freeze the first candidate commit. Run the exact-SHA affected,
-  Python 3.12, and PostgreSQL gates before opening the PR.
+- Commit the positional-array review repair and this evidence, freeze the new
+  full candidate SHA, and rerun the focused Python 3.12 and PostgreSQL gates
+  required by the source change. Then push once, open the PR, collect the
+  single GitHub-native Copilot review plus configured automated reviewers,
+  aggregate findings, and repair once if necessary.

--- a/specs/operations/20260816_jravan_hyosu_state_worklog.md
+++ b/specs/operations/20260816_jravan_hyosu_state_worklog.md
@@ -54,7 +54,145 @@
 ## Current state
 
 - Worktree is based on current `origin/master` and clean at iteration start.
-- No source or test changes have been made yet.
-- Next safe action: inspect repository H1/H6 layouts and standard schemas, then
-  verify the current and prior official specifications and relevant public
-  community reports before writing regressions.
+- Focused red-first storage contracts have been added locally; production
+  source is still unchanged. The worktree is intentionally dirty only for the
+  new tests and this worklog until the red evidence is committed.
+
+## Official current/prior contract
+
+- The official JV-Data Ver.4.9.0.1 PDF and SDK 5.0.0 Python/C#/C++ structures
+  agree on H1 as 28,955 bytes and H6 as 102,890 bytes. The repository offsets,
+  entry sizes, counts, and six-part race key match those primary sources.
+  Official current PDF:
+  https://jra-van.jp/dlb/sdv/sdk/JV-Data4901.pdf
+- The immediately prior Ver.4.8.0.2 contains the same H1/H6 record lengths,
+  positions, repeat counts, status values, and key fields. No version switch is
+  needed between these two supported official layouts.
+- Both define `DataKubun` 2/4/5 as provided states, 9 as race cancellation, and
+  0 as physical deletion caused by a provider correction. H1 contains seven
+  non-trifecta arrays and 14 total/refund-total fields; H6 contains 4,896
+  trifecta rows and two total/refund-total fields.
+- Historical availability differs without changing the physical record:
+  H1 is provided from 1986; old popularity values can use 99/999 cancellation
+  sentinels; refund horse/bracket information and several refund totals are
+  populated only from 2002-06-15. H6 is provided only from 2004-08-14. Blank
+  pre-introduction fields therefore mean unknown/not supplied and must remain
+  nullable rather than fail or be fabricated.
+- The H6 release-flag description says “3連複” in both current and prior PDFs,
+  but the section title, field name, 4,896 ordered combinations, and every SDK
+  structure name it as 3連単. This is a long-standing documentation typo, not a
+  second layout.
+- The repository also accepts 317-byte H1 and 78-byte H6 flat compatibility
+  records. Neither current nor immediately prior official specifications
+  define those physical records. They will remain supported as a public
+  compatibility input, but will not be described as an official historical
+  layout.
+
+## Community and sample-importer change audit
+
+- The JRA-VAN developer-community thread about the official JV-Data import
+  class documents a split-table state bug: child insertion was conditional on
+  release flags, then header presence incorrectly selected UPDATE when a flag
+  changed from 0 to 7. The inverse 7-to-0 transition also made flag-gated
+  updates unsafe. Support advised not to use the release flag as the child
+  update condition; the reporter selected DELETE-INSERT so newly appearing and
+  disappearing combinations are both represented.
+  https://developer.jra-van.jp/t/topic/64
+- JRA-VAN support states in the same thread that the H1 and H6 C++/VB sample
+  importers were corrected on 2024-08-07, including horizontally equivalent
+  errors. This behavioral change is newer than the stable physical layout and
+  is therefore part of the required compatibility audit.
+- Implementation decision: always persist valid H1/H6 child combinations
+  independent of the release flag, and replace the complete owned child set
+  inside the same transaction as the header. This handles both pre-fix and
+  post-fix sample behavior without relying on header presence to choose
+  INSERT versus UPDATE.
+- A current community answer also confirms that the `RACE` data spec can emit
+  H1/H6 and that H1 contains final vote counts, not payouts:
+  https://developer.jra-van.jp/t/topic/860
+- Read-only registered-data inspection found cancellation-state H1 and H6
+  physical records with many expanded combinations, not merely empty headers.
+  No race identity was recorded. This supports retaining status 9 as a
+  queryable header plus its supplied child set, followed only by physical
+  removal on status 0.
+
+## Confirmed implementation gap
+
+- Public reverse mappings currently select legacy names `HYO_TANPUKU` and
+  `HYO_SANRENTAN`, which have no physical schema definitions. The actual
+  standard owners are `HYOSU` and `HYOSU2`; H1 owns five child tables and H6
+  owns `HYOSU_SANRENTAN`.
+- Generic row upsert cannot create one standard header, expand concatenated
+  refund arrays into numbered header columns, merge Tansyo/Fukusyo and
+  Umaren/Wide rows into their shared child tables, or remove combinations that
+  disappear in a later complete record.
+- Existing standard tables have no declared primary keys. The repair must add
+  deterministic official-key unique indexes on clean tables and fail closed
+  if duplicate existing official keys prevent safe upsert. It must also run
+  additive migration on every owner and child before verification.
+- The H6 parser places total fields only on expanded child rows. A valid full
+  record with no combinations therefore returns a header without its physical
+  totals. Totals must be attached to the base header before expansion so an
+  empty replacement can clear children while preserving its own totals.
+
+## Red-first evidence
+
+- Against unchanged production source at HEAD
+  `4337ff3aeea20e1f888d98dc9265341675d4f0b3`, the focused H1/H6 contract run
+  produced `8 failed, 4 skipped, 45 deselected`.
+- Both ordinary and optimized standard importers routed H1/H6 to nonexistent
+  legacy alias tables instead of the physical owners. The empty full H6 record
+  lost both physical totals. Existing duplicate H1 official keys did not raise
+  `SchemaMigrationError`. The rollback tests could not reach their transaction
+  assertion because the initial standard import already failed.
+- This is the required pre-repair proof that the new owner, state-replacement,
+  total-preservation, duplicate-key, and rollback checks can reject the current
+  implementation. No production repair has been applied yet.
+
+## Implementation and pre-candidate validation
+
+- Standard-name resolution now sends H1 to physical owner `HYOSU` and H6 to
+  `HYOSU2`, while every physical child table is addressable and the existing
+  public reverse aliases remain unchanged.
+- Both importers now materialize each physical H1/H6 record as one owner plus
+  its complete owned child set. Valid combinations are persisted independently
+  of release flags, Tansyo/Fukusyo and Umaren/Wide partial rows are merged by
+  their official keys, and a later complete record clears combinations that
+  disappeared. DataKubun 9 remains queryable and DataKubun 0 removes children
+  before the owner in the same transaction.
+- Owner and child schemas are migrated and verified together. Deterministic
+  official-key unique indexes fail closed on existing duplicates. Successful
+  verification is cached only after an importer-owned commit; a failed child
+  write rolls back the owner and complete child replacement.
+- Packed H1/H6 refund arrays and physical totals are translated to numbered
+  standard columns. H6 now attaches its two totals to the base parsed header,
+  so a complete record with no child combination retains its own totals.
+- The repository's 317-byte H1 and 78-byte H6 compatibility inputs remain
+  supported as complete one-row physical snapshots. They are tested but are
+  not described as an official historical layout.
+- The repaired focused contract first passed `15 passed, 6 skipped`; the
+  expanded storage, mapping, and parser compatibility set then passed
+  `255 passed, 20 skipped` on SQLite/local paths. Fatal-error Ruff selection,
+  bytecode compilation, diff whitespace checks, and parser/importer syntax
+  checks passed.
+- A disposable fresh PostgreSQL 16 instance ran the complete expanded-record
+  storage file with integration enabled: `65 passed`. It covered both
+  importers, H1/H6 current snapshot replacement, cancellation/erase, duplicate
+  rejection, additive child migration, rollback preservation, and the existing
+  O1-O6 contracts. The instance was removed after the run.
+- A read-only registered-data replay selected one cancellation-state physical
+  snapshot for each record type without recording race identity. H1 expanded
+  to 1,501 normalized source rows and the expected 18 horse, 36 bracket, 153
+  quinella/wide, 306 exacta, and 816 trio child keys; H6 expanded to all 4,896
+  ordered trifecta child keys. Both importers stored one status-9 owner plus the
+  complete child sets, then removed every owner and child row on a status-0
+  replay. This is stored-data evidence only; a new provider acquisition remains
+  a mandatory repository release gate.
+
+## Next safe action
+
+- Review the complete uncommitted diff for correctness and minimize any
+  duplicated or over-broad surface. Replay one registered acquired H1 and H6
+  physical snapshot through both standard importers without recording race
+  identity, then freeze the first candidate commit. Run the exact-SHA affected,
+  Python 3.12, and PostgreSQL gates before opening the PR.

--- a/src/database/table_mappings.py
+++ b/src/database/table_mappings.py
@@ -53,9 +53,20 @@ JRAVAN_TO_JLTSQL: Dict[str, str] = {
     "ODDS_SANRENTAN_HEAD": "NL_O6",
     "ODDS_SANRENTAN": "NL_O6",
 
-    # 票数 (Vote Counts)
-    "HYO_TANPUKU": "NL_H1",   # 単複票数 (Win/Place Votes)
-    "HYO_SANRENTAN": "NL_H6", # 三連単票数 (Trifecta Votes)
+    # 票数 (Vote Counts). One physical H1/H6 record owns a header and
+    # multiple child tables. Keep every physical standard table addressable,
+    # followed by the historical aliases so the public reverse mapping stays
+    # backward compatible.
+    "HYOSU": "NL_H1",
+    "HYOSU_TANPUKU": "NL_H1",
+    "HYOSU_WAKU": "NL_H1",
+    "HYOSU_UMARENWIDE": "NL_H1",
+    "HYOSU_UMATAN": "NL_H1",
+    "HYOSU_SANREN": "NL_H1",
+    "HYOSU2": "NL_H6",
+    "HYOSU_SANRENTAN": "NL_H6",
+    "HYO_TANPUKU": "NL_H1",   # historical API alias
+    "HYO_SANRENTAN": "NL_H6", # historical API alias
 
     # スケジュール・その他 (Schedule & Others)
     "SCHEDULE": "NL_YS",      # 開催スケジュール (Race Schedule)
@@ -145,7 +156,7 @@ JLTSQL_TO_JRAVAN: Dict[str, str] = {
 }
 
 # Importer-only physical-record owners for standard schemas that split one
-# normalized NL_O* stream across a header and one or more child tables.
+# normalized stream across a header and one or more child tables.
 STANDARD_EXPANDED_RECORD_OWNER: dict[str, str] = {
     "NL_O1": "ODDS_TANPUKUWAKU_HEAD",
     "NL_O2": "ODDS_UMAREN_HEAD",
@@ -153,6 +164,8 @@ STANDARD_EXPANDED_RECORD_OWNER: dict[str, str] = {
     "NL_O4": "ODDS_UMATAN_HEAD",
     "NL_O5": "ODDS_SANREN_HEAD",
     "NL_O6": "ODDS_SANRENTAN_HEAD",
+    "NL_H1": "HYOSU",
+    "NL_H6": "HYOSU2",
 }
 
 # テーブル名 → レコード種別コード逆マッピング

--- a/src/importer/importer.py
+++ b/src/importer/importer.py
@@ -979,7 +979,7 @@ def _upsert_rows_by_official_key(
     return total
 
 
-def _rollback_coupled_odds(database: BaseDatabase) -> None:
+def _rollback_coupled_snapshot(database: BaseDatabase) -> None:
     try:
         database.rollback()
     except DatabaseError:
@@ -987,7 +987,7 @@ def _rollback_coupled_odds(database: BaseDatabase) -> None:
             database.invalidate_connection()
         except Exception as invalidation_error:
             logger.error(
-                "Failed to invalidate database after standard odds rollback failure",
+                "Failed to invalidate database after coupled snapshot rollback failure",
                 error=str(invalidation_error),
             )
         raise
@@ -1093,7 +1093,7 @@ def insert_standard_odds_batch(
     except (DatabaseError, SchemaMigrationError):
         if verification_cache is not None:
             verification_cache.pop(owner_table_name, None)
-        _rollback_coupled_odds(database)
+        _rollback_coupled_snapshot(database)
         raise
 
 
@@ -1137,7 +1137,7 @@ def delete_standard_odds_record(
     except (DatabaseError, SchemaMigrationError):
         if verification_cache is not None:
             verification_cache.pop(owner_table_name, None)
-        _rollback_coupled_odds(database)
+        _rollback_coupled_snapshot(database)
         raise
 
 
@@ -1211,6 +1211,9 @@ def _standard_vote_physical_fingerprint(
     raw = record.get("_raw")
     if isinstance(raw, (bytes, bytearray, memoryview)):
         return owner_table_name, "raw", id(raw)
+    physical_record_id = record.get("_physical_record_id")
+    if physical_record_id not in (None, ""):
+        return owner_table_name, "parser", str(physical_record_id)
     if "RecordDelimiter" in record or "RecordSeparator" in record:
         # The compatibility layouts contain one complete physical record per
         # parser row, so adjacent revisions must not be coalesced.
@@ -1525,7 +1528,6 @@ def insert_standard_vote_batch(
             owner_table_name,
             list(header_by_key.values()),
             _STANDARD_VOTE_RACE_KEY_COLUMNS,
-            preserve_existing_on_null=True,
         )
         for child_table, keyed_rows in child_by_table.items():
             _upsert_rows_by_official_key(
@@ -1542,7 +1544,7 @@ def insert_standard_vote_batch(
     except (DatabaseError, SchemaMigrationError):
         if verification_cache is not None:
             verification_cache.pop(owner_table_name, None)
-        _rollback_coupled_odds(database)
+        _rollback_coupled_snapshot(database)
         raise
 
 
@@ -1589,7 +1591,7 @@ def delete_standard_vote_record(
     except (DatabaseError, SchemaMigrationError):
         if verification_cache is not None:
             verification_cache.pop(owner_table_name, None)
-        _rollback_coupled_odds(database)
+        _rollback_coupled_snapshot(database)
         raise
 
 

--- a/src/importer/importer.py
+++ b/src/importer/importer.py
@@ -1141,6 +1141,463 @@ def delete_standard_odds_record(
         raise
 
 
+_STANDARD_VOTE_RACE_KEY_COLUMNS = _MINING_RACE_KEY_COLUMNS
+_STANDARD_VOTE_CONFIG: dict[str, dict[str, Any]] = {
+    "H1": {
+        "owner": "HYOSU",
+        "children": {
+            "HYOSU_TANPUKU": (*_STANDARD_VOTE_RACE_KEY_COLUMNS, "Umaban"),
+            "HYOSU_WAKU": (*_STANDARD_VOTE_RACE_KEY_COLUMNS, "Kumi"),
+            "HYOSU_UMARENWIDE": (*_STANDARD_VOTE_RACE_KEY_COLUMNS, "Kumi"),
+            "HYOSU_UMATAN": (*_STANDARD_VOTE_RACE_KEY_COLUMNS, "Kumi"),
+            "HYOSU_SANREN": (*_STANDARD_VOTE_RACE_KEY_COLUMNS, "Kumi"),
+        },
+    },
+    "H6": {
+        "owner": "HYOSU2",
+        "children": {
+            "HYOSU_SANRENTAN": (*_STANDARD_VOTE_RACE_KEY_COLUMNS, "Kumi"),
+        },
+    },
+}
+_STANDARD_VOTE_CONFIG_BY_OWNER = {
+    config["owner"]: (record_type, config)
+    for record_type, config in _STANDARD_VOTE_CONFIG.items()
+}
+_H1_TOTAL_NAMES = (
+    "TanHyoTotal",
+    "FukuHyoTotal",
+    "WakuHyoTotal",
+    "UmarenHyoTotal",
+    "WideHyoTotal",
+    "UmatanHyoTotal",
+    "SanrenfukuHyoTotal",
+    "TanHenkanHyoTotal",
+    "FukuHenkanHyoTotal",
+    "WakuHenkanHyoTotal",
+    "UmarenHenkanHyoTotal",
+    "WideHenkanHyoTotal",
+    "UmatanHenkanHyoTotal",
+    "SanrenfukuHenkanHyoTotal",
+)
+
+
+def _standard_vote_config(
+    record: dict,
+    table_name: str,
+) -> tuple[str, dict[str, Any]] | None:
+    """Resolve a split standard vote owner for one normalized parser row."""
+    configured = _STANDARD_VOTE_CONFIG_BY_OWNER.get(table_name)
+    if configured is None:
+        return None
+    record_type, config = configured
+    if _record_type_from_record(record) != record_type:
+        raise SchemaMigrationError(
+            f"{table_name} received a non-{record_type} standard vote row"
+        )
+    return record_type, config
+
+
+def _standard_vote_physical_fingerprint(
+    record: dict,
+    owner_table_name: str,
+) -> tuple:
+    """Identify all normalized rows emitted from one physical H1/H6 record."""
+    configured = _standard_vote_config(record, owner_table_name)
+    if configured is None:
+        raise SchemaMigrationError(
+            f"{owner_table_name} is not a standard vote owner table"
+        )
+    raw = record.get("_raw")
+    if isinstance(raw, (bytes, bytearray, memoryview)):
+        return owner_table_name, "raw", id(raw)
+    if "RecordDelimiter" in record or "RecordSeparator" in record:
+        # The compatibility layouts contain one complete physical record per
+        # parser row, so adjacent revisions must not be coalesced.
+        return owner_table_name, "flat", id(record)
+    return (
+        owner_table_name,
+        "header",
+        _record_type_from_record(record),
+        resolve_record_data_kubun(record),
+        record.get("MakeDate"),
+        *(record.get(column) for column in _STANDARD_VOTE_RACE_KEY_COLUMNS),
+    )
+
+
+def verify_standard_vote_tables(
+    database: BaseDatabase,
+    owner_table_name: str,
+) -> tuple[str, dict[str, Any]]:
+    """Require all vote header/child tables and fail closed on duplicate keys."""
+    configured = _STANDARD_VOTE_CONFIG_BY_OWNER.get(owner_table_name)
+    if configured is None:
+        raise SchemaMigrationError(
+            f"Unknown standard vote owner table: {owner_table_name}"
+        )
+
+    from src.database.migration import migrate_table_if_needed, verify_table_schema
+    from src.database.schema_jravan import JRAVAN_SCHEMAS
+
+    record_type, config = configured
+    table_keys = {
+        owner_table_name: _STANDARD_VOTE_RACE_KEY_COLUMNS,
+        **config["children"],
+    }
+    for table_name, key_columns in table_keys.items():
+        schema_sql = JRAVAN_SCHEMAS.get(table_name)
+        if not schema_sql or not database.table_exists_strict(table_name):
+            raise SchemaMigrationError(
+                f"{record_type} standard vote import requires table {table_name}"
+            )
+        migrate_table_if_needed(database, table_name, schema_sql, commit=False)
+        verify_table_schema(database, table_name, schema_sql)
+        index_name = f"jltsql_uq_{table_name.lower()}"
+        columns = ", ".join(key_columns)
+        try:
+            database.execute(
+                f"CREATE UNIQUE INDEX IF NOT EXISTS {index_name} "
+                f"ON {table_name} ({columns})"
+            )
+        except DatabaseError as error:
+            raise SchemaMigrationError(
+                f"{table_name} contains duplicate official keys; "
+                "deduplicate or rebuild it before standard vote import"
+            ) from error
+    return record_type, config
+
+
+def _expand_standard_vote_flags(
+    source: dict,
+    field_name: str,
+    count: int,
+) -> None:
+    if field_name not in source:
+        return
+    packed = str(source.get(field_name) or "")
+    for index in range(count):
+        source[f"{field_name}{index + 1}"] = (
+            packed[index : index + 1] or None
+        )
+
+
+def _standard_vote_header_source(record_type: str, record: dict) -> dict:
+    """Translate normalized H1/H6 header fields to standard-schema columns."""
+    source = clean_record_metadata(record)
+    if record_type == "H1":
+        _expand_standard_vote_flags(source, "HenkanUma", 28)
+        _expand_standard_vote_flags(source, "HenkanWaku", 8)
+        _expand_standard_vote_flags(source, "HenkanDoWaku", 8)
+        for index, field_name in enumerate(_H1_TOTAL_NAMES, start=1):
+            source[f"HyoTotal{index}"] = source.get(field_name)
+    else:
+        source["HatubaiFlag1"] = source.get("HatubaiFlag")
+        _expand_standard_vote_flags(source, "HenkanUma", 18)
+        source["HyoTotal1"] = source.get("SanrentanHyoTotal")
+        source["HyoTotal2"] = source.get("SanrentanHenkanHyoTotal")
+    return source
+
+
+def _valid_vote_combination(value: Any) -> bool:
+    text = str(value or "").strip()
+    return bool(text) and text != "TOTAL" and bool(text.strip("0"))
+
+
+def prepare_standard_vote_record(
+    record: dict,
+    owner_table_name: str,
+) -> tuple[dict, list[tuple[str, dict]]]:
+    """Build one standard vote header and its routed partial child rows."""
+    configured = _standard_vote_config(record, owner_table_name)
+    if configured is None:
+        raise SchemaMigrationError(
+            f"{owner_table_name} is not a standard vote owner table"
+        )
+    record_type, config = configured
+    source = _standard_vote_header_source(record_type, record)
+    header = convert_record_types(source, owner_table_name)
+    missing_header_key = [
+        column
+        for column in _STANDARD_VOTE_RACE_KEY_COLUMNS
+        if header.get(column) in (None, "")
+    ]
+    if missing_header_key:
+        raise SchemaMigrationError(
+            f"{record_type} standard vote header has incomplete key: "
+            f"{missing_header_key}"
+        )
+    if resolve_record_data_kubun(record) == "0":
+        return header, []
+
+    base = {
+        column: source.get(column)
+        for column in ("MakeDate", *_STANDARD_VOTE_RACE_KEY_COLUMNS)
+    }
+    child_sources: list[tuple[str, dict]] = []
+
+    def append_child(table_name: str, key_name: str, key_value: Any, **values: Any) -> None:
+        if not _valid_vote_combination(key_value):
+            return
+        child_sources.append(
+            (table_name, {**base, key_name: key_value, **values})
+        )
+
+    if record_type == "H1":
+        bet_type = source.get("BetType")
+        if bet_type == "Tansyo":
+            append_child(
+                "HYOSU_TANPUKU",
+                "Umaban",
+                source.get("Kumi"),
+                TanHyo=source.get("Hyo"),
+                TanNinki=source.get("Ninki"),
+            )
+        elif bet_type == "Fukusyo":
+            append_child(
+                "HYOSU_TANPUKU",
+                "Umaban",
+                source.get("Kumi"),
+                FukuHyo=source.get("Hyo"),
+                FukuNinki=source.get("Ninki"),
+            )
+        elif bet_type == "Wakuren":
+            append_child(
+                "HYOSU_WAKU", "Kumi", source.get("Kumi"),
+                Hyo=source.get("Hyo"), Ninki=source.get("Ninki")
+            )
+        elif bet_type == "Umaren":
+            append_child(
+                "HYOSU_UMARENWIDE", "Kumi", source.get("Kumi"),
+                UmarenHyo=source.get("Hyo"), UmarenNinki=source.get("Ninki")
+            )
+        elif bet_type == "Wide":
+            append_child(
+                "HYOSU_UMARENWIDE", "Kumi", source.get("Kumi"),
+                WideHyo=source.get("Hyo"), WideNinki=source.get("Ninki")
+            )
+        elif bet_type == "Umatan":
+            append_child(
+                "HYOSU_UMATAN", "Kumi", source.get("Kumi"),
+                Hyo=source.get("Hyo"), Ninki=source.get("Ninki")
+            )
+        elif bet_type == "Sanrenpuku":
+            append_child(
+                "HYOSU_SANREN", "Kumi", source.get("Kumi"),
+                Hyo=source.get("Hyo"), Ninki=source.get("Ninki")
+            )
+        elif bet_type not in (None, "", "Total"):
+            raise SchemaMigrationError(
+                f"H1 standard vote row has unsupported BetType: {bet_type!r}"
+            )
+
+        if bet_type in (None, ""):
+            append_child(
+                "HYOSU_TANPUKU", "Umaban", source.get("TanUma"),
+                TanHyo=source.get("TanHyo"), TanNinki=source.get("TanNinki")
+            )
+            append_child(
+                "HYOSU_TANPUKU", "Umaban", source.get("FukuUma"),
+                FukuHyo=source.get("FukuHyo"), FukuNinki=source.get("FukuNinki")
+            )
+            append_child(
+                "HYOSU_WAKU", "Kumi", source.get("WakuKumi"),
+                Hyo=source.get("WakuHyo"), Ninki=source.get("WakuNinki")
+            )
+            append_child(
+                "HYOSU_UMARENWIDE", "Kumi", source.get("UmarenKumi"),
+                UmarenHyo=source.get("UmarenHyo"),
+                UmarenNinki=source.get("UmarenNinki")
+            )
+            append_child(
+                "HYOSU_UMARENWIDE", "Kumi", source.get("WideKumi"),
+                WideHyo=source.get("WideHyo"), WideNinki=source.get("WideNinki")
+            )
+            append_child(
+                "HYOSU_UMATAN", "Kumi", source.get("UmatanKumi"),
+                Hyo=source.get("UmatanHyo"), Ninki=source.get("UmatanNinki")
+            )
+            append_child(
+                "HYOSU_SANREN", "Kumi", source.get("SanrenfukuKumi"),
+                Hyo=source.get("SanrenfukuHyo"),
+                Ninki=source.get("SanrenfukuNinki")
+            )
+    else:
+        append_child(
+            "HYOSU_SANRENTAN", "Kumi", source.get("SanrentanKumi"),
+            Hyo=source.get("SanrentanHyo"), Ninki=source.get("SanrentanNinki")
+        )
+
+    children: list[tuple[str, dict]] = []
+    for child_table, child_source in child_sources:
+        child = convert_record_types(child_source, child_table)
+        child_keys = config["children"][child_table]
+        missing_child_key = [
+            column for column in child_keys if child.get(column) in (None, "")
+        ]
+        if missing_child_key:
+            raise SchemaMigrationError(
+                f"{record_type} standard vote child has incomplete key: "
+                f"{missing_child_key}"
+            )
+        children.append((child_table, child))
+    return header, children
+
+
+def insert_standard_vote_batch(
+    database: BaseDatabase,
+    owner_table_name: str,
+    records: list[dict],
+    *,
+    commit_batch: bool,
+    verification_cache: dict[str, tuple[str, dict[str, Any]]] | None = None,
+) -> int:
+    """Atomically replace one complete H1/H6 standard-schema snapshot."""
+    if not records:
+        return 0
+    try:
+        if commit_batch:
+            database.begin_transaction()
+        verified = (
+            verification_cache.get(owner_table_name)
+            if verification_cache is not None
+            else None
+        )
+        if verified is None:
+            verified = verify_standard_vote_tables(database, owner_table_name)
+        _, config = verified
+        fingerprints = {
+            _standard_vote_physical_fingerprint(record, owner_table_name)
+            for record in records
+        }
+        if len(fingerprints) != 1:
+            raise SchemaMigrationError(
+                "standard vote batch spans multiple physical records"
+            )
+
+        header_by_key: dict[tuple, dict] = {}
+        child_by_table: dict[str, dict[tuple, dict]] = {
+            table_name: {} for table_name in config["children"]
+        }
+        for record in records:
+            header, children = prepare_standard_vote_record(record, owner_table_name)
+            if header.get("DataKubun") == "0":
+                raise SchemaMigrationError(
+                    "standard vote erase must be applied at the physical-record boundary"
+                )
+            header_key = tuple(
+                header[column] for column in _STANDARD_VOTE_RACE_KEY_COLUMNS
+            )
+            existing_header = header_by_key.get(header_key)
+            if existing_header is None:
+                header_by_key[header_key] = header
+            else:
+                existing_header.update(
+                    {column: value for column, value in header.items() if value is not None}
+                )
+            for child_table, child in children:
+                child_keys = config["children"][child_table]
+                child_key = tuple(child[column] for column in child_keys)
+                existing_child = child_by_table[child_table].get(child_key)
+                if existing_child is None:
+                    child_by_table[child_table][child_key] = child
+                else:
+                    existing_child.update(
+                        {column: value for column, value in child.items() if value is not None}
+                    )
+
+        if len(header_by_key) != 1:
+            raise SchemaMigrationError(
+                "standard vote physical record spans multiple race keys"
+            )
+        current_header = next(iter(header_by_key.values()))
+        where = " AND ".join(
+            f"{column} = ?" for column in _STANDARD_VOTE_RACE_KEY_COLUMNS
+        )
+        race_key_values = tuple(
+            current_header[column] for column in _STANDARD_VOTE_RACE_KEY_COLUMNS
+        )
+        for child_table in config["children"]:
+            database.execute(
+                f"DELETE FROM {child_table} WHERE {where}", race_key_values
+            )
+        _upsert_rows_by_official_key(
+            database,
+            owner_table_name,
+            list(header_by_key.values()),
+            _STANDARD_VOTE_RACE_KEY_COLUMNS,
+            preserve_existing_on_null=True,
+        )
+        for child_table, keyed_rows in child_by_table.items():
+            _upsert_rows_by_official_key(
+                database,
+                child_table,
+                list(keyed_rows.values()),
+                config["children"][child_table],
+            )
+        if commit_batch:
+            database.commit()
+            if verification_cache is not None:
+                verification_cache[owner_table_name] = verified
+        return len(records)
+    except (DatabaseError, SchemaMigrationError):
+        if verification_cache is not None:
+            verification_cache.pop(owner_table_name, None)
+        _rollback_coupled_odds(database)
+        raise
+
+
+def delete_standard_vote_record(
+    database: BaseDatabase,
+    record: dict,
+    owner_table_name: str,
+    *,
+    commit_batch: bool,
+    verification_cache: dict[str, tuple[str, dict[str, Any]]] | None = None,
+) -> int:
+    """Atomically erase a complete split H1/H6 standard physical record."""
+    if resolve_record_data_kubun(record) != "0":
+        raise SchemaMigrationError("standard vote physical erase requires DataKubun=0")
+    try:
+        if commit_batch:
+            database.begin_transaction()
+        verified = (
+            verification_cache.get(owner_table_name)
+            if verification_cache is not None
+            else None
+        )
+        if verified is None:
+            verified = verify_standard_vote_tables(database, owner_table_name)
+        _, config = verified
+        header, _ = prepare_standard_vote_record(record, owner_table_name)
+        where = " AND ".join(
+            f"{column} = ?" for column in _STANDARD_VOTE_RACE_KEY_COLUMNS
+        )
+        values = tuple(
+            header[column] for column in _STANDARD_VOTE_RACE_KEY_COLUMNS
+        )
+        deleted = 0
+        for table_name in (*config["children"], owner_table_name):
+            deleted += max(
+                database.execute(f"DELETE FROM {table_name} WHERE {where}", values),
+                0,
+            )
+        if commit_batch:
+            database.commit()
+            if verification_cache is not None:
+                verification_cache[owner_table_name] = verified
+        return deleted
+    except (DatabaseError, SchemaMigrationError):
+        if verification_cache is not None:
+            verification_cache.pop(owner_table_name, None)
+        _rollback_coupled_odds(database)
+        raise
+
+
+def _is_standard_vote_record_erase(record: dict, table_name: str) -> bool:
+    configured = _standard_vote_config(record, table_name)
+    return configured is not None and resolve_record_data_kubun(record) == "0"
+
+
 def _is_standard_odds_record_erase(record: dict, table_name: str) -> bool:
     configured = _standard_odds_config(record, table_name)
     return configured is not None and resolve_record_data_kubun(record) == "0"
@@ -1939,6 +2396,10 @@ class DataImporter:
             str,
             tuple[str, dict[str, Any]],
         ] = {}
+        self._verified_standard_vote_configs: dict[
+            str,
+            tuple[str, dict[str, Any]],
+        ] = {}
 
         # Map record types to table names
         # Note: Table names match schema.py table definitions (e.g. NL_RA, not NL_RA_RACE)
@@ -2149,6 +2610,7 @@ class DataImporter:
         # Group records by type for batch insertion
         batch_buffers: Dict[str, List[dict]] = {}
         standard_odds_fingerprints: dict[str, tuple] = {}
+        standard_vote_fingerprints: dict[str, tuple] = {}
         last_expanded_record_fingerprint = None
 
         try:
@@ -2176,6 +2638,24 @@ class DataImporter:
                 if table_name not in self._verified_mining_native_tables:
                     if verify_mining_native_schema(self.database, record, table_name):
                         self._verified_mining_native_tables.add(table_name)
+
+                if _is_standard_vote_record_erase(record, table_name):
+                    pending = batch_buffers.setdefault(table_name, [])
+                    if pending:
+                        self._flush_batch(table_name, pending, auto_commit)
+                        batch_buffers[table_name] = []
+                    delete_standard_vote_record(
+                        self.database,
+                        record,
+                        table_name,
+                        commit_batch=auto_commit,
+                        verification_cache=self._verified_standard_vote_configs,
+                    )
+                    standard_vote_fingerprints.pop(table_name, None)
+                    self._records_imported += 1
+                    self._batches_processed += 1
+                    last_expanded_record_fingerprint = None
+                    continue
 
                 if _is_standard_odds_record_erase(record, table_name):
                     pending = batch_buffers.setdefault(table_name, [])
@@ -2243,6 +2723,21 @@ class DataImporter:
                         raise
                     self._records_imported += rows
                     self._batches_processed += 1
+                    continue
+
+                if table_name in _STANDARD_VOTE_CONFIG_BY_OWNER:
+                    fingerprint = _standard_vote_physical_fingerprint(
+                        record,
+                        table_name,
+                    )
+                    pending = batch_buffers.setdefault(table_name, [])
+                    previous = standard_vote_fingerprints.get(table_name)
+                    if pending and previous != fingerprint:
+                        self._flush_batch(table_name, pending, auto_commit)
+                        pending = []
+                        batch_buffers[table_name] = pending
+                    pending.append(record)
+                    standard_vote_fingerprints[table_name] = fingerprint
                     continue
 
                 if table_name in _STANDARD_ODDS_CONFIG_BY_OWNER:
@@ -2320,6 +2815,19 @@ class DataImporter:
         if table_name not in self._verified_ys_tables:
             if verify_ys_storage_schema(self.database, table_name):
                 self._verified_ys_tables.add(table_name)
+
+        if table_name in _STANDARD_VOTE_CONFIG_BY_OWNER:
+            rows = insert_standard_vote_batch(
+                self.database,
+                table_name,
+                batch,
+                commit_batch=auto_commit,
+                verification_cache=self._verified_standard_vote_configs,
+            )
+            self._records_imported += rows
+            if rows:
+                self._batches_processed += 1
+            return
 
         if table_name in _STANDARD_ODDS_CONFIG_BY_OWNER:
             rows = insert_standard_odds_batch(
@@ -2659,6 +3167,17 @@ class DataImporter:
             if table_name not in self._verified_mining_native_tables:
                 if verify_mining_native_schema(self.database, record, table_name):
                     self._verified_mining_native_tables.add(table_name)
+            if _is_standard_vote_record_erase(record, table_name):
+                delete_standard_vote_record(
+                    self.database,
+                    record,
+                    table_name,
+                    commit_batch=auto_commit,
+                    verification_cache=self._verified_standard_vote_configs,
+                )
+                self._records_imported += 1
+                self._batches_processed += 1
+                return True
             if _is_standard_odds_record_erase(record, table_name):
                 delete_standard_odds_record(
                     self.database,
@@ -2697,6 +3216,18 @@ class DataImporter:
                 self._records_imported += rows
                 self._batches_processed += 1
                 return True
+            if table_name in _STANDARD_VOTE_CONFIG_BY_OWNER:
+                rows = insert_standard_vote_batch(
+                    self.database,
+                    table_name,
+                    [record],
+                    commit_batch=auto_commit,
+                    verification_cache=self._verified_standard_vote_configs,
+                )
+                self._records_imported += rows
+                if rows:
+                    self._batches_processed += 1
+                return rows == 1
             if table_name in _STANDARD_ODDS_CONFIG_BY_OWNER:
                 rows = insert_standard_odds_batch(
                     self.database,

--- a/src/importer/importer_optimized.py
+++ b/src/importer/importer_optimized.py
@@ -17,6 +17,7 @@ from src.importer.importer import (
     _PREPARED_KS_SEISEKI_ROWS_KEY,
     _RC_STORAGE_TABLES,
     _STANDARD_ODDS_CONFIG_BY_OWNER,
+    _STANDARD_VOTE_CONFIG_BY_OWNER,
     _TK_CHILD_STORAGE_TABLES,
     _YS_STORAGE_TABLES,
     _delete_mining_race_rows,
@@ -26,16 +27,20 @@ from src.importer.importer import (
     _is_mining_snapshot_follower,
     _is_official_record_erase,
     _is_standard_odds_record_erase,
+    _is_standard_vote_record_erase,
     _mining_native_snapshot_rows,
     _record_type_from_record,
     _standard_odds_physical_fingerprint,
+    _standard_vote_physical_fingerprint,
     apply_rc_batch,
     apply_ys_batch,
     clean_record_metadata,
     delete_standard_odds_record,
+    delete_standard_vote_record,
     insert_ch_coupled_batch,
     insert_ks_coupled_batch,
     insert_standard_odds_batch,
+    insert_standard_vote_batch,
     insert_tk_coupled_batch,
     prepare_ch_coupled_rows,
     prepare_ks_coupled_rows,
@@ -88,6 +93,7 @@ class OptimizedDataImporter:
         self._verified_ys_tables: set[str] = set()
         self._verified_tk_header_tables: dict[str, str] = {}
         self._verified_standard_odds_configs: dict[str, tuple[str, dict]] = {}
+        self._verified_standard_vote_configs: dict[str, tuple[str, dict]] = {}
 
         # Detect database type for optimization
         self.db_type = self._detect_database_type()
@@ -261,6 +267,7 @@ class OptimizedDataImporter:
         # Group records by type for batch insertion
         batch_buffers: Dict[str, List[dict]] = {}
         standard_odds_fingerprints: dict[str, tuple] = {}
+        standard_vote_fingerprints: dict[str, tuple] = {}
         verified_ch_result_tables: Dict[str, str] = {}
         verified_ks_result_tables: Dict[str, str] = {}
         last_expanded_record_fingerprint = None
@@ -296,6 +303,28 @@ class OptimizedDataImporter:
                 if table_name not in self._verified_mining_native_tables:
                     if verify_mining_native_schema(self.database, record, table_name):
                         self._verified_mining_native_tables.add(table_name)
+
+                if _is_standard_vote_record_erase(record, table_name):
+                    pending = batch_buffers.setdefault(table_name, [])
+                    if pending:
+                        self._flush_batch_optimized(
+                            table_name,
+                            pending,
+                            commit_batch=auto_commit,
+                        )
+                        batch_buffers[table_name] = []
+                    delete_standard_vote_record(
+                        self.database,
+                        record,
+                        table_name,
+                        commit_batch=auto_commit,
+                        verification_cache=self._verified_standard_vote_configs,
+                    )
+                    standard_vote_fingerprints.pop(table_name, None)
+                    self._records_imported += 1
+                    self._batches_processed += 1
+                    last_expanded_record_fingerprint = None
+                    continue
 
                 if _is_standard_odds_record_erase(record, table_name):
                     pending = batch_buffers.setdefault(table_name, [])
@@ -392,6 +421,25 @@ class OptimizedDataImporter:
                             commit_batch=auto_commit,
                         )
                         batch_buffers[table_name] = []
+                    continue
+
+                if table_name in _STANDARD_VOTE_CONFIG_BY_OWNER:
+                    fingerprint = _standard_vote_physical_fingerprint(
+                        record,
+                        table_name,
+                    )
+                    pending = batch_buffers.setdefault(table_name, [])
+                    previous = standard_vote_fingerprints.get(table_name)
+                    if pending and previous != fingerprint:
+                        self._flush_batch_optimized(
+                            table_name,
+                            pending,
+                            commit_batch=auto_commit,
+                        )
+                        pending = []
+                        batch_buffers[table_name] = pending
+                    pending.append(record)
+                    standard_vote_fingerprints[table_name] = fingerprint
                     continue
 
                 if table_name in _STANDARD_ODDS_CONFIG_BY_OWNER:
@@ -555,6 +603,19 @@ class OptimizedDataImporter:
                 batch,
                 commit_batch=commit_batch,
                 optimized=True,
+            )
+            self._records_imported += rows
+            if rows:
+                self._batches_processed += 1
+            return
+
+        if table_name in _STANDARD_VOTE_CONFIG_BY_OWNER:
+            rows = insert_standard_vote_batch(
+                self.database,
+                table_name,
+                batch,
+                commit_batch=commit_batch,
+                verification_cache=self._verified_standard_vote_configs,
             )
             self._records_imported += rows
             if rows:

--- a/src/parser/h1_parser.py
+++ b/src/parser/h1_parser.py
@@ -80,6 +80,14 @@ class H1Parser:
         except Exception:
             return ""
 
+    @staticmethod
+    def decode_fixed_flags(data: bytes) -> str:
+        """Decode positional one-byte flags without shifting blank entries."""
+        try:
+            return data.decode("cp932", errors="replace")
+        except Exception:
+            return " " * len(data)
+
     def _parse_header(self, data: bytes) -> Dict[str, str]:
         """Parse common header fields (first 83 bytes)."""
         h = {}
@@ -98,9 +106,9 @@ class H1Parser:
             h[f"HatubaiFlag{i+1}"] = self.decode_field(data[31+i:32+i])
         h["FukuChakuBaraiKey"] = self.decode_field(data[38:39])
         # HenkanUma[28], HenkanWaku[8], HenkanDoWaku[8] — stored as concatenated strings
-        h["HenkanUma"] = self.decode_field(data[39:67])
-        h["HenkanWaku"] = self.decode_field(data[67:75])
-        h["HenkanDoWaku"] = self.decode_field(data[75:83])
+        h["HenkanUma"] = self.decode_fixed_flags(data[39:67])
+        h["HenkanWaku"] = self.decode_fixed_flags(data[67:75])
+        h["HenkanDoWaku"] = self.decode_fixed_flags(data[75:83])
         return h
 
     def parse(self, data: bytes) -> Optional[Union[Dict[str, str], List[Dict[str, str]]]]:

--- a/src/parser/h1_parser.py
+++ b/src/parser/h1_parser.py
@@ -28,6 +28,8 @@ H1レコードパーサー: ５．票数１（全掛式）
 """
 
 from typing import Dict, List, Optional, Union
+from uuid import uuid4
+
 from src.utils.logger import get_logger
 
 
@@ -136,6 +138,7 @@ class H1Parser:
     def _parse_full(self, data: bytes) -> List[Dict[str, str]]:
         """Parse full 28,955-byte struct into multiple rows."""
         header = self._parse_header(data)
+        header["_physical_record_id"] = uuid4().hex
 
         # Parse HyoTotal[14] × 11 bytes at position 28799
         totals = {}

--- a/src/parser/h6_parser.py
+++ b/src/parser/h6_parser.py
@@ -50,6 +50,14 @@ class H6Parser:
         except Exception:
             return ""
 
+    @staticmethod
+    def decode_fixed_flags(data: bytes) -> str:
+        """Decode positional one-byte flags without shifting blank entries."""
+        try:
+            return data.decode("cp932", errors="replace")
+        except Exception:
+            return " " * len(data)
+
     def _parse_header(self, data: bytes) -> Dict[str, str]:
         """Parse common header fields (first 50 bytes)."""
         h = {}
@@ -65,7 +73,7 @@ class H6Parser:
         h["TorokuTosu"] = self.decode_field(data[27:29])
         h["SyussoTosu"] = self.decode_field(data[29:31])
         h["HatubaiFlag"] = self.decode_field(data[31:32])
-        h["HenkanUma"] = self.decode_field(data[32:50])
+        h["HenkanUma"] = self.decode_fixed_flags(data[32:50])
         return h
 
     def parse(self, data: bytes) -> Optional[Union[Dict[str, str], List[Dict[str, str]]]]:

--- a/src/parser/h6_parser.py
+++ b/src/parser/h6_parser.py
@@ -96,6 +96,8 @@ class H6Parser:
         # Parse HyoTotal[2] × 11 bytes at position 102866
         total_hyo = self.decode_field(data[102866:102877])
         henkan_hyo = self.decode_field(data[102877:102888])
+        header["SanrentanHyoTotal"] = total_hyo
+        header["SanrentanHenkanHyoTotal"] = henkan_hyo
 
         rows = []
         # HyoSanrentan[4896] × 21 bytes starting at position 50
@@ -113,8 +115,6 @@ class H6Parser:
             row["SanrentanKumi"] = kumi
             row["SanrentanHyo"] = hyo
             row["SanrentanNinki"] = ninki
-            row["SanrentanHyoTotal"] = total_hyo
-            row["SanrentanHenkanHyoTotal"] = henkan_hyo
             rows.append(row)
 
         return rows if rows else [header]

--- a/src/parser/h6_parser.py
+++ b/src/parser/h6_parser.py
@@ -21,6 +21,8 @@ HYO_INFO4: kumi(6) + hyo(11) + ninki(4) = 21
 """
 
 from typing import Dict, List, Optional, Union
+from uuid import uuid4
+
 from src.utils.logger import get_logger
 
 
@@ -100,6 +102,7 @@ class H6Parser:
     def _parse_full(self, data: bytes) -> List[Dict[str, str]]:
         """Parse full 102,890-byte struct into multiple rows."""
         header = self._parse_header(data)
+        header["_physical_record_id"] = uuid4().hex
 
         # Parse HyoTotal[2] × 11 bytes at position 102866
         total_hyo = self.decode_field(data[102866:102877])

--- a/tests/test_expanded_record_storage.py
+++ b/tests/test_expanded_record_storage.py
@@ -1158,6 +1158,34 @@ def test_sqlite_standard_vote_refund_arrays_keep_blank_positions(
 
 
 @pytest.mark.parametrize("importer_class", (DataImporter, OptimizedDataImporter))
+def test_sqlite_standard_h6_direct_parser_revisions_replace_nullable_snapshot(
+    sqlite_db, importer_class
+):
+    _create_jravan_tables(sqlite_db, _STANDARD_H6_TABLES)
+    parser = H6Parser()
+    first = _flatten(parser.parse(_make_h6_vote_record()))
+    second_raw = bytearray(
+        _make_h6_vote_record(data_kubun="4", populated=False)
+    )
+    second_raw[32:50] = b" " * 18
+    second_raw[102866:102888] = b" " * 22
+    second = _flatten(parser.parse(bytes(second_raw)))
+
+    stats = importer_class(
+        sqlite_db, use_jravan_schema=True, batch_size=10000
+    ).import_records(iter([*first, *second]))
+
+    assert stats["records_failed"] == 0
+    assert sqlite_db.fetch_one(
+        "SELECT HenkanUma1 AS refund_flag, HyoTotal1 AS total1, "
+        "HyoTotal2 AS total2 FROM HYOSU2"
+    ) == {"refund_flag": None, "total1": None, "total2": None}
+    assert sqlite_db.fetch_one(
+        "SELECT COUNT(*) AS cnt FROM HYOSU_SANRENTAN"
+    )["cnt"] == 0
+
+
+@pytest.mark.parametrize("importer_class", (DataImporter, OptimizedDataImporter))
 def test_sqlite_standard_vote_flat_compatibility_layouts(
     sqlite_db, importer_class
 ):
@@ -1251,7 +1279,10 @@ def test_postgresql_standard_h6_migrates_existing_child_columns(
     )
 
 
-def test_sqlite_standard_h1_duplicate_header_keys_fail_closed(sqlite_db):
+@pytest.mark.parametrize("importer_class", (DataImporter, OptimizedDataImporter))
+def test_sqlite_standard_h1_duplicate_header_keys_fail_closed(
+    sqlite_db, importer_class
+):
     _create_jravan_tables(sqlite_db, _STANDARD_H1_TABLES)
     duplicate_key = (2026, 419, "06", 3, 8, 11)
     for status in ("2", "4"):
@@ -1265,7 +1296,7 @@ def test_sqlite_standard_h1_duplicate_header_keys_fail_closed(sqlite_db):
     rows = _flatten(H1Parser().parse(_make_h1_vote_record()))
 
     with pytest.raises(SchemaMigrationError, match="duplicate official keys"):
-        DataImporter(sqlite_db, use_jravan_schema=True).import_records(iter(rows))
+        importer_class(sqlite_db, use_jravan_schema=True).import_records(iter(rows))
 
     assert sqlite_db.fetch_one("SELECT COUNT(*) AS cnt FROM HYOSU")["cnt"] == 2
 

--- a/tests/test_expanded_record_storage.py
+++ b/tests/test_expanded_record_storage.py
@@ -1114,6 +1114,50 @@ def test_h6_empty_full_record_retains_physical_totals_on_header():
 
 
 @pytest.mark.parametrize("importer_class", (DataImporter, OptimizedDataImporter))
+def test_sqlite_standard_vote_refund_arrays_keep_blank_positions(
+    sqlite_db, importer_class
+):
+    _create_jravan_tables(
+        sqlite_db, (*_STANDARD_H1_TABLES, *_STANDARD_H6_TABLES)
+    )
+    h1_raw = bytearray(_make_h1_vote_record(populated=False))
+    h1_raw[39:67] = b" 1" + (b" " * 26)
+    h1_raw[67:75] = b" 1" + (b" " * 6)
+    h1_raw[75:83] = b"  1" + (b" " * 5)
+    h1_raw[28799 + (7 * 11) : 28799 + (8 * 11)] = b" " * 11
+    h6_raw = bytearray(_make_h6_vote_record(populated=False))
+    h6_raw[32:50] = b"  1" + (b" " * 15)
+    h1_rows = _flatten(H1Parser().parse(bytes(h1_raw)))
+    h6_rows = _flatten(H6Parser().parse(bytes(h6_raw)))
+
+    assert len(h1_rows[0]["HenkanUma"]) == 28
+    assert len(h1_rows[0]["HenkanWaku"]) == 8
+    assert len(h1_rows[0]["HenkanDoWaku"]) == 8
+    assert len(h6_rows[0]["HenkanUma"]) == 18
+    importer = importer_class(sqlite_db, use_jravan_schema=True)
+    assert importer.import_records(iter(h1_rows))["records_failed"] == 0
+    assert importer.import_records(iter(h6_rows))["records_failed"] == 0
+
+    assert sqlite_db.fetch_one(
+        "SELECT HenkanUma1 AS uma1, HenkanUma2 AS uma2, "
+        "HenkanWaku1 AS waku1, HenkanWaku2 AS waku2, "
+        "HenkanDoWaku2 AS dowaku2, HenkanDoWaku3 AS dowaku3, "
+        "HyoTotal8 AS refund_total FROM HYOSU"
+    ) == {
+        "uma1": None,
+        "uma2": "1",
+        "waku1": None,
+        "waku2": "1",
+        "dowaku2": None,
+        "dowaku3": "1",
+        "refund_total": None,
+    }
+    assert sqlite_db.fetch_one(
+        "SELECT HenkanUma2 AS uma2, HenkanUma3 AS uma3 FROM HYOSU2"
+    ) == {"uma2": None, "uma3": "1"}
+
+
+@pytest.mark.parametrize("importer_class", (DataImporter, OptimizedDataImporter))
 def test_sqlite_standard_vote_flat_compatibility_layouts(
     sqlite_db, importer_class
 ):

--- a/tests/test_expanded_record_storage.py
+++ b/tests/test_expanded_record_storage.py
@@ -17,6 +17,8 @@ from src.importer import importer as importer_module
 from src.importer.importer import DataImporter, ImporterError
 from src.importer.importer_optimized import OptimizedDataImporter
 from src.parser.av_parser import AVParser
+from src.parser.h1_parser import H1Parser
+from src.parser.h6_parser import H6Parser
 from src.parser.o1_parser import O1Parser
 from src.parser.o2_parser import O2Parser
 from src.realtime.updater import RealtimeUpdater
@@ -65,6 +67,143 @@ def _make_empty_o2_record() -> bytes:
     raw = _odds_header("O2") + b"7" + b"0" * (153 * 13) + b"00000000999\r\n"
     assert len(raw) == O2Parser.RECORD_LENGTH
     return raw
+
+
+def _make_h1_vote_record(
+    *,
+    data_kubun: str = "4",
+    populated: bool = True,
+    total_start: int = 1000,
+) -> bytes:
+    data = bytearray(b" " * H1Parser.RECORD_LENGTH)
+    data[0:2] = b"H1"
+    data[2:3] = data_kubun.encode("ascii")
+    data[3:11] = b"20260419"
+    data[11:15] = b"2026"
+    data[15:19] = b"0419"
+    data[19:21] = b"06"
+    data[21:23] = b"03"
+    data[23:25] = b"08"
+    data[25:27] = b"11"
+    data[27:29] = b"18"
+    data[29:31] = b"18"
+    data[31:38] = b"7777777" if populated else b"0000000"
+    data[38:39] = b"3"
+    data[39:67] = b"10" + (b"0" * 26)
+    data[67:75] = b"01000000"
+    data[75:83] = b"00100000"
+    if populated:
+        entries = (
+            (83, b"01", b"00000000101", b"01"),
+            (503, b"01", b"00000000202", b"02"),
+            (923, b"12", b"00000000303", b"03"),
+            (1463, b"0102", b"00000000404", b"004"),
+            (4217, b"0102", b"00000000505", b"005"),
+            (6971, b"0102", b"00000000606", b"006"),
+            (12479, b"010203", b"00000000707", b"007"),
+        )
+        for offset, kumi, hyo, ninki in entries:
+            data[offset : offset + len(kumi)] = kumi
+            data[offset + len(kumi) : offset + len(kumi) + 11] = hyo
+            data[
+                offset + len(kumi) + 11 : offset + len(kumi) + 11 + len(ninki)
+            ] = ninki
+    for index in range(14):
+        data[28799 + index * 11 : 28810 + index * 11] = (
+            f"{total_start + index:011d}".encode("ascii")
+        )
+    data[-2:] = b"\r\n"
+    return bytes(data)
+
+
+def _make_h6_vote_record(
+    *,
+    data_kubun: str = "4",
+    populated: bool = True,
+    child_hyo: str = "00000000808",
+    total_hyo: str = "00000008000",
+    refund_hyo: str = "00000000008",
+) -> bytes:
+    data = bytearray(b" " * H6Parser.RECORD_LENGTH)
+    data[0:2] = b"H6"
+    data[2:3] = data_kubun.encode("ascii")
+    data[3:11] = b"20260419"
+    data[11:15] = b"2026"
+    data[15:19] = b"0419"
+    data[19:21] = b"06"
+    data[21:23] = b"03"
+    data[23:25] = b"08"
+    data[25:27] = b"11"
+    data[27:29] = b"18"
+    data[29:31] = b"18"
+    data[31:32] = b"7" if populated else b"0"
+    data[32:50] = b"100000000000000001"
+    if populated:
+        data[50:56] = b"010203"
+        data[56:67] = child_hyo.encode("ascii")
+        data[67:71] = b"0008"
+    data[102866:102877] = total_hyo.encode("ascii")
+    data[102877:102888] = refund_hyo.encode("ascii")
+    data[-2:] = b"\r\n"
+    return bytes(data)
+
+
+def _make_h1_vote_flat_record() -> bytes:
+    data = bytearray(b" " * H1Parser.RECORD_LENGTH_FLAT)
+    data[0:2] = b"H1"
+    data[2:3] = b"4"
+    data[3:11] = b"20260419"
+    data[11:15] = b"2026"
+    data[15:19] = b"0419"
+    data[19:21] = b"06"
+    data[21:23] = b"03"
+    data[23:25] = b"08"
+    data[25:27] = b"11"
+    data[27:29] = b"18"
+    data[29:31] = b"18"
+    data[31:38] = b"7777777"
+    data[38:39] = b"3"
+    data[39:42] = b"101"
+    fields = (
+        (42, "01", 2), (44, "00000000101", 11), (55, "01", 2),
+        (57, "01", 2), (59, "00000000202", 11), (70, "02", 2),
+        (72, "12", 2), (74, "00000000303", 11), (85, "03", 2),
+        (87, "0102", 4), (91, "00000000404", 11), (102, "004", 3),
+        (105, "0102", 4), (109, "00000000505", 11), (120, "005", 3),
+        (123, "0102", 4), (127, "00000000606", 11), (138, "006", 3),
+        (141, "010203", 6), (147, "00000000707", 11), (158, "007", 3),
+    )
+    for offset, value, length in fields:
+        data[offset : offset + length] = _pad(value, length)
+    for index in range(14):
+        offset = 161 + index * 11
+        data[offset : offset + 11] = f"{1000 + index:011d}".encode("ascii")
+    data[-2:] = b"\r\n"
+    return bytes(data)
+
+
+def _make_h6_vote_flat_record() -> bytes:
+    data = bytearray(b" " * H6Parser.RECORD_LENGTH_FLAT)
+    data[0:2] = b"H6"
+    data[2:3] = b"4"
+    data[3:11] = b"20260419"
+    data[11:15] = b"2026"
+    data[15:19] = b"0419"
+    data[19:21] = b"06"
+    data[21:23] = b"03"
+    data[23:25] = b"08"
+    data[25:27] = b"11"
+    data[27:29] = b"18"
+    data[29:31] = b"18"
+    data[31:32] = b"7"
+    data[32:33] = b"1"
+    data[33:39] = b"010203"
+    data[39:50] = b"00000000808"
+    data[50:54] = b"0008"
+    data[54:65] = b"00000008000"
+    data[65:76] = b"00000000008"
+    data[-2:] = b"\r\n"
+    return bytes(data)
 
 
 def _make_av_record(data_kubun: str = "1") -> bytes:
@@ -787,6 +926,339 @@ def test_sqlite_standard_odds_child_failure_rolls_back_header(
     assert sqlite_db.fetch_all(
         "SELECT Kumi AS kumi FROM ODDS_UMAREN"
     ) == [{"kumi": "0102"}]
+
+
+_STANDARD_H1_TABLES = (
+    "HYOSU",
+    "HYOSU_TANPUKU",
+    "HYOSU_WAKU",
+    "HYOSU_UMARENWIDE",
+    "HYOSU_UMATAN",
+    "HYOSU_SANREN",
+)
+_STANDARD_H6_TABLES = ("HYOSU2", "HYOSU_SANRENTAN")
+
+
+def _assert_standard_h1_replaces_complete_snapshot(db, importer_class):
+    _create_jravan_tables(db, _STANDARD_H1_TABLES)
+    importer = importer_class(db, use_jravan_schema=True, batch_size=1)
+    populated = _flatten(H1Parser().parse(_make_h1_vote_record()))
+
+    stats = importer.import_records(iter(populated))
+
+    assert stats["records_failed"] == 0
+    assert db.fetch_one(
+        "SELECT DataKubun AS status, HenkanUma1 AS henkan_uma1, "
+        "HenkanWaku2 AS henkan_waku2, HenkanDoWaku3 AS henkan_dowaku3, "
+        "HyoTotal1 AS total1, HyoTotal14 AS total14 FROM HYOSU"
+    ) == {
+        "status": "4",
+        "henkan_uma1": "1",
+        "henkan_waku2": "1",
+        "henkan_dowaku3": "1",
+        "total1": "00000001000",
+        "total14": "00000001013",
+    }
+    assert db.fetch_one(
+        "SELECT Umaban AS umaban, TanHyo AS tan_hyo, TanNinki AS tan_ninki, "
+        "FukuHyo AS fuku_hyo, FukuNinki AS fuku_ninki FROM HYOSU_TANPUKU"
+    ) == {
+        "umaban": 1,
+        "tan_hyo": "00000000101",
+        "tan_ninki": "01",
+        "fuku_hyo": "00000000202",
+        "fuku_ninki": "02",
+    }
+    assert db.fetch_one(
+        "SELECT Kumi AS kumi, UmarenHyo AS umaren_hyo, "
+        "WideHyo AS wide_hyo FROM HYOSU_UMARENWIDE"
+    ) == {
+        "kumi": "0102",
+        "umaren_hyo": "00000000404",
+        "wide_hyo": "00000000505",
+    }
+    for table_name in _STANDARD_H1_TABLES[1:]:
+        assert db.fetch_one(f"SELECT COUNT(*) AS cnt FROM {table_name}")["cnt"] == 1
+
+    empty = _flatten(
+        H1Parser().parse(
+            _make_h1_vote_record(
+                data_kubun="5",
+                populated=False,
+                total_start=9000,
+            )
+        )
+    )
+    assert importer.import_records(iter(empty))["records_failed"] == 0
+    assert db.fetch_one(
+        "SELECT DataKubun AS status, HatubaiFlag1 AS flag, "
+        "HyoTotal1 AS total1 FROM HYOSU"
+    ) == {"status": "5", "flag": "0", "total1": "00000009000"}
+    for table_name in _STANDARD_H1_TABLES[1:]:
+        assert db.fetch_one(f"SELECT COUNT(*) AS cnt FROM {table_name}")["cnt"] == 0
+
+    # The inverse 0-to-7 release-flag transition must recreate children even
+    # though the header already exists.
+    assert importer.import_records(iter(populated))["records_failed"] == 0
+    for table_name in _STANDARD_H1_TABLES[1:]:
+        assert db.fetch_one(f"SELECT COUNT(*) AS cnt FROM {table_name}")["cnt"] == 1
+
+    erase = _flatten(
+        H1Parser().parse(
+            _make_h1_vote_record(data_kubun="0", populated=False)
+        )
+    )
+    assert importer.import_records(iter(erase))["records_failed"] == 0
+    for table_name in _STANDARD_H1_TABLES:
+        assert db.fetch_one(f"SELECT COUNT(*) AS cnt FROM {table_name}")["cnt"] == 0
+
+
+def _assert_standard_h6_replaces_complete_snapshot(db, importer_class):
+    _create_jravan_tables(db, _STANDARD_H6_TABLES)
+    importer = importer_class(db, use_jravan_schema=True, batch_size=1)
+    populated = _flatten(H6Parser().parse(_make_h6_vote_record()))
+
+    stats = importer.import_records(iter(populated))
+
+    assert stats["records_failed"] == 0
+    assert db.fetch_one(
+        "SELECT DataKubun AS status, HatubaiFlag1 AS flag, "
+        "HenkanUma1 AS henkan_uma1, HenkanUma18 AS henkan_uma18, "
+        "HyoTotal1 AS total1, HyoTotal2 AS total2 FROM HYOSU2"
+    ) == {
+        "status": "4",
+        "flag": "7",
+        "henkan_uma1": "1",
+        "henkan_uma18": "1",
+        "total1": "00000008000",
+        "total2": "00000000008",
+    }
+    assert db.fetch_one(
+        "SELECT Kumi AS kumi, Hyo AS hyo, Ninki AS ninki "
+        "FROM HYOSU_SANRENTAN"
+    ) == {"kumi": "010203", "hyo": "00000000808", "ninki": 8}
+
+    empty = _flatten(
+        H6Parser().parse(
+            _make_h6_vote_record(
+                data_kubun="5",
+                populated=False,
+                total_hyo="00000009000",
+                refund_hyo="00000000009",
+            )
+        )
+    )
+    assert importer.import_records(iter(empty))["records_failed"] == 0
+    assert db.fetch_one(
+        "SELECT DataKubun AS status, HatubaiFlag1 AS flag, "
+        "HyoTotal1 AS total1, HyoTotal2 AS total2 FROM HYOSU2"
+    ) == {
+        "status": "5",
+        "flag": "0",
+        "total1": "00000009000",
+        "total2": "00000000009",
+    }
+    assert db.fetch_one("SELECT COUNT(*) AS cnt FROM HYOSU_SANRENTAN")["cnt"] == 0
+
+    assert importer.import_records(iter(populated))["records_failed"] == 0
+    assert db.fetch_one("SELECT COUNT(*) AS cnt FROM HYOSU_SANRENTAN")["cnt"] == 1
+
+    erase = _flatten(
+        H6Parser().parse(
+            _make_h6_vote_record(data_kubun="0", populated=False)
+        )
+    )
+    assert importer.import_records(iter(erase))["records_failed"] == 0
+    for table_name in _STANDARD_H6_TABLES:
+        assert db.fetch_one(f"SELECT COUNT(*) AS cnt FROM {table_name}")["cnt"] == 0
+
+
+@pytest.mark.parametrize("importer_class", (DataImporter, OptimizedDataImporter))
+def test_sqlite_standard_h1_replaces_complete_snapshot(sqlite_db, importer_class):
+    _assert_standard_h1_replaces_complete_snapshot(sqlite_db, importer_class)
+
+
+@pytest.mark.parametrize("importer_class", (DataImporter, OptimizedDataImporter))
+def test_postgresql_standard_h1_replaces_complete_snapshot(
+    postgresql_db, importer_class
+):
+    _assert_standard_h1_replaces_complete_snapshot(postgresql_db, importer_class)
+
+
+@pytest.mark.parametrize("importer_class", (DataImporter, OptimizedDataImporter))
+def test_sqlite_standard_h6_replaces_complete_snapshot(sqlite_db, importer_class):
+    _assert_standard_h6_replaces_complete_snapshot(sqlite_db, importer_class)
+
+
+@pytest.mark.parametrize("importer_class", (DataImporter, OptimizedDataImporter))
+def test_postgresql_standard_h6_replaces_complete_snapshot(
+    postgresql_db, importer_class
+):
+    _assert_standard_h6_replaces_complete_snapshot(postgresql_db, importer_class)
+
+
+def test_h6_empty_full_record_retains_physical_totals_on_header():
+    rows = _flatten(
+        H6Parser().parse(
+            _make_h6_vote_record(
+                populated=False,
+                total_hyo="00000009000",
+                refund_hyo="00000000009",
+            )
+        )
+    )
+
+    assert len(rows) == 1
+    assert rows[0]["SanrentanHyoTotal"] == "00000009000"
+    assert rows[0]["SanrentanHenkanHyoTotal"] == "00000000009"
+
+
+@pytest.mark.parametrize("importer_class", (DataImporter, OptimizedDataImporter))
+def test_sqlite_standard_vote_flat_compatibility_layouts(
+    sqlite_db, importer_class
+):
+    _create_jravan_tables(
+        sqlite_db, (*_STANDARD_H1_TABLES, *_STANDARD_H6_TABLES)
+    )
+    importer = importer_class(sqlite_db, use_jravan_schema=True, batch_size=1)
+
+    h1 = H1Parser().parse(_make_h1_vote_flat_record())
+    h6 = H6Parser().parse(_make_h6_vote_flat_record())
+    assert importer.import_records(iter([h1]))["records_failed"] == 0
+    assert importer.import_records(iter([h6]))["records_failed"] == 0
+
+    assert sqlite_db.fetch_one(
+        "SELECT HyoTotal1 AS total1, HyoTotal14 AS total14 FROM HYOSU"
+    ) == {"total1": "00000001000", "total14": "00000001013"}
+    assert sqlite_db.fetch_one(
+        "SELECT TanHyo AS tan_hyo, FukuHyo AS fuku_hyo FROM HYOSU_TANPUKU"
+    ) == {"tan_hyo": "00000000101", "fuku_hyo": "00000000202"}
+    assert sqlite_db.fetch_one(
+        "SELECT UmarenHyo AS umaren_hyo, WideHyo AS wide_hyo "
+        "FROM HYOSU_UMARENWIDE"
+    ) == {"umaren_hyo": "00000000404", "wide_hyo": "00000000505"}
+    assert sqlite_db.fetch_one(
+        "SELECT HyoTotal1 AS total1, HyoTotal2 AS total2 FROM HYOSU2"
+    ) == {"total1": "00000008000", "total2": "00000000008"}
+    assert sqlite_db.fetch_one(
+        "SELECT Kumi AS kumi, Hyo AS hyo FROM HYOSU_SANRENTAN"
+    ) == {"kumi": "010203", "hyo": "00000000808"}
+
+
+@pytest.mark.parametrize("importer_class", (DataImporter, OptimizedDataImporter))
+def test_sqlite_standard_vote_verification_is_reused(
+    sqlite_db, importer_class, monkeypatch
+):
+    _create_jravan_tables(sqlite_db, _STANDARD_H6_TABLES)
+    verification_calls = 0
+    original_verify = importer_module.verify_standard_vote_tables
+
+    def counted_verify(*args, **kwargs):
+        nonlocal verification_calls
+        verification_calls += 1
+        return original_verify(*args, **kwargs)
+
+    monkeypatch.setattr(importer_module, "verify_standard_vote_tables", counted_verify)
+    importer = importer_class(sqlite_db, use_jravan_schema=True)
+    first = _flatten(H6Parser().parse(_make_h6_vote_record()))
+    second = _flatten(
+        H6Parser().parse(
+            _make_h6_vote_record(data_kubun="5", child_hyo="00000000909")
+        )
+    )
+
+    assert importer.import_records(iter(first))["records_failed"] == 0
+    assert importer.import_records(iter(second))["records_failed"] == 0
+    assert verification_calls == 1
+
+
+def _assert_standard_h6_migrates_existing_child_columns(db, importer_class):
+    _create_jravan_tables(db, ["HYOSU2"])
+    db.execute(
+        "CREATE TABLE HYOSU_SANRENTAN ("
+        "MakeDate DATE, Year SMALLINT, MonthDay SMALLINT, JyoCD CHAR(2), "
+        "Kaiji SMALLINT, Nichiji SMALLINT, RaceNum SMALLINT, "
+        "Kumi VARCHAR(6), Hyo VARCHAR(11))"
+    )
+    db.commit()
+    rows = _flatten(H6Parser().parse(_make_h6_vote_record()))
+
+    stats = importer_class(db, use_jravan_schema=True).import_records(iter(rows))
+
+    assert stats["records_failed"] == 0
+    assert db.fetch_one(
+        "SELECT Ninki AS ninki FROM HYOSU_SANRENTAN"
+    ) == {"ninki": 8}
+
+
+@pytest.mark.parametrize("importer_class", (DataImporter, OptimizedDataImporter))
+def test_sqlite_standard_h6_migrates_existing_child_columns(
+    sqlite_db, importer_class
+):
+    _assert_standard_h6_migrates_existing_child_columns(sqlite_db, importer_class)
+
+
+@pytest.mark.parametrize("importer_class", (DataImporter, OptimizedDataImporter))
+def test_postgresql_standard_h6_migrates_existing_child_columns(
+    postgresql_db, importer_class
+):
+    _assert_standard_h6_migrates_existing_child_columns(
+        postgresql_db, importer_class
+    )
+
+
+def test_sqlite_standard_h1_duplicate_header_keys_fail_closed(sqlite_db):
+    _create_jravan_tables(sqlite_db, _STANDARD_H1_TABLES)
+    duplicate_key = (2026, 419, "06", 3, 8, 11)
+    for status in ("2", "4"):
+        sqlite_db.execute(
+            "INSERT INTO HYOSU "
+            "(DataKubun, Year, MonthDay, JyoCD, Kaiji, Nichiji, RaceNum) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?)",
+            (status, *duplicate_key),
+        )
+    sqlite_db.commit()
+    rows = _flatten(H1Parser().parse(_make_h1_vote_record()))
+
+    with pytest.raises(SchemaMigrationError, match="duplicate official keys"):
+        DataImporter(sqlite_db, use_jravan_schema=True).import_records(iter(rows))
+
+    assert sqlite_db.fetch_one("SELECT COUNT(*) AS cnt FROM HYOSU")["cnt"] == 2
+
+
+@pytest.mark.parametrize("importer_class", (DataImporter, OptimizedDataImporter))
+def test_sqlite_standard_h6_child_failure_restores_previous_snapshot(
+    sqlite_db, importer_class
+):
+    _create_jravan_tables(sqlite_db, _STANDARD_H6_TABLES)
+    importer = importer_class(sqlite_db, use_jravan_schema=True)
+    original = _flatten(H6Parser().parse(_make_h6_vote_record()))
+    assert importer.import_records(iter(original))["records_failed"] == 0
+    sqlite_db.execute(
+        "CREATE TRIGGER reject_standard_h6_child "
+        "BEFORE INSERT ON HYOSU_SANRENTAN "
+        "BEGIN SELECT RAISE(ABORT, 'child rejected'); END"
+    )
+    sqlite_db.commit()
+    replacement = _flatten(
+        H6Parser().parse(
+            _make_h6_vote_record(
+                data_kubun="9",
+                child_hyo="00000000999",
+                total_hyo="00000009999",
+            )
+        )
+    )
+
+    with pytest.raises(ImporterError, match="child rejected"):
+        importer.import_records(iter(replacement))
+
+    assert sqlite_db.fetch_one(
+        "SELECT DataKubun AS status, HyoTotal1 AS total1 FROM HYOSU2"
+    ) == {"status": "4", "total1": "00000008000"}
+    assert sqlite_db.fetch_one(
+        "SELECT Hyo AS hyo FROM HYOSU_SANRENTAN"
+    ) == {"hyo": "00000000808"}
 
 
 def test_sqlite_importer_stores_official_av_record(sqlite_db):

--- a/tests/test_table_mappings.py
+++ b/tests/test_table_mappings.py
@@ -41,5 +41,20 @@ def test_training_sale_odds_and_vote_mappings():
 
     assert RECORD_TYPE_TO_TABLE["H1"] == "NL_H1"
     assert RECORD_TYPE_TO_TABLE["H6"] == "NL_H6"
+    for standard_name in (
+        "HYOSU",
+        "HYOSU_TANPUKU",
+        "HYOSU_WAKU",
+        "HYOSU_UMARENWIDE",
+        "HYOSU_UMATAN",
+        "HYOSU_SANREN",
+    ):
+        assert JRAVAN_TO_JLTSQL[standard_name] == "NL_H1"
+    for standard_name in ("HYOSU2", "HYOSU_SANRENTAN"):
+        assert JRAVAN_TO_JLTSQL[standard_name] == "NL_H6"
     assert JRAVAN_TO_JLTSQL["HYO_TANPUKU"] == "NL_H1"
     assert JRAVAN_TO_JLTSQL["HYO_SANRENTAN"] == "NL_H6"
+    assert JLTSQL_TO_JRAVAN["NL_H1"] == "HYO_TANPUKU"
+    assert JLTSQL_TO_JRAVAN["NL_H6"] == "HYO_SANRENTAN"
+    assert STANDARD_EXPANDED_RECORD_OWNER["NL_H1"] == "HYOSU"
+    assert STANDARD_EXPANDED_RECORD_OWNER["NL_H6"] == "HYOSU2"


### PR DESCRIPTION
## Summary

- make the standard-schema importers store H1/H6 vote snapshots in their physical parent and child tables
- replace each complete child snapshot atomically, retain cancellation snapshots, and erase the snapshot for physical-delete records
- fail closed when existing duplicate official keys prevent creation of the required unique indexes
- preserve fixed-position refund/release flags, including blank nullable positions
- keep the existing compact flat-input compatibility path

## Specification basis

The implementation was checked against the current and immediately prior public JV-Data specifications. The H1/H6 layouts are unchanged across those versions. It also accounts for the public developer-forum correction concerning child-row handling: the complete valid child set is authoritative for a snapshot, instead of treating release flags as row-deletion instructions.

The worklog records the specification/version comparison, compatibility decisions, and test evidence without publishing private runtime details.

## Red-first evidence

Before the implementation repair, the new contract tests produced:

- 8 failures, 4 skips, 45 deselections
- missing standard-table routing for legacy public aliases
- lost H6 totals when the child set was empty
- no duplicate-key migration gate
- rollback behavior could not reach the required replacement path

A later positional-flag regression test was also confirmed red before the parser repair:

- 2 failures
- expected 28 positional H1 flags but received 1

## Validation

Final PR head: `f7c4155a63845fea256d56f9202813246dacbe69`  
Source candidate: `bcb91bf51d96e0b8b1f515910f748cb9f7716832`

On the source candidate:

- affected Python 3.12 suite: 796 passed, 22 skipped, 12 subtests
- workflow-equivalent test selection: 893 passed, 2 skipped, 12 subtests
- expanded storage/mapping/parser suite: 257 passed, 20 skipped
- fresh disposable PostgreSQL 16 integration: 67 passed
- blocking flake8 rules (E9/F63/F7/F82): 0 findings
- distribution build and content check: passed; `specs/` is not included
- registered-data replay: H1 1,501 rows and H6 4,896 rows, for both importers; cancellation retention and physical deletion both verified

After the evidence-only documentation commit, the exact final PR head passed the minimum focused suite:

- 17 passed, 6 skipped
- clean worktree

The registered-data replay supports the storage contract but is not being treated as the final release acquisition gate. A new provider acquisition using the released-code candidate remains mandatory before release.

## Release

No release is performed by this PR. Release-readiness, documentation/privacy audit, distribution audit, and new acquisition validation will be handled in the subsequent release iteration.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for importing and storing H1/H6 vote-count records in standard and compatible layouts.
  * Added handling for vote-record updates, replacements, deletions, and batch processing.
  * Preserved blank positional values when parsing vote data.
* **Bug Fixes**
  * Corrected duplicated total fields in H6 combination records.
  * Improved transactional safety so failed child-record updates roll back cleanly.
  * Added duplicate-key validation and compatibility with existing flat layouts.
* **Tests**
  * Expanded coverage across SQLite and PostgreSQL for parsing, migration, replacement, deletion, rollback, and compatibility scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->