### PR TITLE
test: add official JV-Data layout oracle

### DIFF
--- a/scripts/official_jvdata_oracle.py
+++ b/scripts/official_jvdata_oracle.py
@@ -293,9 +293,17 @@ def _validate_manifest(manifest: Any) -> list[str]:
     source = manifest.get("source")
     if not isinstance(source, dict) or not SHA256_PATTERN.fullmatch(str(source.get("sha256", ""))):
         errors.append("source:invalid-sha256")
-    if not isinstance(source, dict) or not str(source.get("artifact", "")).strip():
+    if (
+        not isinstance(source, dict)
+        or not isinstance(source.get("artifact"), str)
+        or not source["artifact"].strip()
+    ):
         errors.append("source:artifact-missing")
-    if not isinstance(source, dict) or not str(source.get("jvdata_version", "")).strip():
+    if (
+        not isinstance(source, dict)
+        or not isinstance(source.get("jvdata_version"), str)
+        or not source["jvdata_version"].strip()
+    ):
         errors.append("source:jvdata-version-missing")
 
     structures = manifest.get("structures")
@@ -307,6 +315,10 @@ def _validate_manifest(manifest: Any) -> list[str]:
         return errors + ["root-records:not-an-object"]
     if not isinstance(summary, dict):
         return errors + ["summary:not-an-object"]
+    if not structures:
+        errors.append("structures:empty")
+    if not root_records:
+        errors.append("root-records:empty")
 
     calculated_repeat_count = 0
     for structure_name, structure in structures.items():
@@ -328,9 +340,14 @@ def _validate_manifest(manifest: Any) -> list[str]:
             if not isinstance(field, dict):
                 errors.append(f"{structure_name}:invalid-field")
                 continue
-            field_name = str(field.get("name", ""))
+            raw_field_name = field.get("name")
+            field_name = str(raw_field_name)
             prefix = f"{structure_name}.{field_name}"
-            if not field_name or field_name in names:
+            if (
+                not isinstance(raw_field_name, str)
+                or not raw_field_name.strip()
+                or field_name in names
+            ):
                 errors.append(f"{structure_name}:invalid-or-duplicate-field:{field_name}")
             names.add(field_name)
             kind = field.get("kind")
@@ -360,11 +377,25 @@ def _validate_manifest(manifest: Any) -> list[str]:
                     errors.append(f"{prefix}:invalid-element-kind")
                     continue
                 end = start + stride * (count - 1) + field_width - 1
-                target = field.get("struct") if element_kind == "nested" else None
+                if element_kind == "scalar":
+                    target = None
+                    if field.get("decoder") not in {"text", "bytes"}:
+                        errors.append(f"{prefix}:invalid-decoder")
+                else:
+                    target = field.get("struct")
             else:
                 end = start + field_width - 1
-                target = field.get("struct") if kind == "nested" else None
+                if kind == "scalar":
+                    target = None
+                    if field.get("decoder") not in {"text", "bytes"}:
+                        errors.append(f"{prefix}:invalid-decoder")
+                else:
+                    target = field.get("struct")
 
+            if kind == "nested" or (kind == "repeat" and field.get("element_kind") == "nested"):
+                if not isinstance(target, str) or not target.strip():
+                    errors.append(f"{prefix}:struct-missing")
+                    target = None
             if target is not None:
                 if target not in structures:
                     errors.append(f"{prefix}:unknown-struct:{target}")
@@ -437,7 +468,10 @@ def _validate_manifest(manifest: Any) -> list[str]:
     root_leaf_count = 0
     for record_type, contract in root_records.items():
         prefix = f"root:{record_type}"
-        if not isinstance(record_type, str) or not re.fullmatch(r"[A-Z0-9]{2}", record_type):
+        valid_record_type = isinstance(record_type, str) and bool(
+            re.fullmatch(r"[A-Z0-9]{2}", record_type)
+        )
+        if not valid_record_type:
             errors.append(f"{prefix}:invalid-record-type")
         if not isinstance(contract, dict):
             errors.append(f"{prefix}:invalid-contract")
@@ -446,6 +480,16 @@ def _validate_manifest(manifest: Any) -> list[str]:
         if structure_name not in structures:
             errors.append(f"{prefix}:unknown-struct:{structure_name}")
             continue
+        if valid_record_type and not structure_name.startswith(f"JV_{record_type}_"):
+            errors.append(f"{prefix}:structure-name-mismatch:{structure_name}")
+        root_fields = structures[structure_name].get("fields")
+        if (
+            not isinstance(root_fields, list)
+            or not root_fields
+            or not isinstance(root_fields[0], dict)
+            or root_fields[0].get("name") != "head"
+        ):
+            errors.append(f"{prefix}:head-missing:{structure_name}")
         length = contract.get("length")
         structure_width = structures[structure_name].get("width")
         if not _plain_integer(length) or length != structure_width:

--- a/scripts/official_jvdata_oracle.py
+++ b/scripts/official_jvdata_oracle.py
@@ -1,0 +1,539 @@
+#!/usr/bin/env python3
+"""Generate and validate a compact oracle from the official SDK structure file.
+
+The generated manifest contains layout facts only: structure/field names,
+one-based byte starts, widths, nested structure references, and repeat counts.
+It never copies provider records or the SDK source itself into the repository.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import hashlib
+import json
+import re
+import sys
+from functools import cache
+from pathlib import Path
+from typing import Any
+
+MANIFEST_SCHEMA_VERSION = 1
+SHA256_PATTERN = re.compile(r"^[0-9a-f]{64}$")
+
+
+class OracleExtractionError(ValueError):
+    """Raised when an SDK structure expression is outside the reviewed grammar."""
+
+
+def _integer(expression: ast.expr, environment: dict[str, int] | None = None) -> int:
+    environment = environment or {}
+    if isinstance(expression, ast.Constant) and isinstance(expression.value, int):
+        return expression.value
+    if isinstance(expression, ast.Name) and expression.id in environment:
+        return environment[expression.id]
+    if isinstance(expression, ast.UnaryOp) and isinstance(expression.op, ast.USub):
+        return -_integer(expression.operand, environment)
+    if isinstance(expression, ast.BinOp):
+        left = _integer(expression.left, environment)
+        right = _integer(expression.right, environment)
+        if isinstance(expression.op, ast.Add):
+            return left + right
+        if isinstance(expression.op, ast.Sub):
+            return left - right
+        if isinstance(expression.op, ast.Mult):
+            return left * right
+    raise OracleExtractionError(f"unsupported integer expression: {ast.unparse(expression)}")
+
+
+def _slice_call(
+    expression: ast.expr,
+    *,
+    loop_variable: str | None = None,
+) -> dict[str, Any]:
+    environment_zero = {loop_variable: 0} if loop_variable else {}
+    environment_one = {loop_variable: 1} if loop_variable else {}
+
+    if (
+        isinstance(expression, ast.Call)
+        and isinstance(expression.func, ast.Name)
+        and expression.func.id in {"MidB2S", "MidB2B"}
+        and len(expression.args) == 3
+    ):
+        start_expression = expression.args[1]
+        result = {
+            "kind": "scalar",
+            "start": _integer(start_expression, environment_zero),
+            "width": _integer(expression.args[2], environment_zero),
+            "decoder": "text" if expression.func.id == "MidB2S" else "bytes",
+        }
+    elif (
+        isinstance(expression, ast.Call)
+        and isinstance(expression.func, ast.Attribute)
+        and expression.func.attr == "SetDataB"
+        and isinstance(expression.func.value, ast.Name)
+        and len(expression.args) == 1
+    ):
+        inner = expression.args[0]
+        if not (
+            isinstance(inner, ast.Call)
+            and isinstance(inner.func, ast.Name)
+            and inner.func.id == "MidB2B"
+            and len(inner.args) == 3
+        ):
+            raise OracleExtractionError(
+                f"nested structure without MidB2B: {ast.unparse(expression)}"
+            )
+        start_expression = inner.args[1]
+        result = {
+            "kind": "nested",
+            "start": _integer(start_expression, environment_zero),
+            "width": _integer(inner.args[2], environment_zero),
+            "struct": expression.func.value.id,
+        }
+    else:
+        raise OracleExtractionError(f"unsupported field expression: {ast.unparse(expression)}")
+
+    if loop_variable:
+        result["stride"] = _integer(start_expression, environment_one) - _integer(
+            start_expression, environment_zero
+        )
+    return result
+
+
+def _field(expression: ast.expr, name: str) -> dict[str, Any]:
+    if not isinstance(expression, ast.ListComp):
+        return {"name": name, **_slice_call(expression)}
+
+    if len(expression.generators) != 1:
+        raise OracleExtractionError(f"repeat must have one generator: {name}")
+    generator = expression.generators[0]
+    if generator.ifs or generator.is_async or not isinstance(generator.target, ast.Name):
+        raise OracleExtractionError(f"unsupported repeat generator: {name}")
+    iterator = generator.iter
+    if not (
+        isinstance(iterator, ast.Call)
+        and isinstance(iterator.func, ast.Name)
+        and iterator.func.id == "range"
+        and len(iterator.args) == 1
+    ):
+        raise OracleExtractionError(f"repeat must use range(count): {name}")
+
+    element = _slice_call(expression.elt, loop_variable=generator.target.id)
+    result: dict[str, Any] = {
+        "name": name,
+        "kind": "repeat",
+        "start": element["start"],
+        "width": element["width"],
+        "stride": element.pop("stride"),
+        "count": _integer(iterator.args[0]),
+        "element_kind": element.pop("kind"),
+    }
+    result.update({key: value for key, value in element.items() if key not in {"start", "width"}})
+    return result
+
+
+def _set_data_return(class_node: ast.ClassDef) -> ast.Call:
+    method = next(
+        (
+            node
+            for node in class_node.body
+            if isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef) and node.name == "SetDataB"
+        ),
+        None,
+    )
+    if method is None:
+        raise OracleExtractionError(f"{class_node.name}: SetDataB is missing")
+    returns = [node for node in ast.walk(method) if isinstance(node, ast.Return)]
+    if len(returns) != 1:
+        raise OracleExtractionError(f"{class_node.name}: expected one return")
+    value = returns[0].value
+    if not (
+        isinstance(value, ast.Call) and isinstance(value.func, ast.Name) and value.func.id == "cls"
+    ):
+        raise OracleExtractionError(f"{class_node.name}: return must construct cls")
+    return value
+
+
+def _field_end(field: dict[str, Any]) -> int:
+    if field["kind"] == "repeat":
+        return field["start"] + field["stride"] * (field["count"] - 1) + field["width"] - 1
+    return field["start"] + field["width"] - 1
+
+
+def _expanded_counts(structures: dict[str, dict[str, Any]]) -> dict[str, int]:
+    visiting: set[str] = set()
+
+    @cache
+    def count(structure_name: str) -> int:
+        if structure_name in visiting:
+            raise OracleExtractionError(f"cyclic structure: {structure_name}")
+        if structure_name not in structures:
+            raise OracleExtractionError(f"unknown structure: {structure_name}")
+        visiting.add(structure_name)
+        total = 0
+        for field in structures[structure_name]["fields"]:
+            if field["kind"] == "scalar":
+                total += 1
+            elif field["kind"] == "nested":
+                total += count(field["struct"])
+            elif field["element_kind"] == "scalar":
+                total += field["count"]
+            else:
+                total += field["count"] * count(field["struct"])
+        visiting.remove(structure_name)
+        return total
+
+    return {name: count(name) for name in structures}
+
+
+def extract_manifest_from_source(
+    source: str,
+    *,
+    artifact: str,
+    jvdata_version: str,
+    source_sha256: str | None = None,
+) -> dict[str, Any]:
+    """Extract the reviewed AST grammar into a compact manifest."""
+
+    tree = ast.parse(source)
+    structures: dict[str, dict[str, Any]] = {}
+    root_records: dict[str, dict[str, Any]] = {}
+
+    for class_node in (node for node in tree.body if isinstance(node, ast.ClassDef)):
+        annotations = [
+            node
+            for node in class_node.body
+            if isinstance(node, ast.AnnAssign) and isinstance(node.target, ast.Name)
+        ]
+        if not annotations:
+            continue
+        constructor = _set_data_return(class_node)
+        if len(annotations) != len(constructor.args):
+            raise OracleExtractionError(
+                f"{class_node.name}: {len(annotations)} fields != {len(constructor.args)} values"
+            )
+        fields = [
+            _field(expression, annotation.target.id)
+            for annotation, expression in zip(annotations, constructor.args, strict=True)
+        ]
+        structures[class_node.name] = {
+            "width": max(_field_end(field) for field in fields),
+            "fields": fields,
+        }
+
+    expanded_counts = _expanded_counts(structures)
+    for name, count in expanded_counts.items():
+        structures[name]["expanded_leaf_count"] = count
+
+    for name, structure in structures.items():
+        fields = structure["fields"]
+        if name.startswith("JV_") and fields and fields[0]["name"] == "head":
+            parts = name.split("_")
+            if len(parts) < 3 or len(parts[1]) != 2:
+                raise OracleExtractionError(f"invalid root structure name: {name}")
+            record_type = parts[1]
+            if record_type in root_records:
+                raise OracleExtractionError(f"duplicate root record: {record_type}")
+            root_records[record_type] = {"struct": name, "length": structure["width"]}
+
+    digest = source_sha256 or hashlib.sha256(source.encode("utf-8")).hexdigest()
+    manifest = {
+        "manifest_schema_version": MANIFEST_SCHEMA_VERSION,
+        "source": {
+            "artifact": artifact,
+            "jvdata_version": jvdata_version,
+            "sha256": digest,
+        },
+        "structures": structures,
+        "root_records": dict(sorted(root_records.items())),
+        "summary": {
+            "structure_count": len(structures),
+            "repeat_template_count": sum(
+                field["kind"] == "repeat"
+                for structure in structures.values()
+                for field in structure["fields"]
+            ),
+            "root_record_count": len(root_records),
+            "expanded_leaf_count": sum(
+                expanded_counts[contract["struct"]] for contract in root_records.values()
+            ),
+        },
+    }
+    errors = validate_manifest(manifest)
+    if errors:
+        raise OracleExtractionError("; ".join(errors))
+    return manifest
+
+
+def _positive_integer(value: Any) -> bool:
+    return isinstance(value, int) and not isinstance(value, bool) and value > 0
+
+
+def _plain_integer(value: Any) -> bool:
+    return isinstance(value, int) and not isinstance(value, bool)
+
+
+def validate_manifest(manifest: Any) -> list[str]:
+    """Return stable errors for an incomplete or internally inconsistent oracle."""
+
+    try:
+        return _validate_manifest(manifest)
+    except Exception as exc:  # A crashed inspection is not a passing inspection.
+        return [f"manifest:unreadable:{type(exc).__name__}"]
+
+
+def _validate_manifest(manifest: Any) -> list[str]:
+    errors: list[str] = []
+    if not isinstance(manifest, dict):
+        return ["manifest:not-an-object"]
+    if manifest.get("manifest_schema_version") != MANIFEST_SCHEMA_VERSION:
+        errors.append("manifest:unsupported-schema-version")
+
+    source = manifest.get("source")
+    if not isinstance(source, dict) or not SHA256_PATTERN.fullmatch(str(source.get("sha256", ""))):
+        errors.append("source:invalid-sha256")
+    if not isinstance(source, dict) or not str(source.get("artifact", "")).strip():
+        errors.append("source:artifact-missing")
+    if not isinstance(source, dict) or not str(source.get("jvdata_version", "")).strip():
+        errors.append("source:jvdata-version-missing")
+
+    structures = manifest.get("structures")
+    root_records = manifest.get("root_records")
+    summary = manifest.get("summary")
+    if not isinstance(structures, dict):
+        return errors + ["structures:not-an-object"]
+    if not isinstance(root_records, dict):
+        return errors + ["root-records:not-an-object"]
+    if not isinstance(summary, dict):
+        return errors + ["summary:not-an-object"]
+
+    calculated_repeat_count = 0
+    for structure_name, structure in structures.items():
+        if not isinstance(structure, dict):
+            errors.append(f"{structure_name}:not-an-object")
+            continue
+        width = structure.get("width")
+        fields = structure.get("fields")
+        if not _positive_integer(width):
+            errors.append(f"{structure_name}:invalid-width")
+            continue
+        if not isinstance(fields, list) or not fields:
+            errors.append(f"{structure_name}:fields-missing")
+            continue
+
+        intervals: list[tuple[int, int]] = []
+        names: set[str] = set()
+        for field in fields:
+            if not isinstance(field, dict):
+                errors.append(f"{structure_name}:invalid-field")
+                continue
+            field_name = str(field.get("name", ""))
+            prefix = f"{structure_name}.{field_name}"
+            if not field_name or field_name in names:
+                errors.append(f"{structure_name}:invalid-or-duplicate-field:{field_name}")
+            names.add(field_name)
+            kind = field.get("kind")
+            start = field.get("start")
+            field_width = field.get("width")
+            if kind not in {"scalar", "nested", "repeat"}:
+                errors.append(f"{prefix}:invalid-kind")
+                continue
+            if not _positive_integer(start) or not _positive_integer(field_width):
+                errors.append(f"{prefix}:invalid-span")
+                continue
+
+            if kind == "repeat":
+                calculated_repeat_count += 1
+                count = field.get("count")
+                stride = field.get("stride")
+                element_kind = field.get("element_kind")
+                if not _positive_integer(count):
+                    errors.append(f"{prefix}:invalid-repeat-count")
+                    continue
+                if not _positive_integer(stride):
+                    errors.append(f"{prefix}:invalid-repeat-stride")
+                    continue
+                if stride != field_width:
+                    errors.append(f"{prefix}:repeat-stride-width-mismatch:{stride}!={field_width}")
+                if element_kind not in {"scalar", "nested"}:
+                    errors.append(f"{prefix}:invalid-element-kind")
+                    continue
+                end = start + stride * (count - 1) + field_width - 1
+                target = field.get("struct") if element_kind == "nested" else None
+            else:
+                end = start + field_width - 1
+                target = field.get("struct") if kind == "nested" else None
+
+            if target is not None:
+                if target not in structures:
+                    errors.append(f"{prefix}:unknown-struct:{target}")
+                else:
+                    target_width = structures[target].get("width")
+                    if field_width != target_width:
+                        errors.append(
+                            f"{prefix}:nested-width-mismatch:{field_width}!={target_width}"
+                        )
+            intervals.append((start, end))
+
+        cursor = 1
+        for start, end in sorted(intervals):
+            if start > cursor:
+                errors.extend(f"{structure_name}:gap:{byte}" for byte in range(cursor, start))
+            elif start < cursor:
+                errors.append(f"{structure_name}:overlap:{start}")
+            cursor = max(cursor, end + 1)
+        if cursor <= width:
+            errors.extend(f"{structure_name}:gap:{byte}" for byte in range(cursor, width + 1))
+        elif cursor - 1 > width:
+            errors.append(f"{structure_name}:extent-exceeds-width:{cursor - 1}>{width}")
+
+    calculated_leaf_counts: dict[str, int] = {}
+    visiting: set[str] = set()
+
+    def leaf_count(structure_name: str) -> int:
+        if structure_name in calculated_leaf_counts:
+            return calculated_leaf_counts[structure_name]
+        if structure_name in visiting or structure_name not in structures:
+            return 0
+        visiting.add(structure_name)
+        total = 0
+        for field in structures[structure_name].get("fields", []):
+            if not isinstance(field, dict):
+                continue
+            if field.get("kind") == "scalar":
+                total += 1
+            elif field.get("kind") == "nested":
+                target = str(field.get("struct", ""))
+                if target in visiting:
+                    errors.append(
+                        f"{structure_name}.{field.get('name', '')}:" f"cyclic-struct:{target}"
+                    )
+                else:
+                    total += leaf_count(target)
+            elif field.get("kind") == "repeat" and _positive_integer(field.get("count")):
+                if field.get("element_kind") == "scalar":
+                    element_count = 1
+                else:
+                    target = str(field.get("struct", ""))
+                    if target in visiting:
+                        errors.append(
+                            f"{structure_name}.{field.get('name', '')}:" f"cyclic-struct:{target}"
+                        )
+                        element_count = 0
+                    else:
+                        element_count = leaf_count(target)
+                total += field["count"] * element_count
+        visiting.remove(structure_name)
+        calculated_leaf_counts[structure_name] = total
+        declared = structures[structure_name].get("expanded_leaf_count")
+        if not _plain_integer(declared) or declared != total:
+            errors.append(f"{structure_name}:expanded-leaf-count:{declared}!={total}")
+        return total
+
+    for structure_name in structures:
+        leaf_count(structure_name)
+
+    root_leaf_count = 0
+    for record_type, contract in root_records.items():
+        prefix = f"root:{record_type}"
+        if not isinstance(record_type, str) or not re.fullmatch(r"[A-Z0-9]{2}", record_type):
+            errors.append(f"{prefix}:invalid-record-type")
+        if not isinstance(contract, dict):
+            errors.append(f"{prefix}:invalid-contract")
+            continue
+        structure_name = contract.get("struct")
+        if structure_name not in structures:
+            errors.append(f"{prefix}:unknown-struct:{structure_name}")
+            continue
+        length = contract.get("length")
+        structure_width = structures[structure_name].get("width")
+        if not _plain_integer(length) or length != structure_width:
+            errors.append(f"{prefix}:length-mismatch:{length}!={structure_width}")
+        root_leaf_count += calculated_leaf_counts.get(structure_name, 0)
+
+    expected_summary = {
+        "structure_count": len(structures),
+        "repeat_template_count": calculated_repeat_count,
+        "root_record_count": len(root_records),
+        "expanded_leaf_count": root_leaf_count,
+    }
+    summary_codes = {
+        "structure_count": "structure-count",
+        "repeat_template_count": "repeat-template-count",
+        "root_record_count": "root-record-count",
+        "expanded_leaf_count": "expanded-leaf-count",
+    }
+    for key, expected in expected_summary.items():
+        actual = summary.get(key)
+        if not _plain_integer(actual) or actual != expected:
+            errors.append(f"summary:{summary_codes[key]}:{actual}!={expected}")
+    return sorted(set(errors))
+
+
+def load_manifest(path: Path) -> dict[str, Any]:
+    """Load a UTF-8 JSON oracle manifest."""
+
+    value = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(value, dict):
+        raise ValueError("manifest root must be an object")
+    return value
+
+
+def _write_manifest(path: Path, manifest: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(manifest, ensure_ascii=False, indent=2) + "\n",
+        encoding="utf-8",
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    generate = subparsers.add_parser("generate")
+    generate.add_argument("--source", type=Path, required=True)
+    generate.add_argument("--output", type=Path, required=True)
+    generate.add_argument(
+        "--artifact",
+        default="JRA-VAN Data Lab SDK 5.0.0 Python JV-Data structures",
+    )
+    generate.add_argument("--jvdata-version", default="4.9.0.1")
+    validate = subparsers.add_parser("validate")
+    validate.add_argument("--manifest", type=Path, required=True)
+    args = parser.parse_args(argv)
+
+    try:
+        if args.command == "generate":
+            source_bytes = args.source.read_bytes()
+            source = source_bytes.decode("utf-8-sig")
+            manifest = extract_manifest_from_source(
+                source,
+                artifact=args.artifact,
+                jvdata_version=args.jvdata_version,
+                source_sha256=hashlib.sha256(source_bytes).hexdigest(),
+            )
+            _write_manifest(args.output, manifest)
+            print(
+                "OFFICIAL ORACLE GENERATED: "
+                f"{manifest['summary']['root_record_count']} records, "
+                f"{manifest['summary']['structure_count']} structures, "
+                f"{manifest['summary']['expanded_leaf_count']} leaves"
+            )
+            return 0
+
+        manifest = load_manifest(args.manifest)
+        errors = validate_manifest(manifest)
+        if errors:
+            for error in errors:
+                print(f"OFFICIAL ORACLE FAIL: {error}")
+            return 1
+        print("OFFICIAL ORACLE PASS")
+        return 0
+    except Exception as exc:
+        print(f"OFFICIAL ORACLE ERROR: {type(exc).__name__}: {exc}")
+        return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/official_jvdata_oracle.py
+++ b/scripts/official_jvdata_oracle.py
@@ -113,6 +113,8 @@ def _slice_call(
     loop_variable: str | None = None,
 ) -> dict[str, Any]:
     environment_zero = {loop_variable: 0} if loop_variable else {}
+    if isinstance(expression, ast.Call) and expression.keywords:
+        raise OracleExtractionError("field call keyword arguments are outside the reviewed grammar")
 
     if (
         isinstance(expression, ast.Call)
@@ -136,6 +138,10 @@ def _slice_call(
         and len(expression.args) == 1
     ):
         inner = expression.args[0]
+        if isinstance(inner, ast.Call) and inner.keywords:
+            raise OracleExtractionError(
+                "slice call keyword arguments are outside the reviewed grammar"
+            )
         if not (
             isinstance(inner, ast.Call)
             and isinstance(inner.func, ast.Name)
@@ -192,6 +198,10 @@ def _field(expression: ast.expr, name: str) -> dict[str, Any]:
     if generator.ifs or generator.is_async or not isinstance(generator.target, ast.Name):
         raise OracleExtractionError(f"unsupported repeat generator: {name}")
     iterator = generator.iter
+    if isinstance(iterator, ast.Call) and iterator.keywords:
+        raise OracleExtractionError(
+            f"{name}: range keyword arguments are outside the reviewed grammar"
+        )
     if not (
         isinstance(iterator, ast.Call)
         and isinstance(iterator.func, ast.Name)
@@ -372,11 +382,19 @@ def _validate_manifest(manifest: Any) -> list[str]:
     errors: list[str] = []
     if not isinstance(manifest, dict):
         return ["manifest:not-an-object"]
-    if manifest.get("manifest_schema_version") != MANIFEST_SCHEMA_VERSION:
+    manifest_schema_version = manifest.get("manifest_schema_version")
+    if (
+        not _plain_integer(manifest_schema_version)
+        or manifest_schema_version != MANIFEST_SCHEMA_VERSION
+    ):
         errors.append("manifest:unsupported-schema-version")
 
     source = manifest.get("source")
-    if not isinstance(source, dict) or not SHA256_PATTERN.fullmatch(str(source.get("sha256", ""))):
+    if (
+        not isinstance(source, dict)
+        or not isinstance(source.get("sha256"), str)
+        or not SHA256_PATTERN.fullmatch(source["sha256"])
+    ):
         errors.append("source:invalid-sha256")
     if (
         not isinstance(source, dict)

--- a/scripts/official_jvdata_oracle.py
+++ b/scripts/official_jvdata_oracle.py
@@ -20,6 +20,34 @@ from typing import Any
 
 MANIFEST_SCHEMA_VERSION = 1
 SHA256_PATTERN = re.compile(r"^[0-9a-f]{64}$")
+OFFICIAL_YMD_FIELDS = [
+    {"name": "Year", "kind": "scalar", "start": 1, "width": 4, "decoder": "text"},
+    {"name": "Month", "kind": "scalar", "start": 5, "width": 2, "decoder": "text"},
+    {"name": "Day", "kind": "scalar", "start": 7, "width": 2, "decoder": "text"},
+]
+OFFICIAL_RECORD_ID_FIELDS = [
+    {
+        "name": "RecordSpec",
+        "kind": "scalar",
+        "start": 1,
+        "width": 2,
+        "decoder": "text",
+    },
+    {
+        "name": "DataKubun",
+        "kind": "scalar",
+        "start": 3,
+        "width": 1,
+        "decoder": "text",
+    },
+    {
+        "name": "MakeDate",
+        "kind": "nested",
+        "start": 4,
+        "width": 8,
+        "struct": "YMD",
+    },
+]
 
 
 class OracleExtractionError(ValueError):
@@ -46,13 +74,45 @@ def _integer(expression: ast.expr, environment: dict[str, int] | None = None) ->
     raise OracleExtractionError(f"unsupported integer expression: {ast.unparse(expression)}")
 
 
+def _affine_integer(expression: ast.expr, variable: str) -> tuple[int, int]:
+    """Return the constant and coefficient for a reviewed affine expression."""
+
+    if isinstance(expression, ast.Constant) and isinstance(expression.value, int):
+        return expression.value, 0
+    if isinstance(expression, ast.Name) and expression.id == variable:
+        return 0, 1
+    if isinstance(expression, ast.UnaryOp) and isinstance(expression.op, ast.USub):
+        constant, coefficient = _affine_integer(expression.operand, variable)
+        return -constant, -coefficient
+    if isinstance(expression, ast.BinOp):
+        left_constant, left_coefficient = _affine_integer(expression.left, variable)
+        right_constant, right_coefficient = _affine_integer(expression.right, variable)
+        if isinstance(expression.op, ast.Add):
+            return (
+                left_constant + right_constant,
+                left_coefficient + right_coefficient,
+            )
+        if isinstance(expression.op, ast.Sub):
+            return (
+                left_constant - right_constant,
+                left_coefficient - right_coefficient,
+            )
+        if isinstance(expression.op, ast.Mult):
+            if left_coefficient and right_coefficient:
+                raise OracleExtractionError(f"non-affine expression: {ast.unparse(expression)}")
+            return (
+                left_constant * right_constant,
+                left_constant * right_coefficient + left_coefficient * right_constant,
+            )
+    raise OracleExtractionError(f"non-affine expression: {ast.unparse(expression)}")
+
+
 def _slice_call(
     expression: ast.expr,
     *,
     loop_variable: str | None = None,
 ) -> dict[str, Any]:
     environment_zero = {loop_variable: 0} if loop_variable else {}
-    environment_one = {loop_variable: 1} if loop_variable else {}
 
     if (
         isinstance(expression, ast.Call)
@@ -61,10 +121,11 @@ def _slice_call(
         and len(expression.args) == 3
     ):
         start_expression = expression.args[1]
+        width_expression = expression.args[2]
         result = {
             "kind": "scalar",
             "start": _integer(start_expression, environment_zero),
-            "width": _integer(expression.args[2], environment_zero),
+            "width": _integer(width_expression, environment_zero),
             "decoder": "text" if expression.func.id == "MidB2S" else "bytes",
         }
     elif (
@@ -85,19 +146,39 @@ def _slice_call(
                 f"nested structure without MidB2B: {ast.unparse(expression)}"
             )
         start_expression = inner.args[1]
+        width_expression = inner.args[2]
         result = {
             "kind": "nested",
             "start": _integer(start_expression, environment_zero),
-            "width": _integer(inner.args[2], environment_zero),
+            "width": _integer(width_expression, environment_zero),
             "struct": expression.func.value.id,
         }
     else:
         raise OracleExtractionError(f"unsupported field expression: {ast.unparse(expression)}")
 
     if loop_variable:
-        result["stride"] = _integer(start_expression, environment_one) - _integer(
-            start_expression, environment_zero
-        )
+        try:
+            start, stride = _affine_integer(start_expression, loop_variable)
+        except OracleExtractionError as exc:
+            raise OracleExtractionError(
+                f"non-affine repeat offset: {ast.unparse(start_expression)}"
+            ) from exc
+        try:
+            width, width_coefficient = _affine_integer(
+                width_expression,
+                loop_variable,
+            )
+        except OracleExtractionError as exc:
+            raise OracleExtractionError(
+                f"non-affine repeat width: {ast.unparse(width_expression)}"
+            ) from exc
+        if width_coefficient:
+            raise OracleExtractionError(
+                "repeat width depends on loop variable: " f"{ast.unparse(width_expression)}"
+            )
+        result["start"] = start
+        result["width"] = width
+        result["stride"] = stride
     return result
 
 
@@ -209,6 +290,10 @@ def extract_manifest_from_source(
         if not annotations:
             continue
         constructor = _set_data_return(class_node)
+        if constructor.keywords:
+            raise OracleExtractionError(
+                f"{class_node.name}: keyword arguments are outside the reviewed grammar"
+            )
         if len(annotations) != len(constructor.args):
             raise OracleExtractionError(
                 f"{class_node.name}: {len(annotations)} fields != {len(constructor.args)} values"
@@ -319,6 +404,20 @@ def _validate_manifest(manifest: Any) -> list[str]:
         errors.append("structures:empty")
     if not root_records:
         errors.append("root-records:empty")
+    ymd = structures.get("YMD")
+    if (
+        not isinstance(ymd, dict)
+        or ymd.get("width") != 8
+        or ymd.get("fields") != OFFICIAL_YMD_FIELDS
+    ):
+        errors.append("record-header:invalid-ymd")
+    record_id = structures.get("RECORD_ID")
+    if (
+        not isinstance(record_id, dict)
+        or record_id.get("width") != 11
+        or record_id.get("fields") != OFFICIAL_RECORD_ID_FIELDS
+    ):
+        errors.append("record-header:invalid-record-id")
 
     calculated_repeat_count = 0
     for structure_name, structure in structures.items():
@@ -410,12 +509,12 @@ def _validate_manifest(manifest: Any) -> list[str]:
         cursor = 1
         for start, end in sorted(intervals):
             if start > cursor:
-                errors.extend(f"{structure_name}:gap:{byte}" for byte in range(cursor, start))
+                errors.append(f"{structure_name}:gap:{cursor}-{start - 1}")
             elif start < cursor:
                 errors.append(f"{structure_name}:overlap:{start}")
             cursor = max(cursor, end + 1)
         if cursor <= width:
-            errors.extend(f"{structure_name}:gap:{byte}" for byte in range(cursor, width + 1))
+            errors.append(f"{structure_name}:gap:{cursor}-{width}")
         elif cursor - 1 > width:
             errors.append(f"{structure_name}:extent-exceeds-width:{cursor - 1}>{width}")
 
@@ -490,6 +589,15 @@ def _validate_manifest(manifest: Any) -> list[str]:
             or root_fields[0].get("name") != "head"
         ):
             errors.append(f"{prefix}:head-missing:{structure_name}")
+        else:
+            head = root_fields[0]
+            if (
+                head.get("kind") != "nested"
+                or head.get("start") != 1
+                or head.get("width") != 11
+                or head.get("struct") != "RECORD_ID"
+            ):
+                errors.append(f"{prefix}:invalid-head-contract:{structure_name}")
         length = contract.get("length")
         structure_width = structures[structure_name].get("width")
         if not _plain_integer(length) or length != structure_width:

--- a/scripts/official_jvdata_oracle.py
+++ b/scripts/official_jvdata_oracle.py
@@ -56,7 +56,11 @@ class OracleExtractionError(ValueError):
 
 def _integer(expression: ast.expr, environment: dict[str, int] | None = None) -> int:
     environment = environment or {}
-    if isinstance(expression, ast.Constant) and isinstance(expression.value, int):
+    if (
+        isinstance(expression, ast.Constant)
+        and isinstance(expression.value, int)
+        and not isinstance(expression.value, bool)
+    ):
         return expression.value
     if isinstance(expression, ast.Name) and expression.id in environment:
         return environment[expression.id]
@@ -77,7 +81,11 @@ def _integer(expression: ast.expr, environment: dict[str, int] | None = None) ->
 def _affine_integer(expression: ast.expr, variable: str) -> tuple[int, int]:
     """Return the constant and coefficient for a reviewed affine expression."""
 
-    if isinstance(expression, ast.Constant) and isinstance(expression.value, int):
+    if (
+        isinstance(expression, ast.Constant)
+        and isinstance(expression.value, int)
+        and not isinstance(expression.value, bool)
+    ):
         return expression.value, 0
     if isinstance(expression, ast.Name) and expression.id == variable:
         return 0, 1
@@ -110,6 +118,7 @@ def _affine_integer(expression: ast.expr, variable: str) -> tuple[int, int]:
 def _slice_call(
     expression: ast.expr,
     *,
+    source_parameter: str,
     loop_variable: str | None = None,
 ) -> dict[str, Any]:
     environment_zero = {loop_variable: 0} if loop_variable else {}
@@ -122,6 +131,13 @@ def _slice_call(
         and expression.func.id in {"MidB2S", "MidB2B"}
         and len(expression.args) == 3
     ):
+        source_expression = expression.args[0]
+        if not (
+            isinstance(source_expression, ast.Name) and source_expression.id == source_parameter
+        ):
+            raise OracleExtractionError(
+                "slice source must be the reviewed byte parameter " f"{source_parameter}"
+            )
         start_expression = expression.args[1]
         width_expression = expression.args[2]
         result = {
@@ -150,6 +166,13 @@ def _slice_call(
         ):
             raise OracleExtractionError(
                 f"nested structure without MidB2B: {ast.unparse(expression)}"
+            )
+        source_expression = inner.args[0]
+        if not (
+            isinstance(source_expression, ast.Name) and source_expression.id == source_parameter
+        ):
+            raise OracleExtractionError(
+                "slice source must be the reviewed byte parameter " f"{source_parameter}"
             )
         start_expression = inner.args[1]
         width_expression = inner.args[2]
@@ -188,9 +211,12 @@ def _slice_call(
     return result
 
 
-def _field(expression: ast.expr, name: str) -> dict[str, Any]:
+def _field(expression: ast.expr, name: str, *, source_parameter: str) -> dict[str, Any]:
     if not isinstance(expression, ast.ListComp):
-        return {"name": name, **_slice_call(expression)}
+        return {
+            "name": name,
+            **_slice_call(expression, source_parameter=source_parameter),
+        }
 
     if len(expression.generators) != 1:
         raise OracleExtractionError(f"repeat must have one generator: {name}")
@@ -210,7 +236,11 @@ def _field(expression: ast.expr, name: str) -> dict[str, Any]:
     ):
         raise OracleExtractionError(f"repeat must use range(count): {name}")
 
-    element = _slice_call(expression.elt, loop_variable=generator.target.id)
+    element = _slice_call(
+        expression.elt,
+        source_parameter=source_parameter,
+        loop_variable=generator.target.id,
+    )
     result: dict[str, Any] = {
         "name": name,
         "kind": "repeat",
@@ -224,26 +254,45 @@ def _field(expression: ast.expr, name: str) -> dict[str, Any]:
     return result
 
 
-def _set_data_return(class_node: ast.ClassDef) -> ast.Call:
-    method = next(
-        (
-            node
-            for node in class_node.body
-            if isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef) and node.name == "SetDataB"
-        ),
-        None,
-    )
-    if method is None:
-        raise OracleExtractionError(f"{class_node.name}: SetDataB is missing")
-    returns = [node for node in ast.walk(method) if isinstance(node, ast.Return)]
-    if len(returns) != 1:
-        raise OracleExtractionError(f"{class_node.name}: expected one return")
-    value = returns[0].value
+def _set_data_return(class_node: ast.ClassDef) -> tuple[ast.Call, str]:
+    methods = [
+        node
+        for node in class_node.body
+        if isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef) and node.name == "SetDataB"
+    ]
+    if len(methods) != 1:
+        raise OracleExtractionError(f"{class_node.name}: expected exactly one SetDataB")
+    method = methods[0]
+    if not isinstance(method, ast.FunctionDef):
+        raise OracleExtractionError(f"{class_node.name}: SetDataB must be synchronous")
+    if not (
+        len(method.decorator_list) == 1
+        and isinstance(method.decorator_list[0], ast.Name)
+        and method.decorator_list[0].id == "classmethod"
+    ):
+        raise OracleExtractionError(f"{class_node.name}: SetDataB must be a classmethod")
+
+    arguments = method.args
+    if not (
+        not arguments.posonlyargs
+        and [argument.arg for argument in arguments.args] == ["cls", "b"]
+        and arguments.vararg is None
+        and not arguments.kwonlyargs
+        and not arguments.kw_defaults
+        and arguments.kwarg is None
+        and not arguments.defaults
+    ):
+        raise OracleExtractionError(
+            f"{class_node.name}: SetDataB signature must be exactly (cls, b)"
+        )
+    if len(method.body) != 1 or not isinstance(method.body[0], ast.Return):
+        raise OracleExtractionError(f"{class_node.name}: SetDataB must contain one direct return")
+    value = method.body[0].value
     if not (
         isinstance(value, ast.Call) and isinstance(value.func, ast.Name) and value.func.id == "cls"
     ):
         raise OracleExtractionError(f"{class_node.name}: return must construct cls")
-    return value
+    return value, arguments.args[1].arg
 
 
 def _field_end(field: dict[str, Any]) -> int:
@@ -299,7 +348,7 @@ def extract_manifest_from_source(
         ]
         if not annotations:
             continue
-        constructor = _set_data_return(class_node)
+        constructor, source_parameter = _set_data_return(class_node)
         if constructor.keywords:
             raise OracleExtractionError(
                 f"{class_node.name}: keyword arguments are outside the reviewed grammar"
@@ -309,7 +358,11 @@ def extract_manifest_from_source(
                 f"{class_node.name}: {len(annotations)} fields != {len(constructor.args)} values"
             )
         fields = [
-            _field(expression, annotation.target.id)
+            _field(
+                expression,
+                annotation.target.id,
+                source_parameter=source_parameter,
+            )
             for annotation, expression in zip(annotations, constructor.args, strict=True)
         ]
         structures[class_node.name] = {

--- a/specs/operations/20260816_release_readiness_worklog.md
+++ b/specs/operations/20260816_release_readiness_worklog.md
@@ -933,6 +933,21 @@
   review evidence. Resume that session against the final pushed full SHA after
   the 01:10 JST reset and do not merge PR #194 before its grouped critical
   review is complete.
+- A final Codex fail-open pass after the first review repair found that Python
+  equality allowed Boolean `manifest_schema_version` to impersonate integer
+  version 1, source SHA validation stringified a non-string 64-digit integer,
+  and field decoder calls could silently ignore unreviewed keyword arguments.
+  The three new tests produced the required red result of 3 failed and 34
+  passed on candidate `3f3905666248776565bc8cb7fdbebafadcd009f7` before the
+  implementation changed.
+- Manifest validation now requires the schema version to be a non-Boolean
+  integer and the source SHA-256 to be a lowercase 64-character string. The
+  extractor rejects keywords on scalar/nested slice calls and repeat `range`
+  calls, including nested slice calls, so a newly introduced argument cannot
+  be silently discarded. The paired oracle module is 37 passed. Regeneration
+  from the exact official source still expands 38 records, 94 structures, and
+  46,985 leaves and remains byte-for-byte identical with SHA-256
+  `437a21ea582315f807609dbee809c581518b31d6b48bddc96fd57b92c84e366a`.
 - Known findings remain release blockers rather than oracle exceptions: HY
   field/primary-key semantics, CK omitted repeats, six standard-schema storage
   routes, schema metadata integrity, obsolete routes, and strict fresh

--- a/specs/operations/20260816_release_readiness_worklog.md
+++ b/specs/operations/20260816_release_readiness_worklog.md
@@ -886,6 +886,53 @@
   80 bytes. The `UMA`/UM standard table is correctly 60 bytes with the 1-byte
   flag and 19-byte reserve, so no UM schema change is warranted from that
   search result.
+- PR #194 was opened from the first pushed candidate
+  `798d4210e00edeb654417eaeaa5f81d6f399e144`. GitHub Actions run
+  `31951212329` executed on that exact SHA and passed the fail-closed CI
+  self-check, Linux deterministic tree (2,322 passed, 79 explicit environment
+  skips, 14 slow deselections, and 15 passing subtests), distribution content,
+  Windows launcher, and fatal lint gates. The optional tokenless coverage
+  upload could not publish but its configured non-gating step and job
+  completed successfully; it is not counted as test evidence. The performance
+  job was a zero-step PR skip by workflow design.
+- The first grouped GitHub review identified three actionable fail-open or
+  incompleteness classes: inferring a repeat stride from only two evaluations,
+  accepting a same-prefix root with an arbitrary field renamed `head`, and
+  comparing history sets without constraining duplicate or extra entries.
+  Two related review nits identified unbounded per-byte gap diagnostics and
+  unreviewed constructor keyword arguments. These findings were aggregated
+  before modifying the candidate.
+- Before the grouped repair, the new negative matrix produced 10 failures and
+  23 passes. Seven failures directly reproduced the review findings; three
+  additional failures were expected-value drift after the synthetic positive
+  fixture was corrected to contain the real common header contract. A separate
+  complete-header semantic negative then produced 1 failure and 33 passes,
+  demonstrating that width and name checks alone still admitted a false
+  header. These are the required red results for this inspector change.
+- The extractor now accepts repeat starts only when they are provably affine in
+  the loop variable, rejects loop-dependent widths and constructor keyword
+  arguments, and reports a contiguous gap as one bounded range. Manifest
+  validation requires the exact 8-byte date and 11-byte common record-header
+  field contracts, and every root must begin at byte 1 with that nested header.
+  The history tests require exact cardinality in addition to exact identity
+  sets, so duplicate or unreviewed entries cannot disappear under set
+  comparison. Paired positive and negative coverage is 34 passed in the oracle
+  module alone.
+- Regeneration with the repaired extractor from the same official source
+  produced 38 records, 94 structures, and 46,985 expanded leaves and was
+  byte-for-byte identical to the tracked manifest; both files had SHA-256
+  `437a21ea582315f807609dbee809c581518b31d6b48bddc96fd57b92c84e366a`.
+  The affected CPython 3.12 selection passed 227 tests. The fail-closed CI
+  self-check reports `TEST GATE PASS`; Ruff, Black, isolated fatal flake8, and
+  `git diff --check` all pass. Pytest emitted best-effort temporary-directory
+  cleanup warnings during the gate self-tests, but no test or gate failed and
+  no repository artifact was created.
+- Claude Code session `365b9699-b517-405f-b567-b6c87fd77266` remains the same
+  Fable session for this iteration. Its prior request reached the account
+  session limit before communication or inspection; therefore it is still not
+  review evidence. Resume that session against the final pushed full SHA after
+  the 01:10 JST reset and do not merge PR #194 before its grouped critical
+  review is complete.
 - Known findings remain release blockers rather than oracle exceptions: HY
   field/primary-key semantics, CK omitted repeats, six standard-schema storage
   routes, schema metadata integrity, obsolete routes, and strict fresh

--- a/specs/operations/20260816_release_readiness_worklog.md
+++ b/specs/operations/20260816_release_readiness_worklog.md
@@ -860,6 +860,32 @@
   import `tomllib`, so it was not treated as project evidence after that
   precondition failure; all accepted local evidence uses the required 3.12
   runtime.
+- The first clean local candidate was
+  `9374c8df1f19cd84a638a0a14f3613cb16a65502`. Exact-SHA focused evidence was
+  209 passed, `TEST GATE PASS`, fatal flake8 zero, and a clean worktree. It was
+  not pushed because the grouped critical review had not yet completed.
+- Started a new Claude Code session
+  `365b9699-b517-405f-b567-b6c87fd77266` with `--model fable --effort high` for
+  a read-only critical review of that candidate. Fable was selected because a
+  validator can create false release confidence if it fails open. The request
+  stopped at the service session limit before any review content or source
+  inspection ran; it is not review evidence and must be resumed in the same
+  session after the next 01:10 JST reset before merge.
+- While that external review was unavailable, Codex independently challenged
+  the generic validator rather than waiting idle. A single grouped negative
+  matrix proved 10 fail-open shapes red on the first candidate: empty manifests,
+  non-string source identities, non-string field names, missing scalar/repeat
+  decoders, missing direct/repeated nested targets, a root without `head`, and
+  a root redirected to a non-root structure. The run was 10 failed and 16
+  passed. The validator now rejects each shape directly, while the paired
+  complete fixture and official manifest remain green; the broader affected
+  selection is 219 passed with the CI self-check and fatal lint still green.
+- A separate search found a `BameiEng VARCHAR(80)` declaration and tested the
+  hypothesis that the 2006 UM change remained unfixed. It belongs to the
+  distinct `HANSYOKU`/HN contract, whose current official English-name field is
+  80 bytes. The `UMA`/UM standard table is correctly 60 bytes with the 1-byte
+  flag and 19-byte reserve, so no UM schema change is warranted from that
+  search result.
 - Known findings remain release blockers rather than oracle exceptions: HY
   field/primary-key semantics, CK omitted repeats, six standard-schema storage
   routes, schema metadata integrity, obsolete routes, and strict fresh

--- a/specs/operations/20260816_release_readiness_worklog.md
+++ b/specs/operations/20260816_release_readiness_worklog.md
@@ -957,3 +957,47 @@
   affected parser/fixture contracts; commit a clean candidate; obtain one
   grouped Fable critical review and GitHub review on that exact candidate; then
   fix any independently reproduced findings together before merge.
+- On 2026-08-17 the user explicitly authorized a Codex critical agent as the
+  substitute review gate when the same Claude Code session remained blocked by
+  its account limit. A read-only reviewer ran with `gpt-5.6-sol` at `xhigh`
+  reasoning because this iteration changes an inspector whose failure mode is
+  false release confidence. It reviewed exact full SHA
+  `857533a3c1f29b899d2ce34fb076dc9c44afef09` and returned `NEEDS_CHANGES`.
+  The independently reproduced grouped findings were: Boolean AST constants
+  accepted as integer layout expressions; unreviewed `SetDataB` method shapes
+  and non-`b` slice sources accepted; and official manifest/history fixtures
+  structurally validated without binding every official fact and provenance
+  field. The reviewer also independently confirmed the three official source
+  hashes, all 38 current lengths, all 10 physical history changes, the PR-to-BR
+  transition, the UM same-length semantic split, and distribution exclusion of
+  `specs/`, the oracle fixtures, and the extraction script.
+- Before changing the inspector implementation, the grouped regression matrix
+  was run against the implementation at full SHA
+  `857533a3c1f29b899d2ce34fb076dc9c44afef09`. It produced the required red
+  result of 19 failed and 2 passed: four Boolean arithmetic paths, seven
+  method/source-buffer paths, one same-shape manifest drift, and seven history
+  content/provenance drifts failed to say no; the two already-covered
+  nested/range keyword branches remained green.
+- The extractor now excludes Boolean constants from both integer evaluators,
+  requires exactly one synchronous direct `@classmethod SetDataB(cls, b)` with
+  one unconditional constructor return, and requires every scalar or nested
+  slice to read that reviewed byte parameter. The official manifest and history
+  ledger are now bound in CI by canonical JSON SHA-256 in addition to the
+  readable semantic assertions; strict ledger schema-version typing prevents
+  `True` from impersonating version 1. All 21 grouped negative/paired cases are
+  green, and the complete oracle plus current-record selection is 166 passed.
+  Ruff, Black, and `git diff --check` pass.
+- Regeneration after the grouped repair from the pinned official SDK source is
+  still byte-for-byte identical to the tracked manifest: 38 records, 94
+  structures, 46,985 expanded leaves, raw-file SHA-256
+  `437a21ea582315f807609dbee809c581518b31d6b48bddc96fd57b92c84e366a`.
+  The broader affected selection on CPython 3.12.11 is 251 passed, the
+  repository fail-closed self-check reports `TEST GATE PASS`, and isolated
+  fatal flake8 reports zero findings.
+  A broader pre-existing packaging condition remains for release audit: the
+  sdist ships some tests whose excluded script/fixture dependencies are absent.
+  It is not a PR #194-specific oracle defect and was not mixed into this repair.
+- Next safe action: run the affected broader selection and CI-equivalent local
+  gates, commit and push one clean candidate, then perform the single final
+  exact-SHA gate (checks, unresolved threads, review evidence, and clean
+  worktree) before merging PR #194.

--- a/specs/operations/20260816_release_readiness_worklog.md
+++ b/specs/operations/20260816_release_readiness_worklog.md
@@ -759,3 +759,113 @@
   jobs pass. The compact official oracle and known HY, CK, standard-schema,
   metadata, obsolete-route, and strict fresh E2E blockers remain separate
   required iterations after this PR.
+
+## Official 38-record oracle iteration start
+
+- Objective and minimum scope: add a compact, mechanically validated oracle
+  derived from the official current JV-Data layout, make the deterministic CI
+  collect it, label reconstructed database fixtures truthfully, and add the
+  current and historical physical-length regressions needed to expose known
+  specification gaps. Storage mapping is deliberately outside this physical
+  oracle PR: HY, CK, standard-schema routing, metadata, and fresh live E2E are
+  repaired in the following independent iterations rather than being made
+  green by encoding the current implementation's assumptions here.
+- Repository: `miyamamoto/jrvltsql`.
+- Dedicated worktree:
+  `/home/keiba/scratch/20260816_jrvltsql_official_oracle`.
+- Branch: `agent/official-oracle-20260816`.
+- Base and initial HEAD:
+  `8baf34a79783370f17ac8430151cd212a496965e` (latest fetched
+  `origin/master`, squash merge of PR #193).
+- Dependency order: PR #193's fail-closed whole-tree CI is merged first; this
+  oracle iteration is based on that merge and must itself merge before HY/CK
+  and storage-routing implementation iterations use its contracts.
+- Prior production/release reference remains version `1.6.10`; no release or
+  release-lock mutation is authorized by this iteration alone.
+- Initial state is clean. Existing independent audit evidence reports 38
+  current record lengths matching official SDK 5.0.0, 94 structures, 93
+  repeated templates, and 46,985 recursively expanded scalar leaves with no
+  official-layout gap or overlap. The implementation must reproduce or encode
+  that evidence from repository-tracked inputs rather than relying on a local
+  scratch-only report.
+- Initial safe action: inventory tracked official-spec inputs and current
+  contract tests, then design one compact physical manifest/validator with
+  red-first tests for missing spans, overlap, incorrect repeat count, unknown
+  nested structures, source provenance, and inspection failure. Leaf-to-storage
+  disposition and nonexistent storage targets belong to the following schema
+  implementation iteration because they require model/storage decisions beyond
+  the official byte layout.
+- STOP conditions: do not copy or redistribute proprietary provider samples;
+  do not invent offsets from current parser code as the oracle; do not mark a
+  known HY/CK/storage mismatch green by reproducing the implementation's own
+  assumptions; do not claim 64-bit support; do not merge if the oracle cannot
+  identify its official source/version/hash or if any required contract remains
+  unresolved.
+- Red-first evidence: before adding the oracle implementation or manifest,
+  `tests/test_official_jvdata_oracle.py` failed during collection with
+  `ModuleNotFoundError: scripts.official_jvdata_oracle`. No oracle assertion
+  ran, so this is an explicit missing-inspection red rather than a parser
+  failure. The paired validator negatives and official-manifest assertions
+  must turn green only after the independent extractor, tracked manifest, and
+  provenance are present.
+- Implemented `scripts/official_jvdata_oracle.py` as a reviewed-AST extractor
+  for the SDK's scalar, nested, and fixed-repeat grammar. It produces only
+  derived names, one-based byte spans, widths, repeat counts/strides, source
+  identity, and aggregate counts; it does not copy SDK source or provider
+  records. The validator fails closed on unreadable input, incomplete source
+  identity, bad spans, gaps, overlap, invalid repeat definitions, unknown or
+  cyclic structures, nested-width mismatch, count mismatch, and root-length
+  mismatch.
+- The tracked SDK 5.0.0 manifest identifies source SHA-256
+  `8994f985fce846f1b4fcbc3ddf2a5c6394c586a458478346891222b3b61e4ee3`
+  and independently expands to 38 root records, 94 structures, 93 repeat
+  templates, and 46,985 scalar leaves. Regeneration from that exact official
+  source is byte-for-byte identical to the tracked JSON, and the validator
+  reports `OFFICIAL ORACLE PASS`.
+- Added a physical-layout history ledger backed by official workbook SHA-256
+  `6a567f10b601115eca350571f36d27d9d28bd2d3835ea72b5bc057711155d4a7`
+  for 4.8.0.2 and
+  `23bafd375f704acbdd696b5032ac1619f17d47e882587d6e7954b610527a8234`
+  for 4.9.0.1. It records the 2003 SE, BR, and BN length changes; the 2023 UM,
+  BR, HN, SK, CK, HS, and BT changes; the PR-to-BR identifier transition; and
+  the 2006 UM same-length semantic split. The latter is explicitly marked as
+  requiring generation provenance because record length cannot distinguish
+  the old 80-byte English-name interpretation from the current 60+1+19 byte
+  fields.
+- `test_current_record_validation.py` now derives all 38 current lengths and
+  every historical rejection case from these official manifests instead of a
+  second hand-maintained matrix. The factory still accepts only the current N
+  layout; it rejects every ledgered previous physical length, including both
+  pre-2003 and 4.8.0.2 generations where applicable.
+- Additional validator negatives were proven red before implementation:
+  self-reference produced only aggregate count mismatches rather than a cycle
+  error; missing artifact/version provenance passed; and Boolean leaf counts
+  were accepted as integers. The red run was 3 failed and 13 passed after the
+  earlier cycle/history red run of 2 failed and 11 passed. All are now explicit
+  failures with paired complete-manifest green coverage.
+- Focused green evidence after implementation is 124 passed across the oracle
+  and current-record validation modules. Direct CLI validation passes; source
+  regeneration is byte-identical; all three official source hashes were
+  independently recomputed. The whole-tree CI command merged in PR #193
+  collects `tests/test_official_jvdata_oracle.py` automatically because it
+  collects all `tests/test_*.py` outside only the explicit integration/E2E
+  directories. The reconstructed database fixtures were already truthfully
+  renamed and documented by PR #193, so no second relocation is needed here.
+- A broader affected-contract run under isolated CPython 3.12.11 passed 209
+  tests covering the oracle, all current/legacy physical record validation, and
+  reconstructed database-row fixtures. The fail-closed CI self-check reports
+  `TEST GATE PASS`; Ruff reports no findings on the three changed Python files;
+  isolated fatal flake8 reports zero; Black is clean; JSON parsing and
+  `git diff --check` pass. The host's unqualified `python3` is 3.10 and cannot
+  import `tomllib`, so it was not treated as project evidence after that
+  precondition failure; all accepted local evidence uses the required 3.12
+  runtime.
+- Known findings remain release blockers rather than oracle exceptions: HY
+  field/primary-key semantics, CK omitted repeats, six standard-schema storage
+  routes, schema metadata integrity, obsolete routes, and strict fresh
+  acquisition-to-SQLite/PostgreSQL evidence. No support statement, version,
+  tag, or release lock changed in this iteration.
+- Next safe action: run fatal lint, the fail-closed CI self-check, and the
+  affected parser/fixture contracts; commit a clean candidate; obtain one
+  grouped Fable critical review and GitHub review on that exact candidate; then
+  fix any independently reproduced findings together before merge.

--- a/tests/fixtures/official_layout/README.md
+++ b/tests/fixtures/official_layout/README.md
@@ -1,0 +1,26 @@
+# Official layout oracle fixtures
+
+These JSON files contain derived layout facts and change-history references for
+JV-Data. They do not contain provider records or a copy of the SDK source.
+
+- `jvdata_sdk500_manifest.json` was generated from the Python structure file
+  included with JRA-VAN Data Lab. SDK 5.0.0. Its `source.sha256` identifies the
+  exact local source artifact used by the maintainer.
+- `jvdata_layout_history.json` records physical-length and same-length semantic
+  changes cited by the official 4.8.0.2 and 4.9.0.1 specification workbooks.
+
+The manifest is intentionally independent of jrvltsql parser and schema code.
+When the official source changes, regenerate it from a separately obtained SDK
+file and review the resulting diff before updating parser or storage contracts:
+
+```console
+python scripts/official_jvdata_oracle.py generate \
+  --source /path/to/JVData_Struct.py \
+  --output tests/fixtures/official_layout/jvdata_sdk500_manifest.json \
+  --jvdata-version 4.9.0.1
+python scripts/official_jvdata_oracle.py validate \
+  --manifest tests/fixtures/official_layout/jvdata_sdk500_manifest.json
+```
+
+The reconstructed binary fixtures elsewhere under `tests/fixtures` serve only
+as parser value regressions. They are not official-layout evidence.

--- a/tests/fixtures/official_layout/jvdata_layout_history.json
+++ b/tests/fixtures/official_layout/jvdata_layout_history.json
@@ -1,0 +1,141 @@
+{
+  "ledger_schema_version": 1,
+  "sources": [
+    {
+      "artifact": "JV-Data4802.xlsx",
+      "jvdata_version": "4.8.0.2",
+      "sha256": "6a567f10b601115eca350571f36d27d9d28bd2d3835ea72b5bc057711155d4a7"
+    },
+    {
+      "artifact": "JV-Data4901.xlsx",
+      "jvdata_version": "4.9.0.1",
+      "sha256": "23bafd375f704acbdd696b5032ac1619f17d47e882587d6e7954b610527a8234"
+    }
+  ],
+  "physical_length_changes": [
+    {
+      "record_type": "SE",
+      "effective_date": "2003-04-22",
+      "official_spec_version": "1.0.1-beta",
+      "before_length": 547,
+      "after_length": 555,
+      "source": "JV-Data4901.xlsx:変更履歴:331"
+    },
+    {
+      "record_type": "BR",
+      "effective_date": "2003-06-03",
+      "official_spec_version": "1.0.5-beta",
+      "before_length": 467,
+      "after_length": 537,
+      "source": "JV-Data4901.xlsx:変更履歴:317"
+    },
+    {
+      "record_type": "BN",
+      "effective_date": "2003-06-03",
+      "official_spec_version": "1.0.5-beta",
+      "before_length": 413,
+      "after_length": 477,
+      "source": "JV-Data4901.xlsx:変更履歴:319"
+    },
+    {
+      "record_type": "UM",
+      "effective_date": "2023-08-08",
+      "official_spec_version": "4.9.0",
+      "before_length": 1577,
+      "after_length": 1609,
+      "source": "JV-Data4901.xlsx:変更履歴:38"
+    },
+    {
+      "record_type": "BR",
+      "effective_date": "2023-08-08",
+      "official_spec_version": "4.9.0",
+      "before_length": 537,
+      "after_length": 545,
+      "source": "JV-Data4901.xlsx:変更履歴:39"
+    },
+    {
+      "record_type": "HN",
+      "effective_date": "2023-08-08",
+      "official_spec_version": "4.9.0",
+      "before_length": 245,
+      "after_length": 251,
+      "source": "JV-Data4901.xlsx:変更履歴:40"
+    },
+    {
+      "record_type": "SK",
+      "effective_date": "2023-08-08",
+      "official_spec_version": "4.9.0",
+      "before_length": 178,
+      "after_length": 208,
+      "source": "JV-Data4901.xlsx:変更履歴:41"
+    },
+    {
+      "record_type": "CK",
+      "effective_date": "2023-08-08",
+      "official_spec_version": "4.9.0",
+      "before_length": 6864,
+      "after_length": 6870,
+      "source": "JV-Data4901.xlsx:変更履歴:42"
+    },
+    {
+      "record_type": "HS",
+      "effective_date": "2023-08-08",
+      "official_spec_version": "4.9.0",
+      "before_length": 196,
+      "after_length": 200,
+      "source": "JV-Data4901.xlsx:変更履歴:43"
+    },
+    {
+      "record_type": "BT",
+      "effective_date": "2023-08-08",
+      "official_spec_version": "4.9.0",
+      "before_length": 6887,
+      "after_length": 6889,
+      "source": "JV-Data4901.xlsx:変更履歴:44"
+    }
+  ],
+  "record_type_changes": [
+    {
+      "effective_date": "2003-04-22",
+      "before_record_type": "PR",
+      "after_record_type": "BR",
+      "official_spec_version": "1.0.1-beta"
+    }
+  ],
+  "same_length_semantic_changes": [
+    {
+      "record_type": "UM",
+      "announced_date": "2006-03-09",
+      "effective_date": "2006-06-06",
+      "official_spec_version": "2.1.4",
+      "length_unchanged": true,
+      "before_fields": [
+        {
+          "name": "BameiEng",
+          "start": 119,
+          "width": 80
+        }
+      ],
+      "current_fields": [
+        {
+          "name": "BameiEng",
+          "start": 119,
+          "width": 60
+        },
+        {
+          "name": "ZaikyuFlag",
+          "start": 179,
+          "width": 1
+        },
+        {
+          "name": "Reserved",
+          "start": 180,
+          "width": 19
+        }
+      ],
+      "provenance_required": true,
+      "reason": "Record length alone cannot distinguish the pre-change physical generation from the current field semantics.",
+      "source": "JV-Data4901.xlsx:変更履歴:184-187"
+    }
+  ]
+}

--- a/tests/fixtures/official_layout/jvdata_sdk500_manifest.json
+++ b/tests/fixtures/official_layout/jvdata_sdk500_manifest.json
@@ -1,0 +1,6291 @@
+{
+  "manifest_schema_version": 1,
+  "source": {
+    "artifact": "JRA-VAN Data Lab SDK 5.0.0 Python JV-Data structures",
+    "jvdata_version": "4.9.0.1",
+    "sha256": "8994f985fce846f1b4fcbc3ddf2a5c6394c586a458478346891222b3b61e4ee3"
+  },
+  "structures": {
+    "YMD": {
+      "width": 8,
+      "fields": [
+        {
+          "name": "Year",
+          "kind": "scalar",
+          "start": 1,
+          "width": 4,
+          "decoder": "text"
+        },
+        {
+          "name": "Month",
+          "kind": "scalar",
+          "start": 5,
+          "width": 2,
+          "decoder": "text"
+        },
+        {
+          "name": "Day",
+          "kind": "scalar",
+          "start": 7,
+          "width": 2,
+          "decoder": "text"
+        }
+      ],
+      "expanded_leaf_count": 3
+    },
+    "HMS": {
+      "width": 6,
+      "fields": [
+        {
+          "name": "Hour",
+          "kind": "scalar",
+          "start": 1,
+          "width": 2,
+          "decoder": "text"
+        },
+        {
+          "name": "Minute",
+          "kind": "scalar",
+          "start": 3,
+          "width": 2,
+          "decoder": "text"
+        },
+        {
+          "name": "Second",
+          "kind": "scalar",
+          "start": 5,
+          "width": 2,
+          "decoder": "text"
+        }
+      ],
+      "expanded_leaf_count": 3
+    },
+    "HM": {
+      "width": 4,
+      "fields": [
+        {
+          "name": "Hour",
+          "kind": "scalar",
+          "start": 1,
+          "width": 2,
+          "decoder": "text"
+        },
+        {
+          "name": "Minute",
+          "kind": "scalar",
+          "start": 3,
+          "width": 2,
+          "decoder": "text"
+        }
+      ],
+      "expanded_leaf_count": 2
+    },
+    "MDHM": {
+      "width": 8,
+      "fields": [
+        {
+          "name": "Month",
+          "kind": "scalar",
+          "start": 1,
+          "width": 2,
+          "decoder": "text"
+        },
+        {
+          "name": "Day",
+          "kind": "scalar",
+          "start": 3,
+          "width": 2,
+          "decoder": "text"
+        },
+        {
+          "name": "Hour",
+          "kind": "scalar",
+          "start": 5,
+          "width": 2,
+          "decoder": "text"
+        },
+        {
+          "name": "Minute",
+          "kind": "scalar",
+          "start": 7,
+          "width": 2,
+          "decoder": "text"
+        }
+      ],
+      "expanded_leaf_count": 4
+    },
+    "RECORD_ID": {
+      "width": 11,
+      "fields": [
+        {
+          "name": "RecordSpec",
+          "kind": "scalar",
+          "start": 1,
+          "width": 2,
+          "decoder": "text"
+        },
+        {
+          "name": "DataKubun",
+          "kind": "scalar",
+          "start": 3,
+          "width": 1,
+          "decoder": "text"
+        },
+        {
+          "name": "MakeDate",
+          "kind": "nested",
+          "start": 4,
+          "width": 8,
+          "struct": "YMD"
+        }
+      ],
+      "expanded_leaf_count": 5
+    },
+    "RACE_ID": {
+      "width": 16,
+      "fields": [
+        {
+          "name": "Year",
+          "kind": "scalar",
+          "start": 1,
+          "width": 4,
+          "decoder": "text"
+        },
+        {
+          "name": "MonthDay",
+          "kind": "scalar",
+          "start": 5,
+          "width": 4,
+          "decoder": "text"
+        },
+        {
+          "name": "JyoCD",
+          "kind": "scalar",
+          "start": 9,
+          "width": 2,
+          "decoder": "text"
+        },
+        {
+          "name": "Kaiji",
+          "kind": "scalar",
+          "start": 11,
+          "width": 2,
+          "decoder": "text"
+        },
+        {
+          "name": "Nichiji",
+          "kind": "scalar",
+          "start": 13,
+          "width": 2,
+          "decoder": "text"
+        },
+        {
+          "name": "RaceNum",
+          "kind": "scalar",
+          "start": 15,
+          "width": 2,
+          "decoder": "text"
+        }
+      ],
+      "expanded_leaf_count": 6
+    },
+    "RACE_ID2": {
+      "width": 14,
+      "fields": [
+        {
+          "name": "Year",
+          "kind": "scalar",
+          "start": 1,
+          "width": 4,
+          "decoder": "text"
+        },
+        {
+          "name": "MonthDay",
+          "kind": "scalar",
+          "start": 5,
+          "width": 4,
+          "decoder": "text"
+        },
+        {
+          "name": "JyoCD",
+          "kind": "scalar",
+          "start": 9,
+          "width": 2,
+          "decoder": "text"
+        },
+        {
+          "name": "Kaiji",
+          "kind": "scalar",
+          "start": 11,
+          "width": 2,
+          "decoder": "text"
+        },
+        {
+          "name": "Nichiji",
+          "kind": "scalar",
+          "start": 13,
+          "width": 2,
+          "decoder": "text"
+        }
+      ],
+      "expanded_leaf_count": 5
+    },
+    "SEI_RUIKEI_INFO": {
+      "width": 60,
+      "fields": [
+        {
+          "name": "SetYear",
+          "kind": "scalar",
+          "start": 1,
+          "width": 4,
+          "decoder": "text"
+        },
+        {
+          "name": "HonSyokinTotal",
+          "kind": "scalar",
+          "start": 5,
+          "width": 10,
+          "decoder": "text"
+        },
+        {
+          "name": "FukaSyokin",
+          "kind": "scalar",
+          "start": 15,
+          "width": 10,
+          "decoder": "text"
+        },
+        {
+          "name": "ChakuKaisu",
+          "kind": "repeat",
+          "start": 25,
+          "width": 6,
+          "stride": 6,
+          "count": 6,
+          "element_kind": "scalar",
+          "decoder": "text"
+        }
+      ],
+      "expanded_leaf_count": 9
+    },
+    "SAIKIN_JYUSYO_INFO": {
+      "width": 163,
+      "fields": [
+        {
+          "name": "SaikinJyusyoid",
+          "kind": "nested",
+          "start": 1,
+          "width": 16,
+          "struct": "RACE_ID"
+        },
+        {
+          "name": "Hondai",
+          "kind": "scalar",
+          "start": 17,
+          "width": 60,
+          "decoder": "text"
+        },
+        {
+          "name": "Ryakusyo10",
+          "kind": "scalar",
+          "start": 77,
+          "width": 20,
+          "decoder": "text"
+        },
+        {
+          "name": "Ryakusyo6",
+          "kind": "scalar",
+          "start": 97,
+          "width": 12,
+          "decoder": "text"
+        },
+        {
+          "name": "Ryakusyo3",
+          "kind": "scalar",
+          "start": 109,
+          "width": 6,
+          "decoder": "text"
+        },
+        {
+          "name": "GradeCD",
+          "kind": "scalar",
+          "start": 115,
+          "width": 1,
+          "decoder": "text"
+        },
+        {
+          "name": "SyussoTosu",
+          "kind": "scalar",
+          "start": 116,
+          "width": 2,
+          "decoder": "text"
+        },
+        {
+          "name": "KettoNum",
+          "kind": "scalar",
+          "start": 118,
+          "width": 10,
+          "decoder": "text"
+        },
+        {
+          "name": "Bamei",
+          "kind": "scalar",
+          "start": 128,
+          "width": 36,
+          "decoder": "text"
+        }
+      ],
+      "expanded_leaf_count": 14
+    },
+    "HON_ZEN_RUIKEISEI_INFO": {
+      "width": 1052,
+      "fields": [
+        {
+          "name": "SetYear",
+          "kind": "scalar",
+          "start": 1,
+          "width": 4,
+          "decoder": "text"
+        },
+        {
+          "name": "HonSyokinHeichi",
+          "kind": "scalar",
+          "start": 5,
+          "width": 10,
+          "decoder": "text"
+        },
+        {
+          "name": "HonSyokinSyogai",
+          "kind": "scalar",
+          "start": 15,
+          "width": 10,
+          "decoder": "text"
+        },
+        {
+          "name": "FukaSyokinHeichi",
+          "kind": "scalar",
+          "start": 25,
+          "width": 10,
+          "decoder": "text"
+        },
+        {
+          "name": "FukaSyokinSyogai",
+          "kind": "scalar",
+          "start": 35,
+          "width": 10,
+          "decoder": "text"
+        },
+        {
+          "name": "ChakuKaisuHeichi",
+          "kind": "nested",
+          "start": 45,
+          "width": 36,
+          "struct": "CHAKUKAISU6_INFO"
+        },
+        {
+          "name": "ChakuKaisuSyogai",
+          "kind": "nested",
+          "start": 81,
+          "width": 36,
+          "struct": "CHAKUKAISU6_INFO"
+        },
+        {
+          "name": "ChakuKaisuJyo",
+          "kind": "repeat",
+          "start": 117,
+          "width": 36,
+          "stride": 36,
+          "count": 20,
+          "element_kind": "nested",
+          "struct": "CHAKUKAISU6_INFO"
+        },
+        {
+          "name": "ChakuKaisuKyori",
+          "kind": "repeat",
+          "start": 837,
+          "width": 36,
+          "stride": 36,
+          "count": 6,
+          "element_kind": "nested",
+          "struct": "CHAKUKAISU6_INFO"
+        }
+      ],
+      "expanded_leaf_count": 173
+    },
+    "RACE_INFO": {
+      "width": 587,
+      "fields": [
+        {
+          "name": "YoubiCD",
+          "kind": "scalar",
+          "start": 1,
+          "width": 1,
+          "decoder": "text"
+        },
+        {
+          "name": "TokuNum",
+          "kind": "scalar",
+          "start": 2,
+          "width": 4,
+          "decoder": "text"
+        },
+        {
+          "name": "Hondai",
+          "kind": "scalar",
+          "start": 6,
+          "width": 60,
+          "decoder": "text"
+        },
+        {
+          "name": "Fukudai",
+          "kind": "scalar",
+          "start": 66,
+          "width": 60,
+          "decoder": "text"
+        },
+        {
+          "name": "Kakko",
+          "kind": "scalar",
+          "start": 126,
+          "width": 60,
+          "decoder": "text"
+        },
+        {
+          "name": "HondaiEng",
+          "kind": "scalar",
+          "start": 186,
+          "width": 120,
+          "decoder": "text"
+        },
+        {
+          "name": "FukudaiEng",
+          "kind": "scalar",
+          "start": 306,
+          "width": 120,
+          "decoder": "text"
+        },
+        {
+          "name": "KakkoEng",
+          "kind": "scalar",
+          "start": 426,
+          "width": 120,
+          "decoder": "text"
+        },
+        {
+          "name": "Ryakusyo10",
+          "kind": "scalar",
+          "start": 546,
+          "width": 20,
+          "decoder": "text"
+        },
+        {
+          "name": "Ryakusyo6",
+          "kind": "scalar",
+          "start": 566,
+          "width": 12,
+          "decoder": "text"
+        },
+        {
+          "name": "Ryakusyo3",
+          "kind": "scalar",
+          "start": 578,
+          "width": 6,
+          "decoder": "text"
+        },
+        {
+          "name": "Kubun",
+          "kind": "scalar",
+          "start": 584,
+          "width": 1,
+          "decoder": "text"
+        },
+        {
+          "name": "Nkai",
+          "kind": "scalar",
+          "start": 585,
+          "width": 3,
+          "decoder": "text"
+        }
+      ],
+      "expanded_leaf_count": 13
+    },
+    "TENKO_BABA_INFO": {
+      "width": 3,
+      "fields": [
+        {
+          "name": "TenkoCD",
+          "kind": "scalar",
+          "start": 1,
+          "width": 1,
+          "decoder": "text"
+        },
+        {
+          "name": "SibaBabaCD",
+          "kind": "scalar",
+          "start": 2,
+          "width": 1,
+          "decoder": "text"
+        },
+        {
+          "name": "DirtBabaCD",
+          "kind": "scalar",
+          "start": 3,
+          "width": 1,
+          "decoder": "text"
+        }
+      ],
+      "expanded_leaf_count": 3
+    },
+    "CHAKUKAISU3_INFO": {
+      "width": 18,
+      "fields": [
+        {
+          "name": "ChakuKaisu",
+          "kind": "repeat",
+          "start": 1,
+          "width": 3,
+          "stride": 3,
+          "count": 6,
+          "element_kind": "scalar",
+          "decoder": "text"
+        }
+      ],
+      "expanded_leaf_count": 6
+    },
+    "CHAKUKAISU4_INFO": {
+      "width": 24,
+      "fields": [
+        {
+          "name": "ChakuKaisu",
+          "kind": "repeat",
+          "start": 1,
+          "width": 4,
+          "stride": 4,
+          "count": 6,
+          "element_kind": "scalar",
+          "decoder": "text"
+        }
+      ],
+      "expanded_leaf_count": 6
+    },
+    "CHAKUKAISU5_INFO": {
+      "width": 30,
+      "fields": [
+        {
+          "name": "ChakuKaisu",
+          "kind": "repeat",
+          "start": 1,
+          "width": 5,
+          "stride": 5,
+          "count": 6,
+          "element_kind": "scalar",
+          "decoder": "text"
+        }
+      ],
+      "expanded_leaf_count": 6
+    },
+    "CHAKUKAISU6_INFO": {
+      "width": 36,
+      "fields": [
+        {
+          "name": "ChakuKaisu",
+          "kind": "repeat",
+          "start": 1,
+          "width": 6,
+          "stride": 6,
+          "count": 6,
+          "element_kind": "scalar",
+          "decoder": "text"
+        }
+      ],
+      "expanded_leaf_count": 6
+    },
+    "RACE_JYOKEN": {
+      "width": 21,
+      "fields": [
+        {
+          "name": "SyubetuCD",
+          "kind": "scalar",
+          "start": 1,
+          "width": 2,
+          "decoder": "text"
+        },
+        {
+          "name": "KigoCD",
+          "kind": "scalar",
+          "start": 3,
+          "width": 3,
+          "decoder": "text"
+        },
+        {
+          "name": "JyuryoCD",
+          "kind": "scalar",
+          "start": 6,
+          "width": 1,
+          "decoder": "text"
+        },
+        {
+          "name": "JyokenCD",
+          "kind": "repeat",
+          "start": 7,
+          "width": 3,
+          "stride": 3,
+          "count": 5,
+          "element_kind": "scalar",
+          "decoder": "text"
+        }
+      ],
+      "expanded_leaf_count": 8
+    },
+    "TOKUUMA_INFO": {
+      "width": 70,
+      "fields": [
+        {
+          "name": "Num",
+          "kind": "scalar",
+          "start": 1,
+          "width": 3,
+          "decoder": "text"
+        },
+        {
+          "name": "KettoNum",
+          "kind": "scalar",
+          "start": 4,
+          "width": 10,
+          "decoder": "text"
+        },
+        {
+          "name": "Bamei",
+          "kind": "scalar",
+          "start": 14,
+          "width": 36,
+          "decoder": "text"
+        },
+        {
+          "name": "UmaKigoCD",
+          "kind": "scalar",
+          "start": 50,
+          "width": 2,
+          "decoder": "text"
+        },
+        {
+          "name": "SexCD",
+          "kind": "scalar",
+          "start": 52,
+          "width": 1,
+          "decoder": "text"
+        },
+        {
+          "name": "TozaiCD",
+          "kind": "scalar",
+          "start": 53,
+          "width": 1,
+          "decoder": "text"
+        },
+        {
+          "name": "ChokyosiCode",
+          "kind": "scalar",
+          "start": 54,
+          "width": 5,
+          "decoder": "text"
+        },
+        {
+          "name": "ChokyosiRyakusyo",
+          "kind": "scalar",
+          "start": 59,
+          "width": 8,
+          "decoder": "text"
+        },
+        {
+          "name": "Futan",
+          "kind": "scalar",
+          "start": 67,
+          "width": 3,
+          "decoder": "text"
+        },
+        {
+          "name": "Koryu",
+          "kind": "scalar",
+          "start": 70,
+          "width": 1,
+          "decoder": "text"
+        }
+      ],
+      "expanded_leaf_count": 10
+    },
+    "JV_TK_TOKUUMA": {
+      "width": 21657,
+      "fields": [
+        {
+          "name": "head",
+          "kind": "nested",
+          "start": 1,
+          "width": 11,
+          "struct": "RECORD_ID"
+        },
+        {
+          "name": "id",
+          "kind": "nested",
+          "start": 12,
+          "width": 16,
+          "struct": "RACE_ID"
+        },
+        {
+          "name": "RaceInfo",
+          "kind": "nested",
+          "start": 28,
+          "width": 587,
+          "struct": "RACE_INFO"
+        },
+        {
+          "name": "GradeCD",
+          "kind": "scalar",
+          "start": 615,
+          "width": 1,
+          "decoder": "text"
+        },
+        {
+          "name": "JyokenInfo",
+          "kind": "nested",
+          "start": 616,
+          "width": 21,
+          "struct": "RACE_JYOKEN"
+        },
+        {
+          "name": "Kyori",
+          "kind": "scalar",
+          "start": 637,
+          "width": 4,
+          "decoder": "text"
+        },
+        {
+          "name": "TrackCD",
+          "kind": "scalar",
+          "start": 641,
+          "width": 2,
+          "decoder": "text"
+        },
+        {
+          "name": "CourseKubunCD",
+          "kind": "scalar",
+          "start": 643,
+          "width": 2,
+          "decoder": "text"
+        },
+        {
+          "name": "HandiDate",
+          "kind": "nested",
+          "start": 645,
+          "width": 8,
+          "struct": "YMD"
+        },
+        {
+          "name": "TorokuTosu",
+          "kind": "scalar",
+          "start": 653,
+          "width": 3,
+          "decoder": "text"
+        },
+        {
+          "name": "TokuUmaInfo",
+          "kind": "repeat",
+          "start": 656,
+          "width": 70,
+          "stride": 70,
+          "count": 300,
+          "element_kind": "nested",
+          "struct": "TOKUUMA_INFO"
+        },
+        {
+          "name": "crlf",
+          "kind": "scalar",
+          "start": 21656,
+          "width": 2,
+          "decoder": "text"
+        }
+      ],
+      "expanded_leaf_count": 3041
+    },
+    "CORNER_INFO": {
+      "width": 72,
+      "fields": [
+        {
+          "name": "Corner",
+          "kind": "scalar",
+          "start": 1,
+          "width": 1,
+          "decoder": "text"
+        },
+        {
+          "name": "Syukaisu",
+          "kind": "scalar",
+          "start": 2,
+          "width": 1,
+          "decoder": "text"
+        },
+        {
+          "name": "Jyuni",
+          "kind": "scalar",
+          "start": 3,
+          "width": 70,
+          "decoder": "text"
+        }
+      ],
+      "expanded_leaf_count": 3
+    },
+    "JV_RA_RACE": {
+      "width": 1272,
+      "fields": [
+        {
+          "name": "head",
+          "kind": "nested",
+          "start": 1,
+          "width": 11,
+          "struct": "RECORD_ID"
+        },
+        {
+          "name": "id",
+          "kind": "nested",
+          "start": 12,
+          "width": 16,
+          "struct": "RACE_ID"
+        },
+        {
+          "name": "RaceInfo",
+          "kind": "nested",
+          "start": 28,
+          "width": 587,
+          "struct": "RACE_INFO"
+        },
+        {
+          "name": "GradeCD",
+          "kind": "scalar",
+          "start": 615,
+          "width": 1,
+          "decoder": "text"
+        },
+        {
+          "name": "GradeCDBefore",
+          "kind": "scalar",
+          "start": 616,
+          "width": 1,
+          "decoder": "text"
+        },
+        {
+          "name": "JyokenInfo",
+          "kind": "nested",
+          "start": 617,
+          "width": 21,
+          "struct": "RACE_JYOKEN"
+        },
+        {
+          "name": "JyokenName",
+          "kind": "scalar",
+          "start": 638,
+          "width": 60,
+          "decoder": "text"
+        },
+        {
+          "name": "Kyori",
+          "kind": "scalar",
+          "start": 698,
+          "width": 4,
+          "decoder": "text"
+        },
+        {
+          "name": "KyoriBefore",
+          "kind": "scalar",
+          "start": 702,
+          "width": 4,
+          "decoder": "text"
+        },
+        {
+          "name": "TrackCD",
+          "kind": "scalar",
+          "start": 706,
+          "width": 2,
+          "decoder": "text"
+        },
+        {
+          "name": "TrackCDBefore",
+          "kind": "scalar",
+          "start": 708,
+          "width": 2,
+          "decoder": "text"
+        },
+        {
+          "name": "CourseKubunCD",
+          "kind": "scalar",
+          "start": 710,
+          "width": 2,
+          "decoder": "text"
+        },
+        {
+          "name": "CourseKubunCDBefore",
+          "kind": "scalar",
+          "start": 712,
+          "width": 2,
+          "decoder": "text"
+        },
+        {
+          "name": "Honsyokin",
+          "kind": "repeat",
+          "start": 714,
+          "width": 8,
+          "stride": 8,
+          "count": 7,
+          "element_kind": "scalar",
+          "decoder": "text"
+        },
+        {
+          "name": "HonsyokinBefore",
+          "kind": "repeat",
+          "start": 770,
+          "width": 8,
+          "stride": 8,
+          "count": 5,
+          "element_kind": "scalar",
+          "decoder": "text"
+        },
+        {
+          "name": "Fukasyokin",
+          "kind": "repeat",
+          "start": 810,
+          "width": 8,
+          "stride": 8,
+          "count": 5,
+          "element_kind": "scalar",
+          "decoder": "text"
+        },
+        {
+          "name": "FukasyokinBefore",
+          "kind": "repeat",
+          "start": 850,
+          "width": 8,
+          "stride": 8,
+          "count": 3,
+          "element_kind": "scalar",
+          "decoder": "text"
+        },
+        {
+          "name": "HassoTime",
+          "kind": "scalar",
+          "start": 874,
+          "width": 4,
+          "decoder": "text"
+        },
+        {
+          "name": "HassoTimeBefore",
+          "kind": "scalar",
+          "start": 878,
+          "width": 4,
+          "decoder": "text"
+        },
+        {
+          "name": "TorokuTosu",
+          "kind": "scalar",
+          "start": 882,
+          "width": 2,
+          "decoder": "text"
+        },
+        {
+          "name": "SyussoTosu",
+          "kind": "scalar",
+          "start": 884,
+          "width": 2,
+          "decoder": "text"
+        },
+        {
+          "name": "NyusenTosu",
+          "kind": "scalar",
+          "start": 886,
+          "width": 2,
+          "decoder": "text"
+        },
+        {
+          "name": "TenkoBaba",
+          "kind": "nested",
+          "start": 888,
+          "width": 3,
+          "struct": "TENKO_BABA_INFO"
+        },
+        {
+          "name": "LapTime",
+          "kind": "repeat",
+          "start": 891,
+          "width": 3,
+          "stride": 3,
+          "count": 25,
+          "element_kind": "scalar",
+          "decoder": "text"
+        },
+        {
+          "name": "SyogaiMileTime",
+          "kind": "scalar",
+          "start": 966,
+          "width": 4,
+          "decoder": "text"
+        },
+        {
+          "name": "HaronTimeS3",
+          "kind": "scalar",
+          "start": 970,
+          "width": 3,
+          "decoder": "text"
+        },
+        {
+          "name": "HaronTimeS4",
+          "kind": "scalar",
+          "start": 973,
+          "width": 3,
+          "decoder": "text"
+        },
+        {
+          "name": "HaronTimeL3",
+          "kind": "scalar",
+          "start": 976,
+          "width": 3,
+          "decoder": "text"
+        },
+        {
+          "name": "HaronTimeL4",
+          "kind": "scalar",
+          "start": 979,
+          "width": 3,
+          "decoder": "text"
+        },
+        {
+          "name": "CornerInfo",
+          "kind": "repeat",
+          "start": 982,
+          "width": 72,
+          "stride": 72,
+          "count": 4,
+          "element_kind": "nested",
+          "struct": "CORNER_INFO"
+        },
+        {
+          "name": "RecordUpKubun",
+          "kind": "scalar",
+          "start": 1270,
+          "width": 1,
+          "decoder": "text"
+        },
+        {
+          "name": "crlf",
+          "kind": "scalar",
+          "start": 1271,
+          "width": 2,
+          "decoder": "text"
+        }
+      ],
+      "expanded_leaf_count": 113
+    },
+    "CHAKUUMA_INFO": {
+      "width": 46,
+      "fields": [
+        {
+          "name": "KettoNum",
+          "kind": "scalar",
+          "start": 1,
+          "width": 10,
+          "decoder": "text"
+        },
+        {
+          "name": "Bamei",
+          "kind": "scalar",
+          "start": 11,
+          "width": 36,
+          "decoder": "text"
+        }
+      ],
+      "expanded_leaf_count": 2
+    },
+    "JV_SE_RACE_UMA": {
+      "width": 555,
+      "fields": [
+        {
+          "name": "head",
+          "kind": "nested",
+          "start": 1,
+          "width": 11,
+          "struct": "RECORD_ID"
+        },
+        {
+          "name": "id",
+          "kind": "nested",
+          "start": 12,
+          "width": 16,
+          "struct": "RACE_ID"
+        },
+        {
+          "name": "Wakuban",
+          "kind": "scalar",
+          "start": 28,
+          "width": 1,
+          "decoder": "text"
+        },
+        {
+          "name": "Umaban",
+          "kind": "scalar",
+          "start": 29,
+          "width": 2,
+          "decoder": "text"
+        },
+        {
+          "name": "KettoNum",
+          "kind": "scalar",
+          "start": 31,
+          "width": 10,
+          "decoder": "text"
+        },
+        {
+          "name": "Bamei",
+          "kind": "scalar",
+          "start": 41,
+          "width": 36,
+          "decoder": "text"
+        },
+        {
+          "name": "UmaKigoCD",
+          "kind": "scalar",
+          "start": 77,
+          "width": 2,
+          "decoder": "text"
+        },
+        {
+          "name": "SexCD",
+          "kind": "scalar",
+          "start": 79,
+          "width": 1,
+          "decoder": "text"
+        },
+        {
+          "name": "HinsyuCD",
+          "kind": "scalar",
+          "start": 80,
+          "width": 1,
+          "decoder": "text"
+        },
+        {
+          "name": "KeiroCD",
+          "kind": "scalar",
+          "start": 81,
+          "width": 2,
+          "decoder": "text"
+        },
+        {
+          "name": "Barei",
+          "kind": "scalar",
+          "start": 83,
+          "width": 2,
+          "decoder": "text"
+        },
+        {
+          "name": "TozaiCD",
+          "kind": "scalar",
+          "start": 85,
+          "width": 1,
+          "decoder": "text"
+        },
+        {
+          "name": "ChokyosiCode",
+          "kind": "scalar",
+          "start": 86,
+          "width": 5,
+          "decoder": "text"
+        },
+        {
+          "name": "ChokyosiRyakusyo",
+          "kind": "scalar",
+          "start": 91,
+          "width": 8,
+          "decoder": "text"
+        },
+        {
+          "name": "BanusiCode",
+          "kind": "scalar",
+          "start": 99,
+          "width": 6,
+          "decoder": "text"
+        },
+        {
+          "name": "BanusiName",
+          "kind": "scalar",
+          "start": 105,
+          "width": 64,
+          "decoder": "text"
+        },
+        {
+          "name": "Fukusyoku",
+          "kind": "scalar",
+          "start": 169,
+          "width": 60,
+          "decoder": "text"
+        },
+        {
+          "name": "reserved1",
+          "kind": "scalar",
+          "start": 229,
+          "width": 60,
+          "decoder": "text"
+        },
+        {
+          "name": "Futan",
+          "kind": "scalar",
+          "start": 289,
+          "width": 3,
+          "decoder": "text"
+        },
+        {
+          "name": "FutanBefore",
+          "kind": "scalar",
+          "start": 292,
+          "width": 3,
+          "decoder": "text"
+        },
+        {
+          "name": "Blinker",
+          "kind": "scalar",
+          "start": 295,
+          "width": 1,
+          "decoder": "text"
+        },
+        {
+          "name": "reserved2",
+          "kind": "scalar",
+          "start": 296,
+          "width": 1,
+          "decoder": "text"
+        },
+        {
+          "name": "KisyuCode",
+          "kind": "scalar",
+          "start": 297,
+          "width": 5,
+          "decoder": "text"
+        },
+        {
+          "name": "KisyuCodeBefore",
+          "kind": "scalar",
+          "start": 302,
+          "width": 5,
+          "decoder": "text"
+        },
+        {
+          "name": "KisyuRyakusyo",
+          "kind": "scalar",
+          "start": 307,
+          "width": 8,
+          "decoder": "text"
+        },
+        {
+          "name": "KisyuRyakusyoBefore",
+          "kind": "scalar",
+          "start": 315,
+          "width": 8,
+          "decoder": "text"
+        },
+        {
+          "name": "MinaraiCD",
+          "kind": "scalar",
+          "start": 323,
+          "width": 1,
+          "decoder": "text"
+        },
+        {
+          "name": "MinaraiCDBefore",
+          "kind": "scalar",
+          "start": 324,
+          "width": 1,
+          "decoder": "text"
+        },
+        {
+          "name": "BaTaijyu",
+          "kind": "scalar",
+          "start": 325,
+          "width": 3,
+          "decoder": "text"
+        },
+        {
+          "name": "ZogenFugo",
+          "kind": "scalar",
+          "start": 328,
+          "width": 1,
+          "decoder": "text"
+        },
+        {
+          "name": "ZogenSa",
+          "kind": "scalar",
+          "start": 329,
+          "width": 3,
+          "decoder": "text"
+        },
+        {
+          "name": "IJyoCD",
+          "kind": "scalar",
+          "start": 332,
+          "width": 1,
+          "decoder": "text"
+        },
+        {
+          "name": "NyusenJyuni",
+          "kind": "scalar",
+          "start": 333,
+          "width": 2,
+          "decoder": "text"
+        },
+        {
+          "name": "KakuteiJyuni",
+          "kind": "scalar",
+          "start": 335,
+          "width": 2,
+          "decoder": "text"
+        },
+        {
+          "name": "DochakuKubun",
+          "kind": "scalar",
+          "start": 337,
+          "width": 1,
+          "decoder": "text"
+        },
+        {
+          "name": "DochakuTosu",
+          "kind": "scalar",
+          "start": 338,
+          "width": 1,
+          "decoder": "text"
+        },
+        {
+          "name": "Time",
+          "kind": "scalar",
+          "start": 339,
+          "width": 4,
+          "decoder": "text"
+        },
+        {
+          "name": "ChakusaCD",
+          "kind": "scalar",
+          "start": 343,
+          "width": 3,
+          "decoder": "text"
+        },
+        {
+          "name": "ChakusaCDP",
+          "kind": "scalar",
+          "start": 346,
+          "width": 3,
+          "decoder": "text"
+        },
+        {
+          "name": "ChakusaCDPP",
+          "kind": "scalar",
+          "start": 349,
+          "width": 3,
+          "decoder": "text"
+        },
+        {
+          "name": "Jyuni1c",
+          "kind": "scalar",
+          "start": 352,
+          "width": 2,
+          "decoder": "text"
+        },
+        {
+          "name": "Jyuni2c",
+          "kind": "scalar",
+          "start": 354,
+          "width": 2,
+          "decoder": "text"
+        },
+        {
+          "name": "Jyuni3c",
+          "kind": "scalar",
+          "start": 356,
+          "width": 2,
+          "decoder": "text"
+        },
+        {
+          "name": "Jyuni4c",
+          "kind": "scalar",
+          "start": 358,
+          "width": 2,
+          "decoder": "text"
+        },
+        {
+          "name": "Odds",
+          "kind": "scalar",
+          "start": 360,
+          "width": 4,
+          "decoder": "text"
+        },
+        {
+          "name": "Ninki",
+          "kind": "scalar",
+          "start": 364,
+          "width": 2,
+          "decoder": "text"
+        },
+        {
+          "name": "Honsyokin",
+          "kind": "scalar",
+          "start": 366,
+          "width": 8,
+          "decoder": "text"
+        },
+        {
+          "name": "Fukasyokin",
+          "kind": "scalar",
+          "start": 374,
+          "width": 8,
+          "decoder": "text"
+        },
+        {
+          "name": "reserved3",
+          "kind": "scalar",
+          "start": 382,
+          "width": 3,
+          "decoder": "text"
+        },
+        {
+          "name": "reserved4",
+          "kind": "scalar",
+          "start": 385,
+          "width": 3,
+          "decoder": "text"
+        },
+        {
+          "name": "HaronTimeL4",
+          "kind": "scalar",
+          "start": 388,
+          "width": 3,
+          "decoder": "text"
+        },
+        {
+          "name": "HaronTimeL3",
+          "kind": "scalar",
+          "start": 391,
+          "width": 3,
+          "decoder": "text"
+        },
+        {
+          "name": "ChakuUmaInfo",
+          "kind": "repeat",
+          "start": 394,
+          "width": 46,
+          "stride": 46,
+          "count": 3,
+          "element_kind": "nested",
+          "struct": "CHAKUUMA_INFO"
+        },
+        {
+          "name": "TimeDiff",
+          "kind": "scalar",
+          "start": 532,
+          "width": 4,
+          "decoder": "text"
+        },
+        {
+          "name": "RecordUpKubun",
+          "kind": "scalar",
+          "start": 536,
+          "width": 1,
+          "decoder": "text"
+        },
+        {
+          "name": "DMKubun",
+          "kind": "scalar",
+          "start": 537,
+          "width": 1,
+          "decoder": "text"
+        },
+        {
+          "name": "DMTime",
+          "kind": "scalar",
+          "start": 538,
+          "width": 5,
+          "decoder": "text"
+        },
+        {
+          "name": "DMGosaP",
+          "kind": "scalar",
+          "start": 543,
+          "width": 4,
+          "decoder": "text"
+        },
+        {
+          "name": "DMGosaM",
+          "kind": "scalar",
+          "start": 547,
+          "width": 4,
+          "decoder": "text"
+        },
+        {
+          "name": "DMJyuni",
+          "kind": "scalar",
+          "start": 551,
+          "width": 2,
+          "decoder": "text"
+        },
+        {
+          "name": "KyakusituKubun",
+          "kind": "scalar",
+          "start": 553,
+          "width": 1,
+          "decoder": "text"
+        },
+        {
+          "name": "crlf",
+          "kind": "scalar",
+          "start": 554,
+          "width": 2,
+          "decoder": "text"
+        }
+      ],
+      "expanded_leaf_count": 76
+    },
+    "PAY_INFO1": {
+      "width": 13,
+      "fields": [
+        {
+          "name": "Umaban",
+          "kind": "scalar",
+          "start": 1,
+          "width": 2,
+          "decoder": "text"
+        },
+        {
+          "name": "Pay",
+          "kind": "scalar",
+          "start": 3,
+          "width": 9,
+          "decoder": "text"
+        },
+        {
+          "name": "Ninki",
+          "kind": "scalar",
+          "start": 12,
+          "width": 2,
+          "decoder": "text"
+        }
+      ],
+      "expanded_leaf_count": 3
+    },
+    "PAY_INFO2": {
+      "width": 16,
+      "fields": [
+        {
+          "name": "Kumi",
+          "kind": "scalar",
+          "start": 1,
+          "width": 4,
+          "decoder": "text"
+        },
+        {
+          "name": "Pay",
+          "kind": "scalar",
+          "start": 5,
+          "width": 9,
+          "decoder": "text"
+        },
+        {
+          "name": "Ninki",
+          "kind": "scalar",
+          "start": 14,
+          "width": 3,
+          "decoder": "text"
+        }
+      ],
+      "expanded_leaf_count": 3
+    },
+    "PAY_INFO3": {
+      "width": 18,
+      "fields": [
+        {
+          "name": "Kumi",
+          "kind": "scalar",
+          "start": 1,
+          "width": 6,
+          "decoder": "text"
+        },
+        {
+          "name": "Pay",
+          "kind": "scalar",
+          "start": 7,
+          "width": 9,
+          "decoder": "text"
+        },
+        {
+          "name": "Ninki",
+          "kind": "scalar",
+          "start": 16,
+          "width": 3,
+          "decoder": "text"
+        }
+      ],
+      "expanded_leaf_count": 3
+    },
+    "PAY_INFO4": {
+      "width": 19,
+      "fields": [
+        {
+          "name": "Kumi",
+          "kind": "scalar",
+          "start": 1,
+          "width": 6,
+          "decoder": "text"
+        },
+        {
+          "name": "Pay",
+          "kind": "scalar",
+          "start": 7,
+          "width": 9,
+          "decoder": "text"
+        },
+        {
+          "name": "Ninki",
+          "kind": "scalar",
+          "start": 16,
+          "width": 4,
+          "decoder": "text"
+        }
+      ],
+      "expanded_leaf_count": 3
+    },
+    "JV_HR_PAY": {
+      "width": 719,
+      "fields": [
+        {
+          "name": "head",
+          "kind": "nested",
+          "start": 1,
+          "width": 11,
+          "struct": "RECORD_ID"
+        },
+        {
+          "name": "id",
+          "kind": "nested",
+          "start": 12,
+          "width": 16,
+          "struct": "RACE_ID"
+        },
+        {
+          "name": "TorokuTosu",
+          "kind": "scalar",
+          "start": 28,
+          "width": 2,
+          "decoder": "text"
+        },
+        {
+          "name": "SyussoTosu",
+          "kind": "scalar",
+          "start": 30,
+          "width": 2,
+          "decoder": "text"
+        },
+        {
+          "name": "FuseirituFlag",
+          "kind": "repeat",
+          "start": 32,
+          "width": 1,
+          "stride": 1,
+          "count": 9,
+          "element_kind": "scalar",
+          "decoder": "text"
+        },
+        {
+          "name": "TokubaraiFlag",
+          "kind": "repeat",
+          "start": 41,
+          "width": 1,
+          "stride": 1,
+          "count": 9,
+          "element_kind": "scalar",
+          "decoder": "text"
+        },
+        {
+          "name": "HenkanFlag",
+          "kind": "repeat",
+          "start": 50,
+          "width": 1,
+          "stride": 1,
+          "count": 9,
+          "element_kind": "scalar",
+          "decoder": "text"
+        },
+        {
+          "name": "HenkanUma",
+          "kind": "repeat",
+          "start": 59,
+          "width": 1,
+          "stride": 1,
+          "count": 28,
+          "element_kind": "scalar",
+          "decoder": "text"
+        },
+        {
+          "name": "HenkanWaku",
+          "kind": "repeat",
+          "start": 87,
+          "width": 1,
+          "stride": 1,
+          "count": 8,
+          "element_kind": "scalar",
+          "decoder": "text"
+        },
+        {
+          "name": "HenkanDoWaku",
+          "kind": "repeat",
+          "start": 95,
+          "width": 1,
+          "stride": 1,
+          "count": 8,
+          "element_kind": "scalar",
+          "decoder": "text"
+        },
+        {
+          "name": "PayTansyo",
+          "kind": "repeat",
+          "start": 103,
+          "width": 13,
+          "stride": 13,
+          "count": 3,
+          "element_kind": "nested",
+          "struct": "PAY_INFO1"
+        },
+        {
+          "name": "PayFukusyo",
+          "kind": "repeat",
+          "start": 142,
+          "width": 13,
+          "stride": 13,
+          "count": 5,
+          "element_kind": "nested",
+          "struct": "PAY_INFO1"
+        },
+        {
+          "name": "PayWakuren",
+          "kind": "repeat",
+          "start": 207,
+          "width": 13,
+          "stride": 13,
+          "count": 3,
+          "element_kind": "nested",
+          "struct": "PAY_INFO1"
+        },
+        {
+          "name": "PayUmaren",
+          "kind": "repeat",
+          "start": 246,
+          "width": 16,
+          "stride": 16,
+          "count": 3,
+          "element_kind": "nested",
+          "struct": "PAY_INFO2"
+        },
+        {
+          "name": "PayWide",
+          "kind": "repeat",
+          "start": 294,
+          "width": 16,
+          "stride": 16,
+          "count": 7,
+          "element_kind": "nested",
+          "struct": "PAY_INFO2"
+        },
+        {
+          "name": "PayReserved1",
+          "kind": "repeat",
+          "start": 406,
+          "width": 16,
+          "stride": 16,
+          "count": 3,
+          "element_kind": "nested",
+          "struct": "PAY_INFO2"
+        },
+        {
+          "name": "PayUmatan",
+          "kind": "repeat",
+          "start": 454,
+          "width": 16,
+          "stride": 16,
+          "count": 6,
+          "element_kind": "nested",
+          "struct": "PAY_INFO2"
+        },
+        {
+          "name": "PaySanrenpuku",
+          "kind": "repeat",
+          "start": 550,
+          "width": 18,
+          "stride": 18,
+          "count": 3,
+          "element_kind": "nested",
+          "struct": "PAY_INFO3"
+        },
+        {
+          "name": "PaySanrentan",
+          "kind": "repeat",
+          "start": 604,
+          "width": 19,
+          "stride": 19,
+          "count": 6,
+          "element_kind": "nested",
+          "struct": "PAY_INFO4"
+        },
+        {
+          "name": "crlf",
+          "kind": "scalar",
+          "start": 718,
+          "width": 2,
+          "decoder": "text"
+        }
+      ],
+      "expanded_leaf_count": 202
+    },
+    "HYO_INFO1": {
+      "width": 15,
+      "fields": [
+        {
+          "name": "Umaban",
+          "kind": "scalar",
+          "start": 1,
+          "width": 2,
+          "decoder": "text"
+        },
+        {
+          "name": "Hyo",
+          "kind": "scalar",
+          "start": 3,
+          "width": 11,
+          "decoder": "text"
+        },
+        {
+          "name": "Ninki",
+          "kind": "scalar",
+          "start": 14,
+          "width": 2,
+          "decoder": "text"
+        }
+      ],
+      "expanded_leaf_count": 3
+    },
+    "HYO_INFO2": {
+      "width": 18,
+      "fields": [
+        {
+          "name": "Kumi",
+          "kind": "scalar",
+          "start": 1,
+          "width": 4,
+          "decoder": "text"
+        },
+        {
+          "name": "Hyo",
+          "kind": "scalar",
+          "start": 5,
+          "width": 11,
+          "decoder": "text"
+        },
+        {
+          "name": "Ninki",
+          "kind": "scalar",
+          "start": 16,
+          "width": 3,
+          "decoder": "text"
+        }
+      ],
+      "expanded_leaf_count": 3
+    },
+    "HYO_INFO3": {
+      "width": 20,
+      "fields": [
+        {
+          "name": "Kumi",
+          "kind": "scalar",
+          "start": 1,
+          "width": 6,
+          "decoder": "text"
+        },
+        {
+          "name": "Hyo",
+          "kind": "scalar",
+          "start": 7,
+          "width": 11,
+          "decoder": "text"
+        },
+        {
+          "name": "Ninki",
+          "kind": "scalar",
+          "start": 18,
+          "width": 3,
+          "decoder": "text"
+        }
+      ],
+      "expanded_leaf_count": 3
+    },
+    "HYO_INFO4": {
+      "width": 21,
+      "fields": [
+        {
+          "name": "Kumi",
+          "kind": "scalar",
+          "start": 1,
+          "width": 6,
+          "decoder": "text"
+        },
+        {
+          "name": "Hyo",
+          "kind": "scalar",
+          "start": 7,
+          "width": 11,
+          "decoder": "text"
+        },
+        {
+          "name": "Ninki",
+          "kind": "scalar",
+          "start": 18,
+          "width": 4,
+          "decoder": "text"
+        }
+      ],
+      "expanded_leaf_count": 3
+    },
+    "JV_H1_HYOSU_ZENKAKE": {
+      "width": 28955,
+      "fields": [
+        {
+          "name": "head",
+          "kind": "nested",
+          "start": 1,
+          "width": 11,
+          "struct": "RECORD_ID"
+        },
+        {
+          "name": "id",
+          "kind": "nested",
+          "start": 12,
+          "width": 16,
+          "struct": "RACE_ID"
+        },
+        {
+          "name": "TorokuTosu",
+          "kind": "scalar",
+          "start": 28,
+          "width": 2,
+          "decoder": "text"
+        },
+        {
+          "name": "SyussoTosu",
+          "kind": "scalar",
+          "start": 30,
+          "width": 2,
+          "decoder": "text"
+        },
+        {
+          "name": "HatubaiFlag",
+          "kind": "repeat",
+          "start": 32,
+          "width": 1,
+          "stride": 1,
+          "count": 7,
+          "element_kind": "scalar",
+          "decoder": "text"
+        },
+        {
+          "name": "FukuChakuBaraiKey",
+          "kind": "scalar",
+          "start": 39,
+          "width": 1,
+          "decoder": "text"
+        },
+        {
+          "name": "HenkanUma",
+          "kind": "repeat",
+          "start": 40,
+          "width": 1,
+          "stride": 1,
+          "count": 28,
+          "element_kind": "scalar",
+          "decoder": "text"
+        },
+        {
+          "name": "HenkanWaku",
+          "kind": "repeat",
+          "start": 68,
+          "width": 1,
+          "stride": 1,
+          "count": 8,
+          "element_kind": "scalar",
+          "decoder": "text"
+        },
+        {
+          "name": "HenkanDoWaku",
+          "kind": "repeat",
+          "start": 76,
+          "width": 1,
+          "stride": 1,
+          "count": 8,
+          "element_kind": "scalar",
+          "decoder": "text"
+        },
+        {
+          "name": "HyoTansyo",
+          "kind": "repeat",
+          "start": 84,
+          "width": 15,
+          "stride": 15,
+          "count": 28,
+          "element_kind": "nested",
+          "struct": "HYO_INFO1"
+        },
+        {
+          "name": "HyoFukusyo",
+          "kind": "repeat",
+          "start": 504,
+          "width": 15,
+          "stride": 15,
+          "count": 28,
+          "element_kind": "nested",
+          "struct": "HYO_INFO1"
+        },
+        {
+          "name": "HyoWakuren",
+          "kind": "repeat",
+          "start": 924,
+          "width": 15,
+          "stride": 15,
+          "count": 36,
+          "element_kind": "nested",
+          "struct": "HYO_INFO1"
+        },
+        {
+          "name": "HyoUmaren",
+          "kind": "repeat",
+          "start": 1464,
+          "width": 18,
+          "stride": 18,
+          "count": 153,
+          "element_kind": "nested",
+          "struct": "HYO_INFO2"
+        },
+        {
+          "name": "HyoWide",
+          "kind": "repeat",
+          "start": 4218,
+          "width": 18,
+          "stride": 18,
+          "count": 153,
+          "element_kind": "nested",
+          "struct": "HYO_INFO2"
+        },
+        {
+          "name": "HyoUmatan",
+          "kind": "repeat",
+          "start": 6972,
+          "width": 18,
+          "stride": 18,
+          "count": 306,
+          "element_kind": "nested",
+          "struct": "HYO_INFO2"
+        },
+        {
+          "name": "HyoSanrenpuku",
+          "kind": "repeat",
+          "start": 12480,
+          "width": 20,
+          "stride": 20,
+          "count": 816,
+          "element_kind": "nested",
+          "struct": "HYO_INFO3"
+        },
+        {
+          "name": "HyoTotal",
+          "kind": "repeat",
+          "start": 28800,
+          "width": 11,
+          "stride": 11,
+          "count": 14,
+          "element_kind": "scalar",
+          "decoder": "text"
+        },
+        {
+          "name": "crlf",
+          "kind": "scalar",
+          "start": 28954,
+          "width": 2,
+          "decoder": "text"
+        }
+      ],
+      "expanded_leaf_count": 4640
+    },
+    "JV_H6_HYOSU_SANRENTAN": {
+      "width": 102890,
+      "fields": [
+        {
+          "name": "head",
+          "kind": "nested",
+          "start": 1,
+          "width": 11,
+          "struct": "RECORD_ID"
+        },
+        {
+          "name": "id",
+          "kind": "nested",
+          "start": 12,
+          "width": 16,
+          "struct": "RACE_ID"
+        },
+        {
+          "name": "TorokuTosu",
+          "kind": "scalar",
+          "start": 28,
+          "width": 2,
+          "decoder": "text"
+        },
+        {
+          "name": "SyussoTosu",
+          "kind": "scalar",
+          "start": 30,
+          "width": 2,
+          "decoder": "text"
+        },
+        {
+          "name": "HatubaiFlag",
+          "kind": "scalar",
+          "start": 32,
+          "width": 1,
+          "decoder": "text"
+        },
+        {
+          "name": "HenkanUma",
+          "kind": "repeat",
+          "start": 33,
+          "width": 1,
+          "stride": 1,
+          "count": 18,
+          "element_kind": "scalar",
+          "decoder": "text"
+        },
+        {
+          "name": "HyoSanrentan",
+          "kind": "repeat",
+          "start": 51,
+          "width": 21,
+          "stride": 21,
+          "count": 4896,
+          "element_kind": "nested",
+          "struct": "HYO_INFO4"
+        },
+        {
+          "name": "HyoTotal",
+          "kind": "repeat",
+          "start": 102867,
+          "width": 11,
+          "stride": 11,
+          "count": 2,
+          "element_kind": "scalar",
+          "decoder": "text"
+        },
+        {
+          "name": "crlf",
+          "kind": "scalar",
+          "start": 102889,
+          "width": 2,
+          "decoder": "text"
+        }
+      ],
+      "expanded_leaf_count": 14723
+    },
+    "ODDS_TANSYO_INFO": {
+      "width": 8,
+      "fields": [
+        {
+          "name": "Umaban",
+          "kind": "scalar",
+          "start": 1,
+          "width": 2,
+          "decoder": "text"
+        },
+        {
+          "name": "Odds",
+          "kind": "scalar",
+          "start": 3,
+          "width": 4,
+          "decoder": "text"
+        },
+        {
+          "name": "Ninki",
+          "kind": "scalar",
+          "start": 7,
+          "width": 2,
+          "decoder": "text"
+        }
+      ],
+      "expanded_leaf_count": 3
+    },
+    "ODDS_FUKUSYO_INFO": {
+      "width": 12,
+      "fields": [
+        {
+          "name": "Umaban",
+          "kind": "scalar",
+          "start": 1,
+          "width": 2,
+          "decoder": "text"
+        },
+        {
+          "name": "OddsLow",
+          "kind": "scalar",
+          "start": 3,
+          "width": 4,
+          "decoder": "text"
+        },
+        {
+          "name": "OddsHigh",
+          "kind": "scalar",
+          "start": 7,
+          "width": 4,
+          "decoder": "text"
+        },
+        {
+          "name": "Ninki",
+          "kind": "scalar",
+          "start": 11,
+          "width": 2,
+          "decoder": "text"
+        }
+      ],
+      "expanded_leaf_count": 4
+    },
+    "ODDS_WAKUREN_INFO": {
+      "width": 9,
+      "fields": [
+        {
+          "name": "Kumi",
+          "kind": "scalar",
+          "start": 1,
+          "width": 2,
+          "decoder": "text"
+        },
+        {
+          "name": "Odds",
+          "kind": "scalar",
+          "start": 3,
+          "width": 5,
+          "decoder": "text"
+        },
+        {
+          "name": "Ninki",
+          "kind": "scalar",
+          "start": 8,
+          "width": 2,
+          "decoder": "text"
+        }
+      ],
+      "expanded_leaf_count": 3
+    },
+    "JV_O1_ODDS_TANFUKUWAKU": {
+      "width": 962,
+      "fields": [
+        {
+          "name": "head",
+          "kind": "nested",
+          "start": 1,
+          "width": 11,
+          "struct": "RECORD_ID"
+        },
+        {
+          "name": "id",
+          "kind": "nested",
+          "start": 12,
+          "width": 16,
+          "struct": "RACE_ID"
+        },
+        {
+          "name": "HappyoTime",
+          "kind": "nested",
+          "start": 28,
+          "width": 8,
+          "struct": "MDHM"
+        },
+        {
+          "name": "TorokuTosu",
+          "kind": "scalar",
+          "start": 36,
+          "width": 2,
+          "decoder": "text"
+        },
+        {
+          "name": "SyussoTosu",
+          "kind": "scalar",
+          "start": 38,
+          "width": 2,
+          "decoder": "text"
+        },
+        {
+          "name": "TansyoFlag",
+          "kind": "scalar",
+          "start": 40,
+          "width": 1,
+          "decoder": "text"
+        },
+        {
+          "name": "FukusyoFlag",
+          "kind": "scalar",
+          "start": 41,
+          "width": 1,
+          "decoder": "text"
+        },
+        {
+          "name": "WakurenFlag",
+          "kind": "scalar",
+          "start": 42,
+          "width": 1,
+          "decoder": "text"
+        },
+        {
+          "name": "FukuChakuBaraiKey",
+          "kind": "scalar",
+          "start": 43,
+          "width": 1,
+          "decoder": "text"
+        },
+        {
+          "name": "OddsTansyoInfo",
+          "kind": "repeat",
+          "start": 44,
+          "width": 8,
+          "stride": 8,
+          "count": 28,
+          "element_kind": "nested",
+          "struct": "ODDS_TANSYO_INFO"
+        },
+        {
+          "name": "OddsFukusyoInfo",
+          "kind": "repeat",
+          "start": 268,
+          "width": 12,
+          "stride": 12,
+          "count": 28,
+          "element_kind": "nested",
+          "struct": "ODDS_FUKUSYO_INFO"
+        },
+        {
+          "name": "OddsWakurenInfo",
+          "kind": "repeat",
+          "start": 604,
+          "width": 9,
+          "stride": 9,
+          "count": 36,
+          "element_kind": "nested",
+          "struct": "ODDS_WAKUREN_INFO"
+        },
+        {
+          "name": "TotalHyosuTansyo",
+          "kind": "scalar",
+          "start": 928,
+          "width": 11,
+          "decoder": "text"
+        },
+        {
+          "name": "TotalHyosuFukusyo",
+          "kind": "scalar",
+          "start": 939,
+          "width": 11,
+          "decoder": "text"
+        },
+        {
+          "name": "TotalHyosuWakuren",
+          "kind": "scalar",
+          "start": 950,
+          "width": 11,
+          "decoder": "text"
+        },
+        {
+          "name": "crlf",
+          "kind": "scalar",
+          "start": 961,
+          "width": 2,
+          "decoder": "text"
+        }
+      ],
+      "expanded_leaf_count": 329
+    },
+    "ODDS_UMAREN_INFO": {
+      "width": 13,
+      "fields": [
+        {
+          "name": "Kumi",
+          "kind": "scalar",
+          "start": 1,
+          "width": 4,
+          "decoder": "text"
+        },
+        {
+          "name": "Odds",
+          "kind": "scalar",
+          "start": 5,
+          "width": 6,
+          "decoder": "text"
+        },
+        {
+          "name": "Ninki",
+          "kind": "scalar",
+          "start": 11,
+          "width": 3,
+          "decoder": "text"
+        }
+      ],
+      "expanded_leaf_count": 3
+    },
+    "JV_O2_ODDS_UMAREN": {
+      "width": 2042,
+      "fields": [
+        {
+          "name": "head",
+          "kind": "nested",
+          "start": 1,
+          "width": 11,
+          "struct": "RECORD_ID"
+        },
+        {
+          "name": "id",
+          "kind": "nested",
+          "start": 12,
+          "width": 16,
+          "struct": "RACE_ID"
+        },
+        {
+          "name": "HappyoTime",
+          "kind": "nested",
+          "start": 28,
+          "width": 8,
+          "struct": "MDHM"
+        },
+        {
+          "name": "TorokuTosu",
+          "kind": "scalar",
+          "start": 36,
+          "width": 2,
+          "decoder": "text"
+        },
+        {
+          "name": "SyussoTosu",
+          "kind": "scalar",
+          "start": 38,
+          "width": 2,
+          "decoder": "text"
+        },
+        {
+          "name": "UmarenFlag",
+          "kind": "scalar",
+          "start": 40,
+          "width": 1,
+          "decoder": "text"
+        },
+        {
+          "name": "OddsUmarenInfo",
+          "kind": "repeat",
+          "start": 41,
+          "width": 13,
+          "stride": 13,
+          "count": 153,
+          "element_kind": "nested",
+          "struct": "ODDS_UMAREN_INFO"
+        },
+        {
+          "name": "TotalHyosuUmaren",
+          "kind": "scalar",
+          "start": 2030,
+          "width": 11,
+          "decoder": "text"
+        },
+        {
+          "name": "crlf",
+          "kind": "scalar",
+          "start": 2041,
+          "width": 2,
+          "decoder": "text"
+        }
+      ],
+      "expanded_leaf_count": 479
+    },
+    "ODDS_WIDE_INFO": {
+      "width": 17,
+      "fields": [
+        {
+          "name": "Kumi",
+          "kind": "scalar",
+          "start": 1,
+          "width": 4,
+          "decoder": "text"
+        },
+        {
+          "name": "OddsLow",
+          "kind": "scalar",
+          "start": 5,
+          "width": 5,
+          "decoder": "text"
+        },
+        {
+          "name": "OddsHigh",
+          "kind": "scalar",
+          "start": 10,
+          "width": 5,
+          "decoder": "text"
+        },
+        {
+          "name": "Ninki",
+          "kind": "scalar",
+          "start": 15,
+          "width": 3,
+          "decoder": "text"
+        }
+      ],
+      "expanded_leaf_count": 4
+    },
+    "JV_O3_ODDS_WIDE": {
+      "width": 2654,
+      "fields": [
+        {
+          "name": "head",
+          "kind": "nested",
+          "start": 1,
+          "width": 11,
+          "struct": "RECORD_ID"
+        },
+        {
+          "name": "id",
+          "kind": "nested",
+          "start": 12,
+          "width": 16,
+          "struct": "RACE_ID"
+        },
+        {
+          "name": "HappyoTime",
+          "kind": "nested",
+          "start": 28,
+          "width": 8,
+          "struct": "MDHM"
+        },
+        {
+          "name": "TorokuTosu",
+          "kind": "scalar",
+          "start": 36,
+          "width": 2,
+          "decoder": "text"
+        },
+        {
+          "name": "SyussoTosu",
+          "kind": "scalar",
+          "start": 38,
+          "width": 2,
+          "decoder": "text"
+        },
+        {
+          "name": "WideFlag",
+          "kind": "scalar",
+          "start": 40,
+          "width": 1,
+          "decoder": "text"
+        },
+        {
+          "name": "OddsWideInfo",
+          "kind": "repeat",
+          "start": 41,
+          "width": 17,
+          "stride": 17,
+          "count": 153,
+          "element_kind": "nested",
+          "struct": "ODDS_WIDE_INFO"
+        },
+        {
+          "name": "TotalHyosuWide",
+          "kind": "scalar",
+          "start": 2642,
+          "width": 11,
+          "decoder": "text"
+        },
+        {
+          "name": "crlf",
+          "kind": "scalar",
+          "start": 2653,
+          "width": 2,
+          "decoder": "text"
+        }
+      ],
+      "expanded_leaf_count": 632
+    },
+    "ODDS_UMATAN_INFO": {
+      "width": 13,
+      "fields": [
+        {
+          "name": "Kumi",
+          "kind": "scalar",
+          "start": 1,
+          "width": 4,
+          "decoder": "text"
+        },
+        {
+          "name": "Odds",
+          "kind": "scalar",
+          "start": 5,
+          "width": 6,
+          "decoder": "text"
+        },
+        {
+          "name": "Ninki",
+          "kind": "scalar",
+          "start": 11,
+          "width": 3,
+          "decoder": "text"
+        }
+      ],
+      "expanded_leaf_count": 3
+    },
+    "JV_O4_ODDS_UMATAN": {
+      "width": 4031,
+      "fields": [
+        {
+          "name": "head",
+          "kind": "nested",
+          "start": 1,
+          "width": 11,
+          "struct": "RECORD_ID"
+        },
+        {
+          "name": "id",
+          "kind": "nested",
+          "start": 12,
+          "width": 16,
+          "struct": "RACE_ID"
+        },
+        {
+          "name": "HappyoTime",
+          "kind": "nested",
+          "start": 28,
+          "width": 8,
+          "struct": "MDHM"
+        },
+        {
+          "name": "TorokuTosu",
+          "kind": "scalar",
+          "start": 36,
+          "width": 2,
+          "decoder": "text"
+        },
+        {
+          "name": "SyussoTosu",
+          "kind": "scalar",
+          "start": 38,
+          "width": 2,
+          "decoder": "text"
+        },
+        {
+          "name": "UmatanFlag",
+          "kind": "scalar",
+          "start": 40,
+          "width": 1,
+          "decoder": "text"
+        },
+        {
+          "name": "OddsUmatanInfo",
+          "kind": "repeat",
+          "start": 41,
+          "width": 13,
+          "stride": 13,
+          "count": 306,
+          "element_kind": "nested",
+          "struct": "ODDS_UMATAN_INFO"
+        },
+        {
+          "name": "TotalHyosuUmatan",
+          "kind": "scalar",
+          "start": 4019,
+          "width": 11,
+          "decoder": "text"
+        },
+        {
+          "name": "crlf",
+          "kind": "scalar",
+          "start": 4030,
+          "width": 2,
+          "decoder": "text"
+        }
+      ],
+      "expanded_leaf_count": 938
+    },
+    "ODDS_SANREN_INFO": {
+      "width": 15,
+      "fields": [
+        {
+          "name": "Kumi",
+          "kind": "scalar",
+          "start": 1,
+          "width": 6,
+          "decoder": "text"
+        },
+        {
+          "name": "Odds",
+          "kind": "scalar",
+          "start": 7,
+          "width": 6,
+          "decoder": "text"
+        },
+        {
+          "name": "Ninki",
+          "kind": "scalar",
+          "start": 13,
+          "width": 3,
+          "decoder": "text"
+        }
+      ],
+      "expanded_leaf_count": 3
+    },
+    "JV_O5_ODDS_SANREN": {
+      "width": 12293,
+      "fields": [
+        {
+          "name": "head",
+          "kind": "nested",
+          "start": 1,
+          "width": 11,
+          "struct": "RECORD_ID"
+        },
+        {
+          "name": "id",
+          "kind": "nested",
+          "start": 12,
+          "width": 16,
+          "struct": "RACE_ID"
+        },
+        {
+          "name": "HappyoTime",
+          "kind": "nested",
+          "start": 28,
+          "width": 8,
+          "struct": "MDHM"
+        },
+        {
+          "name": "TorokuTosu",
+          "kind": "scalar",
+          "start": 36,
+          "width": 2,
+          "decoder": "text"
+        },
+        {
+          "name": "SyussoTosu",
+          "kind": "scalar",
+          "start": 38,
+          "width": 2,
+          "decoder": "text"
+        },
+        {
+          "name": "SanrenpukuFlag",
+          "kind": "scalar",
+          "start": 40,
+          "width": 1,
+          "decoder": "text"
+        },
+        {
+          "name": "OddsSanrenInfo",
+          "kind": "repeat",
+          "start": 41,
+          "width": 15,
+          "stride": 15,
+          "count": 816,
+          "element_kind": "nested",
+          "struct": "ODDS_SANREN_INFO"
+        },
+        {
+          "name": "TotalHyosuSanrenpuku",
+          "kind": "scalar",
+          "start": 12281,
+          "width": 11,
+          "decoder": "text"
+        },
+        {
+          "name": "crlf",
+          "kind": "scalar",
+          "start": 12292,
+          "width": 2,
+          "decoder": "text"
+        }
+      ],
+      "expanded_leaf_count": 2468
+    },
+    "ODDS_SANRENTAN_INFO": {
+      "width": 17,
+      "fields": [
+        {
+          "name": "Kumi",
+          "kind": "scalar",
+          "start": 1,
+          "width": 6,
+          "decoder": "text"
+        },
+        {
+          "name": "Odds",
+          "kind": "scalar",
+          "start": 7,
+          "width": 7,
+          "decoder": "text"
+        },
+        {
+          "name": "Ninki",
+          "kind": "scalar",
+          "start": 14,
+          "width": 4,
+          "decoder": "text"
+        }
+      ],
+      "expanded_leaf_count": 3
+    },
+    "JV_O6_ODDS_SANRENTAN": {
+      "width": 83285,
+      "fields": [
+        {
+          "name": "head",
+          "kind": "nested",
+          "start": 1,
+          "width": 11,
+          "struct": "RECORD_ID"
+        },
+        {
+          "name": "id",
+          "kind": "nested",
+          "start": 12,
+          "width": 16,
+          "struct": "RACE_ID"
+        },
+        {
+          "name": "HappyoTime",
+          "kind": "nested",
+          "start": 28,
+          "width": 8,
+          "struct": "MDHM"
+        },
+        {
+          "name": "TorokuTosu",
+          "kind": "scalar",
+          "start": 36,
+          "width": 2,
+          "decoder": "text"
+        },
+        {
+          "name": "SyussoTosu",
+          "kind": "scalar",
+          "start": 38,
+          "width": 2,
+          "decoder": "text"
+        },
+        {
+          "name": "SanrentanFlag",
+          "kind": "scalar",
+          "start": 40,
+          "width": 1,
+          "decoder": "text"
+        },
+        {
+          "name": "OddsSanrentanInfo",
+          "kind": "repeat",
+          "start": 41,
+          "width": 17,
+          "stride": 17,
+          "count": 4896,
+          "element_kind": "nested",
+          "struct": "ODDS_SANRENTAN_INFO"
+        },
+        {
+          "name": "TotalHyosuSanrentan",
+          "kind": "scalar",
+          "start": 83273,
+          "width": 11,
+          "decoder": "text"
+        },
+        {
+          "name": "crlf",
+          "kind": "scalar",
+          "start": 83284,
+          "width": 2,
+          "decoder": "text"
+        }
+      ],
+      "expanded_leaf_count": 14708
+    },
+    "KETTO3_INFO": {
+      "width": 46,
+      "fields": [
+        {
+          "name": "HansyokuNum",
+          "kind": "scalar",
+          "start": 1,
+          "width": 10,
+          "decoder": "text"
+        },
+        {
+          "name": "Bamei",
+          "kind": "scalar",
+          "start": 11,
+          "width": 36,
+          "decoder": "text"
+        }
+      ],
+      "expanded_leaf_count": 2
+    },
+    "JV_UM_UMA": {
+      "width": 1609,
+      "fields": [
+        {
+          "name": "head",
+          "kind": "nested",
+          "start": 1,
+          "width": 11,
+          "struct": "RECORD_ID"
+        },
+        {
+          "name": "KettoNum",
+          "kind": "scalar",
+          "start": 12,
+          "width": 10,
+          "decoder": "text"
+        },
+        {
+          "name": "DelKubun",
+          "kind": "scalar",
+          "start": 22,
+          "width": 1,
+          "decoder": "text"
+        },
+        {
+          "name": "RegDate",
+          "kind": "nested",
+          "start": 23,
+          "width": 8,
+          "struct": "YMD"
+        },
+        {
+          "name": "DelDate",
+          "kind": "nested",
+          "start": 31,
+          "width": 8,
+          "struct": "YMD"
+        },
+        {
+          "name": "BirthDate",
+          "kind": "nested",
+          "start": 39,
+          "width": 8,
+          "struct": "YMD"
+        },
+        {
+          "name": "Bamei",
+          "kind": "scalar",
+          "start": 47,
+          "width": 36,
+          "decoder": "text"
+        },
+        {
+          "name": "BameiKana",
+          "kind": "scalar",
+          "start": 83,
+          "width": 36,
+          "decoder": "text"
+        },
+        {
+          "name": "BameiEng",
+          "kind": "scalar",
+          "start": 119,
+          "width": 60,
+          "decoder": "text"
+        },
+        {
+          "name": "ZaikyuFlag",
+          "kind": "scalar",
+          "start": 179,
+          "width": 1,
+          "decoder": "text"
+        },
+        {
+          "name": "Reserved",
+          "kind": "scalar",
+          "start": 180,
+          "width": 19,
+          "decoder": "text"
+        },
+        {
+          "name": "UmaKigoCD",
+          "kind": "scalar",
+          "start": 199,
+          "width": 2,
+          "decoder": "text"
+        },
+        {
+          "name": "SexCD",
+          "kind": "scalar",
+          "start": 201,
+          "width": 1,
+          "decoder": "text"
+        },
+        {
+          "name": "HinsyuCD",
+          "kind": "scalar",
+          "start": 202,
+          "width": 1,
+          "decoder": "text"
+        },
+        {
+          "name": "KeiroCD",
+          "kind": "scalar",
+          "start": 203,
+          "width": 2,
+          "decoder": "text"
+        },
+        {
+          "name": "Ketto3Info",
+          "kind": "repeat",
+          "start": 205,
+          "width": 46,
+          "stride": 46,
+          "count": 14,
+          "element_kind": "nested",
+          "struct": "KETTO3_INFO"
+        },
+        {
+          "name": "TozaiCD",
+          "kind": "scalar",
+          "start": 849,
+          "width": 1,
+          "decoder": "text"
+        },
+        {
+          "name": "ChokyosiCode",
+          "kind": "scalar",
+          "start": 850,
+          "width": 5,
+          "decoder": "text"
+        },
+        {
+          "name": "ChokyosiRyakusyo",
+          "kind": "scalar",
+          "start": 855,
+          "width": 8,
+          "decoder": "text"
+        },
+        {
+          "name": "Syotai",
+          "kind": "scalar",
+          "start": 863,
+          "width": 20,
+          "decoder": "text"
+        },
+        {
+          "name": "BreederCode",
+          "kind": "scalar",
+          "start": 883,
+          "width": 8,
+          "decoder": "text"
+        },
+        {
+          "name": "BreederName",
+          "kind": "scalar",
+          "start": 891,
+          "width": 72,
+          "decoder": "text"
+        },
+        {
+          "name": "SanchiName",
+          "kind": "scalar",
+          "start": 963,
+          "width": 20,
+          "decoder": "text"
+        },
+        {
+          "name": "BanusiCode",
+          "kind": "scalar",
+          "start": 983,
+          "width": 6,
+          "decoder": "text"
+        },
+        {
+          "name": "BanusiName",
+          "kind": "scalar",
+          "start": 989,
+          "width": 64,
+          "decoder": "text"
+        },
+        {
+          "name": "RuikeiHonsyoHeiti",
+          "kind": "scalar",
+          "start": 1053,
+          "width": 9,
+          "decoder": "text"
+        },
+        {
+          "name": "RuikeiHonsyoSyogai",
+          "kind": "scalar",
+          "start": 1062,
+          "width": 9,
+          "decoder": "text"
+        },
+        {
+          "name": "RuikeiFukaHeichi",
+          "kind": "scalar",
+          "start": 1071,
+          "width": 9,
+          "decoder": "text"
+        },
+        {
+          "name": "RuikeiFukaSyogai",
+          "kind": "scalar",
+          "start": 1080,
+          "width": 9,
+          "decoder": "text"
+        },
+        {
+          "name": "RuikeiSyutokuHeichi",
+          "kind": "scalar",
+          "start": 1089,
+          "width": 9,
+          "decoder": "text"
+        },
+        {
+          "name": "RuikeiSyutokuSyogai",
+          "kind": "scalar",
+          "start": 1098,
+          "width": 9,
+          "decoder": "text"
+        },
+        {
+          "name": "ChakuSogo",
+          "kind": "nested",
+          "start": 1107,
+          "width": 18,
+          "struct": "CHAKUKAISU3_INFO"
+        },
+        {
+          "name": "ChakuChuo",
+          "kind": "nested",
+          "start": 1125,
+          "width": 18,
+          "struct": "CHAKUKAISU3_INFO"
+        },
+        {
+          "name": "ChakuKaisuBa",
+          "kind": "repeat",
+          "start": 1143,
+          "width": 18,
+          "stride": 18,
+          "count": 7,
+          "element_kind": "nested",
+          "struct": "CHAKUKAISU3_INFO"
+        },
+        {
+          "name": "ChakuKaisuJyotai",
+          "kind": "repeat",
+          "start": 1269,
+          "width": 18,
+          "stride": 18,
+          "count": 12,
+          "element_kind": "nested",
+          "struct": "CHAKUKAISU3_INFO"
+        },
+        {
+          "name": "ChakuKaisuKyori",
+          "kind": "repeat",
+          "start": 1485,
+          "width": 18,
+          "stride": 18,
+          "count": 6,
+          "element_kind": "nested",
+          "struct": "CHAKUKAISU3_INFO"
+        },
+        {
+          "name": "Kyakusitu",
+          "kind": "repeat",
+          "start": 1593,
+          "width": 3,
+          "stride": 3,
+          "count": 4,
+          "element_kind": "scalar",
+          "decoder": "text"
+        },
+        {
+          "name": "RaceCount",
+          "kind": "scalar",
+          "start": 1605,
+          "width": 3,
+          "decoder": "text"
+        },
+        {
+          "name": "crlf",
+          "kind": "scalar",
+          "start": 1608,
+          "width": 2,
+          "decoder": "text"
+        }
+      ],
+      "expanded_leaf_count": 236
+    },
+    "HATUKIJYO_INFO": {
+      "width": 67,
+      "fields": [
+        {
+          "name": "Hatukijyoid",
+          "kind": "nested",
+          "start": 1,
+          "width": 16,
+          "struct": "RACE_ID"
+        },
+        {
+          "name": "SyussoTosu",
+          "kind": "scalar",
+          "start": 17,
+          "width": 2,
+          "decoder": "text"
+        },
+        {
+          "name": "KettoNum",
+          "kind": "scalar",
+          "start": 19,
+          "width": 10,
+          "decoder": "text"
+        },
+        {
+          "name": "Bamei",
+          "kind": "scalar",
+          "start": 29,
+          "width": 36,
+          "decoder": "text"
+        },
+        {
+          "name": "KakuteiJyuni",
+          "kind": "scalar",
+          "start": 65,
+          "width": 2,
+          "decoder": "text"
+        },
+        {
+          "name": "IJyoCD",
+          "kind": "scalar",
+          "start": 67,
+          "width": 1,
+          "decoder": "text"
+        }
+      ],
+      "expanded_leaf_count": 11
+    },
+    "HATUSYORI_INFO": {
+      "width": 64,
+      "fields": [
+        {
+          "name": "Hatusyoriid",
+          "kind": "nested",
+          "start": 1,
+          "width": 16,
+          "struct": "RACE_ID"
+        },
+        {
+          "name": "SyussoTosu",
+          "kind": "scalar",
+          "start": 17,
+          "width": 2,
+          "decoder": "text"
+        },
+        {
+          "name": "KettoNum",
+          "kind": "scalar",
+          "start": 19,
+          "width": 10,
+          "decoder": "text"
+        },
+        {
+          "name": "Bamei",
+          "kind": "scalar",
+          "start": 29,
+          "width": 36,
+          "decoder": "text"
+        }
+      ],
+      "expanded_leaf_count": 9
+    },
+    "JV_KS_KISYU": {
+      "width": 4173,
+      "fields": [
+        {
+          "name": "head",
+          "kind": "nested",
+          "start": 1,
+          "width": 11,
+          "struct": "RECORD_ID"
+        },
+        {
+          "name": "KisyuCode",
+          "kind": "scalar",
+          "start": 12,
+          "width": 5,
+          "decoder": "text"
+        },
+        {
+          "name": "DelKubun",
+          "kind": "scalar",
+          "start": 17,
+          "width": 1,
+          "decoder": "text"
+        },
+        {
+          "name": "IssueDate",
+          "kind": "nested",
+          "start": 18,
+          "width": 8,
+          "struct": "YMD"
+        },
+        {
+          "name": "DelDate",
+          "kind": "nested",
+          "start": 26,
+          "width": 8,
+          "struct": "YMD"
+        },
+        {
+          "name": "BirthDate",
+          "kind": "nested",
+          "start": 34,
+          "width": 8,
+          "struct": "YMD"
+        },
+        {
+          "name": "KisyuName",
+          "kind": "scalar",
+          "start": 42,
+          "width": 34,
+          "decoder": "text"
+        },
+        {
+          "name": "reserved",
+          "kind": "scalar",
+          "start": 76,
+          "width": 34,
+          "decoder": "text"
+        },
+        {
+          "name": "KisyuNameKana",
+          "kind": "scalar",
+          "start": 110,
+          "width": 30,
+          "decoder": "text"
+        },
+        {
+          "name": "KisyuRyakusyo",
+          "kind": "scalar",
+          "start": 140,
+          "width": 8,
+          "decoder": "text"
+        },
+        {
+          "name": "KisyuNameEng",
+          "kind": "scalar",
+          "start": 148,
+          "width": 80,
+          "decoder": "text"
+        },
+        {
+          "name": "SexCD",
+          "kind": "scalar",
+          "start": 228,
+          "width": 1,
+          "decoder": "text"
+        },
+        {
+          "name": "SikakuCD",
+          "kind": "scalar",
+          "start": 229,
+          "width": 1,
+          "decoder": "text"
+        },
+        {
+          "name": "MinaraiCD",
+          "kind": "scalar",
+          "start": 230,
+          "width": 1,
+          "decoder": "text"
+        },
+        {
+          "name": "TozaiCD",
+          "kind": "scalar",
+          "start": 231,
+          "width": 1,
+          "decoder": "text"
+        },
+        {
+          "name": "Syotai",
+          "kind": "scalar",
+          "start": 232,
+          "width": 20,
+          "decoder": "text"
+        },
+        {
+          "name": "ChokyosiCode",
+          "kind": "scalar",
+          "start": 252,
+          "width": 5,
+          "decoder": "text"
+        },
+        {
+          "name": "ChokyosiRyakusyo",
+          "kind": "scalar",
+          "start": 257,
+          "width": 8,
+          "decoder": "text"
+        },
+        {
+          "name": "HatuKiJyo",
+          "kind": "repeat",
+          "start": 265,
+          "width": 67,
+          "stride": 67,
+          "count": 2,
+          "element_kind": "nested",
+          "struct": "HATUKIJYO_INFO"
+        },
+        {
+          "name": "HatuSyori",
+          "kind": "repeat",
+          "start": 399,
+          "width": 64,
+          "stride": 64,
+          "count": 2,
+          "element_kind": "nested",
+          "struct": "HATUSYORI_INFO"
+        },
+        {
+          "name": "SaikinJyusyo",
+          "kind": "repeat",
+          "start": 527,
+          "width": 163,
+          "stride": 163,
+          "count": 3,
+          "element_kind": "nested",
+          "struct": "SAIKIN_JYUSYO_INFO"
+        },
+        {
+          "name": "HonZenRuikei",
+          "kind": "repeat",
+          "start": 1016,
+          "width": 1052,
+          "stride": 1052,
+          "count": 3,
+          "element_kind": "nested",
+          "struct": "HON_ZEN_RUIKEISEI_INFO"
+        },
+        {
+          "name": "crlf",
+          "kind": "scalar",
+          "start": 4172,
+          "width": 2,
+          "decoder": "text"
+        }
+      ],
+      "expanded_leaf_count": 630
+    },
+    "JV_CH_CHOKYOSI": {
+      "width": 3862,
+      "fields": [
+        {
+          "name": "head",
+          "kind": "nested",
+          "start": 1,
+          "width": 11,
+          "struct": "RECORD_ID"
+        },
+        {
+          "name": "ChokyosiCode",
+          "kind": "scalar",
+          "start": 12,
+          "width": 5,
+          "decoder": "text"
+        },
+        {
+          "name": "DelKubun",
+          "kind": "scalar",
+          "start": 17,
+          "width": 1,
+          "decoder": "text"
+        },
+        {
+          "name": "IssueDate",
+          "kind": "nested",
+          "start": 18,
+          "width": 8,
+          "struct": "YMD"
+        },
+        {
+          "name": "DelDate",
+          "kind": "nested",
+          "start": 26,
+          "width": 8,
+          "struct": "YMD"
+        },
+        {
+          "name": "BirthDate",
+          "kind": "nested",
+          "start": 34,
+          "width": 8,
+          "struct": "YMD"
+        },
+        {
+          "name": "ChokyosiName",
+          "kind": "scalar",
+          "start": 42,
+          "width": 34,
+          "decoder": "text"
+        },
+        {
+          "name": "ChokyosiNameKana",
+          "kind": "scalar",
+          "start": 76,
+          "width": 30,
+          "decoder": "text"
+        },
+        {
+          "name": "ChokyosiRyakusyo",
+          "kind": "scalar",
+          "start": 106,
+          "width": 8,
+          "decoder": "text"
+        },
+        {
+          "name": "ChokyosiNameEng",
+          "kind": "scalar",
+          "start": 114,
+          "width": 80,
+          "decoder": "text"
+        },
+        {
+          "name": "SexCD",
+          "kind": "scalar",
+          "start": 194,
+          "width": 1,
+          "decoder": "text"
+        },
+        {
+          "name": "TozaiCD",
+          "kind": "scalar",
+          "start": 195,
+          "width": 1,
+          "decoder": "text"
+        },
+        {
+          "name": "Syotai",
+          "kind": "scalar",
+          "start": 196,
+          "width": 20,
+          "decoder": "text"
+        },
+        {
+          "name": "SaikinJyusyo",
+          "kind": "repeat",
+          "start": 216,
+          "width": 163,
+          "stride": 163,
+          "count": 3,
+          "element_kind": "nested",
+          "struct": "SAIKIN_JYUSYO_INFO"
+        },
+        {
+          "name": "HonZenRuikei",
+          "kind": "repeat",
+          "start": 705,
+          "width": 1052,
+          "stride": 1052,
+          "count": 3,
+          "element_kind": "nested",
+          "struct": "HON_ZEN_RUIKEISEI_INFO"
+        },
+        {
+          "name": "crlf",
+          "kind": "scalar",
+          "start": 3861,
+          "width": 2,
+          "decoder": "text"
+        }
+      ],
+      "expanded_leaf_count": 585
+    },
+    "JV_BR_BREEDER": {
+      "width": 545,
+      "fields": [
+        {
+          "name": "head",
+          "kind": "nested",
+          "start": 1,
+          "width": 11,
+          "struct": "RECORD_ID"
+        },
+        {
+          "name": "BreederCode",
+          "kind": "scalar",
+          "start": 12,
+          "width": 8,
+          "decoder": "text"
+        },
+        {
+          "name": "BreederName_Co",
+          "kind": "scalar",
+          "start": 20,
+          "width": 72,
+          "decoder": "text"
+        },
+        {
+          "name": "BreederName",
+          "kind": "scalar",
+          "start": 92,
+          "width": 72,
+          "decoder": "text"
+        },
+        {
+          "name": "BreederNameKana",
+          "kind": "scalar",
+          "start": 164,
+          "width": 72,
+          "decoder": "text"
+        },
+        {
+          "name": "BreederNameEng",
+          "kind": "scalar",
+          "start": 236,
+          "width": 168,
+          "decoder": "text"
+        },
+        {
+          "name": "Address",
+          "kind": "scalar",
+          "start": 404,
+          "width": 20,
+          "decoder": "text"
+        },
+        {
+          "name": "HonRuikei",
+          "kind": "repeat",
+          "start": 424,
+          "width": 60,
+          "stride": 60,
+          "count": 2,
+          "element_kind": "nested",
+          "struct": "SEI_RUIKEI_INFO"
+        },
+        {
+          "name": "crlf",
+          "kind": "scalar",
+          "start": 544,
+          "width": 2,
+          "decoder": "text"
+        }
+      ],
+      "expanded_leaf_count": 30
+    },
+    "JV_BN_BANUSI": {
+      "width": 477,
+      "fields": [
+        {
+          "name": "head",
+          "kind": "nested",
+          "start": 1,
+          "width": 11,
+          "struct": "RECORD_ID"
+        },
+        {
+          "name": "BanusiCode",
+          "kind": "scalar",
+          "start": 12,
+          "width": 6,
+          "decoder": "text"
+        },
+        {
+          "name": "BanusiName_Co",
+          "kind": "scalar",
+          "start": 18,
+          "width": 64,
+          "decoder": "text"
+        },
+        {
+          "name": "BanusiName",
+          "kind": "scalar",
+          "start": 82,
+          "width": 64,
+          "decoder": "text"
+        },
+        {
+          "name": "BanusiNameKana",
+          "kind": "scalar",
+          "start": 146,
+          "width": 50,
+          "decoder": "text"
+        },
+        {
+          "name": "BanusiNameEng",
+          "kind": "scalar",
+          "start": 196,
+          "width": 100,
+          "decoder": "text"
+        },
+        {
+          "name": "Fukusyoku",
+          "kind": "scalar",
+          "start": 296,
+          "width": 60,
+          "decoder": "text"
+        },
+        {
+          "name": "HonRuikei",
+          "kind": "repeat",
+          "start": 356,
+          "width": 60,
+          "stride": 60,
+          "count": 2,
+          "element_kind": "nested",
+          "struct": "SEI_RUIKEI_INFO"
+        },
+        {
+          "name": "crlf",
+          "kind": "scalar",
+          "start": 476,
+          "width": 2,
+          "decoder": "text"
+        }
+      ],
+      "expanded_leaf_count": 30
+    },
+    "JV_HN_HANSYOKU": {
+      "width": 251,
+      "fields": [
+        {
+          "name": "head",
+          "kind": "nested",
+          "start": 1,
+          "width": 11,
+          "struct": "RECORD_ID"
+        },
+        {
+          "name": "HansyokuNum",
+          "kind": "scalar",
+          "start": 12,
+          "width": 10,
+          "decoder": "text"
+        },
+        {
+          "name": "reserved",
+          "kind": "scalar",
+          "start": 22,
+          "width": 8,
+          "decoder": "text"
+        },
+        {
+          "name": "KettoNum",
+          "kind": "scalar",
+          "start": 30,
+          "width": 10,
+          "decoder": "text"
+        },
+        {
+          "name": "DelKubun",
+          "kind": "scalar",
+          "start": 40,
+          "width": 1,
+          "decoder": "text"
+        },
+        {
+          "name": "Bamei",
+          "kind": "scalar",
+          "start": 41,
+          "width": 36,
+          "decoder": "text"
+        },
+        {
+          "name": "BameiKana",
+          "kind": "scalar",
+          "start": 77,
+          "width": 40,
+          "decoder": "text"
+        },
+        {
+          "name": "BameiEng",
+          "kind": "scalar",
+          "start": 117,
+          "width": 80,
+          "decoder": "text"
+        },
+        {
+          "name": "BirthYear",
+          "kind": "scalar",
+          "start": 197,
+          "width": 4,
+          "decoder": "text"
+        },
+        {
+          "name": "SexCD",
+          "kind": "scalar",
+          "start": 201,
+          "width": 1,
+          "decoder": "text"
+        },
+        {
+          "name": "HinsyuCD",
+          "kind": "scalar",
+          "start": 202,
+          "width": 1,
+          "decoder": "text"
+        },
+        {
+          "name": "KeiroCD",
+          "kind": "scalar",
+          "start": 203,
+          "width": 2,
+          "decoder": "text"
+        },
+        {
+          "name": "HansyokuMochiKubun",
+          "kind": "scalar",
+          "start": 205,
+          "width": 1,
+          "decoder": "text"
+        },
+        {
+          "name": "ImportYear",
+          "kind": "scalar",
+          "start": 206,
+          "width": 4,
+          "decoder": "text"
+        },
+        {
+          "name": "SanchiName",
+          "kind": "scalar",
+          "start": 210,
+          "width": 20,
+          "decoder": "text"
+        },
+        {
+          "name": "HansyokuFNum",
+          "kind": "scalar",
+          "start": 230,
+          "width": 10,
+          "decoder": "text"
+        },
+        {
+          "name": "HansyokuMNum",
+          "kind": "scalar",
+          "start": 240,
+          "width": 10,
+          "decoder": "text"
+        },
+        {
+          "name": "crlf",
+          "kind": "scalar",
+          "start": 250,
+          "width": 2,
+          "decoder": "text"
+        }
+      ],
+      "expanded_leaf_count": 22
+    },
+    "JV_SK_SANKU": {
+      "width": 208,
+      "fields": [
+        {
+          "name": "head",
+          "kind": "nested",
+          "start": 1,
+          "width": 11,
+          "struct": "RECORD_ID"
+        },
+        {
+          "name": "KettoNum",
+          "kind": "scalar",
+          "start": 12,
+          "width": 10,
+          "decoder": "text"
+        },
+        {
+          "name": "BirthDate",
+          "kind": "nested",
+          "start": 22,
+          "width": 8,
+          "struct": "YMD"
+        },
+        {
+          "name": "SexCD",
+          "kind": "scalar",
+          "start": 30,
+          "width": 1,
+          "decoder": "text"
+        },
+        {
+          "name": "HinsyuCD",
+          "kind": "scalar",
+          "start": 31,
+          "width": 1,
+          "decoder": "text"
+        },
+        {
+          "name": "KeiroCD",
+          "kind": "scalar",
+          "start": 32,
+          "width": 2,
+          "decoder": "text"
+        },
+        {
+          "name": "SankuMochiKubun",
+          "kind": "scalar",
+          "start": 34,
+          "width": 1,
+          "decoder": "text"
+        },
+        {
+          "name": "ImportYear",
+          "kind": "scalar",
+          "start": 35,
+          "width": 4,
+          "decoder": "text"
+        },
+        {
+          "name": "BreederCode",
+          "kind": "scalar",
+          "start": 39,
+          "width": 8,
+          "decoder": "text"
+        },
+        {
+          "name": "SanchiName",
+          "kind": "scalar",
+          "start": 47,
+          "width": 20,
+          "decoder": "text"
+        },
+        {
+          "name": "HansyokuNum",
+          "kind": "repeat",
+          "start": 67,
+          "width": 10,
+          "stride": 10,
+          "count": 14,
+          "element_kind": "scalar",
+          "decoder": "text"
+        },
+        {
+          "name": "crlf",
+          "kind": "scalar",
+          "start": 207,
+          "width": 2,
+          "decoder": "text"
+        }
+      ],
+      "expanded_leaf_count": 31
+    },
+    "JV_CK_UMA": {
+      "width": 1357,
+      "fields": [
+        {
+          "name": "KettoNum",
+          "kind": "scalar",
+          "start": 1,
+          "width": 10,
+          "decoder": "text"
+        },
+        {
+          "name": "Bamei",
+          "kind": "scalar",
+          "start": 11,
+          "width": 36,
+          "decoder": "text"
+        },
+        {
+          "name": "RuikeiHonsyoHeiti",
+          "kind": "scalar",
+          "start": 47,
+          "width": 9,
+          "decoder": "text"
+        },
+        {
+          "name": "RuikeiHonsyoSyogai",
+          "kind": "scalar",
+          "start": 56,
+          "width": 9,
+          "decoder": "text"
+        },
+        {
+          "name": "RuikeiFukaHeichi",
+          "kind": "scalar",
+          "start": 65,
+          "width": 9,
+          "decoder": "text"
+        },
+        {
+          "name": "RuikeiFukaSyogai",
+          "kind": "scalar",
+          "start": 74,
+          "width": 9,
+          "decoder": "text"
+        },
+        {
+          "name": "RuikeiSyutokuHeichi",
+          "kind": "scalar",
+          "start": 83,
+          "width": 9,
+          "decoder": "text"
+        },
+        {
+          "name": "RuikeiSyutokuSyogai",
+          "kind": "scalar",
+          "start": 92,
+          "width": 9,
+          "decoder": "text"
+        },
+        {
+          "name": "ChakuSogo",
+          "kind": "nested",
+          "start": 101,
+          "width": 18,
+          "struct": "CHAKUKAISU3_INFO"
+        },
+        {
+          "name": "ChakuChuo",
+          "kind": "nested",
+          "start": 119,
+          "width": 18,
+          "struct": "CHAKUKAISU3_INFO"
+        },
+        {
+          "name": "ChakuKaisuBa",
+          "kind": "repeat",
+          "start": 137,
+          "width": 18,
+          "stride": 18,
+          "count": 7,
+          "element_kind": "nested",
+          "struct": "CHAKUKAISU3_INFO"
+        },
+        {
+          "name": "ChakuKaisuJyotai",
+          "kind": "repeat",
+          "start": 263,
+          "width": 18,
+          "stride": 18,
+          "count": 12,
+          "element_kind": "nested",
+          "struct": "CHAKUKAISU3_INFO"
+        },
+        {
+          "name": "ChakuKaisuSibaKyori",
+          "kind": "repeat",
+          "start": 479,
+          "width": 18,
+          "stride": 18,
+          "count": 9,
+          "element_kind": "nested",
+          "struct": "CHAKUKAISU3_INFO"
+        },
+        {
+          "name": "ChakuKaisuDirtKyori",
+          "kind": "repeat",
+          "start": 641,
+          "width": 18,
+          "stride": 18,
+          "count": 9,
+          "element_kind": "nested",
+          "struct": "CHAKUKAISU3_INFO"
+        },
+        {
+          "name": "ChakuKaisuJyoSiba",
+          "kind": "repeat",
+          "start": 803,
+          "width": 18,
+          "stride": 18,
+          "count": 10,
+          "element_kind": "nested",
+          "struct": "CHAKUKAISU3_INFO"
+        },
+        {
+          "name": "ChakuKaisuJyoDirt",
+          "kind": "repeat",
+          "start": 983,
+          "width": 18,
+          "stride": 18,
+          "count": 10,
+          "element_kind": "nested",
+          "struct": "CHAKUKAISU3_INFO"
+        },
+        {
+          "name": "ChakuKaisuJyoSyogai",
+          "kind": "repeat",
+          "start": 1163,
+          "width": 18,
+          "stride": 18,
+          "count": 10,
+          "element_kind": "nested",
+          "struct": "CHAKUKAISU3_INFO"
+        },
+        {
+          "name": "Kyakusitu",
+          "kind": "repeat",
+          "start": 1343,
+          "width": 3,
+          "stride": 3,
+          "count": 4,
+          "element_kind": "scalar",
+          "decoder": "text"
+        },
+        {
+          "name": "RaceCount",
+          "kind": "scalar",
+          "start": 1355,
+          "width": 3,
+          "decoder": "text"
+        }
+      ],
+      "expanded_leaf_count": 427
+    },
+    "JV_CK_HON_RUIKEISEI_INFO": {
+      "width": 1220,
+      "fields": [
+        {
+          "name": "SetYear",
+          "kind": "scalar",
+          "start": 1,
+          "width": 4,
+          "decoder": "text"
+        },
+        {
+          "name": "HonSyokinHeichi",
+          "kind": "scalar",
+          "start": 5,
+          "width": 10,
+          "decoder": "text"
+        },
+        {
+          "name": "HonSyokinSyogai",
+          "kind": "scalar",
+          "start": 15,
+          "width": 10,
+          "decoder": "text"
+        },
+        {
+          "name": "FukaSyokinHeichi",
+          "kind": "scalar",
+          "start": 25,
+          "width": 10,
+          "decoder": "text"
+        },
+        {
+          "name": "FukaSyokinSyogai",
+          "kind": "scalar",
+          "start": 35,
+          "width": 10,
+          "decoder": "text"
+        },
+        {
+          "name": "ChakuKaisuSiba",
+          "kind": "nested",
+          "start": 45,
+          "width": 30,
+          "struct": "CHAKUKAISU5_INFO"
+        },
+        {
+          "name": "ChakuKaisuDirt",
+          "kind": "nested",
+          "start": 75,
+          "width": 30,
+          "struct": "CHAKUKAISU5_INFO"
+        },
+        {
+          "name": "ChakuKaisuSyogai",
+          "kind": "nested",
+          "start": 105,
+          "width": 24,
+          "struct": "CHAKUKAISU4_INFO"
+        },
+        {
+          "name": "ChakuKaisuSibaKyori",
+          "kind": "repeat",
+          "start": 129,
+          "width": 24,
+          "stride": 24,
+          "count": 9,
+          "element_kind": "nested",
+          "struct": "CHAKUKAISU4_INFO"
+        },
+        {
+          "name": "ChakuKaisuDirtKyori",
+          "kind": "repeat",
+          "start": 345,
+          "width": 24,
+          "stride": 24,
+          "count": 9,
+          "element_kind": "nested",
+          "struct": "CHAKUKAISU4_INFO"
+        },
+        {
+          "name": "ChakuKaisuJyoSiba",
+          "kind": "repeat",
+          "start": 561,
+          "width": 24,
+          "stride": 24,
+          "count": 10,
+          "element_kind": "nested",
+          "struct": "CHAKUKAISU4_INFO"
+        },
+        {
+          "name": "ChakuKaisuJyoDirt",
+          "kind": "repeat",
+          "start": 801,
+          "width": 24,
+          "stride": 24,
+          "count": 10,
+          "element_kind": "nested",
+          "struct": "CHAKUKAISU4_INFO"
+        },
+        {
+          "name": "ChakuKaisuJyoSyogai",
+          "kind": "repeat",
+          "start": 1041,
+          "width": 18,
+          "stride": 18,
+          "count": 10,
+          "element_kind": "nested",
+          "struct": "CHAKUKAISU3_INFO"
+        }
+      ],
+      "expanded_leaf_count": 311
+    },
+    "JV_CK_KISYU": {
+      "width": 2479,
+      "fields": [
+        {
+          "name": "KisyuCode",
+          "kind": "scalar",
+          "start": 1,
+          "width": 5,
+          "decoder": "text"
+        },
+        {
+          "name": "KisyuName",
+          "kind": "scalar",
+          "start": 6,
+          "width": 34,
+          "decoder": "text"
+        },
+        {
+          "name": "HonRuikei",
+          "kind": "repeat",
+          "start": 40,
+          "width": 1220,
+          "stride": 1220,
+          "count": 2,
+          "element_kind": "nested",
+          "struct": "JV_CK_HON_RUIKEISEI_INFO"
+        }
+      ],
+      "expanded_leaf_count": 624
+    },
+    "JV_CK_CHOKYOSI": {
+      "width": 2479,
+      "fields": [
+        {
+          "name": "ChokyosiCode",
+          "kind": "scalar",
+          "start": 1,
+          "width": 5,
+          "decoder": "text"
+        },
+        {
+          "name": "ChokyosiName",
+          "kind": "scalar",
+          "start": 6,
+          "width": 34,
+          "decoder": "text"
+        },
+        {
+          "name": "HonRuikei",
+          "kind": "repeat",
+          "start": 40,
+          "width": 1220,
+          "stride": 1220,
+          "count": 2,
+          "element_kind": "nested",
+          "struct": "JV_CK_HON_RUIKEISEI_INFO"
+        }
+      ],
+      "expanded_leaf_count": 624
+    },
+    "JV_CK_BANUSI": {
+      "width": 254,
+      "fields": [
+        {
+          "name": "BanusiCode",
+          "kind": "scalar",
+          "start": 1,
+          "width": 6,
+          "decoder": "text"
+        },
+        {
+          "name": "BanusiName_Co",
+          "kind": "scalar",
+          "start": 7,
+          "width": 64,
+          "decoder": "text"
+        },
+        {
+          "name": "BanusiName",
+          "kind": "scalar",
+          "start": 71,
+          "width": 64,
+          "decoder": "text"
+        },
+        {
+          "name": "HonRuikei",
+          "kind": "repeat",
+          "start": 135,
+          "width": 60,
+          "stride": 60,
+          "count": 2,
+          "element_kind": "nested",
+          "struct": "SEI_RUIKEI_INFO"
+        }
+      ],
+      "expanded_leaf_count": 21
+    },
+    "JV_CK_BREEDER": {
+      "width": 272,
+      "fields": [
+        {
+          "name": "BreederCode",
+          "kind": "scalar",
+          "start": 1,
+          "width": 8,
+          "decoder": "text"
+        },
+        {
+          "name": "BreederName_Co",
+          "kind": "scalar",
+          "start": 9,
+          "width": 72,
+          "decoder": "text"
+        },
+        {
+          "name": "BreederName",
+          "kind": "scalar",
+          "start": 81,
+          "width": 72,
+          "decoder": "text"
+        },
+        {
+          "name": "HonRuikei",
+          "kind": "repeat",
+          "start": 153,
+          "width": 60,
+          "stride": 60,
+          "count": 2,
+          "element_kind": "nested",
+          "struct": "SEI_RUIKEI_INFO"
+        }
+      ],
+      "expanded_leaf_count": 21
+    },
+    "JV_CK_CHAKU": {
+      "width": 6870,
+      "fields": [
+        {
+          "name": "head",
+          "kind": "nested",
+          "start": 1,
+          "width": 11,
+          "struct": "RECORD_ID"
+        },
+        {
+          "name": "id",
+          "kind": "nested",
+          "start": 12,
+          "width": 16,
+          "struct": "RACE_ID"
+        },
+        {
+          "name": "UmaChaku",
+          "kind": "nested",
+          "start": 28,
+          "width": 1357,
+          "struct": "JV_CK_UMA"
+        },
+        {
+          "name": "KisyuChaku",
+          "kind": "nested",
+          "start": 1385,
+          "width": 2479,
+          "struct": "JV_CK_KISYU"
+        },
+        {
+          "name": "ChokyoChaku",
+          "kind": "nested",
+          "start": 3864,
+          "width": 2479,
+          "struct": "JV_CK_CHOKYOSI"
+        },
+        {
+          "name": "BanusiChaku",
+          "kind": "nested",
+          "start": 6343,
+          "width": 254,
+          "struct": "JV_CK_BANUSI"
+        },
+        {
+          "name": "BreederChaku",
+          "kind": "nested",
+          "start": 6597,
+          "width": 272,
+          "struct": "JV_CK_BREEDER"
+        },
+        {
+          "name": "crlf",
+          "kind": "scalar",
+          "start": 6869,
+          "width": 2,
+          "decoder": "text"
+        }
+      ],
+      "expanded_leaf_count": 1729
+    },
+    "RECUMA_INFO": {
+      "width": 130,
+      "fields": [
+        {
+          "name": "KettoNum",
+          "kind": "scalar",
+          "start": 1,
+          "width": 10,
+          "decoder": "text"
+        },
+        {
+          "name": "Bamei",
+          "kind": "scalar",
+          "start": 11,
+          "width": 36,
+          "decoder": "text"
+        },
+        {
+          "name": "UmaKigoCD",
+          "kind": "scalar",
+          "start": 47,
+          "width": 2,
+          "decoder": "text"
+        },
+        {
+          "name": "SexCD",
+          "kind": "scalar",
+          "start": 49,
+          "width": 1,
+          "decoder": "text"
+        },
+        {
+          "name": "ChokyosiCode",
+          "kind": "scalar",
+          "start": 50,
+          "width": 5,
+          "decoder": "text"
+        },
+        {
+          "name": "ChokyosiName",
+          "kind": "scalar",
+          "start": 55,
+          "width": 34,
+          "decoder": "text"
+        },
+        {
+          "name": "Futan",
+          "kind": "scalar",
+          "start": 89,
+          "width": 3,
+          "decoder": "text"
+        },
+        {
+          "name": "KisyuCode",
+          "kind": "scalar",
+          "start": 92,
+          "width": 5,
+          "decoder": "text"
+        },
+        {
+          "name": "KisyuName",
+          "kind": "scalar",
+          "start": 97,
+          "width": 34,
+          "decoder": "text"
+        }
+      ],
+      "expanded_leaf_count": 9
+    },
+    "JV_RC_RECORD": {
+      "width": 501,
+      "fields": [
+        {
+          "name": "head",
+          "kind": "nested",
+          "start": 1,
+          "width": 11,
+          "struct": "RECORD_ID"
+        },
+        {
+          "name": "RecInfoKubun",
+          "kind": "scalar",
+          "start": 12,
+          "width": 1,
+          "decoder": "text"
+        },
+        {
+          "name": "id",
+          "kind": "nested",
+          "start": 13,
+          "width": 16,
+          "struct": "RACE_ID"
+        },
+        {
+          "name": "TokuNum",
+          "kind": "scalar",
+          "start": 29,
+          "width": 4,
+          "decoder": "text"
+        },
+        {
+          "name": "Hondai",
+          "kind": "scalar",
+          "start": 33,
+          "width": 60,
+          "decoder": "text"
+        },
+        {
+          "name": "GradeCD",
+          "kind": "scalar",
+          "start": 93,
+          "width": 1,
+          "decoder": "text"
+        },
+        {
+          "name": "SyubetuCD",
+          "kind": "scalar",
+          "start": 94,
+          "width": 2,
+          "decoder": "text"
+        },
+        {
+          "name": "Kyori",
+          "kind": "scalar",
+          "start": 96,
+          "width": 4,
+          "decoder": "text"
+        },
+        {
+          "name": "TrackCD",
+          "kind": "scalar",
+          "start": 100,
+          "width": 2,
+          "decoder": "text"
+        },
+        {
+          "name": "RecKubun",
+          "kind": "scalar",
+          "start": 102,
+          "width": 1,
+          "decoder": "text"
+        },
+        {
+          "name": "RecTime",
+          "kind": "scalar",
+          "start": 103,
+          "width": 4,
+          "decoder": "text"
+        },
+        {
+          "name": "TenkoBaba",
+          "kind": "nested",
+          "start": 107,
+          "width": 3,
+          "struct": "TENKO_BABA_INFO"
+        },
+        {
+          "name": "RecUmaInfo",
+          "kind": "repeat",
+          "start": 110,
+          "width": 130,
+          "stride": 130,
+          "count": 3,
+          "element_kind": "nested",
+          "struct": "RECUMA_INFO"
+        },
+        {
+          "name": "crlf",
+          "kind": "scalar",
+          "start": 500,
+          "width": 2,
+          "decoder": "text"
+        }
+      ],
+      "expanded_leaf_count": 51
+    },
+    "JV_HC_HANRO": {
+      "width": 60,
+      "fields": [
+        {
+          "name": "head",
+          "kind": "nested",
+          "start": 1,
+          "width": 11,
+          "struct": "RECORD_ID"
+        },
+        {
+          "name": "TresenKubun",
+          "kind": "scalar",
+          "start": 12,
+          "width": 1,
+          "decoder": "text"
+        },
+        {
+          "name": "ChokyoDate",
+          "kind": "nested",
+          "start": 13,
+          "width": 8,
+          "struct": "YMD"
+        },
+        {
+          "name": "ChokyoTime",
+          "kind": "scalar",
+          "start": 21,
+          "width": 4,
+          "decoder": "text"
+        },
+        {
+          "name": "KettoNum",
+          "kind": "scalar",
+          "start": 25,
+          "width": 10,
+          "decoder": "text"
+        },
+        {
+          "name": "HaronTime4",
+          "kind": "scalar",
+          "start": 35,
+          "width": 4,
+          "decoder": "text"
+        },
+        {
+          "name": "LapTime4",
+          "kind": "scalar",
+          "start": 39,
+          "width": 3,
+          "decoder": "text"
+        },
+        {
+          "name": "HaronTime3",
+          "kind": "scalar",
+          "start": 42,
+          "width": 4,
+          "decoder": "text"
+        },
+        {
+          "name": "LapTime3",
+          "kind": "scalar",
+          "start": 46,
+          "width": 3,
+          "decoder": "text"
+        },
+        {
+          "name": "HaronTime2",
+          "kind": "scalar",
+          "start": 49,
+          "width": 4,
+          "decoder": "text"
+        },
+        {
+          "name": "LapTime2",
+          "kind": "scalar",
+          "start": 53,
+          "width": 3,
+          "decoder": "text"
+        },
+        {
+          "name": "LapTime1",
+          "kind": "scalar",
+          "start": 56,
+          "width": 3,
+          "decoder": "text"
+        },
+        {
+          "name": "crlf",
+          "kind": "scalar",
+          "start": 59,
+          "width": 2,
+          "decoder": "text"
+        }
+      ],
+      "expanded_leaf_count": 19
+    },
+    "JV_HS_SALE": {
+      "width": 200,
+      "fields": [
+        {
+          "name": "head",
+          "kind": "nested",
+          "start": 1,
+          "width": 11,
+          "struct": "RECORD_ID"
+        },
+        {
+          "name": "KettoNum",
+          "kind": "scalar",
+          "start": 12,
+          "width": 10,
+          "decoder": "text"
+        },
+        {
+          "name": "HansyokuFNum",
+          "kind": "scalar",
+          "start": 22,
+          "width": 10,
+          "decoder": "text"
+        },
+        {
+          "name": "HansyokuMNum",
+          "kind": "scalar",
+          "start": 32,
+          "width": 10,
+          "decoder": "text"
+        },
+        {
+          "name": "BirthYear",
+          "kind": "scalar",
+          "start": 42,
+          "width": 4,
+          "decoder": "text"
+        },
+        {
+          "name": "SaleCode",
+          "kind": "scalar",
+          "start": 46,
+          "width": 6,
+          "decoder": "text"
+        },
+        {
+          "name": "SaleHostName",
+          "kind": "scalar",
+          "start": 52,
+          "width": 40,
+          "decoder": "text"
+        },
+        {
+          "name": "SaleName",
+          "kind": "scalar",
+          "start": 92,
+          "width": 80,
+          "decoder": "text"
+        },
+        {
+          "name": "FromDate",
+          "kind": "nested",
+          "start": 172,
+          "width": 8,
+          "struct": "YMD"
+        },
+        {
+          "name": "ToDate",
+          "kind": "nested",
+          "start": 180,
+          "width": 8,
+          "struct": "YMD"
+        },
+        {
+          "name": "Barei",
+          "kind": "scalar",
+          "start": 188,
+          "width": 1,
+          "decoder": "text"
+        },
+        {
+          "name": "Price",
+          "kind": "scalar",
+          "start": 189,
+          "width": 10,
+          "decoder": "text"
+        },
+        {
+          "name": "crlf",
+          "kind": "scalar",
+          "start": 199,
+          "width": 2,
+          "decoder": "text"
+        }
+      ],
+      "expanded_leaf_count": 21
+    },
+    "JV_HY_BAMEIORIGIN": {
+      "width": 123,
+      "fields": [
+        {
+          "name": "head",
+          "kind": "nested",
+          "start": 1,
+          "width": 11,
+          "struct": "RECORD_ID"
+        },
+        {
+          "name": "KettoNum",
+          "kind": "scalar",
+          "start": 12,
+          "width": 10,
+          "decoder": "text"
+        },
+        {
+          "name": "Bamei",
+          "kind": "scalar",
+          "start": 22,
+          "width": 36,
+          "decoder": "text"
+        },
+        {
+          "name": "Origin",
+          "kind": "scalar",
+          "start": 58,
+          "width": 64,
+          "decoder": "text"
+        },
+        {
+          "name": "crlf",
+          "kind": "scalar",
+          "start": 122,
+          "width": 2,
+          "decoder": "text"
+        }
+      ],
+      "expanded_leaf_count": 9
+    },
+    "JYUSYO_INFO": {
+      "width": 118,
+      "fields": [
+        {
+          "name": "TokuNum",
+          "kind": "scalar",
+          "start": 1,
+          "width": 4,
+          "decoder": "text"
+        },
+        {
+          "name": "Hondai",
+          "kind": "scalar",
+          "start": 5,
+          "width": 60,
+          "decoder": "text"
+        },
+        {
+          "name": "Ryakusyo10",
+          "kind": "scalar",
+          "start": 65,
+          "width": 20,
+          "decoder": "text"
+        },
+        {
+          "name": "Ryakusyo6",
+          "kind": "scalar",
+          "start": 85,
+          "width": 12,
+          "decoder": "text"
+        },
+        {
+          "name": "Ryakusyo3",
+          "kind": "scalar",
+          "start": 97,
+          "width": 6,
+          "decoder": "text"
+        },
+        {
+          "name": "Nkai",
+          "kind": "scalar",
+          "start": 103,
+          "width": 3,
+          "decoder": "text"
+        },
+        {
+          "name": "GradeCD",
+          "kind": "scalar",
+          "start": 106,
+          "width": 1,
+          "decoder": "text"
+        },
+        {
+          "name": "SyubetuCD",
+          "kind": "scalar",
+          "start": 107,
+          "width": 2,
+          "decoder": "text"
+        },
+        {
+          "name": "KigoCD",
+          "kind": "scalar",
+          "start": 109,
+          "width": 3,
+          "decoder": "text"
+        },
+        {
+          "name": "JyuryoCD",
+          "kind": "scalar",
+          "start": 112,
+          "width": 1,
+          "decoder": "text"
+        },
+        {
+          "name": "Kyori",
+          "kind": "scalar",
+          "start": 113,
+          "width": 4,
+          "decoder": "text"
+        },
+        {
+          "name": "TrackCD",
+          "kind": "scalar",
+          "start": 117,
+          "width": 2,
+          "decoder": "text"
+        }
+      ],
+      "expanded_leaf_count": 12
+    },
+    "JV_YS_SCHEDULE": {
+      "width": 382,
+      "fields": [
+        {
+          "name": "head",
+          "kind": "nested",
+          "start": 1,
+          "width": 11,
+          "struct": "RECORD_ID"
+        },
+        {
+          "name": "id",
+          "kind": "nested",
+          "start": 12,
+          "width": 14,
+          "struct": "RACE_ID2"
+        },
+        {
+          "name": "YoubiCD",
+          "kind": "scalar",
+          "start": 26,
+          "width": 1,
+          "decoder": "text"
+        },
+        {
+          "name": "JyusyoInfo",
+          "kind": "repeat",
+          "start": 27,
+          "width": 118,
+          "stride": 118,
+          "count": 3,
+          "element_kind": "nested",
+          "struct": "JYUSYO_INFO"
+        },
+        {
+          "name": "crlf",
+          "kind": "scalar",
+          "start": 381,
+          "width": 2,
+          "decoder": "text"
+        }
+      ],
+      "expanded_leaf_count": 48
+    },
+    "JV_BT_KEITO": {
+      "width": 6889,
+      "fields": [
+        {
+          "name": "head",
+          "kind": "nested",
+          "start": 1,
+          "width": 11,
+          "struct": "RECORD_ID"
+        },
+        {
+          "name": "HansyokuNum",
+          "kind": "scalar",
+          "start": 12,
+          "width": 10,
+          "decoder": "text"
+        },
+        {
+          "name": "KeitoId",
+          "kind": "scalar",
+          "start": 22,
+          "width": 30,
+          "decoder": "text"
+        },
+        {
+          "name": "KeitoName",
+          "kind": "scalar",
+          "start": 52,
+          "width": 36,
+          "decoder": "text"
+        },
+        {
+          "name": "KeitoEx",
+          "kind": "scalar",
+          "start": 88,
+          "width": 6800,
+          "decoder": "text"
+        },
+        {
+          "name": "crlf",
+          "kind": "scalar",
+          "start": 6888,
+          "width": 2,
+          "decoder": "text"
+        }
+      ],
+      "expanded_leaf_count": 10
+    },
+    "JV_CS_COURSE": {
+      "width": 6829,
+      "fields": [
+        {
+          "name": "head",
+          "kind": "nested",
+          "start": 1,
+          "width": 11,
+          "struct": "RECORD_ID"
+        },
+        {
+          "name": "JyoCD",
+          "kind": "scalar",
+          "start": 12,
+          "width": 2,
+          "decoder": "text"
+        },
+        {
+          "name": "Kyori",
+          "kind": "scalar",
+          "start": 14,
+          "width": 4,
+          "decoder": "text"
+        },
+        {
+          "name": "TrackCD",
+          "kind": "scalar",
+          "start": 18,
+          "width": 2,
+          "decoder": "text"
+        },
+        {
+          "name": "KaishuDate",
+          "kind": "nested",
+          "start": 20,
+          "width": 8,
+          "struct": "YMD"
+        },
+        {
+          "name": "CourseEx",
+          "kind": "scalar",
+          "start": 28,
+          "width": 6800,
+          "decoder": "text"
+        },
+        {
+          "name": "crlf",
+          "kind": "scalar",
+          "start": 6828,
+          "width": 2,
+          "decoder": "text"
+        }
+      ],
+      "expanded_leaf_count": 13
+    },
+    "DM_INFO": {
+      "width": 15,
+      "fields": [
+        {
+          "name": "Umaban",
+          "kind": "scalar",
+          "start": 1,
+          "width": 2,
+          "decoder": "text"
+        },
+        {
+          "name": "DMTime",
+          "kind": "scalar",
+          "start": 3,
+          "width": 5,
+          "decoder": "text"
+        },
+        {
+          "name": "DMGosaP",
+          "kind": "scalar",
+          "start": 8,
+          "width": 4,
+          "decoder": "text"
+        },
+        {
+          "name": "DMGosaM",
+          "kind": "scalar",
+          "start": 12,
+          "width": 4,
+          "decoder": "text"
+        }
+      ],
+      "expanded_leaf_count": 4
+    },
+    "JV_DM_INFO": {
+      "width": 303,
+      "fields": [
+        {
+          "name": "head",
+          "kind": "nested",
+          "start": 1,
+          "width": 11,
+          "struct": "RECORD_ID"
+        },
+        {
+          "name": "id",
+          "kind": "nested",
+          "start": 12,
+          "width": 16,
+          "struct": "RACE_ID"
+        },
+        {
+          "name": "MakeHM",
+          "kind": "nested",
+          "start": 28,
+          "width": 4,
+          "struct": "HM"
+        },
+        {
+          "name": "DMInfo",
+          "kind": "repeat",
+          "start": 32,
+          "width": 15,
+          "stride": 15,
+          "count": 18,
+          "element_kind": "nested",
+          "struct": "DM_INFO"
+        },
+        {
+          "name": "crlf",
+          "kind": "scalar",
+          "start": 302,
+          "width": 2,
+          "decoder": "text"
+        }
+      ],
+      "expanded_leaf_count": 86
+    },
+    "TM_INFO": {
+      "width": 6,
+      "fields": [
+        {
+          "name": "Umaban",
+          "kind": "scalar",
+          "start": 1,
+          "width": 2,
+          "decoder": "text"
+        },
+        {
+          "name": "TMScore",
+          "kind": "scalar",
+          "start": 3,
+          "width": 4,
+          "decoder": "text"
+        }
+      ],
+      "expanded_leaf_count": 2
+    },
+    "JV_TM_INFO": {
+      "width": 141,
+      "fields": [
+        {
+          "name": "head",
+          "kind": "nested",
+          "start": 1,
+          "width": 11,
+          "struct": "RECORD_ID"
+        },
+        {
+          "name": "id",
+          "kind": "nested",
+          "start": 12,
+          "width": 16,
+          "struct": "RACE_ID"
+        },
+        {
+          "name": "MakeHM",
+          "kind": "nested",
+          "start": 28,
+          "width": 4,
+          "struct": "HM"
+        },
+        {
+          "name": "TMInfo",
+          "kind": "repeat",
+          "start": 32,
+          "width": 6,
+          "stride": 6,
+          "count": 18,
+          "element_kind": "nested",
+          "struct": "TM_INFO"
+        },
+        {
+          "name": "crlf",
+          "kind": "scalar",
+          "start": 140,
+          "width": 2,
+          "decoder": "text"
+        }
+      ],
+      "expanded_leaf_count": 50
+    },
+    "WF_RACE_INFO": {
+      "width": 8,
+      "fields": [
+        {
+          "name": "JyoCD",
+          "kind": "scalar",
+          "start": 1,
+          "width": 2,
+          "decoder": "text"
+        },
+        {
+          "name": "Kaiji",
+          "kind": "scalar",
+          "start": 3,
+          "width": 2,
+          "decoder": "text"
+        },
+        {
+          "name": "Nichiji",
+          "kind": "scalar",
+          "start": 5,
+          "width": 2,
+          "decoder": "text"
+        },
+        {
+          "name": "RaceNum",
+          "kind": "scalar",
+          "start": 7,
+          "width": 2,
+          "decoder": "text"
+        }
+      ],
+      "expanded_leaf_count": 4
+    },
+    "WF_YUKO_HYO_INFO": {
+      "width": 11,
+      "fields": [
+        {
+          "name": "Yuko_Hyo",
+          "kind": "scalar",
+          "start": 1,
+          "width": 11,
+          "decoder": "text"
+        }
+      ],
+      "expanded_leaf_count": 1
+    },
+    "WF_PAY_INFO": {
+      "width": 29,
+      "fields": [
+        {
+          "name": "Kumiban",
+          "kind": "scalar",
+          "start": 1,
+          "width": 10,
+          "decoder": "text"
+        },
+        {
+          "name": "Pay",
+          "kind": "scalar",
+          "start": 11,
+          "width": 9,
+          "decoder": "text"
+        },
+        {
+          "name": "Tekichu_Hyo",
+          "kind": "scalar",
+          "start": 20,
+          "width": 10,
+          "decoder": "text"
+        }
+      ],
+      "expanded_leaf_count": 3
+    },
+    "JV_WF_INFO": {
+      "width": 7215,
+      "fields": [
+        {
+          "name": "head",
+          "kind": "nested",
+          "start": 1,
+          "width": 11,
+          "struct": "RECORD_ID"
+        },
+        {
+          "name": "KaisaiDate",
+          "kind": "nested",
+          "start": 12,
+          "width": 8,
+          "struct": "YMD"
+        },
+        {
+          "name": "reserved1",
+          "kind": "scalar",
+          "start": 20,
+          "width": 2,
+          "decoder": "text"
+        },
+        {
+          "name": "WFRaceInfo",
+          "kind": "repeat",
+          "start": 22,
+          "width": 8,
+          "stride": 8,
+          "count": 5,
+          "element_kind": "nested",
+          "struct": "WF_RACE_INFO"
+        },
+        {
+          "name": "reserved2",
+          "kind": "scalar",
+          "start": 62,
+          "width": 6,
+          "decoder": "text"
+        },
+        {
+          "name": "Hatsubai_Hyo",
+          "kind": "scalar",
+          "start": 68,
+          "width": 11,
+          "decoder": "text"
+        },
+        {
+          "name": "WFYukoHyoInfo",
+          "kind": "repeat",
+          "start": 79,
+          "width": 11,
+          "stride": 11,
+          "count": 5,
+          "element_kind": "nested",
+          "struct": "WF_YUKO_HYO_INFO"
+        },
+        {
+          "name": "HenkanFlag",
+          "kind": "scalar",
+          "start": 134,
+          "width": 1,
+          "decoder": "text"
+        },
+        {
+          "name": "FuseiritsuFlag",
+          "kind": "scalar",
+          "start": 135,
+          "width": 1,
+          "decoder": "text"
+        },
+        {
+          "name": "TekichunashiFlag",
+          "kind": "scalar",
+          "start": 136,
+          "width": 1,
+          "decoder": "text"
+        },
+        {
+          "name": "COShoki",
+          "kind": "scalar",
+          "start": 137,
+          "width": 15,
+          "decoder": "text"
+        },
+        {
+          "name": "COZanDaka",
+          "kind": "scalar",
+          "start": 152,
+          "width": 15,
+          "decoder": "text"
+        },
+        {
+          "name": "WFPayInfo",
+          "kind": "repeat",
+          "start": 167,
+          "width": 29,
+          "stride": 29,
+          "count": 243,
+          "element_kind": "nested",
+          "struct": "WF_PAY_INFO"
+        },
+        {
+          "name": "crlf",
+          "kind": "scalar",
+          "start": 7214,
+          "width": 2,
+          "decoder": "text"
+        }
+      ],
+      "expanded_leaf_count": 771
+    },
+    "JV_JG_JOGAIBA": {
+      "width": 80,
+      "fields": [
+        {
+          "name": "head",
+          "kind": "nested",
+          "start": 1,
+          "width": 11,
+          "struct": "RECORD_ID"
+        },
+        {
+          "name": "id",
+          "kind": "nested",
+          "start": 12,
+          "width": 16,
+          "struct": "RACE_ID"
+        },
+        {
+          "name": "KettoNum",
+          "kind": "scalar",
+          "start": 28,
+          "width": 10,
+          "decoder": "text"
+        },
+        {
+          "name": "Bamei",
+          "kind": "scalar",
+          "start": 38,
+          "width": 36,
+          "decoder": "text"
+        },
+        {
+          "name": "ShutsubaTohyoJun",
+          "kind": "scalar",
+          "start": 74,
+          "width": 3,
+          "decoder": "text"
+        },
+        {
+          "name": "ShussoKubun",
+          "kind": "scalar",
+          "start": 77,
+          "width": 1,
+          "decoder": "text"
+        },
+        {
+          "name": "JogaiJotaiKubun",
+          "kind": "scalar",
+          "start": 78,
+          "width": 1,
+          "decoder": "text"
+        },
+        {
+          "name": "crlf",
+          "kind": "scalar",
+          "start": 79,
+          "width": 2,
+          "decoder": "text"
+        }
+      ],
+      "expanded_leaf_count": 17
+    },
+    "JV_WC_WOOD": {
+      "width": 105,
+      "fields": [
+        {
+          "name": "head",
+          "kind": "nested",
+          "start": 1,
+          "width": 11,
+          "struct": "RECORD_ID"
+        },
+        {
+          "name": "TresenKubun",
+          "kind": "scalar",
+          "start": 12,
+          "width": 1,
+          "decoder": "text"
+        },
+        {
+          "name": "ChokyoDate",
+          "kind": "nested",
+          "start": 13,
+          "width": 8,
+          "struct": "YMD"
+        },
+        {
+          "name": "ChokyoTime",
+          "kind": "scalar",
+          "start": 21,
+          "width": 4,
+          "decoder": "text"
+        },
+        {
+          "name": "KettoNum",
+          "kind": "scalar",
+          "start": 25,
+          "width": 10,
+          "decoder": "text"
+        },
+        {
+          "name": "Course",
+          "kind": "scalar",
+          "start": 35,
+          "width": 1,
+          "decoder": "text"
+        },
+        {
+          "name": "BabaAround",
+          "kind": "scalar",
+          "start": 36,
+          "width": 1,
+          "decoder": "text"
+        },
+        {
+          "name": "reserved",
+          "kind": "scalar",
+          "start": 37,
+          "width": 1,
+          "decoder": "text"
+        },
+        {
+          "name": "HaronTime10",
+          "kind": "scalar",
+          "start": 38,
+          "width": 4,
+          "decoder": "text"
+        },
+        {
+          "name": "LapTime10",
+          "kind": "scalar",
+          "start": 42,
+          "width": 3,
+          "decoder": "text"
+        },
+        {
+          "name": "HaronTime9",
+          "kind": "scalar",
+          "start": 45,
+          "width": 4,
+          "decoder": "text"
+        },
+        {
+          "name": "LapTime9",
+          "kind": "scalar",
+          "start": 49,
+          "width": 3,
+          "decoder": "text"
+        },
+        {
+          "name": "HaronTime8",
+          "kind": "scalar",
+          "start": 52,
+          "width": 4,
+          "decoder": "text"
+        },
+        {
+          "name": "LapTime8",
+          "kind": "scalar",
+          "start": 56,
+          "width": 3,
+          "decoder": "text"
+        },
+        {
+          "name": "HaronTime7",
+          "kind": "scalar",
+          "start": 59,
+          "width": 4,
+          "decoder": "text"
+        },
+        {
+          "name": "LapTime7",
+          "kind": "scalar",
+          "start": 63,
+          "width": 3,
+          "decoder": "text"
+        },
+        {
+          "name": "HaronTime6",
+          "kind": "scalar",
+          "start": 66,
+          "width": 4,
+          "decoder": "text"
+        },
+        {
+          "name": "LapTime6",
+          "kind": "scalar",
+          "start": 70,
+          "width": 3,
+          "decoder": "text"
+        },
+        {
+          "name": "HaronTime5",
+          "kind": "scalar",
+          "start": 73,
+          "width": 4,
+          "decoder": "text"
+        },
+        {
+          "name": "LapTime5",
+          "kind": "scalar",
+          "start": 77,
+          "width": 3,
+          "decoder": "text"
+        },
+        {
+          "name": "HaronTime4",
+          "kind": "scalar",
+          "start": 80,
+          "width": 4,
+          "decoder": "text"
+        },
+        {
+          "name": "LapTime4",
+          "kind": "scalar",
+          "start": 84,
+          "width": 3,
+          "decoder": "text"
+        },
+        {
+          "name": "HaronTime3",
+          "kind": "scalar",
+          "start": 87,
+          "width": 4,
+          "decoder": "text"
+        },
+        {
+          "name": "LapTime3",
+          "kind": "scalar",
+          "start": 91,
+          "width": 3,
+          "decoder": "text"
+        },
+        {
+          "name": "HaronTime2",
+          "kind": "scalar",
+          "start": 94,
+          "width": 4,
+          "decoder": "text"
+        },
+        {
+          "name": "LapTime2",
+          "kind": "scalar",
+          "start": 98,
+          "width": 3,
+          "decoder": "text"
+        },
+        {
+          "name": "LapTime1",
+          "kind": "scalar",
+          "start": 101,
+          "width": 3,
+          "decoder": "text"
+        },
+        {
+          "name": "crlf",
+          "kind": "scalar",
+          "start": 104,
+          "width": 2,
+          "decoder": "text"
+        }
+      ],
+      "expanded_leaf_count": 34
+    },
+    "BATAIJYU_INFO": {
+      "width": 45,
+      "fields": [
+        {
+          "name": "Umaban",
+          "kind": "scalar",
+          "start": 1,
+          "width": 2,
+          "decoder": "text"
+        },
+        {
+          "name": "Bamei",
+          "kind": "scalar",
+          "start": 3,
+          "width": 36,
+          "decoder": "text"
+        },
+        {
+          "name": "BaTaijyu",
+          "kind": "scalar",
+          "start": 39,
+          "width": 3,
+          "decoder": "text"
+        },
+        {
+          "name": "ZogenFugo",
+          "kind": "scalar",
+          "start": 42,
+          "width": 1,
+          "decoder": "text"
+        },
+        {
+          "name": "ZogenSa",
+          "kind": "scalar",
+          "start": 43,
+          "width": 3,
+          "decoder": "text"
+        }
+      ],
+      "expanded_leaf_count": 5
+    },
+    "JV_WH_BATAIJYU": {
+      "width": 847,
+      "fields": [
+        {
+          "name": "head",
+          "kind": "nested",
+          "start": 1,
+          "width": 11,
+          "struct": "RECORD_ID"
+        },
+        {
+          "name": "id",
+          "kind": "nested",
+          "start": 12,
+          "width": 16,
+          "struct": "RACE_ID"
+        },
+        {
+          "name": "HappyoTime",
+          "kind": "nested",
+          "start": 28,
+          "width": 8,
+          "struct": "MDHM"
+        },
+        {
+          "name": "BataijyuInfo",
+          "kind": "repeat",
+          "start": 36,
+          "width": 45,
+          "stride": 45,
+          "count": 18,
+          "element_kind": "nested",
+          "struct": "BATAIJYU_INFO"
+        },
+        {
+          "name": "crlf",
+          "kind": "scalar",
+          "start": 846,
+          "width": 2,
+          "decoder": "text"
+        }
+      ],
+      "expanded_leaf_count": 106
+    },
+    "JV_WE_WEATHER": {
+      "width": 42,
+      "fields": [
+        {
+          "name": "head",
+          "kind": "nested",
+          "start": 1,
+          "width": 11,
+          "struct": "RECORD_ID"
+        },
+        {
+          "name": "id",
+          "kind": "nested",
+          "start": 12,
+          "width": 14,
+          "struct": "RACE_ID2"
+        },
+        {
+          "name": "HappyoTime",
+          "kind": "nested",
+          "start": 26,
+          "width": 8,
+          "struct": "MDHM"
+        },
+        {
+          "name": "HenkoID",
+          "kind": "scalar",
+          "start": 34,
+          "width": 1,
+          "decoder": "text"
+        },
+        {
+          "name": "TenkoBaba",
+          "kind": "nested",
+          "start": 35,
+          "width": 3,
+          "struct": "TENKO_BABA_INFO"
+        },
+        {
+          "name": "TenkoBabaBefore",
+          "kind": "nested",
+          "start": 38,
+          "width": 3,
+          "struct": "TENKO_BABA_INFO"
+        },
+        {
+          "name": "crlf",
+          "kind": "scalar",
+          "start": 41,
+          "width": 2,
+          "decoder": "text"
+        }
+      ],
+      "expanded_leaf_count": 22
+    },
+    "JV_AV_INFO": {
+      "width": 78,
+      "fields": [
+        {
+          "name": "head",
+          "kind": "nested",
+          "start": 1,
+          "width": 11,
+          "struct": "RECORD_ID"
+        },
+        {
+          "name": "id",
+          "kind": "nested",
+          "start": 12,
+          "width": 16,
+          "struct": "RACE_ID"
+        },
+        {
+          "name": "HappyoTime",
+          "kind": "nested",
+          "start": 28,
+          "width": 8,
+          "struct": "MDHM"
+        },
+        {
+          "name": "Umaban",
+          "kind": "scalar",
+          "start": 36,
+          "width": 2,
+          "decoder": "text"
+        },
+        {
+          "name": "Bamei",
+          "kind": "scalar",
+          "start": 38,
+          "width": 36,
+          "decoder": "text"
+        },
+        {
+          "name": "JiyuKubun",
+          "kind": "scalar",
+          "start": 74,
+          "width": 3,
+          "decoder": "text"
+        },
+        {
+          "name": "crlf",
+          "kind": "scalar",
+          "start": 77,
+          "width": 2,
+          "decoder": "text"
+        }
+      ],
+      "expanded_leaf_count": 19
+    },
+    "JC_INFO": {
+      "width": 43,
+      "fields": [
+        {
+          "name": "Futan",
+          "kind": "scalar",
+          "start": 1,
+          "width": 3,
+          "decoder": "text"
+        },
+        {
+          "name": "KisyuCode",
+          "kind": "scalar",
+          "start": 4,
+          "width": 5,
+          "decoder": "text"
+        },
+        {
+          "name": "KisyuName",
+          "kind": "scalar",
+          "start": 9,
+          "width": 34,
+          "decoder": "text"
+        },
+        {
+          "name": "MinaraiCD",
+          "kind": "scalar",
+          "start": 43,
+          "width": 1,
+          "decoder": "text"
+        }
+      ],
+      "expanded_leaf_count": 4
+    },
+    "JV_JC_INFO": {
+      "width": 161,
+      "fields": [
+        {
+          "name": "head",
+          "kind": "nested",
+          "start": 1,
+          "width": 11,
+          "struct": "RECORD_ID"
+        },
+        {
+          "name": "id",
+          "kind": "nested",
+          "start": 12,
+          "width": 16,
+          "struct": "RACE_ID"
+        },
+        {
+          "name": "HappyoTime",
+          "kind": "nested",
+          "start": 28,
+          "width": 8,
+          "struct": "MDHM"
+        },
+        {
+          "name": "Umaban",
+          "kind": "scalar",
+          "start": 36,
+          "width": 2,
+          "decoder": "text"
+        },
+        {
+          "name": "Bamei",
+          "kind": "scalar",
+          "start": 38,
+          "width": 36,
+          "decoder": "text"
+        },
+        {
+          "name": "JCInfoAfter",
+          "kind": "nested",
+          "start": 74,
+          "width": 43,
+          "struct": "JC_INFO"
+        },
+        {
+          "name": "JCInfoBefore",
+          "kind": "nested",
+          "start": 117,
+          "width": 43,
+          "struct": "JC_INFO"
+        },
+        {
+          "name": "crlf",
+          "kind": "scalar",
+          "start": 160,
+          "width": 2,
+          "decoder": "text"
+        }
+      ],
+      "expanded_leaf_count": 26
+    },
+    "TC_INFO": {
+      "width": 4,
+      "fields": [
+        {
+          "name": "Ji",
+          "kind": "scalar",
+          "start": 1,
+          "width": 2,
+          "decoder": "text"
+        },
+        {
+          "name": "Fun",
+          "kind": "scalar",
+          "start": 3,
+          "width": 2,
+          "decoder": "text"
+        }
+      ],
+      "expanded_leaf_count": 2
+    },
+    "JV_TC_INFO": {
+      "width": 45,
+      "fields": [
+        {
+          "name": "head",
+          "kind": "nested",
+          "start": 1,
+          "width": 11,
+          "struct": "RECORD_ID"
+        },
+        {
+          "name": "id",
+          "kind": "nested",
+          "start": 12,
+          "width": 16,
+          "struct": "RACE_ID"
+        },
+        {
+          "name": "HappyoTime",
+          "kind": "nested",
+          "start": 28,
+          "width": 8,
+          "struct": "MDHM"
+        },
+        {
+          "name": "TCInfoAfter",
+          "kind": "nested",
+          "start": 36,
+          "width": 4,
+          "struct": "TC_INFO"
+        },
+        {
+          "name": "TCInfoBefore",
+          "kind": "nested",
+          "start": 40,
+          "width": 4,
+          "struct": "TC_INFO"
+        },
+        {
+          "name": "crlf",
+          "kind": "scalar",
+          "start": 44,
+          "width": 2,
+          "decoder": "text"
+        }
+      ],
+      "expanded_leaf_count": 20
+    },
+    "CC_INFO": {
+      "width": 6,
+      "fields": [
+        {
+          "name": "Kyori",
+          "kind": "scalar",
+          "start": 1,
+          "width": 4,
+          "decoder": "text"
+        },
+        {
+          "name": "TruckCd",
+          "kind": "scalar",
+          "start": 5,
+          "width": 2,
+          "decoder": "text"
+        }
+      ],
+      "expanded_leaf_count": 2
+    },
+    "JV_CC_INFO": {
+      "width": 50,
+      "fields": [
+        {
+          "name": "head",
+          "kind": "nested",
+          "start": 1,
+          "width": 11,
+          "struct": "RECORD_ID"
+        },
+        {
+          "name": "id",
+          "kind": "nested",
+          "start": 12,
+          "width": 16,
+          "struct": "RACE_ID"
+        },
+        {
+          "name": "HappyoTime",
+          "kind": "nested",
+          "start": 28,
+          "width": 8,
+          "struct": "MDHM"
+        },
+        {
+          "name": "CCInfoAfter",
+          "kind": "nested",
+          "start": 36,
+          "width": 6,
+          "struct": "CC_INFO"
+        },
+        {
+          "name": "CCInfoBefore",
+          "kind": "nested",
+          "start": 42,
+          "width": 6,
+          "struct": "CC_INFO"
+        },
+        {
+          "name": "JiyuCd",
+          "kind": "scalar",
+          "start": 48,
+          "width": 1,
+          "decoder": "text"
+        },
+        {
+          "name": "crlf",
+          "kind": "scalar",
+          "start": 49,
+          "width": 2,
+          "decoder": "text"
+        }
+      ],
+      "expanded_leaf_count": 21
+    }
+  },
+  "root_records": {
+    "AV": {
+      "struct": "JV_AV_INFO",
+      "length": 78
+    },
+    "BN": {
+      "struct": "JV_BN_BANUSI",
+      "length": 477
+    },
+    "BR": {
+      "struct": "JV_BR_BREEDER",
+      "length": 545
+    },
+    "BT": {
+      "struct": "JV_BT_KEITO",
+      "length": 6889
+    },
+    "CC": {
+      "struct": "JV_CC_INFO",
+      "length": 50
+    },
+    "CH": {
+      "struct": "JV_CH_CHOKYOSI",
+      "length": 3862
+    },
+    "CK": {
+      "struct": "JV_CK_CHAKU",
+      "length": 6870
+    },
+    "CS": {
+      "struct": "JV_CS_COURSE",
+      "length": 6829
+    },
+    "DM": {
+      "struct": "JV_DM_INFO",
+      "length": 303
+    },
+    "H1": {
+      "struct": "JV_H1_HYOSU_ZENKAKE",
+      "length": 28955
+    },
+    "H6": {
+      "struct": "JV_H6_HYOSU_SANRENTAN",
+      "length": 102890
+    },
+    "HC": {
+      "struct": "JV_HC_HANRO",
+      "length": 60
+    },
+    "HN": {
+      "struct": "JV_HN_HANSYOKU",
+      "length": 251
+    },
+    "HR": {
+      "struct": "JV_HR_PAY",
+      "length": 719
+    },
+    "HS": {
+      "struct": "JV_HS_SALE",
+      "length": 200
+    },
+    "HY": {
+      "struct": "JV_HY_BAMEIORIGIN",
+      "length": 123
+    },
+    "JC": {
+      "struct": "JV_JC_INFO",
+      "length": 161
+    },
+    "JG": {
+      "struct": "JV_JG_JOGAIBA",
+      "length": 80
+    },
+    "KS": {
+      "struct": "JV_KS_KISYU",
+      "length": 4173
+    },
+    "O1": {
+      "struct": "JV_O1_ODDS_TANFUKUWAKU",
+      "length": 962
+    },
+    "O2": {
+      "struct": "JV_O2_ODDS_UMAREN",
+      "length": 2042
+    },
+    "O3": {
+      "struct": "JV_O3_ODDS_WIDE",
+      "length": 2654
+    },
+    "O4": {
+      "struct": "JV_O4_ODDS_UMATAN",
+      "length": 4031
+    },
+    "O5": {
+      "struct": "JV_O5_ODDS_SANREN",
+      "length": 12293
+    },
+    "O6": {
+      "struct": "JV_O6_ODDS_SANRENTAN",
+      "length": 83285
+    },
+    "RA": {
+      "struct": "JV_RA_RACE",
+      "length": 1272
+    },
+    "RC": {
+      "struct": "JV_RC_RECORD",
+      "length": 501
+    },
+    "SE": {
+      "struct": "JV_SE_RACE_UMA",
+      "length": 555
+    },
+    "SK": {
+      "struct": "JV_SK_SANKU",
+      "length": 208
+    },
+    "TC": {
+      "struct": "JV_TC_INFO",
+      "length": 45
+    },
+    "TK": {
+      "struct": "JV_TK_TOKUUMA",
+      "length": 21657
+    },
+    "TM": {
+      "struct": "JV_TM_INFO",
+      "length": 141
+    },
+    "UM": {
+      "struct": "JV_UM_UMA",
+      "length": 1609
+    },
+    "WC": {
+      "struct": "JV_WC_WOOD",
+      "length": 105
+    },
+    "WE": {
+      "struct": "JV_WE_WEATHER",
+      "length": 42
+    },
+    "WF": {
+      "struct": "JV_WF_INFO",
+      "length": 7215
+    },
+    "WH": {
+      "struct": "JV_WH_BATAIJYU",
+      "length": 847
+    },
+    "YS": {
+      "struct": "JV_YS_SCHEDULE",
+      "length": 382
+    }
+  },
+  "summary": {
+    "structure_count": 94,
+    "repeat_template_count": 93,
+    "root_record_count": 38,
+    "expanded_leaf_count": 46985
+  }
+}

--- a/tests/test_current_record_validation.py
+++ b/tests/test_current_record_validation.py
@@ -1,51 +1,28 @@
 """Fail-closed gates for current JV-Data fixed-length records."""
 
+import json
+from pathlib import Path
+
 import pytest
 
 from src.parser.base import validate_fixed_record
 from src.parser.factory import ParserFactory
 
-
+OFFICIAL_LAYOUT_ROOT = Path(__file__).parent / "fixtures" / "official_layout"
+CURRENT_LAYOUT = json.loads(
+    (OFFICIAL_LAYOUT_ROOT / "jvdata_sdk500_manifest.json").read_text(encoding="utf-8")
+)
+LAYOUT_HISTORY = json.loads(
+    (OFFICIAL_LAYOUT_ROOT / "jvdata_layout_history.json").read_text(encoding="utf-8")
+)
 CURRENT_LENGTHS = {
-    "AV": (78,),
-    "BN": (477,),
-    "BR": (545,),
-    "BT": (6889,),
-    "CC": (50,),
-    "CH": (3862,),
-    "CK": (6870,),
-    "CS": (6829,),
-    "DM": (303,),
-    "HR": (719,),
-    "H1": (28955,),
-    "H6": (102890,),
-    "HC": (60,),
-    "HN": (251,),
-    "HS": (200,),
-    "HY": (123,),
-    "JC": (161,),
-    "JG": (80,),
-    "KS": (4173,),
-    "O1": (962,),
-    "O2": (2042,),
-    "O3": (2654,),
-    "O4": (4031,),
-    "O5": (12293,),
-    "O6": (83285,),
-    "RA": (1272,),
-    "RC": (501,),
-    "SE": (555,),
-    "SK": (208,),
-    "TC": (45,),
-    "TK": (21657,),
-    "TM": (141,),
-    "UM": (1609,),
-    "WC": (105,),
-    "WE": (42,),
-    "WF": (7215,),
-    "WH": (847,),
-    "YS": (382,),
+    record_type: (contract["length"],)
+    for record_type, contract in CURRENT_LAYOUT["root_records"].items()
 }
+PREVIOUS_OFFICIAL_LENGTHS = tuple(
+    (change["record_type"], change["before_length"])
+    for change in LAYOUT_HISTORY["physical_length_changes"]
+)
 
 # These parsers also require populated domain-specific arrays or master fields.
 # Their valid payloads are covered by dedicated official-contract tests; this
@@ -157,17 +134,9 @@ def test_provider_parser_rejects_repository_only_flattened_vote_records(
 
 @pytest.mark.parametrize(
     ("record_type", "previous_official_length"),
-    (
-        ("UM", 1577),
-        ("BR", 537),
-        ("HN", 245),
-        ("SK", 178),
-        ("CK", 6864),
-        ("HS", 196),
-        ("BT", 6887),
-    ),
+    PREVIOUS_OFFICIAL_LENGTHS,
 )
-def test_provider_parser_rejects_4802_lengths_changed_in_4901(
+def test_provider_parser_rejects_every_ledgered_previous_physical_length(
     record_type,
     previous_official_length,
 ):

--- a/tests/test_official_jvdata_oracle.py
+++ b/tests/test_official_jvdata_oracle.py
@@ -1,0 +1,314 @@
+"""Independent contracts for the compact official JV-Data layout oracle."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from scripts.official_jvdata_oracle import (
+    extract_manifest_from_source,
+    load_manifest,
+    validate_manifest,
+)
+from src.parser.factory import ALL_RECORD_TYPES, ParserFactory
+
+FIXTURE_ROOT = Path(__file__).parent / "fixtures" / "official_layout"
+MANIFEST_PATH = FIXTURE_ROOT / "jvdata_sdk500_manifest.json"
+HISTORY_PATH = FIXTURE_ROOT / "jvdata_layout_history.json"
+OFFICIAL_SOURCE_SHA256 = "8994f985fce846f1b4fcbc3ddf2a5c6394c586a458478346891222b3b61e4ee3"
+
+
+def _valid_manifest() -> dict:
+    return {
+        "manifest_schema_version": 1,
+        "source": {
+            "artifact": "synthetic oracle unit fixture",
+            "jvdata_version": "test",
+            "sha256": "a" * 64,
+        },
+        "structures": {
+            "Child": {
+                "width": 2,
+                "expanded_leaf_count": 1,
+                "fields": [
+                    {
+                        "name": "value",
+                        "kind": "scalar",
+                        "start": 1,
+                        "width": 2,
+                        "decoder": "text",
+                    }
+                ],
+            },
+            "JV_ZZ_ROOT": {
+                "width": 6,
+                "expanded_leaf_count": 3,
+                "fields": [
+                    {
+                        "name": "head",
+                        "kind": "nested",
+                        "start": 1,
+                        "width": 2,
+                        "struct": "Child",
+                    },
+                    {
+                        "name": "values",
+                        "kind": "repeat",
+                        "start": 3,
+                        "width": 2,
+                        "stride": 2,
+                        "count": 2,
+                        "element_kind": "scalar",
+                        "decoder": "text",
+                    },
+                ],
+            },
+        },
+        "root_records": {"ZZ": {"struct": "JV_ZZ_ROOT", "length": 6}},
+        "summary": {
+            "structure_count": 2,
+            "repeat_template_count": 1,
+            "root_record_count": 1,
+            "expanded_leaf_count": 3,
+        },
+    }
+
+
+def _set(path, value):
+    def mutate(manifest):
+        node = manifest
+        for key in path[:-1]:
+            node = node[key]
+        node[path[-1]] = value
+
+    return mutate
+
+
+def _make_child_self_referential(manifest):
+    manifest["structures"]["Child"]["fields"][0] = {
+        "name": "value",
+        "kind": "nested",
+        "start": 1,
+        "width": 2,
+        "struct": "Child",
+    }
+
+
+@pytest.mark.parametrize(
+    ("mutate", "expected_error"),
+    [
+        (_set(("structures", "JV_ZZ_ROOT", "fields", 1, "start"), 4), "JV_ZZ_ROOT:gap:3"),
+        (
+            _set(("structures", "JV_ZZ_ROOT", "fields", 1, "start"), 2),
+            "JV_ZZ_ROOT:overlap:2",
+        ),
+        (
+            _set(("structures", "JV_ZZ_ROOT", "fields", 1, "count"), 0),
+            "JV_ZZ_ROOT.values:invalid-repeat-count",
+        ),
+        (
+            _set(("structures", "JV_ZZ_ROOT", "fields", 0, "struct"), "Missing"),
+            "JV_ZZ_ROOT.head:unknown-struct:Missing",
+        ),
+        (
+            _set(("structures", "JV_ZZ_ROOT", "fields", 0, "width"), 1),
+            "JV_ZZ_ROOT.head:nested-width-mismatch:1!=2",
+        ),
+        (
+            _set(("summary", "expanded_leaf_count"), 2),
+            "summary:expanded-leaf-count:2!=3",
+        ),
+        (
+            _set(("source", "sha256"), "not-a-sha256"),
+            "source:invalid-sha256",
+        ),
+        (
+            _set(("source", "artifact"), ""),
+            "source:artifact-missing",
+        ),
+        (
+            _set(("source", "jvdata_version"), ""),
+            "source:jvdata-version-missing",
+        ),
+        (
+            _set(("structures", "Child", "expanded_leaf_count"), True),
+            "Child:expanded-leaf-count:True!=1",
+        ),
+        (
+            _make_child_self_referential,
+            "Child.value:cyclic-struct:Child",
+        ),
+    ],
+)
+def test_oracle_validator_rejects_every_fail_open_shape(mutate, expected_error):
+    manifest = _valid_manifest()
+    mutate(manifest)
+
+    assert expected_error in validate_manifest(manifest)
+
+
+def test_oracle_validator_accepts_paired_complete_control():
+    assert validate_manifest(_valid_manifest()) == []
+
+
+def test_extractor_understands_scalar_nested_and_repeat_templates():
+    source = """
+from dataclasses import dataclass
+
+@dataclass
+class Child:
+    value: str
+    @classmethod
+    def SetDataB(cls, b):
+        return cls(MidB2S(b, 1, 2))
+
+@dataclass
+class JV_ZZ_ROOT:
+    head: Child
+    values: list[str]
+    @classmethod
+    def SetDataB(cls, b):
+        return cls(
+            Child.SetDataB(MidB2B(b, 1, 2)),
+            [MidB2S(b, 3 + 2 * i, 2) for i in range(2)],
+        )
+"""
+
+    manifest = extract_manifest_from_source(
+        source,
+        artifact="synthetic oracle unit fixture",
+        jvdata_version="test",
+    )
+
+    assert validate_manifest(manifest) == []
+    assert manifest["root_records"] == {"ZZ": {"struct": "JV_ZZ_ROOT", "length": 6}}
+    assert manifest["summary"] == _valid_manifest()["summary"]
+    assert manifest["structures"]["JV_ZZ_ROOT"]["fields"][1] == {
+        "name": "values",
+        "kind": "repeat",
+        "start": 3,
+        "width": 2,
+        "stride": 2,
+        "count": 2,
+        "element_kind": "scalar",
+        "decoder": "text",
+    }
+
+
+def test_tracked_official_manifest_is_complete_and_matches_dispatch():
+    manifest = load_manifest(MANIFEST_PATH)
+
+    assert validate_manifest(manifest) == []
+    assert manifest["source"]["sha256"] == OFFICIAL_SOURCE_SHA256
+    assert manifest["source"]["jvdata_version"] == "4.9.0.1"
+    assert manifest["summary"] == {
+        "structure_count": 94,
+        "repeat_template_count": 93,
+        "root_record_count": 38,
+        "expanded_leaf_count": 46985,
+    }
+    assert set(manifest["root_records"]) == set(ALL_RECORD_TYPES)
+
+    factory = ParserFactory()
+    for record_type, contract in manifest["root_records"].items():
+        assert factory.get_parser(record_type).RECORD_LENGTH == contract["length"]
+
+
+def test_official_hy_and_ck_sentinels_cannot_follow_current_implementation_drift():
+    manifest = load_manifest(MANIFEST_PATH)
+    structures = manifest["structures"]
+
+    hy_fields = {
+        field["name"]: (field["start"], field["width"])
+        for field in structures["JV_HY_BAMEIORIGIN"]["fields"]
+    }
+    assert hy_fields["KettoNum"] == (12, 10)
+    assert hy_fields["Bamei"] == (22, 36)
+    assert hy_fields["Origin"] == (58, 64)
+
+    ck = manifest["root_records"]["CK"]
+    assert ck == {"struct": "JV_CK_CHAKU", "length": 6870}
+    assert structures["JV_CK_CHAKU"]["expanded_leaf_count"] == 1729
+    ck_uma_repeats = {
+        field["name"]: field["count"]
+        for field in structures["JV_CK_UMA"]["fields"]
+        if field["kind"] == "repeat"
+    }
+    assert ck_uma_repeats == {
+        "ChakuKaisuBa": 7,
+        "ChakuKaisuJyotai": 12,
+        "ChakuKaisuSibaKyori": 9,
+        "ChakuKaisuDirtKyori": 9,
+        "ChakuKaisuJyoSiba": 10,
+        "ChakuKaisuJyoDirt": 10,
+        "ChakuKaisuJyoSyogai": 10,
+        "Kyakusitu": 4,
+    }
+
+
+def test_official_layout_history_is_provenanced_and_continuous_to_current():
+    history = json.loads(HISTORY_PATH.read_text(encoding="utf-8"))
+    current = load_manifest(MANIFEST_PATH)
+
+    assert history["ledger_schema_version"] == 1
+    assert {(source["jvdata_version"], source["sha256"]) for source in history["sources"]} == {
+        (
+            "4.8.0.2",
+            "6a567f10b601115eca350571f36d27d9d28bd2d3835ea72b5bc057711155d4a7",
+        ),
+        (
+            "4.9.0.1",
+            "23bafd375f704acbdd696b5032ac1619f17d47e882587d6e7954b610527a8234",
+        ),
+    }
+
+    expected_changes = {
+        ("SE", 547, 555),
+        ("BR", 467, 537),
+        ("BN", 413, 477),
+        ("UM", 1577, 1609),
+        ("BR", 537, 545),
+        ("HN", 245, 251),
+        ("SK", 178, 208),
+        ("CK", 6864, 6870),
+        ("HS", 196, 200),
+        ("BT", 6887, 6889),
+    }
+    changes = history["physical_length_changes"]
+    assert {
+        (change["record_type"], change["before_length"], change["after_length"])
+        for change in changes
+    } == expected_changes
+
+    by_record = {}
+    for change in sorted(changes, key=lambda item: item["effective_date"]):
+        record_type = change["record_type"]
+        previous = by_record.get(record_type)
+        if previous is not None:
+            assert change["before_length"] == previous
+        by_record[record_type] = change["after_length"]
+    for record_type, latest_length in by_record.items():
+        assert current["root_records"][record_type]["length"] == latest_length
+
+    assert history["record_type_changes"] == [
+        {
+            "effective_date": "2003-04-22",
+            "before_record_type": "PR",
+            "after_record_type": "BR",
+            "official_spec_version": "1.0.1-beta",
+        }
+    ]
+
+    semantic_change = history["same_length_semantic_changes"][0]
+    assert semantic_change["record_type"] == "UM"
+    assert semantic_change["length_unchanged"] is True
+    assert semantic_change["provenance_required"] is True
+    um_fields = {
+        field["name"]: (field["start"], field["width"])
+        for field in current["structures"]["JV_UM_UMA"]["fields"]
+    }
+    assert um_fields["BameiEng"] == (119, 60)
+    assert um_fields["ZaikyuFlag"] == (179, 1)
+    assert um_fields["Reserved"] == (180, 19)

--- a/tests/test_official_jvdata_oracle.py
+++ b/tests/test_official_jvdata_oracle.py
@@ -229,6 +229,14 @@ def _empty_oracle(manifest):
             "source:invalid-sha256",
         ),
         (
+            _set(("source", "sha256"), int("1" * 64)),
+            "source:invalid-sha256",
+        ),
+        (
+            _set(("manifest_schema_version",), True),
+            "manifest:unsupported-schema-version",
+        ),
+        (
             _set(("source", "artifact"), ""),
             "source:artifact-missing",
         ),
@@ -437,6 +445,29 @@ class JV_ZZ_ROOT:
             RECORD_ID.SetDataB(MidB2B(b, 1, 11)),
             extra=MidB2S(b, 12, 1),
         )
+"""
+
+    with pytest.raises(
+        OracleExtractionError,
+        match="keyword arguments are outside the reviewed grammar",
+    ):
+        extract_manifest_from_source(
+            source,
+            artifact="synthetic oracle unit fixture",
+            jvdata_version="test",
+        )
+
+
+def test_extractor_rejects_slice_keyword_arguments():
+    source = """
+from dataclasses import dataclass
+
+@dataclass
+class Scalar:
+    value: str
+    @classmethod
+    def SetDataB(cls, b):
+        return cls(MidB2S(b, 1, 1, unexpected=True))
 """
 
     with pytest.raises(

--- a/tests/test_official_jvdata_oracle.py
+++ b/tests/test_official_jvdata_oracle.py
@@ -96,6 +96,38 @@ def _make_child_self_referential(manifest):
     }
 
 
+def _point_root_at_non_root_child(manifest):
+    manifest["root_records"]["ZZ"] = {"struct": "Child", "length": 2}
+    manifest["summary"]["expanded_leaf_count"] = 1
+
+
+def _remove_child_decoder(manifest):
+    manifest["structures"]["Child"]["fields"][0].pop("decoder")
+
+
+def _remove_repeat_decoder(manifest):
+    manifest["structures"]["JV_ZZ_ROOT"]["fields"][1].pop("decoder")
+
+
+def _make_repeat_nested_without_target(manifest):
+    field = manifest["structures"]["JV_ZZ_ROOT"]["fields"][1]
+    field.pop("decoder")
+    field["element_kind"] = "nested"
+    manifest["structures"]["JV_ZZ_ROOT"]["expanded_leaf_count"] = 1
+    manifest["summary"]["expanded_leaf_count"] = 1
+
+
+def _empty_oracle(manifest):
+    manifest["structures"] = {}
+    manifest["root_records"] = {}
+    manifest["summary"] = {
+        "structure_count": 0,
+        "repeat_template_count": 0,
+        "root_record_count": 0,
+        "expanded_leaf_count": 0,
+    }
+
+
 @pytest.mark.parametrize(
     ("mutate", "expected_error"),
     [
@@ -129,12 +161,52 @@ def _make_child_self_referential(manifest):
             "source:artifact-missing",
         ),
         (
+            _set(("source", "artifact"), 123),
+            "source:artifact-missing",
+        ),
+        (
             _set(("source", "jvdata_version"), ""),
+            "source:jvdata-version-missing",
+        ),
+        (
+            _set(("source", "jvdata_version"), 4901),
             "source:jvdata-version-missing",
         ),
         (
             _set(("structures", "Child", "expanded_leaf_count"), True),
             "Child:expanded-leaf-count:True!=1",
+        ),
+        (
+            _set(("structures", "Child", "fields", 0, "name"), None),
+            "Child:invalid-or-duplicate-field:None",
+        ),
+        (
+            _set(("structures", "JV_ZZ_ROOT", "fields", 0, "struct"), None),
+            "JV_ZZ_ROOT.head:struct-missing",
+        ),
+        (
+            _remove_child_decoder,
+            "Child.value:invalid-decoder",
+        ),
+        (
+            _remove_repeat_decoder,
+            "JV_ZZ_ROOT.values:invalid-decoder",
+        ),
+        (
+            _make_repeat_nested_without_target,
+            "JV_ZZ_ROOT.values:struct-missing",
+        ),
+        (
+            _set(("structures", "JV_ZZ_ROOT", "fields", 0, "name"), "not_head"),
+            "root:ZZ:head-missing:JV_ZZ_ROOT",
+        ),
+        (
+            _point_root_at_non_root_child,
+            "root:ZZ:structure-name-mismatch:Child",
+        ),
+        (
+            _empty_oracle,
+            "structures:empty",
         ),
         (
             _make_child_self_referential,

--- a/tests/test_official_jvdata_oracle.py
+++ b/tests/test_official_jvdata_oracle.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import json
 from copy import deepcopy
 from pathlib import Path
@@ -20,6 +21,56 @@ FIXTURE_ROOT = Path(__file__).parent / "fixtures" / "official_layout"
 MANIFEST_PATH = FIXTURE_ROOT / "jvdata_sdk500_manifest.json"
 HISTORY_PATH = FIXTURE_ROOT / "jvdata_layout_history.json"
 OFFICIAL_SOURCE_SHA256 = "8994f985fce846f1b4fcbc3ddf2a5c6394c586a458478346891222b3b61e4ee3"
+OFFICIAL_MANIFEST_CONTRACT_SHA256 = (
+    "f35859d252fd20e4d7e38ee8d0a224deae87a62bae9db1995ed897bdccef6c45"
+)
+OFFICIAL_HISTORY_CONTRACT_SHA256 = (
+    "e697a97c2730099239f432203d56fea2869e11264e483b39f953257f9dc60d66"
+)
+
+
+def _canonical_contract_sha256(value) -> str:
+    payload = json.dumps(
+        value,
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    return hashlib.sha256(payload).hexdigest()
+
+
+def _extractor_fixture(root_field: str, set_data_methods: str) -> str:
+    return f"""
+from dataclasses import dataclass
+
+@dataclass
+class YMD:
+    Year: str
+    Month: str
+    Day: str
+    @classmethod
+    def SetDataB(cls, b):
+        return cls(MidB2S(b, 1, 4), MidB2S(b, 5, 2), MidB2S(b, 7, 2))
+
+@dataclass
+class RECORD_ID:
+    RecordSpec: str
+    DataKubun: str
+    MakeDate: YMD
+    @classmethod
+    def SetDataB(cls, b):
+        return cls(
+            MidB2S(b, 1, 2),
+            MidB2S(b, 3, 1),
+            YMD.SetDataB(MidB2B(b, 4, 8)),
+        )
+
+@dataclass
+class JV_ZZ_ROOT:
+    head: RECORD_ID
+    {root_field}
+{set_data_methods}
+"""
 
 
 def _valid_manifest() -> dict:
@@ -481,9 +532,129 @@ class Scalar:
         )
 
 
-def test_tracked_official_manifest_is_complete_and_matches_dispatch():
-    manifest = load_manifest(MANIFEST_PATH)
+@pytest.mark.parametrize(
+    ("root_field", "field_expression"),
+    (
+        ("value: str", "MidB2S(b, 11 + True, 1)"),
+        ("value: str", "MidB2S(b, 12, True + 0)"),
+        (
+            "values: list[str]",
+            "[MidB2S(b, 12 + i, 1) for i in range(1 + True)]",
+        ),
+        (
+            "values: list[str]",
+            "[MidB2S(b, 12 + True * i, 1) for i in range(2)]",
+        ),
+    ),
+)
+def test_extractor_rejects_boolean_integer_expressions(root_field, field_expression):
+    source = _extractor_fixture(
+        root_field,
+        f"""    @classmethod
+    def SetDataB(cls, b):
+        return cls(
+            RECORD_ID.SetDataB(MidB2B(b, 1, 11)),
+            {field_expression},
+        )
+""",
+    )
 
+    with pytest.raises(OracleExtractionError):
+        extract_manifest_from_source(
+            source,
+            artifact="synthetic oracle unit fixture",
+            jvdata_version="test",
+        )
+
+
+@pytest.mark.parametrize(
+    "set_data_methods",
+    (
+        """    @classmethod
+    def SetDataB(cls, b):
+        return cls(
+            RECORD_ID.SetDataB(MidB2B(b, 1, 11)),
+            MidB2S(other, 12, 1),
+        )
+""",
+        """    @classmethod
+    def SetDataB(cls, b):
+        return cls(
+            RECORD_ID.SetDataB(MidB2B(b, 1, 11)),
+            MidB2S(transform(b), 12, 1),
+        )
+""",
+        """    def SetDataB(cls, b):
+        return cls(
+            RECORD_ID.SetDataB(MidB2B(b, 1, 11)),
+            MidB2S(b, 12, 1),
+        )
+""",
+        """    @classmethod
+    def SetDataB(cls, payload):
+        return cls(
+            RECORD_ID.SetDataB(MidB2B(payload, 1, 11)),
+            MidB2S(payload, 12, 1),
+        )
+""",
+        """    @classmethod
+    def SetDataB(cls, b):
+        if b:
+            return cls(
+                RECORD_ID.SetDataB(MidB2B(b, 1, 11)),
+                MidB2S(b, 12, 1),
+            )
+""",
+        """    @classmethod
+    def SetDataB(cls, b):
+        return cls(
+            RECORD_ID.SetDataB(MidB2B(b, 1, 11)),
+            MidB2S(b, 12, 1),
+        )
+    @classmethod
+    def SetDataB(cls, b):
+        return cls(
+            RECORD_ID.SetDataB(MidB2B(b, 1, 11)),
+            MidB2S(b, 99, 1),
+        )
+""",
+        """    @classmethod
+    async def SetDataB(cls, b):
+        return cls(
+            RECORD_ID.SetDataB(MidB2B(b, 1, 11)),
+            MidB2S(b, 12, 1),
+        )
+""",
+        """    @classmethod
+    def SetDataB(cls, b):
+        return cls(
+            RECORD_ID.SetDataB(MidB2B(b, 1, 11, unexpected=True)),
+            MidB2S(b, 12, 1),
+        )
+""",
+        """    @classmethod
+    def SetDataB(cls, b):
+        return cls(
+            RECORD_ID.SetDataB(MidB2B(b, 1, 11)),
+            [MidB2S(b, 12 + i, 1) for i in range(1, unexpected=True)],
+        )
+""",
+    ),
+)
+def test_extractor_rejects_unreviewed_method_and_source_grammar(set_data_methods):
+    root_field = "values: list[str]" if "for i in range" in set_data_methods else "value: str"
+    source = _extractor_fixture(root_field, set_data_methods)
+
+    with pytest.raises(OracleExtractionError):
+        extract_manifest_from_source(
+            source,
+            artifact="synthetic oracle unit fixture",
+            jvdata_version="test",
+        )
+
+
+def _assert_manifest_truth_contract(manifest):
+    assert _canonical_contract_sha256(manifest) == OFFICIAL_MANIFEST_CONTRACT_SHA256
     assert validate_manifest(manifest) == []
     assert manifest["source"]["sha256"] == OFFICIAL_SOURCE_SHA256
     assert manifest["source"]["jvdata_version"] == "4.9.0.1"
@@ -495,9 +666,24 @@ def test_tracked_official_manifest_is_complete_and_matches_dispatch():
     }
     assert set(manifest["root_records"]) == set(ALL_RECORD_TYPES)
 
+
+def test_tracked_official_manifest_is_complete_and_matches_dispatch():
+    manifest = load_manifest(MANIFEST_PATH)
+
+    _assert_manifest_truth_contract(manifest)
+
     factory = ParserFactory()
     for record_type, contract in manifest["root_records"].items():
         assert factory.get_parser(record_type).RECORD_LENGTH == contract["length"]
+
+
+def test_manifest_truth_contract_rejects_same_shape_content_drift():
+    manifest = load_manifest(MANIFEST_PATH)
+    manifest["structures"]["HMS"]["fields"][0]["name"] = "InventedHour"
+    manifest["structures"]["HMS"]["fields"][0]["decoder"] = "bytes"
+
+    with pytest.raises(AssertionError):
+        _assert_manifest_truth_contract(manifest)
 
 
 def test_official_hy_and_ck_sentinels_cannot_follow_current_implementation_drift():
@@ -538,10 +724,10 @@ def _assert_history_cardinality(history):
     assert len(history["same_length_semantic_changes"]) == 1
 
 
-def test_official_layout_history_is_provenanced_and_continuous_to_current():
-    history = json.loads(HISTORY_PATH.read_text(encoding="utf-8"))
-    current = load_manifest(MANIFEST_PATH)
-
+def _assert_history_truth_contract(history):
+    assert _canonical_contract_sha256(history) == OFFICIAL_HISTORY_CONTRACT_SHA256
+    assert isinstance(history["ledger_schema_version"], int)
+    assert not isinstance(history["ledger_schema_version"], bool)
     assert history["ledger_schema_version"] == 1
     _assert_history_cardinality(history)
     assert {(source["jvdata_version"], source["sha256"]) for source in history["sources"]} == {
@@ -573,16 +759,6 @@ def test_official_layout_history_is_provenanced_and_continuous_to_current():
         for change in changes
     } == expected_changes
 
-    by_record = {}
-    for change in sorted(changes, key=lambda item: item["effective_date"]):
-        record_type = change["record_type"]
-        previous = by_record.get(record_type)
-        if previous is not None:
-            assert change["before_length"] == previous
-        by_record[record_type] = change["after_length"]
-    for record_type, latest_length in by_record.items():
-        assert current["root_records"][record_type]["length"] == latest_length
-
     assert history["record_type_changes"] == [
         {
             "effective_date": "2003-04-22",
@@ -596,6 +772,25 @@ def test_official_layout_history_is_provenanced_and_continuous_to_current():
     assert semantic_change["record_type"] == "UM"
     assert semantic_change["length_unchanged"] is True
     assert semantic_change["provenance_required"] is True
+
+
+def test_official_layout_history_is_provenanced_and_continuous_to_current():
+    history = json.loads(HISTORY_PATH.read_text(encoding="utf-8"))
+    current = load_manifest(MANIFEST_PATH)
+
+    _assert_history_truth_contract(history)
+
+    changes = history["physical_length_changes"]
+    by_record = {}
+    for change in sorted(changes, key=lambda item: item["effective_date"]):
+        record_type = change["record_type"]
+        previous = by_record.get(record_type)
+        if previous is not None:
+            assert change["before_length"] == previous
+        by_record[record_type] = change["after_length"]
+    for record_type, latest_length in by_record.items():
+        assert current["root_records"][record_type]["length"] == latest_length
+
     um_fields = {
         field["name"]: (field["start"], field["width"])
         for field in current["structures"]["JV_UM_UMA"]["fields"]
@@ -603,6 +798,26 @@ def test_official_layout_history_is_provenanced_and_continuous_to_current():
     assert um_fields["BameiEng"] == (119, 60)
     assert um_fields["ZaikyuFlag"] == (179, 1)
     assert um_fields["Reserved"] == (180, 19)
+
+
+@pytest.mark.parametrize(
+    ("path", "value"),
+    (
+        (("ledger_schema_version",), True),
+        (("sources", 0, "artifact"), "wrong.xlsx"),
+        (("physical_length_changes", 0, "source"), "wrong:999"),
+        (("physical_length_changes", 0, "official_spec_version"), "wrong"),
+        (("physical_length_changes", 0, "effective_date"), "1900-01-01"),
+        (("same_length_semantic_changes", 0, "before_fields"), []),
+        (("same_length_semantic_changes", 0, "reason"), "wrong"),
+    ),
+)
+def test_history_truth_contract_rejects_content_and_provenance_drift(path, value):
+    history = json.loads(HISTORY_PATH.read_text(encoding="utf-8"))
+    _set(path, value)(history)
+
+    with pytest.raises(AssertionError):
+        _assert_history_truth_contract(history)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_official_jvdata_oracle.py
+++ b/tests/test_official_jvdata_oracle.py
@@ -3,11 +3,13 @@
 from __future__ import annotations
 
 import json
+from copy import deepcopy
 from pathlib import Path
 
 import pytest
 
 from scripts.official_jvdata_oracle import (
+    OracleExtractionError,
     extract_manifest_from_source,
     load_manifest,
     validate_manifest,
@@ -29,6 +31,60 @@ def _valid_manifest() -> dict:
             "sha256": "a" * 64,
         },
         "structures": {
+            "YMD": {
+                "width": 8,
+                "expanded_leaf_count": 3,
+                "fields": [
+                    {
+                        "name": "Year",
+                        "kind": "scalar",
+                        "start": 1,
+                        "width": 4,
+                        "decoder": "text",
+                    },
+                    {
+                        "name": "Month",
+                        "kind": "scalar",
+                        "start": 5,
+                        "width": 2,
+                        "decoder": "text",
+                    },
+                    {
+                        "name": "Day",
+                        "kind": "scalar",
+                        "start": 7,
+                        "width": 2,
+                        "decoder": "text",
+                    },
+                ],
+            },
+            "RECORD_ID": {
+                "width": 11,
+                "expanded_leaf_count": 5,
+                "fields": [
+                    {
+                        "name": "RecordSpec",
+                        "kind": "scalar",
+                        "start": 1,
+                        "width": 2,
+                        "decoder": "text",
+                    },
+                    {
+                        "name": "DataKubun",
+                        "kind": "scalar",
+                        "start": 3,
+                        "width": 1,
+                        "decoder": "text",
+                    },
+                    {
+                        "name": "MakeDate",
+                        "kind": "nested",
+                        "start": 4,
+                        "width": 8,
+                        "struct": "YMD",
+                    },
+                ],
+            },
             "Child": {
                 "width": 2,
                 "expanded_leaf_count": 1,
@@ -43,20 +99,20 @@ def _valid_manifest() -> dict:
                 ],
             },
             "JV_ZZ_ROOT": {
-                "width": 6,
-                "expanded_leaf_count": 3,
+                "width": 15,
+                "expanded_leaf_count": 7,
                 "fields": [
                     {
                         "name": "head",
                         "kind": "nested",
                         "start": 1,
-                        "width": 2,
-                        "struct": "Child",
+                        "width": 11,
+                        "struct": "RECORD_ID",
                     },
                     {
                         "name": "values",
                         "kind": "repeat",
-                        "start": 3,
+                        "start": 12,
                         "width": 2,
                         "stride": 2,
                         "count": 2,
@@ -66,12 +122,12 @@ def _valid_manifest() -> dict:
                 ],
             },
         },
-        "root_records": {"ZZ": {"struct": "JV_ZZ_ROOT", "length": 6}},
+        "root_records": {"ZZ": {"struct": "JV_ZZ_ROOT", "length": 15}},
         "summary": {
-            "structure_count": 2,
+            "structure_count": 4,
             "repeat_template_count": 1,
             "root_record_count": 1,
-            "expanded_leaf_count": 3,
+            "expanded_leaf_count": 7,
         },
     }
 
@@ -101,6 +157,15 @@ def _point_root_at_non_root_child(manifest):
     manifest["summary"]["expanded_leaf_count"] = 1
 
 
+def _point_root_at_prefixed_scalar_head(manifest):
+    fake_root = deepcopy(manifest["structures"]["Child"])
+    fake_root["fields"][0]["name"] = "head"
+    manifest["structures"]["JV_ZZ_CHILD"] = fake_root
+    manifest["root_records"]["ZZ"] = {"struct": "JV_ZZ_CHILD", "length": 2}
+    manifest["summary"]["structure_count"] = 5
+    manifest["summary"]["expanded_leaf_count"] = 1
+
+
 def _remove_child_decoder(manifest):
     manifest["structures"]["Child"]["fields"][0].pop("decoder")
 
@@ -113,8 +178,12 @@ def _make_repeat_nested_without_target(manifest):
     field = manifest["structures"]["JV_ZZ_ROOT"]["fields"][1]
     field.pop("decoder")
     field["element_kind"] = "nested"
-    manifest["structures"]["JV_ZZ_ROOT"]["expanded_leaf_count"] = 1
-    manifest["summary"]["expanded_leaf_count"] = 1
+    manifest["structures"]["JV_ZZ_ROOT"]["expanded_leaf_count"] = 5
+    manifest["summary"]["expanded_leaf_count"] = 5
+
+
+def _corrupt_record_header_semantics(manifest):
+    manifest["structures"]["RECORD_ID"]["fields"][1]["name"] = "WrongKubun"
 
 
 def _empty_oracle(manifest):
@@ -131,10 +200,13 @@ def _empty_oracle(manifest):
 @pytest.mark.parametrize(
     ("mutate", "expected_error"),
     [
-        (_set(("structures", "JV_ZZ_ROOT", "fields", 1, "start"), 4), "JV_ZZ_ROOT:gap:3"),
         (
-            _set(("structures", "JV_ZZ_ROOT", "fields", 1, "start"), 2),
-            "JV_ZZ_ROOT:overlap:2",
+            _set(("structures", "JV_ZZ_ROOT", "fields", 1, "start"), 15),
+            "JV_ZZ_ROOT:gap:12-14",
+        ),
+        (
+            _set(("structures", "JV_ZZ_ROOT", "fields", 1, "start"), 11),
+            "JV_ZZ_ROOT:overlap:11",
         ),
         (
             _set(("structures", "JV_ZZ_ROOT", "fields", 1, "count"), 0),
@@ -146,11 +218,11 @@ def _empty_oracle(manifest):
         ),
         (
             _set(("structures", "JV_ZZ_ROOT", "fields", 0, "width"), 1),
-            "JV_ZZ_ROOT.head:nested-width-mismatch:1!=2",
+            "JV_ZZ_ROOT.head:nested-width-mismatch:1!=11",
         ),
         (
             _set(("summary", "expanded_leaf_count"), 2),
-            "summary:expanded-leaf-count:2!=3",
+            "summary:expanded-leaf-count:2!=7",
         ),
         (
             _set(("source", "sha256"), "not-a-sha256"),
@@ -205,6 +277,14 @@ def _empty_oracle(manifest):
             "root:ZZ:structure-name-mismatch:Child",
         ),
         (
+            _point_root_at_prefixed_scalar_head,
+            "root:ZZ:invalid-head-contract:JV_ZZ_CHILD",
+        ),
+        (
+            _corrupt_record_header_semantics,
+            "record-header:invalid-record-id",
+        ),
+        (
             _empty_oracle,
             "structures:empty",
         ),
@@ -230,6 +310,32 @@ def test_extractor_understands_scalar_nested_and_repeat_templates():
 from dataclasses import dataclass
 
 @dataclass
+class YMD:
+    Year: str
+    Month: str
+    Day: str
+    @classmethod
+    def SetDataB(cls, b):
+        return cls(
+            MidB2S(b, 1, 4),
+            MidB2S(b, 5, 2),
+            MidB2S(b, 7, 2),
+        )
+
+@dataclass
+class RECORD_ID:
+    RecordSpec: str
+    DataKubun: str
+    MakeDate: YMD
+    @classmethod
+    def SetDataB(cls, b):
+        return cls(
+            MidB2S(b, 1, 2),
+            MidB2S(b, 3, 1),
+            YMD.SetDataB(MidB2B(b, 4, 8)),
+        )
+
+@dataclass
 class Child:
     value: str
     @classmethod
@@ -238,13 +344,13 @@ class Child:
 
 @dataclass
 class JV_ZZ_ROOT:
-    head: Child
+    head: RECORD_ID
     values: list[str]
     @classmethod
     def SetDataB(cls, b):
         return cls(
-            Child.SetDataB(MidB2B(b, 1, 2)),
-            [MidB2S(b, 3 + 2 * i, 2) for i in range(2)],
+            RECORD_ID.SetDataB(MidB2B(b, 1, 11)),
+            [MidB2S(b, 12 + 2 * i, 2) for i in range(2)],
         )
 """
 
@@ -255,18 +361,93 @@ class JV_ZZ_ROOT:
     )
 
     assert validate_manifest(manifest) == []
-    assert manifest["root_records"] == {"ZZ": {"struct": "JV_ZZ_ROOT", "length": 6}}
+    assert manifest["root_records"] == {"ZZ": {"struct": "JV_ZZ_ROOT", "length": 15}}
     assert manifest["summary"] == _valid_manifest()["summary"]
     assert manifest["structures"]["JV_ZZ_ROOT"]["fields"][1] == {
         "name": "values",
         "kind": "repeat",
-        "start": 3,
+        "start": 12,
         "width": 2,
         "stride": 2,
         "count": 2,
         "element_kind": "scalar",
         "decoder": "text",
     }
+
+
+@pytest.mark.parametrize(
+    ("start_expression", "width_expression", "error"),
+    (
+        ("12 + i * i", "1", "non-affine repeat offset"),
+        ("12 + 2 * i", "2 + i", "repeat width depends on loop variable"),
+    ),
+)
+def test_extractor_rejects_non_affine_repeat_layouts(
+    start_expression,
+    width_expression,
+    error,
+):
+    source = f"""
+from dataclasses import dataclass
+
+@dataclass
+class RECORD_ID:
+    value: bytes
+    @classmethod
+    def SetDataB(cls, b):
+        return cls(MidB2B(b, 1, 11))
+
+@dataclass
+class JV_ZZ_ROOT:
+    head: RECORD_ID
+    values: list[str]
+    @classmethod
+    def SetDataB(cls, b):
+        return cls(
+            RECORD_ID.SetDataB(MidB2B(b, 1, 11)),
+            [MidB2S(b, {start_expression}, {width_expression}) for i in range(3)],
+        )
+"""
+
+    with pytest.raises(OracleExtractionError, match=error):
+        extract_manifest_from_source(
+            source,
+            artifact="synthetic oracle unit fixture",
+            jvdata_version="test",
+        )
+
+
+def test_extractor_rejects_constructor_keyword_arguments():
+    source = """
+from dataclasses import dataclass
+
+@dataclass
+class RECORD_ID:
+    value: bytes
+    @classmethod
+    def SetDataB(cls, b):
+        return cls(MidB2B(b, 1, 11))
+
+@dataclass
+class JV_ZZ_ROOT:
+    head: RECORD_ID
+    @classmethod
+    def SetDataB(cls, b):
+        return cls(
+            RECORD_ID.SetDataB(MidB2B(b, 1, 11)),
+            extra=MidB2S(b, 12, 1),
+        )
+"""
+
+    with pytest.raises(
+        OracleExtractionError,
+        match="keyword arguments are outside the reviewed grammar",
+    ):
+        extract_manifest_from_source(
+            source,
+            artifact="synthetic oracle unit fixture",
+            jvdata_version="test",
+        )
 
 
 def test_tracked_official_manifest_is_complete_and_matches_dispatch():
@@ -320,11 +501,18 @@ def test_official_hy_and_ck_sentinels_cannot_follow_current_implementation_drift
     }
 
 
+def _assert_history_cardinality(history):
+    assert len(history["sources"]) == 2
+    assert len(history["physical_length_changes"]) == 10
+    assert len(history["same_length_semantic_changes"]) == 1
+
+
 def test_official_layout_history_is_provenanced_and_continuous_to_current():
     history = json.loads(HISTORY_PATH.read_text(encoding="utf-8"))
     current = load_manifest(MANIFEST_PATH)
 
     assert history["ledger_schema_version"] == 1
+    _assert_history_cardinality(history)
     assert {(source["jvdata_version"], source["sha256"]) for source in history["sources"]} == {
         (
             "4.8.0.2",
@@ -384,3 +572,20 @@ def test_official_layout_history_is_provenanced_and_continuous_to_current():
     assert um_fields["BameiEng"] == (119, 60)
     assert um_fields["ZaikyuFlag"] == (179, 1)
     assert um_fields["Reserved"] == (180, 19)
+
+
+@pytest.mark.parametrize(
+    ("collection", "expected_count"),
+    (
+        ("sources", 2),
+        ("physical_length_changes", 10),
+        ("same_length_semantic_changes", 1),
+    ),
+)
+def test_history_contract_rejects_duplicate_entries(collection, expected_count):
+    history = json.loads(HISTORY_PATH.read_text(encoding="utf-8"))
+    history[collection].append(deepcopy(history[collection][0]))
+
+    assert len(history[collection]) == expected_count + 1
+    with pytest.raises(AssertionError):
+        _assert_history_cardinality(history)


### PR DESCRIPTION
## Summary

- add an independent compact manifest generated from the official SDK 5.0.0 Python JV-Data structures
- validate all 38 root records, 94 structures, 93 repeated templates, and 46,985 expanded scalar leaves for gaps, overlap, widths, repeat contracts, cycles, and source identity
- add a provenance ledger for the official 2003, 2006, and 2023 physical or same-length semantic changes
- derive the current-length and every previous-physical-length rejection test from the official manifests instead of a duplicate hand-maintained matrix
- document clearly that reconstructed database fixtures are not provider-layout evidence

## Red-first evidence

- before implementation, collection failed with `ModuleNotFoundError: scripts.official_jvdata_oracle`
- cycle and missing-history negatives: 2 failed, 11 passed
- missing source identity and Boolean count negatives: 3 failed, 13 passed
- grouped fail-open review on the first candidate: 10 failed, 16 passed for empty, mistyped, decoderless, targetless, and redirected-root manifests

Each negative now has a paired complete-manifest green control.

## Exact candidate evidence

Candidate: `798d4210e00edeb654417eaeaa5f81d6f399e144`

- isolated CPython 3.12.11 affected suite: 219 passed
- fail-closed workflow self-check: `TEST GATE PASS`
- isolated fatal flake8: 0
- Ruff and Black: clean
- official CLI validation: `OFFICIAL ORACLE PASS`
- regeneration from the exact official SDK source is byte-identical to the tracked manifest
- clean worktree and `git diff --check`

Official source identities used for review:

- SDK 5.0.0 Python structure source: `8994f985fce846f1b4fcbc3ddf2a5c6394c586a458478346891222b3b61e4ee3`
- JV-Data 4.8.0.2 workbook: `6a567f10b601115eca350571f36d27d9d28bd2d3835ea72b5bc057711155d4a7`
- JV-Data 4.9.0.1 workbook: `23bafd375f704acbdd696b5032ac1619f17d47e882587d6e7954b610527a8234`

## Deliberate scope and remaining gates

This PR establishes physical-layout truth only. It does not make the known HY semantic mapping, CK omitted repeats, six standard-schema routes, metadata integrity, obsolete route, or fresh acquisition-to-SQLite/PostgreSQL blockers green. Those remain required follow-up implementation iterations. It also makes no product support statement for an unexecuted SDK architecture.

A read-only Claude Code Fable review was requested under session `365b9699-b517-405f-b567-b6c87fd77266`, but the service limit stopped the request before review began. This PR remains draft and will not be merged until that same-session review is resumed after reset, actionable findings are independently reproduced and addressed together, all GitHub reviews are resolved, and the final exact SHA checks pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an official JV-Data layout validation tool for extracting and verifying structure metadata, record lengths, references, and provenance.
  - Added a tracked layout history ledger covering physical and semantic format changes.
  - Improved validation of current and historical record lengths using official layout data.

- **Tests**
  - Added independent checks for malformed layouts, nested and repeated structures, manifest consistency, and historical compatibility.

- **Documentation**
  - Documented fixture provenance, regeneration procedures, and validation workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->