### PR TITLE
Store complete current CK records with strict schema enforcement

### DIFF
--- a/docs/data_support.md
+++ b/docs/data_support.md
@@ -59,7 +59,7 @@ jrvltsql は JRA / 中央競馬専用です。NAR / 地方競馬はこのリポ�
 | `HOSN` | `HOSE` | 競走馬市場取引価格 | `HS` | `NL_HS` | はい | いいえ | はい | 旧名 `HOSE` は受け付けません（下記参照）。 |
 | `HOYU` | - | 馬名の意味由来 | `HY` | `NL_HY` | はい | いいえ | はい | standard / full quickstart に含めています。 |
 | `COMM` | - | 各種解説・コース情報 | `CS` | `NL_CS` | はい | いいえ | はい | full quickstart に含めています。 |
-| `SNPN` | `SNAP` | 出走時点情報 | `CK` | `NL_CK` | はい | はい | はい | validation 上は対応。既定 quickstart では使っていません。旧名 `SNAP` は受け付けません（下記参照）。 |
+| `SNPN` | `SNAP` | 出走時点情報 | `CK` | `NL_CK`、`NL_CK_CHAKU`、`NL_CK_RUIKEI` | はい | はい | はい | 現行6,870バイトをnative名モードで完全格納します。既定 quickstart では使っていません。旧名 `SNAP` は受け付けません（下記参照）。 |
 | `TCVN` | `TCOV` | 特別登録馬情報補填 | 複数のマスタ・レース系レコード | レコード種別に応じた既存 `NL_*` テーブル | いいえ | はい | いいえ | 今週データ更新で使います。旧名 `TCOV` は受け付けません（下記参照）。 |
 | `RCVN` | `RCOV` | レース情報補填 | 複数のマスタ・レース系レコード | レコード種別に応じた既存 `NL_*` テーブル | いいえ | はい | いいえ | 今週データ更新で使います。旧名 `RCOV` は受け付けません（下記参照）。 |
 
@@ -173,7 +173,8 @@ jrvltsql は現在、以下 38 種類の JRA レコード種別に対してパ�
 | `YS`, `TK`, `CS` | `NL_YS`、`NL_TK_RACE`＋`NL_TK`、`NL_CS` |
 | `WE`, `WH`, `AV`, `JC`, `TC`, `CC` | `NL_WE`, `NL_WH`, `NL_AV`, `NL_JC`, `NL_TC`, `NL_CC` |
 | `DM`, `TM`, `WF`, `JG` | `NL_DM`, `NL_TM`, `NL_WF`, `NL_JG` |
-| `HC`, `HS`, `HY`, `WC`, `CK` | `NL_HC`, `NL_HS`, `NL_HY`, `NL_WC`, `NL_CK` |
+| `HC`, `HS`, `HY`, `WC` | `NL_HC`, `NL_HS`, `NL_HY`, `NL_WC` |
+| `CK` | `NL_CK`（互換親）、`NL_CK_CHAKU`（着回数278行）、`NL_CK_RUIKEI`（累計8行） |
 
 対応済みの速報系レコードは `RT_*` にも保存できます。公式時系列オッズは
 `TS_O1` / `TS_O2`、開催週速報オッズは `TS_SOKUHO_O1`〜`TS_SOKUHO_O6`
@@ -191,6 +192,18 @@ jrvltsql は現在、以下 38 種類の JRA レコード種別に対してパ�
 旧標準名テーブルは主キーと文字列日付の契約を満たさないため、自動変換せず停止します。
 バックアップ後に両テーブルを現行schemaで再作成し、保持期間内の現行データを
 再取得してください。
+
+`CK`は現行公式6,870バイトの1,729 scalar leafを扱います。PostgreSQLの
+1テーブル列数上限を超えないよう、native名モードでは互換親`NL_CK`と
+`NL_CK_CHAKU` 278行、`NL_CK_RUIKEI` 8行を1物理レコード単位のtransactionで
+更新します。`DataKubun=0`は7列の公式キーで親子を削除します。旧6,864バイトは
+現行offsetと混同せず拒否します。
+
+既存`NL_CK`には完全展開していない行があるため、追加される
+`CKStorageVersion`が`NULL`の行を完全格納済みと扱ってはいけません。現行`SNPN`を
+再取得して`CKStorageVersion=1`、子行数278/8をキーごとに確認してください。
+CKのJRA-VAN標準名モードはまだ実装しておらず、`CHOKYO_DETAIL`へ誤って部分保存せず
+明示的に停止します。
 
 `DM`は公式303バイトの18頭配列を扱います。native名モードでは`NL_DM`/`RT_DM`へ
 馬ごとの行として保存し、JRA-VAN標準名モードでは`MINING`へ1レース1行のwide形式で

--- a/specs/operations/20260816_release_readiness_worklog.md
+++ b/specs/operations/20260816_release_readiness_worklog.md
@@ -1283,8 +1283,45 @@
   compileall, fatal Ruff `E9/F63/F7/F82`, full Ruff and Black for all new Python
   files, and `git diff --check` also pass. Existing all-rule Ruff debt in large
   legacy modules is unchanged and is not substituted for the fatal gate.
-- Current changes remain uncommitted, so these results are not final candidate
-  evidence. Next safe action: run strict documentation/distribution/mechanical
-  checks, commit the aggregated CK iteration once, and execute one exact-SHA
-  local gate plus one independent critical review. STOP if any leaf/cardinality,
-  schema fail-closed, transaction, documentation, or exact-SHA check regresses.
+- The aggregated implementation was committed as full SHA
+  `a0604c99e5379ecc18d5edc1032ce1a9cf9c72f6` on unchanged base
+  `9f2e2a8c11bae32a76e850c13aa0e112f75ef67a`. Its clean exact-SHA full local
+  suite completed `2428 passed, 92 skipped, 15 subtests passed in 52.97s`;
+  exact disposable PostgreSQL CK verification completed `42 passed in 2.24s`.
+  The test-gate self-check, fatal/new-file lint and formatting, compileall,
+  strict docs, two-artifact distribution-content gate, and clean-tree check all
+  passed on that SHA. The exact PostgreSQL schema/container was removed.
+- An independent read-only Codex critical review used `gpt-5.6-sol` at `xhigh`
+  on clean exact SHA `a0604c99e5379ecc18d5edc1032ce1a9cf9c72f6` and returned
+  `NEEDS_CHANGES` with two P1 fail-open findings. It independently confirmed
+  all CK offsets/repeats against the pinned manifest and found no other parser,
+  storage, history, ordering, marker, or standard-mode blocker.
+- P1 one: PostgreSQL constraint verification checked expected names and token
+  substrings rather than constraint semantics. Keeping every token inside
+  `CHECK (TRUE OR (...))` let both importers accept the malformed schema and
+  replace the preserved parent. The added real PostgreSQL regression failed for
+  both importers with `DID NOT RAISE SchemaMigrationError`; the review's
+  independent fake-catalog probe also accepted a weak count-shape OR check.
+  The repair now verifies constraint type and validated state, the exact ordered
+  local/remote FK columns, referenced parent, and cascade action. It evaluates
+  PostgreSQL's actual `pg_get_expr` CHECK expressions against the full 278 valid
+  CK dimensions plus metric boundary, invalid entity/period/family cases, and
+  paired count/summary NULL-shape positives and negatives. Tautological domain,
+  weak count shape, NOT VALID, RESTRICT, and wrong FK order are all rejected.
+- P1 two: the public single-table creation API excluded strict children from
+  additive repair but still ran only the generic column/PK verifier. A complete
+  SQLite child with `ck_chaku_domain CHECK(TRUE)` therefore returned `True`.
+  The new regression failed exactly at `assert True is False`. A dedicated
+  single-child verifier now validates the selected child and parent without
+  requiring the sibling that may not yet have been created; create-all retains
+  the full coupled verifier.
+- Post-review repair verification is currently uncommitted: the three SQLite
+  schema regressions pass; the complete disposable PostgreSQL 16 CK contract,
+  including both importers and all new malformed constraints, completes
+  `51 passed in 2.22s`; and the broader affected selection completes
+  `701 passed, 36 skipped in 4.67s`. The container and all test schemas were
+  removed. The stale E2E introduction was also corrected from 78/45 to the
+  already asserted 80 total/47 native tables. Next safe action: finish
+  mechanical checks, commit this one aggregated review repair, then run one
+  clean exact-SHA final review/gate. STOP on any false-green schema result,
+  failed test, container residue, source drift, or dirty final worktree.

--- a/specs/operations/20260816_release_readiness_worklog.md
+++ b/specs/operations/20260816_release_readiness_worklog.md
@@ -1152,3 +1152,139 @@
   exact-SHA critical verification and GitHub final gate. STOP if any deletion
   leaves a tombstone, any malformed schema changes a row, or the PR head lacks
   clean exact-SHA evidence.
+
+## Iteration: CK complete official layout and native storage (2026-08-17 JST)
+
+- Objective and minimum scope: replace CK's representative/opaque extraction
+  with a complete, gap-free current-layout parse and lossless native storage for
+  every official leaf. Preserve provider order for `DataKubun=0/1/2`, reject
+  the obsolete 6,864-byte layout, and use normalized child tables where one
+  PostgreSQL row would exceed the database column limit. Canonical standard
+  `CHOKYO_DETAIL` routing remains the immediately following independent
+  standard-schema iteration; other record types and release changes are out of
+  scope here.
+- Repository: `miyamamoto/jrvltsql`.
+- Worktree: `/home/keiba/scratch/20260817_jrvltsql_ck_official`.
+- Branch: `agent/ck-official-20260817`.
+- Base / initial HEAD / `origin/master` full SHA:
+  `9f2e2a8c11bae32a76e850c13aa0e112f75ef67a`.
+- Dependency and production state: PR #195 merged as
+  `9f2e2a8c11bae32a76e850c13aa0e112f75ef67a`; release remains v1.6.10. No
+  version, tag, release lock, distribution, or support statement changes are
+  authorized in this iteration.
+- Official evidence: pinned SDK 5.0.0 structure source SHA-256
+  `8994f985fce846f1b4fcbc3ddf2a5c6394c586a458478346891222b3b61e4ee3`,
+  official JV-Data 4.9.0.1 workbook SHA-256
+  `23bafd375f704acbdd696b5032ac1619f17d47e882587d6e7954b610527a8234`,
+  and official 4.8.0.2 workbook SHA-256
+  `6a567f10b601115eca350571f36d27d9d28bd2d3835ea72b5bc057711155d4a7`.
+  The current record is 6,870 bytes and 1,729 expanded scalar leaves; the older
+  official record is 6,864 bytes because the breeder code/name area changed.
+- Initial observed gap: the current parser reads only the first of six ranks in
+  each of 69 horse count blocks, only the first of four running-style counts,
+  one opaque 1,220-byte block from each of two 2-block jockey/trainer sections,
+  and one opaque 60-byte block from each owner/breeder 2-block section. This
+  omits 988 official leaves and cannot be represented losslessly by the current
+  single-table schema.
+- Design constraint: PostgreSQL cannot hold the complete 1,729-leaf record in
+  one row. The parser contract must expose all leaves deterministically, while
+  native persistence uses an official-key parent plus bounded normalized child
+  rows with explicit block/rank identity. No opaque packed field may be treated
+  as equivalent to leaf-level storage.
+- Red-first requirement: before implementation, add a compact oracle-driven
+  contract that fills first/middle/last sentinels for every repeat family,
+  asserts exact expanded leaf cardinality and no unread byte span, proves
+  current code fails, and covers create/update/delete plus SQLite/PostgreSQL
+  reconnect readback and malformed-schema no-mutation behavior.
+- STOP conditions: do not merge if any official CK leaf is neither stored nor
+  explicitly validated metadata, if old/current layouts can be confused, if
+  child rows can outlive or mismatch their parent, if `DataKubun=0` leaves a
+  tombstone, if a PostgreSQL column-limit assumption is untested, or if exact
+  candidate SHA/review/thread/clean-worktree gates are incomplete.
+- Next safe action: independently derive the complete recursive CK leaf and
+  repeat model from the pinned manifest/workbooks, choose the smallest
+  PostgreSQL-safe normalized schema, and write the grouped red contract before
+  changing parser/importer/schema code.
+- Red-first contract executed at unchanged base full SHA
+  `9f2e2a8c11bae32a76e850c13aa0e112f75ef67a`:
+  `uv run pytest -q tests/test_ck_official_contract.py
+  --basetemp=/home/keiba/scratch/pytest_ck_red --no-cov` returned
+  `9 failed, 1 passed`. The old parser accepted blank/3/9 `DataKubun`, exposed
+  none of the required 70 horse, four professional, or four owner/breeder
+  normalized rows, and the schema/importers had no child-table contract. Both
+  importers therefore inserted the parent when every required child table was
+  absent instead of failing before mutation. The previous 6,864-byte shape was
+  already rejected. This is the required observed red for the new CK integrity
+  check; implementation had not changed when it was captured.
+- The independent design cross-check rejected the tentative wide professional
+  rows because they would make validation and querying unnecessarily opaque.
+  The final native representation preserves keyed `NL_CK` as a compatibility
+  parent and adds two bounded children: `NL_CK_CHAKU` has 278 dimensioned rows
+  with `Count1..Count6` (only the four-value running-style row has NULL 5/6),
+  and `NL_CK_RUIKEI` has eight actor/period summary rows. The children store
+  1,666 count leaves plus 32 summary leaves. The remaining 31 leaves are in the
+  parent or, for CRLF, strictly validated before parse. This three-table shape
+  stays below PostgreSQL's column limit and preserves all 1,729 official leaves.
+- `CKStorageVersion` is importer-owned completion metadata. Additive migration
+  leaves existing parent rows NULL; only a fully validated parent+278+8 write
+  sets it to 1 at the end of the transaction. Existing partial rows cannot be
+  reconstructed from the old representative columns because 988 leaves were
+  never stored. They require current `SNPN` reimport, and complete consumers
+  must verify marker 1 plus the two per-key child cardinalities.
+- The current 6,870-byte parser strictly validates record type, physical length,
+  CRLF, CP932 boundaries, DataKubun `0/1/2`, the seven official key fields, and
+  every numeric payload leaf. A delete validates the envelope and key but does
+  not invent a requirement that the official raw body be blank; it emits no
+  child rows and deletes the exact parent key. The old 6,864-byte shape remains
+  explicitly rejected rather than being guessed by length. Native owner and
+  breeder compatibility column names retain their existing offset meanings;
+  canonical SDK names belong to the separate standard-schema iteration.
+- Both importers now use the same ordered prepare/apply contract. Before any
+  mutation they require exact child columns/types/nullability, composite primary
+  and parent keys, named CHECK bodies, and `ON DELETE CASCADE`; input rows must
+  contain the exact ordered 278/8 dimensions and cannot forge the completion
+  marker. Parent upsert with a NULL marker, exact child replacement, and the
+  final marker update occur in one transaction. Standard-name CK storage fails
+  explicitly until a canonical `CHOKYO_DETAIL` parent/child design is merged.
+- A second validator red was observed after the initial implementation:
+  `test_ck_child_schema_is_never_additively_repaired` failed because the generic
+  `SchemaManager.create_table` silently added a missing `Count6` column and
+  reported success while the required CHECK remained absent. The strict child
+  tables are now excluded from additive repair. A paired create-all red also
+  failed with `assert True is False` when `ck_chaku_domain` was replaced by
+  `CHECK(TRUE)`; create-all now runs the dedicated coupled verifier and reports
+  both children unavailable. Both red tests pass after the repair.
+- The broader parser selection exposed three false-green generic CK tests whose
+  positive fixture left every CK domain field blank. The strict parser correctly
+  rejected it at `Year must contain only ASCII digits`. The fixture now contains
+  a valid current-layout header/key and digits in every official numeric region;
+  the three existing tests pass without weakening production validation.
+- SQLite CK contract after the repairs: `36 passed, 6 skipped in 1.41s`; the six
+  skips are the explicitly gated PostgreSQL cases. A disposable PostgreSQL 16
+  container bound only to `127.0.0.1:55439` then ran the entire contract with
+  the PostgreSQL extra: `42 passed in 2.41s`. This covered both importers,
+  reconnect readback, ordered 1/0/2 replacement, final 278/8 row counts, exact
+  deletion, direct database constraint enforcement, and malformed
+  CHECK/FK/PK/nullability/column contracts preserving the legacy parent. The
+  unique schemas were dropped by fixtures and the auto-remove container was
+  stopped; a subsequent container-name lookup was empty.
+- Broader affected verification covering the CK contract, current-record gate,
+  every schema, migrations, comprehensive E2E schema creation, both importers,
+  parser/factory compatibility, expanded storage, and table mappings completed
+  `700 passed, 28 skipped in 5.00s`. The skips are explicit environment/live
+  gates; CK's PostgreSQL path was executed separately above. `docs/data_support.md`
+  now documents the current 6,870-byte three-table native contract, old-layout
+  rejection, completion marker/reimport requirement, and explicit lack of CK
+  standard-name storage rather than implying a partial table is complete.
+- Strict MkDocs built the public documentation successfully. Wheel and sdist
+  built from the working candidate, the content gate passed both artifacts,
+  `schema_ck.py` was present, and tracked `specs/` plus official oracle inputs
+  remained absent from distributions. The repository test-gate self-check,
+  compileall, fatal Ruff `E9/F63/F7/F82`, full Ruff and Black for all new Python
+  files, and `git diff --check` also pass. Existing all-rule Ruff debt in large
+  legacy modules is unchanged and is not substituted for the fatal gate.
+- Current changes remain uncommitted, so these results are not final candidate
+  evidence. Next safe action: run strict documentation/distribution/mechanical
+  checks, commit the aggregated CK iteration once, and execute one exact-SHA
+  local gate plus one independent critical review. STOP if any leaf/cardinality,
+  schema fail-closed, transaction, documentation, or exact-SHA check regresses.

--- a/specs/operations/20260816_release_readiness_worklog.md
+++ b/specs/operations/20260816_release_readiness_worklog.md
@@ -1358,3 +1358,46 @@
   aggregated structural repair once, and run one final exact-SHA review/gate.
   STOP if structural signature or exhaustive equivalence validation can be
   bypassed, canonical PostgreSQL is rejected, or final evidence is not clean.
+- The second aggregated repair was committed as full SHA
+  `e7064e5416ed6a15b8062d4176f8ecf5dee39d9c`. Its clean exact-SHA full local
+  suite completed `2429 passed, 104 skipped, 15 subtests passed in 50.01s`;
+  disposable PostgreSQL 16 completed `55 passed in 4.02s`; and the test gate,
+  fatal/new-file lint, compileall, strict MkDocs, wheel/sdist content gate,
+  prohibited-public-document scan, retired-document absence, and clean-tree
+  checks passed. The test container was removed.
+- The continued independent `gpt-5.6-sol` `xhigh` Codex review returned
+  `NEEDS_CHANGES` on clean exact SHA
+  `e7064e5416ed6a15b8062d4176f8ecf5dee39d9c`. It confirmed the prior
+  extra-domain and deferrability repairs, CK parser/storage/docs, and the
+  recorded PostgreSQL/focused suites, then found two remaining enforcement
+  gaps. First, the PostgreSQL `ANY(ARRAY[...])` signature lowercased quoted
+  values and extracted literals from an otherwise unvalidated array body; the
+  behavior cases also sampled only one member of each two-value class. A
+  computed second member and a case-changed second member were therefore both
+  accepted as equivalent while rejecting a valid official child row. Second,
+  canonical FK catalog definitions were accepted when SQLite FK enforcement,
+  PostgreSQL internal FK triggers, or PostgreSQL's session trigger mode had
+  been disabled.
+- Red-first evidence for this final aggregated repair was captured before
+  implementation. With SQLite FK enforcement disabled, both importers failed
+  the new expectation with `DID NOT RAISE SchemaMigrationError` (`2 failed`).
+  In disposable PostgreSQL 16, computed/case-changed array members failed the
+  expectation for both importers (`4 failed`), disabled FK triggers failed for
+  both (`2 failed`), and non-enforcing session trigger mode failed for both
+  (`2 failed`). In every case the old verifier allowed import instead of
+  refusing before parent mutation.
+- The repair preserves quoted-literal case, requires every PostgreSQL array
+  member to match the complete canonical text-or-integer literal grammar, and
+  evaluates every member of each official entity/period class including
+  case-changed negative representatives. SQLite now requires
+  `PRAGMA foreign_keys=1`. PostgreSQL now requires session trigger mode
+  `origin` plus the exact four active internal FK triggers, split two on the
+  parent and two on the child, in addition to the existing exact constraint
+  metadata. The paired regressions now pass for both importers: SQLite
+  `2 passed`; PostgreSQL malformed-contract matrix `24 passed`; complete CK
+  contract `39 passed, 26 skipped` without PostgreSQL and `65 passed` with
+  PostgreSQL 16. Next safe action: commit this single aggregated repair, remove
+  the disposable database container, then run one clean exact-SHA full and
+  PostgreSQL gate followed by one final independent review. STOP on any
+  parser/signature ambiguity, inactive FK path, failed test, dirty tree, or
+  review finding.

--- a/specs/operations/20260816_release_readiness_worklog.md
+++ b/specs/operations/20260816_release_readiness_worklog.md
@@ -1325,3 +1325,36 @@
   mechanical checks, commit this one aggregated review repair, then run one
   clean exact-SHA final review/gate. STOP on any false-green schema result,
   failed test, container residue, source drift, or dirty final worktree.
+- The first aggregated review repair was committed as full SHA
+  `812bbd8105496075ff036782527becf5fef9332b`. Its clean exact-SHA full local
+  suite completed `2429 passed, 100 skipped, 15 subtests passed in 52.35s`;
+  the disposable PostgreSQL contract completed `51 passed in 3.26s`; and all
+  exact mechanical/docs/distribution/clean gates passed. The container and
+  schemas were removed.
+- The continued `gpt-5.6-sol` `xhigh` review of exact SHA `812bbd8105496075ff036782527becf5fef9332b`
+  returned `NEEDS_CHANGES` with one remaining P1 and one P2 before root changed
+  the tree. The P1 demonstrated that finite truth samples alone were not an
+  equivalence proof: canonical `ck_chaku_domain OR EntityKubun='EVIL'` passed
+  verification and PostgreSQL stored the invalid child. The new real-PostgreSQL
+  `extra-domain-value` regression preserves that red. The P2 showed an otherwise
+  canonical `DEFERRABLE INITIALLY DEFERRED` FK was accepted, changing enforcement
+  timing inside caller-owned transactions.
+- The second aggregated repair does not grow the sample list around `EVIL`.
+  Instead it parses the PostgreSQL-canonical expression into a complete
+  structural signature of allowed equality/ANY/range/NULL atoms and exact
+  AND/OR/NOT counts, rejects every unrecognized atom/operator, and then evaluates
+  the expression across the complete equivalence classes induced by that fixed
+  vocabulary: 2,400 entity/period/metric/bucket combinations, all 16 count-shape
+  combinations, and all 384 actor/period/six-nullability summary combinations.
+  Structure prevents new literals/predicates; the truth table prevents regrouping
+  the same atoms into different semantics. The FK catalog gate now also requires
+  non-deferrable, initially immediate, `MATCH SIMPLE`, and `ON UPDATE NO ACTION`
+  in addition to the previously exact keys/parent/delete action/validation.
+- Current second-review repair remains uncommitted. SQLite CK verification is
+  `37 passed, 18 skipped`; disposable PostgreSQL 16 is `55 passed in 3.92s`,
+  including the preserved EVIL and deferrable reds for both importers; broader
+  affected verification is `701 passed, 40 skipped in 4.84s`. The container was
+  removed. Next safe action: finish formatting/mechanical checks, commit the
+  aggregated structural repair once, and run one final exact-SHA review/gate.
+  STOP if structural signature or exhaustive equivalence validation can be
+  bypassed, canonical PostgreSQL is rejected, or final evidence is not clean.

--- a/specs/operations/20260816_release_readiness_worklog.md
+++ b/specs/operations/20260816_release_readiness_worklog.md
@@ -1401,3 +1401,22 @@
   PostgreSQL gate followed by one final independent review. STOP on any
   parser/signature ambiguity, inactive FK path, failed test, dirty tree, or
   review finding.
+- The final enforcement repair was committed as full SHA
+  `5c0d86c1b4097a5636ef3cd2960ff9891b2868f2`. On that clean exact SHA, the
+  complete local suite passed `2431 passed, 112 skipped, 15 subtests passed in
+  52.57s`; the complete disposable PostgreSQL 16 CK contract passed `65 passed
+  in 5.09s`; and the test gate, fatal/new-file lint, compileall, `git diff
+  --check`, strict MkDocs, wheel/sdist build and content gate, public-document
+  scan, retired-document absence, container cleanup, and clean-tree checks all
+  passed. The final independent `gpt-5.6-sol` `xhigh` Codex review of that exact
+  SHA returned `GREEN` with no correctness, data-integrity, or release blocker.
+- PR `#196` was opened from the same exact code SHA with the above evidence.
+  GitHub Actions `test`, `lint`, and `windows-batch-syntax` passed; the optional
+  performance job was intentionally skipped; and CodeRabbit completed. Copilot
+  was requested once but explicitly reported that its review quota was
+  exhausted, so it supplied no review evidence. This evidence closes the CK
+  native-complete-storage iteration only. The repository release remains **not
+  ready** until the remaining official-contract/storage iterations, final
+  documentation and open-PR audit, actual fresh acquisition, and SQLite plus
+  PostgreSQL persistence/readback gates are complete. No 64-bit SDK support
+  claim is made without an installed-SDK end-to-end run.

--- a/src/database/schema.py
+++ b/src/database/schema.py
@@ -2778,6 +2778,10 @@ class SchemaManager:
                 migrate_table_if_needed(self.db, table_name, schema_sql)
             self.db.execute(schema_sql)
             verify_table_schema(self.db, table_name, schema_sql)
+            if table_name in STRICT_RECREATE_TABLES:
+                from src.importer.importer import verify_ck_child_table
+
+                verify_ck_child_table(self.db, table_name)
             logger.info(f"Created table: {table_name}")
             return True
         except Exception as e:

--- a/src/database/schema.py
+++ b/src/database/schema.py
@@ -99,6 +99,10 @@ from typing import Any, Dict, List
 
 from src.database.base import BaseDatabase
 from src.database.schema_ch import NL_CH_SCHEMA, NL_CH_SEISEKI_SCHEMA
+from src.database.schema_ck import (
+    NL_CK_CHAKU_SCHEMA,
+    NL_CK_RUIKEI_SCHEMA,
+)
 from src.database.schema_ks import NL_KS_SCHEMA, NL_KS_SEISEKI_SCHEMA
 from src.utils.logger import get_logger
 
@@ -329,6 +333,7 @@ SCHEMAS = {
             BreederName TEXT,
             BreederName_Co TEXT,
             BreederResultsInfo TEXT,
+            CKStorageVersion INTEGER,
             RecordDelimiter TEXT,
             PRIMARY KEY (Year, MonthDay, JyoCD, Kaiji, Nichiji, RaceNum, KettoNum)
         )
@@ -2718,6 +2723,15 @@ for _source_table, _target_table in (
     )
 
 
+SCHEMAS.update(
+    {
+        "NL_CK_CHAKU": NL_CK_CHAKU_SCHEMA,
+        "NL_CK_RUIKEI": NL_CK_RUIKEI_SCHEMA,
+    }
+)
+STRICT_RECREATE_TABLES = frozenset({"NL_CK_CHAKU", "NL_CK_RUIKEI"})
+
+
 class SchemaManager:
     """Schema management for JLTSQL database.
 
@@ -2760,7 +2774,8 @@ class SchemaManager:
             )
 
             schema_sql = SCHEMAS[table_name]
-            migrate_table_if_needed(self.db, table_name, schema_sql)
+            if table_name not in STRICT_RECREATE_TABLES:
+                migrate_table_if_needed(self.db, table_name, schema_sql)
             self.db.execute(schema_sql)
             verify_table_schema(self.db, table_name, schema_sql)
             logger.info(f"Created table: {table_name}")
@@ -2778,7 +2793,14 @@ class SchemaManager:
         from src.database.migration import migrate_all_tables, verify_table_schema
 
         logger.info("Creating all tables...")
-        migrate_all_tables(self.db, SCHEMAS)
+        migrate_all_tables(
+            self.db,
+            {
+                table_name: schema_sql
+                for table_name, schema_sql in SCHEMAS.items()
+                if table_name not in STRICT_RECREATE_TABLES
+            },
+        )
         results = {}
 
         for table_name, schema_sql in SCHEMAS.items():
@@ -2789,6 +2811,15 @@ class SchemaManager:
                 results[table_name] = True
             except Exception as e:
                 logger.error(f"Failed to create table {table_name}: {e}")
+                results[table_name] = False
+
+        try:
+            from src.importer.importer import verify_ck_coupled_tables
+
+            verify_ck_coupled_tables(self.db, "NL_CK")
+        except Exception as e:
+            logger.error(f"Failed to verify coupled CK tables: {e}")
+            for table_name in STRICT_RECREATE_TABLES:
                 results[table_name] = False
 
         success_count = sum(1 for v in results.values() if v)
@@ -2987,7 +3018,14 @@ def create_all_tables(db: BaseDatabase) -> None:
     logger.info("Creating tables...")
 
     # Check and migrate existing tables with mismatched schemas
-    migrate_all_tables(db, SCHEMAS)
+    migrate_all_tables(
+        db,
+        {
+            table_name: schema_sql
+            for table_name, schema_sql in SCHEMAS.items()
+            if table_name not in STRICT_RECREATE_TABLES
+        },
+    )
 
     for table_name, schema_sql in SCHEMAS.items():
         try:
@@ -2997,4 +3035,8 @@ def create_all_tables(db: BaseDatabase) -> None:
         except Exception as e:
             logger.error(f"Failed to create table {table_name}: {e}")
             raise
+
+    from src.importer.importer import verify_ck_coupled_tables
+
+    verify_ck_coupled_tables(db, "NL_CK")
     logger.info(f"Successfully created {len(SCHEMAS)} tables")

--- a/src/database/schema_ck.py
+++ b/src/database/schema_ck.py
@@ -1,0 +1,120 @@
+"""Normalized native schemas for the official current CK record."""
+
+PARENT_KEY_COLUMNS = (
+    ("Year", "INTEGER NOT NULL"),
+    ("MonthDay", "INTEGER NOT NULL"),
+    ("JyoCD", "TEXT NOT NULL"),
+    ("Kaiji", "INTEGER NOT NULL"),
+    ("Nichiji", "INTEGER NOT NULL"),
+    ("RaceNum", "INTEGER NOT NULL"),
+    ("KettoNum", "TEXT NOT NULL"),
+)
+PARENT_KEY = tuple(name for name, _ in PARENT_KEY_COLUMNS)
+
+
+def _create_table(
+    table_name: str,
+    columns: list[tuple[str, str]],
+    primary_key: tuple[str, ...],
+    constraints: tuple[str, ...],
+) -> str:
+    items = [f"            {name} {column_type}" for name, column_type in columns]
+    items.extend(f"            {constraint}" for constraint in constraints)
+    items.append(f"            PRIMARY KEY ({', '.join(primary_key)})")
+    return f"CREATE TABLE IF NOT EXISTS {table_name} (\n" + ",\n".join(items) + "\n        )"
+
+
+def _metric_clause(metric: str, count: int) -> str:
+    return f"(MetricKubun = '{metric}' AND BucketNum BETWEEN 1 AND {count})"
+
+
+_HORSE_METRICS = (
+    ("ChakuSogo", 1),
+    ("ChakuChuo", 1),
+    ("ChakuKaisuBa", 7),
+    ("ChakuKaisuJyotai", 12),
+    ("ChakuKaisuSibaKyori", 9),
+    ("ChakuKaisuDirtKyori", 9),
+    ("ChakuKaisuJyoSiba", 10),
+    ("ChakuKaisuJyoDirt", 10),
+    ("ChakuKaisuJyoSyogai", 10),
+    ("Kyakusitu", 1),
+)
+_PROFESSIONAL_METRICS = (
+    ("ChakuKaisuSiba", 1),
+    ("ChakuKaisuDirt", 1),
+    ("ChakuKaisuSyogai", 1),
+    ("ChakuKaisuSibaKyori", 9),
+    ("ChakuKaisuDirtKyori", 9),
+    ("ChakuKaisuJyoSiba", 10),
+    ("ChakuKaisuJyoDirt", 10),
+    ("ChakuKaisuJyoSyogai", 10),
+)
+_HORSE_DOMAIN = " OR ".join(_metric_clause(*item) for item in _HORSE_METRICS)
+_PROFESSIONAL_DOMAIN = " OR ".join(_metric_clause(*item) for item in _PROFESSIONAL_METRICS)
+_CHAKU_DOMAIN_CHECK = (
+    "CHECK ((EntityKubun = 'UMA' AND PeriodNum = 0 AND ("
+    + _HORSE_DOMAIN
+    + ")) OR (EntityKubun IN ('KISYU', 'CHOKYOSI') AND PeriodNum IN (1, 2) AND ("
+    + _PROFESSIONAL_DOMAIN
+    + ")) OR (EntityKubun IN ('BANUSI', 'BREEDER') AND PeriodNum IN (1, 2) "
+    "AND MetricKubun = 'ChakuKaisu' AND BucketNum = 1))"
+)
+
+
+NL_CK_CHAKU_SCHEMA = _create_table(
+    "NL_CK_CHAKU",
+    [
+        *PARENT_KEY_COLUMNS,
+        ("EntityKubun", "TEXT NOT NULL"),
+        ("PeriodNum", "INTEGER NOT NULL"),
+        ("MetricKubun", "TEXT NOT NULL"),
+        ("BucketNum", "INTEGER NOT NULL"),
+        *((f"Count{rank}", "INTEGER NOT NULL") for rank in range(1, 5)),
+        ("Count5", "INTEGER"),
+        ("Count6", "INTEGER"),
+    ],
+    (*PARENT_KEY, "EntityKubun", "PeriodNum", "MetricKubun", "BucketNum"),
+    (
+        "CONSTRAINT ck_chaku_parent_fk FOREIGN KEY "
+        f"({', '.join(PARENT_KEY)}) REFERENCES NL_CK ({', '.join(PARENT_KEY)}) "
+        "ON DELETE CASCADE",
+        f"CONSTRAINT ck_chaku_domain {_CHAKU_DOMAIN_CHECK}",
+        "CONSTRAINT ck_chaku_count_shape CHECK "
+        "((EntityKubun = 'UMA' AND MetricKubun = 'Kyakusitu' "
+        "AND Count5 IS NULL AND Count6 IS NULL) OR "
+        "(NOT (EntityKubun = 'UMA' AND MetricKubun = 'Kyakusitu') "
+        "AND Count5 IS NOT NULL AND Count6 IS NOT NULL))",
+    ),
+)
+
+NL_CK_RUIKEI_SCHEMA = _create_table(
+    "NL_CK_RUIKEI",
+    [
+        *PARENT_KEY_COLUMNS,
+        ("EntityKubun", "TEXT NOT NULL"),
+        ("PeriodNum", "INTEGER NOT NULL"),
+        ("SetYear", "INTEGER NOT NULL"),
+        ("HonSyokinHeichi", "BIGINT"),
+        ("HonSyokinSyogai", "BIGINT"),
+        ("FukaSyokinHeichi", "BIGINT"),
+        ("FukaSyokinSyogai", "BIGINT"),
+        ("HonSyokinTotal", "BIGINT"),
+        ("FukaSyokin", "BIGINT"),
+    ],
+    (*PARENT_KEY, "EntityKubun", "PeriodNum"),
+    (
+        "CONSTRAINT ck_ruikei_parent_fk FOREIGN KEY "
+        f"({', '.join(PARENT_KEY)}) REFERENCES NL_CK ({', '.join(PARENT_KEY)}) "
+        "ON DELETE CASCADE",
+        "CONSTRAINT ck_ruikei_shape CHECK ((EntityKubun IN ('KISYU', 'CHOKYOSI') "
+        "AND PeriodNum IN (1, 2) AND HonSyokinHeichi IS NOT NULL "
+        "AND HonSyokinSyogai IS NOT NULL AND FukaSyokinHeichi IS NOT NULL "
+        "AND FukaSyokinSyogai IS NOT NULL AND HonSyokinTotal IS NULL "
+        "AND FukaSyokin IS NULL) OR (EntityKubun IN ('BANUSI', 'BREEDER') "
+        "AND PeriodNum IN (1, 2) AND HonSyokinHeichi IS NULL "
+        "AND HonSyokinSyogai IS NULL AND FukaSyokinHeichi IS NULL "
+        "AND FukaSyokinSyogai IS NULL AND HonSyokinTotal IS NOT NULL "
+        "AND FukaSyokin IS NOT NULL))",
+    ),
+)

--- a/src/importer/importer.py
+++ b/src/importer/importer.py
@@ -2357,7 +2357,9 @@ def _verify_ck_postgresql_constraints(
     expected_names = set(_ck_named_constraints(expected_schema))
     rows = database.fetch_all(
         "SELECT conname AS name, contype AS type, confdeltype AS delete_type, "
-        "pg_get_constraintdef(oid) AS definition "
+        "convalidated AS validated, "
+        "confrelid = to_regclass('nl_ck') AS parent_matches, "
+        "pg_get_expr(conbin, conrelid) AS expression "
         "FROM pg_constraint WHERE conrelid = to_regclass(?)",
         (table_name.lower(),),
     )
@@ -2367,45 +2369,254 @@ def _verify_ck_postgresql_constraints(
             f"CK child constraints missing for {table_name}: "
             f"{sorted(expected_names - set(by_name))}"
         )
-    required_tokens = {
-        "ck_chaku_parent_fk": (*_CK_PARENT_KEY, "nl_ck", "cascade"),
-        "ck_chaku_domain": (
-            "entitykubun",
-            "periodnum",
-            "metrickubun",
-            "bucketnum",
-            "uma",
-            "kisyu",
-            "chokyosi",
-            "banusi",
-            "breeder",
-            *tuple(metric for metric, _ in (*_CK_HORSE_METRICS, *_CK_PROFESSIONAL_METRICS)),
-        ),
-        "ck_chaku_count_shape": ("count5", "count6", "kyakusitu", "is null"),
-        "ck_ruikei_parent_fk": (*_CK_PARENT_KEY, "nl_ck", "cascade"),
-        "ck_ruikei_shape": (
-            "entitykubun",
-            "periodnum",
-            "honsyokinheichi",
-            "honsyokinsyogai",
-            "fukasyokinheichi",
-            "fukasyokinsyogai",
-            "honsyokintotal",
-            "fukasyokin",
-            "is not null",
-        ),
+    unexpected = {
+        name
+        for name, row in by_name.items()
+        if str(row.get("type")) in {"c", "f", "u", "x"} and name not in expected_names
     }
+    if unexpected:
+        raise SchemaMigrationError(
+            f"CK child has unexpected constraints for {table_name}: {sorted(unexpected)}"
+        )
+
     for constraint_name in expected_names:
-        definition = str(by_name[constraint_name].get("definition") or "").lower()
-        if not all(str(token).lower() in definition for token in required_tokens[constraint_name]):
+        row = by_name[constraint_name]
+        if not bool(row.get("validated")):
             raise SchemaMigrationError(
-                f"CK child constraint body mismatch for {table_name}.{constraint_name}"
+                f"CK child constraint is not validated for {table_name}.{constraint_name}"
             )
-        if (
-            constraint_name.endswith("parent_fk")
-            and str(by_name[constraint_name].get("delete_type")) != "c"
-        ):
-            raise SchemaMigrationError(f"CK child foreign key is not CASCADE: {table_name}")
+        if constraint_name.endswith("parent_fk"):
+            if (
+                str(row.get("type")) != "f"
+                or str(row.get("delete_type")) != "c"
+                or not bool(row.get("parent_matches"))
+            ):
+                raise SchemaMigrationError(
+                    f"CK child foreign key metadata mismatch for {table_name}"
+                )
+            key_rows = database.fetch_all(
+                "SELECT local_column.attname AS local_name, "
+                "remote_column.attname AS remote_name "
+                "FROM pg_constraint constraint_row "
+                "JOIN LATERAL generate_subscripts(constraint_row.conkey, 1) "
+                "AS key_position(position) ON TRUE "
+                "JOIN pg_attribute local_column "
+                "ON local_column.attrelid = constraint_row.conrelid "
+                "AND local_column.attnum = constraint_row.conkey[key_position.position] "
+                "JOIN pg_attribute remote_column "
+                "ON remote_column.attrelid = constraint_row.confrelid "
+                "AND remote_column.attnum = constraint_row.confkey[key_position.position] "
+                "WHERE constraint_row.conrelid = to_regclass(?) "
+                "AND constraint_row.conname = ? ORDER BY key_position.position",
+                (table_name.lower(), constraint_name),
+            )
+            local_names = [str(key_row["local_name"]).lower() for key_row in key_rows]
+            remote_names = [str(key_row["remote_name"]).lower() for key_row in key_rows]
+            if local_names != [name.lower() for name in _CK_PARENT_KEY] or remote_names != [
+                name.lower() for name in _CK_PARENT_KEY
+            ]:
+                raise SchemaMigrationError(
+                    f"CK child foreign key columns mismatch for {table_name}"
+                )
+            continue
+
+        if str(row.get("type")) != "c" or not row.get("expression"):
+            raise SchemaMigrationError(
+                f"CK child CHECK metadata mismatch for {table_name}.{constraint_name}"
+            )
+        _verify_ck_postgresql_check_truth_table(
+            database,
+            table_name,
+            constraint_name,
+            str(row["expression"]),
+        )
+
+
+def _ck_postgresql_check_cases(
+    constraint_name: str,
+) -> tuple[tuple[tuple[str, str], ...], list[tuple[tuple[Any, ...], bool]]]:
+    if constraint_name == "ck_chaku_domain":
+        columns = (
+            ("EntityKubun", "TEXT"),
+            ("PeriodNum", "INTEGER"),
+            ("MetricKubun", "TEXT"),
+            ("BucketNum", "INTEGER"),
+        )
+        cases = [(dimension, True) for dimension in _CK_EXPECTED_CHAKU_DIMENSIONS]
+        maximums: dict[tuple[str, int, str], int] = {}
+        for entity, period, metric, bucket in _CK_EXPECTED_CHAKU_DIMENSIONS:
+            maximums[(entity, period, metric)] = max(
+                maximums.get((entity, period, metric), 0), bucket
+            )
+        for (entity, period, metric), maximum in maximums.items():
+            cases.append(((entity, period, metric, 0), False))
+            cases.append(((entity, period, metric, maximum + 1), False))
+        cases.extend(
+            [
+                (("INVALID", 0, "ChakuSogo", 1), False),
+                (("UMA", 1, "ChakuSogo", 1), False),
+                (("KISYU", 0, "ChakuKaisuSiba", 1), False),
+                (("CHOKYOSI", 3, "ChakuKaisuSiba", 1), False),
+                (("BANUSI", 0, "ChakuKaisu", 1), False),
+                (("BREEDER", 3, "ChakuKaisu", 1), False),
+                (("UMA", 0, "ChakuKaisuSiba", 1), False),
+                (("KISYU", 1, "ChakuSogo", 1), False),
+                (("BANUSI", 1, "ChakuSogo", 1), False),
+                (("UMA", 0, "INVALID", 1), False),
+            ]
+        )
+        return columns, cases
+
+    if constraint_name == "ck_chaku_count_shape":
+        columns = (
+            ("EntityKubun", "TEXT"),
+            ("MetricKubun", "TEXT"),
+            ("Count5", "INTEGER"),
+            ("Count6", "INTEGER"),
+        )
+        return columns, [
+            (("UMA", "Kyakusitu", None, None), True),
+            (("UMA", "Kyakusitu", 1, 1), False),
+            (("UMA", "Kyakusitu", None, 1), False),
+            (("KISYU", "ChakuKaisuSiba", 1, 1), True),
+            (("KISYU", "ChakuKaisuSiba", 0, 999999), True),
+            (("KISYU", "ChakuKaisuSiba", None, None), False),
+            (("KISYU", "ChakuKaisuSiba", 1, None), False),
+        ]
+
+    if constraint_name == "ck_ruikei_shape":
+        columns = (
+            ("EntityKubun", "TEXT"),
+            ("PeriodNum", "INTEGER"),
+            ("HonSyokinHeichi", "BIGINT"),
+            ("HonSyokinSyogai", "BIGINT"),
+            ("FukaSyokinHeichi", "BIGINT"),
+            ("FukaSyokinSyogai", "BIGINT"),
+            ("HonSyokinTotal", "BIGINT"),
+            ("FukaSyokin", "BIGINT"),
+        )
+        professional = (1, 1, 1, 1, None, None)
+        owner = (None, None, None, None, 1, 1)
+        cases = [
+            ((entity, period, *professional), True)
+            for entity in ("KISYU", "CHOKYOSI")
+            for period in (1, 2)
+        ]
+        cases.extend(
+            ((entity, period, *owner), True)
+            for entity in ("BANUSI", "BREEDER")
+            for period in (1, 2)
+        )
+        cases.extend(
+            [
+                (("KISYU", 1, 0, 9999999999, 0, 9999999999, None, None), True),
+                (("BANUSI", 1, None, None, None, None, 0, 9999999999), True),
+            ]
+        )
+        cases.extend(
+            [
+                (("INVALID", 1, *professional), False),
+                (("KISYU", 0, *professional), False),
+                (("BANUSI", 3, *owner), False),
+            ]
+        )
+        for missing_index in range(4):
+            values = list(professional)
+            values[missing_index] = None
+            cases.append((("KISYU", 1, *values), False))
+        for forbidden_index in (4, 5):
+            values = list(professional)
+            values[forbidden_index] = 1
+            cases.append((("KISYU", 1, *values), False))
+        for missing_index in (4, 5):
+            values = list(owner)
+            values[missing_index] = None
+            cases.append((("BANUSI", 1, *values), False))
+        for forbidden_index in range(4):
+            values = list(owner)
+            values[forbidden_index] = 1
+            cases.append((("BANUSI", 1, *values), False))
+        return columns, cases
+
+    raise SchemaMigrationError(f"Unknown CK PostgreSQL CHECK constraint: {constraint_name}")
+
+
+def _verify_ck_postgresql_check_truth_table(
+    database: BaseDatabase,
+    table_name: str,
+    constraint_name: str,
+    expression: str,
+) -> None:
+    columns, cases = _ck_postgresql_check_cases(constraint_name)
+    value_rows = []
+    parameters: list[Any] = []
+    for case_number, (values, _) in enumerate(cases):
+        casts = ["CAST(? AS INTEGER)"]
+        parameters.append(case_number)
+        for value, (_, sql_type) in zip(values, columns, strict=True):
+            casts.append(f"CAST(? AS {sql_type})")
+            parameters.append(value)
+        value_rows.append(f"({', '.join(casts)})")
+    aliases = ", ".join(("case_number", *(name.lower() for name, _ in columns)))
+    rows = database.fetch_all(
+        "SELECT case_number, COALESCE(("
+        + expression
+        + "), FALSE) AS accepted FROM (VALUES "
+        + ", ".join(value_rows)
+        + f") AS ck_probe({aliases}) ORDER BY case_number",
+        tuple(parameters),
+    )
+    actual = {int(row["case_number"]): bool(row["accepted"]) for row in rows}
+    expected = {case_number: accepted for case_number, (_, accepted) in enumerate(cases)}
+    if actual != expected:
+        mismatches = [
+            case_number
+            for case_number, accepted in expected.items()
+            if actual.get(case_number) != accepted
+        ]
+        raise SchemaMigrationError(
+            f"CK child CHECK behavior mismatch for {table_name}.{constraint_name}: "
+            f"cases={mismatches[:5]}"
+        )
+
+
+def _verify_ck_child_on_target(
+    target: BaseDatabase,
+    main_table_name: str,
+    table_name: str,
+) -> None:
+    from src.database.migration import verify_table_schema
+    from src.database.schema import SCHEMAS
+
+    for required_table in (main_table_name, table_name):
+        if not target.table_exists_strict(required_table):
+            raise SchemaMigrationError(
+                f"CK import requires table {required_table} before mutation"
+            )
+        verify_table_schema(target, required_table, SCHEMAS[required_table])
+
+    schema_sql = SCHEMAS[table_name]
+    actual = _ck_actual_column_contract(target, table_name)
+    expected = _ck_expected_column_contract(schema_sql)
+    if actual != expected:
+        raise SchemaMigrationError(
+            f"CK child columns/types/nullability must match exactly for {table_name}"
+        )
+    if target.get_db_type() == "sqlite":
+        _verify_ck_sqlite_constraints(target, table_name, schema_sql)
+    elif target.get_db_type() == "postgresql":
+        _verify_ck_postgresql_constraints(target, table_name, schema_sql)
+
+
+def verify_ck_child_table(
+    database: BaseDatabase,
+    table_name: str,
+) -> None:
+    """Verify one CK child without requiring its not-yet-created sibling."""
+    if table_name not in {"NL_CK_CHAKU", "NL_CK_RUIKEI"}:
+        raise SchemaMigrationError(f"Unknown CK child table: {table_name}")
+    for target in _ck_schema_targets(database):
+        _verify_ck_child_on_target(target, "NL_CK", table_name)
 
 
 def verify_ck_coupled_tables(
@@ -2417,26 +2628,9 @@ def verify_ck_coupled_tables(
     if child_tables is None:
         return None
 
-    from src.database.migration import verify_table_schema
-    from src.database.schema import SCHEMAS
-
     for target in _ck_schema_targets(database):
-        for table_name in (main_table_name, *child_tables):
-            schema_sql = SCHEMAS[table_name]
-            if not target.table_exists_strict(table_name):
-                raise SchemaMigrationError(f"CK import requires table {table_name} before mutation")
-            verify_table_schema(target, table_name, schema_sql)
-            if table_name != main_table_name:
-                actual = _ck_actual_column_contract(target, table_name)
-                expected = _ck_expected_column_contract(schema_sql)
-                if actual != expected:
-                    raise SchemaMigrationError(
-                        f"CK child columns/types/nullability must match exactly for {table_name}"
-                    )
-                if target.get_db_type() == "sqlite":
-                    _verify_ck_sqlite_constraints(target, table_name, schema_sql)
-                elif target.get_db_type() == "postgresql":
-                    _verify_ck_postgresql_constraints(target, table_name, schema_sql)
+        for table_name in child_tables:
+            _verify_ck_child_on_target(target, main_table_name, table_name)
     return child_tables
 
 

--- a/src/importer/importer.py
+++ b/src/importer/importer.py
@@ -2320,6 +2320,10 @@ def _verify_ck_sqlite_constraints(
     table_name: str,
     expected_schema: str,
 ) -> None:
+    enforcement = database.fetch_one("PRAGMA foreign_keys")
+    if not enforcement or int(next(iter(enforcement.values()), 0)) != 1:
+        raise SchemaMigrationError("CK child foreign-key enforcement is disabled for SQLite")
+
     row = database.fetch_one(
         "SELECT sql FROM sqlite_master WHERE type = 'table' AND name = ?",
         (table_name,),
@@ -2354,9 +2358,18 @@ def _verify_ck_postgresql_constraints(
     table_name: str,
     expected_schema: str,
 ) -> None:
+    trigger_mode = database.fetch_one(
+        "SELECT current_setting('session_replication_role') AS trigger_mode"
+    )
+    if not trigger_mode or str(trigger_mode.get("trigger_mode")) != "origin":
+        raise SchemaMigrationError(
+            "CK child foreign-key enforcement requires PostgreSQL origin trigger mode"
+        )
+
     expected_names = set(_ck_named_constraints(expected_schema))
     rows = database.fetch_all(
-        "SELECT conname AS name, contype AS type, confdeltype AS delete_type, "
+        "SELECT oid AS constraint_oid, conname AS name, contype AS type, "
+        "confdeltype AS delete_type, "
         "confupdtype AS update_type, confmatchtype AS match_type, "
         "condeferrable AS deferrable, condeferred AS initially_deferred, "
         "convalidated AS validated, "
@@ -2424,6 +2437,21 @@ def _verify_ck_postgresql_constraints(
                 raise SchemaMigrationError(
                     f"CK child foreign key columns mismatch for {table_name}"
                 )
+            trigger_rows = database.fetch_all(
+                "SELECT tgenabled AS enabled, tgrelid = to_regclass(?) AS on_child, "
+                "tgrelid = to_regclass('nl_ck') AS on_parent "
+                "FROM pg_trigger WHERE tgconstraint = ? AND tgisinternal ORDER BY oid",
+                (table_name.lower(), int(row["constraint_oid"])),
+            )
+            if (
+                len(trigger_rows) != 4
+                or any(str(trigger["enabled"]) != "O" for trigger in trigger_rows)
+                or sum(bool(trigger["on_child"]) for trigger in trigger_rows) != 2
+                or sum(bool(trigger["on_parent"]) for trigger in trigger_rows) != 2
+            ):
+                raise SchemaMigrationError(
+                    f"CK child foreign-key triggers are not active for {table_name}"
+                )
             continue
 
         if str(row.get("type")) != "c" or not row.get("expression"):
@@ -2455,8 +2483,16 @@ def _ck_postgresql_check_cases(
         )
         buckets = (0, 1, 2, 7, 8, 9, 10, 11, 12, 13)
         cases = []
-        for entity in ("UMA", "KISYU", "BANUSI", "INVALID"):
-            for period in (0, 1, 3):
+        for entity in (
+            "UMA",
+            "KISYU",
+            "CHOKYOSI",
+            "BANUSI",
+            "BREEDER",
+            "INVALID",
+            "chokyosi",
+        ):
+            for period in (0, 1, 2, 3):
                 for metric in metrics:
                     for bucket in buckets:
                         accepted = (
@@ -2465,13 +2501,13 @@ def _ck_postgresql_check_cases(
                             and metric in horse_maximum
                             and 1 <= bucket <= horse_maximum[metric]
                         ) or (
-                            entity == "KISYU"
-                            and period == 1
+                            entity in {"KISYU", "CHOKYOSI"}
+                            and period in {1, 2}
                             and metric in professional_maximum
                             and 1 <= bucket <= professional_maximum[metric]
                         ) or (
-                            entity == "BANUSI"
-                            and period == 1
+                            entity in {"BANUSI", "BREEDER"}
+                            and period in {1, 2}
                             and metric == "ChakuKaisu"
                             and bucket == 1
                         )
@@ -2511,8 +2547,15 @@ def _ck_postgresql_check_cases(
         from itertools import product
 
         cases = []
-        for entity in ("KISYU", "BANUSI", "INVALID"):
-            for period in (0, 1):
+        for entity in (
+            "KISYU",
+            "CHOKYOSI",
+            "BANUSI",
+            "BREEDER",
+            "INVALID",
+            "chokyosi",
+        ):
+            for period in (0, 1, 2):
                 for values in product((None, 1), repeat=6):
                     professional_shape = all(value is not None for value in values[:4]) and all(
                         value is None for value in values[4:]
@@ -2520,9 +2563,9 @@ def _ck_postgresql_check_cases(
                     owner_shape = all(value is None for value in values[:4]) and all(
                         value is not None for value in values[4:]
                     )
-                    accepted = period == 1 and (
-                        (entity == "KISYU" and professional_shape)
-                        or (entity == "BANUSI" and owner_shape)
+                    accepted = period in {1, 2} and (
+                        (entity in {"KISYU", "CHOKYOSI"} and professional_shape)
+                        or (entity in {"BANUSI", "BREEDER"} and owner_shape)
                     )
                     cases.append(((entity, period, *values), accepted))
         return columns, cases
@@ -2539,10 +2582,10 @@ def _ck_postgresql_expected_check_signature(
     operators: Counter[str] = Counter()
 
     def equality(column: str, value: Any) -> None:
-        atoms[f"eq:{column.lower()}:{str(value).lower()}"] += 1
+        atoms[f"eq:{column.lower()}:{value}"] += 1
 
     def any_of(column: str, values: tuple[Any, ...]) -> None:
-        normalized = ",".join(str(value).lower() for value in values)
+        normalized = ",".join(str(value) for value in values)
         atoms[f"any:{column.lower()}:{normalized}"] += 1
 
     def metric_family(metrics: tuple[tuple[str, int], ...]) -> None:
@@ -2627,17 +2670,28 @@ def _ck_postgresql_check_signature(
     from collections import Counter
 
     atoms: Counter[str] = Counter()
-    working = expression.lower()
+    working = expression
 
     def replace_any(match: Any) -> str:
-        column = match.group(1)
+        column = match.group(1).lower()
         raw_values = match.group(2)
-        values = [
-            string_value if string_value else number_value
-            for string_value, number_value in re.findall(
-                r"'([^']*)'(?:\s*::\s*text)?|(-?\d+)", raw_values
+        values = []
+        for raw_value in raw_values.split(","):
+            item = raw_value.strip()
+            string_match = re.fullmatch(
+                r"'([^']*)'(?:\s*::\s*text)?",
+                item,
+                flags=re.IGNORECASE,
             )
-        ]
+            number_match = re.fullmatch(r"-?\d+", item)
+            if string_match:
+                values.append(string_match.group(1))
+            elif number_match:
+                values.append(number_match.group(0))
+            else:
+                raise SchemaMigrationError(
+                    "CK PostgreSQL CHECK array contains a non-literal value"
+                )
         atoms[f"any:{column}:{','.join(values)}"] += 1
         return " atom "
 
@@ -2645,11 +2699,11 @@ def _ck_postgresql_check_signature(
         r"\b([a-z_][a-z0-9_]*)\s*=\s*any\s*\(\s*array\[(.*?)\]\s*\)",
         replace_any,
         working,
-        flags=re.DOTALL,
+        flags=re.DOTALL | re.IGNORECASE,
     )
 
     def replace_null(match: Any) -> str:
-        column = match.group(1)
+        column = match.group(1).lower()
         qualifier = "notnull" if match.group(2) else "null"
         atoms[f"{qualifier}:{column}"] += 1
         return " atom "
@@ -2658,29 +2712,35 @@ def _ck_postgresql_check_signature(
         r"\b([a-z_][a-z0-9_]*)\s+is\s+(not\s+)?null\b",
         replace_null,
         working,
+        flags=re.IGNORECASE,
     )
 
     def replace_text_equality(match: Any) -> str:
-        atoms[f"eq:{match.group(1)}:{match.group(2)}"] += 1
+        atoms[f"eq:{match.group(1).lower()}:{match.group(2)}"] += 1
         return " atom "
 
     working = re.sub(
         r"\b([a-z_][a-z0-9_]*)\s*=\s*'([^']*)'(?:\s*::\s*text)?",
         replace_text_equality,
         working,
+        flags=re.IGNORECASE,
     )
 
     def replace_numeric(match: Any) -> str:
         operator = {"=": "eq", ">=": "ge", "<=": "le"}[match.group(2)]
-        atoms[f"{operator}:{match.group(1)}:{match.group(3)}"] += 1
+        atoms[f"{operator}:{match.group(1).lower()}:{match.group(3)}"] += 1
         return " atom "
 
     working = re.sub(
         r"\b([a-z_][a-z0-9_]*)\s*(>=|<=|=)\s*(-?\d+)\b",
         replace_numeric,
         working,
+        flags=re.IGNORECASE,
     )
-    remaining_words = re.findall(r"[a-z_][a-z0-9_]*|>=|<=|=|-?\d+|'[^']*'|::", working)
+    remaining_words = re.findall(
+        r"[a-z_][a-z0-9_]*|>=|<=|=|-?\d+|'[^']*'|::",
+        working.lower(),
+    )
     operators: Counter[str] = Counter(
         word for word in remaining_words if word in {"and", "or", "not"}
     )

--- a/src/importer/importer.py
+++ b/src/importer/importer.py
@@ -32,6 +32,11 @@ def resolve_standard_storage_table_name(native_table_name: str) -> str:
 def resolve_standard_table_name(database: BaseDatabase, native_table_name: str) -> str:
     """Resolve a canonical standard table and reject unsupported legacy-only storage."""
     standard_name = resolve_standard_storage_table_name(native_table_name)
+    if native_table_name == "NL_CK":
+        raise SchemaMigrationError(
+            "CK standard-schema storage is not implemented; use native NL_CK until the "
+            "canonical CHOKYO_DETAIL parent/child contract is available"
+        )
     if (
         native_table_name == "NL_SK"
         and database.is_connected()
@@ -2185,6 +2190,441 @@ def insert_ks_coupled_batch(
     return succeeded, failed
 
 
+_CK_CHAKU_ROWS_KEY = "_ck_chaku_rows"
+_CK_RUIKEI_ROWS_KEY = "_ck_ruikei_rows"
+_PREPARED_CK_ROWS_KEY = "_prepared_ck_rows"
+_CK_PARENT_KEY = ("Year", "MonthDay", "JyoCD", "Kaiji", "Nichiji", "RaceNum", "KettoNum")
+_CK_HORSE_METRICS = (
+    ("ChakuSogo", 1),
+    ("ChakuChuo", 1),
+    ("ChakuKaisuBa", 7),
+    ("ChakuKaisuJyotai", 12),
+    ("ChakuKaisuSibaKyori", 9),
+    ("ChakuKaisuDirtKyori", 9),
+    ("ChakuKaisuJyoSiba", 10),
+    ("ChakuKaisuJyoDirt", 10),
+    ("ChakuKaisuJyoSyogai", 10),
+    ("Kyakusitu", 1),
+)
+_CK_PROFESSIONAL_METRICS = (
+    ("ChakuKaisuSiba", 1),
+    ("ChakuKaisuDirt", 1),
+    ("ChakuKaisuSyogai", 1),
+    ("ChakuKaisuSibaKyori", 9),
+    ("ChakuKaisuDirtKyori", 9),
+    ("ChakuKaisuJyoSiba", 10),
+    ("ChakuKaisuJyoDirt", 10),
+    ("ChakuKaisuJyoSyogai", 10),
+)
+_CK_EXPECTED_CHAKU_DIMENSIONS = (
+    *(
+        ("UMA", 0, metric, bucket)
+        for metric, count in _CK_HORSE_METRICS
+        for bucket in range(1, count + 1)
+    ),
+    *(
+        (entity, period, metric, bucket)
+        for entity in ("KISYU", "CHOKYOSI")
+        for period in (1, 2)
+        for metric, count in _CK_PROFESSIONAL_METRICS
+        for bucket in range(1, count + 1)
+    ),
+    *((entity, period, "ChakuKaisu", 1) for entity in ("BANUSI", "BREEDER") for period in (1, 2)),
+)
+_CK_EXPECTED_RUIKEI_DIMENSIONS = tuple(
+    (entity, period) for entity in ("KISYU", "CHOKYOSI", "BANUSI", "BREEDER") for period in (1, 2)
+)
+
+
+def _ck_child_tables(main_table_name: str) -> tuple[str, str] | None:
+    if main_table_name == "NL_CK":
+        return "NL_CK_CHAKU", "NL_CK_RUIKEI"
+    return None
+
+
+def _ck_schema_targets(database: BaseDatabase) -> tuple[BaseDatabase, ...]:
+    getter = getattr(database, "get_migration_targets", None)
+    if getter is None:
+        return (database,)
+    targets = tuple(getter())
+    return targets or (database,)
+
+
+def _ck_actual_column_contract(
+    database: BaseDatabase,
+    table_name: str,
+) -> dict[str, tuple[str, bool]]:
+    if database.get_db_type() == "postgresql":
+        rows = database.fetch_all(
+            "SELECT a.attname AS name, format_type(a.atttypid, a.atttypmod) AS type, "
+            "a.attnotnull AS not_null FROM pg_attribute a "
+            "WHERE a.attrelid = to_regclass(?) AND a.attnum > 0 AND NOT a.attisdropped",
+            (table_name.lower(),),
+        )
+    else:
+        rows = database.fetch_all(f'PRAGMA table_info("{table_name}")')
+
+    def normalized_type(value: Any) -> str:
+        normalized = str(value or "").lower().strip()
+        return {
+            "int": "integer",
+            "int4": "integer",
+            "integer": "integer",
+            "int8": "bigint",
+            "bigint": "bigint",
+            "text": "text",
+        }.get(normalized, normalized)
+
+    result = {}
+    for row in rows:
+        not_null_value = row.get("not_null", row.get("notnull", 0))
+        result[str(row["name"]).lower()] = (
+            normalized_type(row.get("type")),
+            bool(not_null_value),
+        )
+    return result
+
+
+def _ck_expected_column_contract(schema_sql: str) -> dict[str, tuple[str, bool]]:
+    from src.database.migration import _extract_column_definitions
+
+    definitions = _extract_column_definitions(schema_sql)
+    if definitions is None:
+        raise SchemaMigrationError("CK expected child columns are unreadable")
+    result = {}
+    for name, definition in definitions.items():
+        tokens = definition.split()
+        result[name.lower()] = (tokens[1].lower(), "NOT NULL" in definition.upper())
+    return result
+
+
+def _ck_named_constraints(create_sql: str) -> dict[str, str]:
+    import re
+
+    from src.database.migration import _schema_body, _split_schema_items
+
+    body = _schema_body(create_sql)
+    if body is None:
+        raise SchemaMigrationError("CK schema SQL has no table body")
+    constraints = {}
+    for item in _split_schema_items(body):
+        match = re.match(r"CONSTRAINT\s+(\w+)\s+(.+)", item, re.IGNORECASE | re.DOTALL)
+        if match:
+            normalized = re.sub(r"[\s\"`]", "", match.group(2)).lower()
+            constraints[match.group(1).lower()] = normalized
+    return constraints
+
+
+def _verify_ck_sqlite_constraints(
+    database: BaseDatabase,
+    table_name: str,
+    expected_schema: str,
+) -> None:
+    row = database.fetch_one(
+        "SELECT sql FROM sqlite_master WHERE type = 'table' AND name = ?",
+        (table_name,),
+    )
+    if not row or not row.get("sql"):
+        raise SchemaMigrationError(f"CK child table definition is unreadable: {table_name}")
+    expected = _ck_named_constraints(expected_schema)
+    actual = _ck_named_constraints(str(row["sql"]))
+    if actual != expected:
+        raise SchemaMigrationError(
+            f"CK child constraints mismatch for {table_name}: "
+            f"actual={sorted(actual)}, expected={sorted(expected)}"
+        )
+
+    foreign_keys = database.fetch_all(f'PRAGMA foreign_key_list("{table_name}")')
+    ordered = sorted(foreign_keys, key=lambda item: int(item["seq"]))
+    local = [str(item["from"]) for item in ordered]
+    remote = [str(item["to"]) for item in ordered]
+    if (
+        len(ordered) != len(_CK_PARENT_KEY)
+        or len({item["id"] for item in ordered}) != 1
+        or [name.lower() for name in local] != [name.lower() for name in _CK_PARENT_KEY]
+        or [name.lower() for name in remote] != [name.lower() for name in _CK_PARENT_KEY]
+        or any(str(item["table"]).lower() != "nl_ck" for item in ordered)
+        or any(str(item["on_delete"]).upper() != "CASCADE" for item in ordered)
+    ):
+        raise SchemaMigrationError(f"CK child foreign key mismatch for {table_name}")
+
+
+def _verify_ck_postgresql_constraints(
+    database: BaseDatabase,
+    table_name: str,
+    expected_schema: str,
+) -> None:
+    expected_names = set(_ck_named_constraints(expected_schema))
+    rows = database.fetch_all(
+        "SELECT conname AS name, contype AS type, confdeltype AS delete_type, "
+        "pg_get_constraintdef(oid) AS definition "
+        "FROM pg_constraint WHERE conrelid = to_regclass(?)",
+        (table_name.lower(),),
+    )
+    by_name = {str(row["name"]).lower(): row for row in rows}
+    if not expected_names <= set(by_name):
+        raise SchemaMigrationError(
+            f"CK child constraints missing for {table_name}: "
+            f"{sorted(expected_names - set(by_name))}"
+        )
+    required_tokens = {
+        "ck_chaku_parent_fk": (*_CK_PARENT_KEY, "nl_ck", "cascade"),
+        "ck_chaku_domain": (
+            "entitykubun",
+            "periodnum",
+            "metrickubun",
+            "bucketnum",
+            "uma",
+            "kisyu",
+            "chokyosi",
+            "banusi",
+            "breeder",
+            *tuple(metric for metric, _ in (*_CK_HORSE_METRICS, *_CK_PROFESSIONAL_METRICS)),
+        ),
+        "ck_chaku_count_shape": ("count5", "count6", "kyakusitu", "is null"),
+        "ck_ruikei_parent_fk": (*_CK_PARENT_KEY, "nl_ck", "cascade"),
+        "ck_ruikei_shape": (
+            "entitykubun",
+            "periodnum",
+            "honsyokinheichi",
+            "honsyokinsyogai",
+            "fukasyokinheichi",
+            "fukasyokinsyogai",
+            "honsyokintotal",
+            "fukasyokin",
+            "is not null",
+        ),
+    }
+    for constraint_name in expected_names:
+        definition = str(by_name[constraint_name].get("definition") or "").lower()
+        if not all(str(token).lower() in definition for token in required_tokens[constraint_name]):
+            raise SchemaMigrationError(
+                f"CK child constraint body mismatch for {table_name}.{constraint_name}"
+            )
+        if (
+            constraint_name.endswith("parent_fk")
+            and str(by_name[constraint_name].get("delete_type")) != "c"
+        ):
+            raise SchemaMigrationError(f"CK child foreign key is not CASCADE: {table_name}")
+
+
+def verify_ck_coupled_tables(
+    database: BaseDatabase,
+    main_table_name: str,
+) -> tuple[str, str] | None:
+    """Verify the complete CK parent/child contract before any mutation."""
+    child_tables = _ck_child_tables(main_table_name)
+    if child_tables is None:
+        return None
+
+    from src.database.migration import verify_table_schema
+    from src.database.schema import SCHEMAS
+
+    for target in _ck_schema_targets(database):
+        for table_name in (main_table_name, *child_tables):
+            schema_sql = SCHEMAS[table_name]
+            if not target.table_exists_strict(table_name):
+                raise SchemaMigrationError(f"CK import requires table {table_name} before mutation")
+            verify_table_schema(target, table_name, schema_sql)
+            if table_name != main_table_name:
+                actual = _ck_actual_column_contract(target, table_name)
+                expected = _ck_expected_column_contract(schema_sql)
+                if actual != expected:
+                    raise SchemaMigrationError(
+                        f"CK child columns/types/nullability must match exactly for {table_name}"
+                    )
+                if target.get_db_type() == "sqlite":
+                    _verify_ck_sqlite_constraints(target, table_name, schema_sql)
+                elif target.get_db_type() == "postgresql":
+                    _verify_ck_postgresql_constraints(target, table_name, schema_sql)
+    return child_tables
+
+
+def prepare_ck_coupled_rows(
+    database: BaseDatabase,
+    record: dict,
+    main_table_name: str,
+    main_row: dict,
+    *,
+    verified_child_tables: tuple[str, str] | None = None,
+) -> tuple[str, list[dict], str, list[dict]] | None:
+    """Validate all CK dimensions, keys, and values before a write begins."""
+    expected_tables = _ck_child_tables(main_table_name)
+    if expected_tables is None:
+        return None
+    child_tables = verified_child_tables or verify_ck_coupled_tables(database, main_table_name)
+    if child_tables != expected_tables:
+        raise SchemaMigrationError("CK normalized child-table resolution is inconsistent")
+    chaku_table, ruikei_table = child_tables
+
+    if "CKStorageVersion" in record:
+        raise SchemaMigrationError("CKStorageVersion is importer-owned metadata")
+    data_kubun = resolve_record_data_kubun(record)
+    chaku_rows = record.get(_CK_CHAKU_ROWS_KEY)
+    ruikei_rows = record.get(_CK_RUIKEI_ROWS_KEY)
+    if data_kubun == "0":
+        if chaku_rows != [] or ruikei_rows != []:
+            raise SchemaMigrationError("CK delete record must not carry normalized child rows")
+        return chaku_table, [], ruikei_table, []
+    if data_kubun not in {"1", "2"}:
+        raise SchemaMigrationError(f"CK import does not support DataKubun={data_kubun!r}")
+    if not isinstance(chaku_rows, list) or not isinstance(ruikei_rows, list):
+        raise SchemaMigrationError("CK import requires both normalized child row lists")
+
+    expected_chaku_fields = set(get_table_column_types(chaku_table))
+    expected_ruikei_fields = set(get_table_column_types(ruikei_table))
+    converted_chaku = []
+    converted_ruikei = []
+    dimensions = []
+    for number, row in enumerate(chaku_rows, start=1):
+        if not isinstance(row, dict) or set(row) != expected_chaku_fields:
+            raise SchemaMigrationError(f"CK count row {number} does not match {chaku_table}")
+        converted = convert_record_types(row, chaku_table)
+        if any(converted.get(key) != main_row.get(key) for key in _CK_PARENT_KEY):
+            raise SchemaMigrationError(f"CK count row {number} has a mismatched parent key")
+        dimension = (
+            converted.get("EntityKubun"),
+            converted.get("PeriodNum"),
+            converted.get("MetricKubun"),
+            converted.get("BucketNum"),
+        )
+        dimensions.append(dimension)
+        last_rank = 4 if dimension[0] == "UMA" and dimension[2] == "Kyakusitu" else 6
+        if any(converted.get(f"Count{rank}") is None for rank in range(1, last_rank + 1)):
+            raise SchemaMigrationError(f"CK count row {number} has a missing official value")
+        if last_rank == 4 and any(converted.get(f"Count{rank}") is not None for rank in (5, 6)):
+            raise SchemaMigrationError("CK running-style row must contain exactly four values")
+        converted_chaku.append(converted)
+    if tuple(dimensions) != _CK_EXPECTED_CHAKU_DIMENSIONS:
+        raise SchemaMigrationError("CK count dimensions are missing, duplicated, or out of order")
+
+    summary_dimensions = []
+    for number, row in enumerate(ruikei_rows, start=1):
+        if not isinstance(row, dict) or set(row) != expected_ruikei_fields:
+            raise SchemaMigrationError(f"CK summary row {number} does not match {ruikei_table}")
+        converted = convert_record_types(row, ruikei_table)
+        if any(converted.get(key) != main_row.get(key) for key in _CK_PARENT_KEY):
+            raise SchemaMigrationError(f"CK summary row {number} has a mismatched parent key")
+        summary_dimensions.append((converted.get("EntityKubun"), converted.get("PeriodNum")))
+        required = (
+            (
+                "SetYear",
+                "HonSyokinHeichi",
+                "HonSyokinSyogai",
+                "FukaSyokinHeichi",
+                "FukaSyokinSyogai",
+            )
+            if converted.get("EntityKubun") in {"KISYU", "CHOKYOSI"}
+            else ("SetYear", "HonSyokinTotal", "FukaSyokin")
+        )
+        if any(converted.get(name) is None for name in required):
+            raise SchemaMigrationError(f"CK summary row {number} has a missing official value")
+        converted_ruikei.append(converted)
+    if tuple(summary_dimensions) != _CK_EXPECTED_RUIKEI_DIMENSIONS:
+        raise SchemaMigrationError("CK summary dimensions are missing, duplicated, or out of order")
+
+    main_row["CKStorageVersion"] = 1
+    return chaku_table, converted_chaku, ruikei_table, converted_ruikei
+
+
+def insert_ck_coupled_batch(
+    database: BaseDatabase,
+    main_table_name: str,
+    prepared: list[tuple[dict, str, list[dict], str, list[dict]]],
+    *,
+    commit_batch: bool,
+    optimized: bool,
+) -> tuple[int, int]:
+    """Apply complete CK records in provider order under one transaction."""
+    if not prepared:
+        return 0, 0
+
+    def begin_if_owned() -> None:
+        if commit_batch:
+            database.begin_transaction()
+
+    def insert_many(table_name: str, rows: list[dict]) -> int:
+        if optimized and hasattr(database, "insert_many_optimized"):
+            return database.insert_many_optimized(table_name, rows)
+        return database.insert_many(table_name, rows)
+
+    def rollback_or_invalidate() -> None:
+        try:
+            database.rollback()
+        except DatabaseError:
+            try:
+                database.invalidate_connection()
+            except Exception as disconnect_error:
+                logger.error(
+                    "Failed to invalidate database after CK rollback failure",
+                    table=main_table_name,
+                    error=str(disconnect_error),
+                )
+            raise
+
+    def write_one(
+        main_row: dict,
+        chaku_table: str,
+        chaku_rows: list[dict],
+        ruikei_table: str,
+        ruikei_rows: list[dict],
+    ) -> None:
+        where = " AND ".join(f"{column} = ?" for column in _CK_PARENT_KEY)
+        values = tuple(main_row.get(column) for column in _CK_PARENT_KEY)
+        if any(value in (None, "") for value in values):
+            raise SchemaMigrationError("CK write has an incomplete parent key")
+        if main_row.get("DataKubun") == "0":
+            database.execute(f"DELETE FROM {chaku_table} WHERE {where}", values)
+            database.execute(f"DELETE FROM {ruikei_table} WHERE {where}", values)
+            database.execute(f"DELETE FROM {main_table_name} WHERE {where}", values)
+            return
+
+        incomplete = dict(main_row)
+        incomplete["CKStorageVersion"] = None
+        insert_many(main_table_name, [incomplete])
+        database.execute(f"DELETE FROM {chaku_table} WHERE {where}", values)
+        database.execute(f"DELETE FROM {ruikei_table} WHERE {where}", values)
+        insert_many(chaku_table, chaku_rows)
+        insert_many(ruikei_table, ruikei_rows)
+        database.execute(
+            f"UPDATE {main_table_name} SET CKStorageVersion = ? WHERE {where}",
+            (1, *values),
+        )
+
+    def write_all(items: list[tuple[dict, str, list[dict], str, list[dict]]]) -> None:
+        for item in items:
+            write_one(*item)
+
+    try:
+        begin_if_owned()
+        write_all(prepared)
+        if commit_batch:
+            database.commit()
+        return len(prepared), 0
+    except DatabaseError:
+        rollback_or_invalidate()
+        if not commit_batch:
+            raise
+
+    succeeded = 0
+    failed = 0
+    for item in prepared:
+        try:
+            begin_if_owned()
+            write_one(*item)
+            database.commit()
+            succeeded += 1
+        except DatabaseError as error:
+            failed += 1
+            rollback_or_invalidate()
+            logger.error(
+                "Failed to insert coupled CK record",
+                table=main_table_name,
+                error=str(error),
+            )
+    return succeeded, failed
+
+
 # ============================================================================
 # REAL型フィールドの変換ルール定義
 # JV-Dataでは一部の数値フィールドが10倍された状態で格納されている
@@ -2422,6 +2862,7 @@ class DataImporter:
         self._jravan_tables_ready = not use_jravan_schema
         self._verified_mining_native_tables: set[str] = set()
         self._verified_hy_tables: set[str] = set()
+        self._verified_ck_child_tables: dict[str, tuple[str, str]] = {}
         self._verified_rc_tables: set[str] = set()
         self._verified_ys_tables: set[str] = set()
         self._verified_tk_header_tables: dict[str, str] = {}
@@ -2930,6 +3371,16 @@ class DataImporter:
                 # has happened yet, and a second failure aborts the import.
                 verified_ch_result_table = verify_ch_coupled_table(self.database, table_name)
 
+        verified_ck_child_tables = self._verified_ck_child_tables.get(table_name)
+        if _ck_child_tables(table_name) is not None and verified_ck_child_tables is None:
+            verified = verify_ck_coupled_tables(self.database, table_name)
+            if verified is None:
+                raise SchemaMigrationError(
+                    f"CK import could not resolve normalized children for {table_name}"
+                )
+            verified_ck_child_tables = verified
+            self._verified_ck_child_tables[table_name] = verified
+
         verified_ks_result_table = None
         if _ks_result_table_name(table_name) is not None:
             try:
@@ -2952,6 +3403,7 @@ class DataImporter:
             converted_batch = []
             prepared_ch: list[tuple[dict, str, list[dict]]] = []
             prepared_ks: list[tuple[dict, str, list[dict]]] = []
+            prepared_ck: list[tuple[dict, str, list[dict], str, list[dict]]] = []
             for original_record, record in zip(batch, clean_batch, strict=True):
                 converted_record = self._convert_record(record, table_name)
                 if (
@@ -2977,6 +3429,24 @@ class DataImporter:
                     if ks_coupled is not None:
                         result_table, result_rows = ks_coupled
                         prepared_ks.append((converted_record, result_table, result_rows))
+                    ck_coupled = prepare_ck_coupled_rows(
+                        self.database,
+                        original_record,
+                        table_name,
+                        converted_record,
+                        verified_child_tables=verified_ck_child_tables,
+                    )
+                    if ck_coupled is not None:
+                        chaku_table, chaku_rows, ruikei_table, ruikei_rows = ck_coupled
+                        prepared_ck.append(
+                            (
+                                converted_record,
+                                chaku_table,
+                                chaku_rows,
+                                ruikei_table,
+                                ruikei_rows,
+                            )
+                        )
                 else:
                     self._records_failed += 1
                     logger.warning(
@@ -3011,6 +3481,22 @@ class DataImporter:
                 )
                 self._records_imported += rows
                 if rows:
+                    self._batches_processed += 1
+                return
+
+            if prepared_ck:
+                if len(prepared_ck) != len(converted_batch):
+                    raise SchemaMigrationError("CK batch lost its coupled child rows")
+                succeeded, failed = insert_ck_coupled_batch(
+                    self.database,
+                    table_name,
+                    prepared_ck,
+                    commit_batch=auto_commit,
+                    optimized=False,
+                )
+                self._records_imported += succeeded
+                self._records_failed += failed
+                if succeeded:
                     self._batches_processed += 1
                 return
 
@@ -3317,6 +3803,35 @@ class DataImporter:
                 if rows:
                     self._batches_processed += 1
                 return rows == 1
+            verified_ck = self._verified_ck_child_tables.get(table_name)
+            if _ck_child_tables(table_name) is not None and verified_ck is None:
+                verified_ck = verify_ck_coupled_tables(self.database, table_name)
+                if verified_ck is None:
+                    raise SchemaMigrationError(
+                        f"CK import could not resolve normalized children for {table_name}"
+                    )
+                self._verified_ck_child_tables[table_name] = verified_ck
+            ck_coupled = prepare_ck_coupled_rows(
+                self.database,
+                record,
+                table_name,
+                converted_record,
+                verified_child_tables=verified_ck,
+            )
+            if ck_coupled is not None:
+                chaku_table, chaku_rows, ruikei_table, ruikei_rows = ck_coupled
+                succeeded, failed = insert_ck_coupled_batch(
+                    self.database,
+                    table_name,
+                    [(converted_record, chaku_table, chaku_rows, ruikei_table, ruikei_rows)],
+                    commit_batch=auto_commit,
+                    optimized=False,
+                )
+                self._records_imported += succeeded
+                self._records_failed += failed
+                if succeeded:
+                    self._batches_processed += 1
+                return succeeded == 1
             coupled = prepare_ch_coupled_rows(self.database, record, table_name)
             if coupled is not None:
                 result_table, result_rows = coupled

--- a/src/importer/importer.py
+++ b/src/importer/importer.py
@@ -2357,6 +2357,8 @@ def _verify_ck_postgresql_constraints(
     expected_names = set(_ck_named_constraints(expected_schema))
     rows = database.fetch_all(
         "SELECT conname AS name, contype AS type, confdeltype AS delete_type, "
+        "confupdtype AS update_type, confmatchtype AS match_type, "
+        "condeferrable AS deferrable, condeferred AS initially_deferred, "
         "convalidated AS validated, "
         "confrelid = to_regclass('nl_ck') AS parent_matches, "
         "pg_get_expr(conbin, conrelid) AS expression "
@@ -2389,6 +2391,10 @@ def _verify_ck_postgresql_constraints(
             if (
                 str(row.get("type")) != "f"
                 or str(row.get("delete_type")) != "c"
+                or str(row.get("update_type")) != "a"
+                or str(row.get("match_type")) != "s"
+                or bool(row.get("deferrable"))
+                or bool(row.get("initially_deferred"))
                 or not bool(row.get("parent_matches"))
             ):
                 raise SchemaMigrationError(
@@ -2442,29 +2448,34 @@ def _ck_postgresql_check_cases(
             ("MetricKubun", "TEXT"),
             ("BucketNum", "INTEGER"),
         )
-        cases = [(dimension, True) for dimension in _CK_EXPECTED_CHAKU_DIMENSIONS]
-        maximums: dict[tuple[str, int, str], int] = {}
-        for entity, period, metric, bucket in _CK_EXPECTED_CHAKU_DIMENSIONS:
-            maximums[(entity, period, metric)] = max(
-                maximums.get((entity, period, metric), 0), bucket
-            )
-        for (entity, period, metric), maximum in maximums.items():
-            cases.append(((entity, period, metric, 0), False))
-            cases.append(((entity, period, metric, maximum + 1), False))
-        cases.extend(
-            [
-                (("INVALID", 0, "ChakuSogo", 1), False),
-                (("UMA", 1, "ChakuSogo", 1), False),
-                (("KISYU", 0, "ChakuKaisuSiba", 1), False),
-                (("CHOKYOSI", 3, "ChakuKaisuSiba", 1), False),
-                (("BANUSI", 0, "ChakuKaisu", 1), False),
-                (("BREEDER", 3, "ChakuKaisu", 1), False),
-                (("UMA", 0, "ChakuKaisuSiba", 1), False),
-                (("KISYU", 1, "ChakuSogo", 1), False),
-                (("BANUSI", 1, "ChakuSogo", 1), False),
-                (("UMA", 0, "INVALID", 1), False),
-            ]
+        horse_maximum = dict(_CK_HORSE_METRICS)
+        professional_maximum = dict(_CK_PROFESSIONAL_METRICS)
+        metrics = tuple(
+            dict.fromkeys((*horse_maximum, *professional_maximum, "ChakuKaisu", "INVALID"))
         )
+        buckets = (0, 1, 2, 7, 8, 9, 10, 11, 12, 13)
+        cases = []
+        for entity in ("UMA", "KISYU", "BANUSI", "INVALID"):
+            for period in (0, 1, 3):
+                for metric in metrics:
+                    for bucket in buckets:
+                        accepted = (
+                            entity == "UMA"
+                            and period == 0
+                            and metric in horse_maximum
+                            and 1 <= bucket <= horse_maximum[metric]
+                        ) or (
+                            entity == "KISYU"
+                            and period == 1
+                            and metric in professional_maximum
+                            and 1 <= bucket <= professional_maximum[metric]
+                        ) or (
+                            entity == "BANUSI"
+                            and period == 1
+                            and metric == "ChakuKaisu"
+                            and bucket == 1
+                        )
+                        cases.append(((entity, period, metric, bucket), accepted))
         return columns, cases
 
     if constraint_name == "ck_chaku_count_shape":
@@ -2474,15 +2485,17 @@ def _ck_postgresql_check_cases(
             ("Count5", "INTEGER"),
             ("Count6", "INTEGER"),
         )
-        return columns, [
-            (("UMA", "Kyakusitu", None, None), True),
-            (("UMA", "Kyakusitu", 1, 1), False),
-            (("UMA", "Kyakusitu", None, 1), False),
-            (("KISYU", "ChakuKaisuSiba", 1, 1), True),
-            (("KISYU", "ChakuKaisuSiba", 0, 999999), True),
-            (("KISYU", "ChakuKaisuSiba", None, None), False),
-            (("KISYU", "ChakuKaisuSiba", 1, None), False),
-        ]
+        cases = []
+        for entity in ("UMA", "OTHER"):
+            for metric in ("Kyakusitu", "OTHER"):
+                for count5 in (None, 1):
+                    for count6 in (None, 1):
+                        running_style = entity == "UMA" and metric == "Kyakusitu"
+                        accepted = (
+                            running_style and count5 is None and count6 is None
+                        ) or (not running_style and count5 is not None and count6 is not None)
+                        cases.append(((entity, metric, count5, count6), accepted))
+        return columns, cases
 
     if constraint_name == "ck_ruikei_shape":
         columns = (
@@ -2495,50 +2508,190 @@ def _ck_postgresql_check_cases(
             ("HonSyokinTotal", "BIGINT"),
             ("FukaSyokin", "BIGINT"),
         )
-        professional = (1, 1, 1, 1, None, None)
-        owner = (None, None, None, None, 1, 1)
-        cases = [
-            ((entity, period, *professional), True)
-            for entity in ("KISYU", "CHOKYOSI")
-            for period in (1, 2)
-        ]
-        cases.extend(
-            ((entity, period, *owner), True)
-            for entity in ("BANUSI", "BREEDER")
-            for period in (1, 2)
-        )
-        cases.extend(
-            [
-                (("KISYU", 1, 0, 9999999999, 0, 9999999999, None, None), True),
-                (("BANUSI", 1, None, None, None, None, 0, 9999999999), True),
-            ]
-        )
-        cases.extend(
-            [
-                (("INVALID", 1, *professional), False),
-                (("KISYU", 0, *professional), False),
-                (("BANUSI", 3, *owner), False),
-            ]
-        )
-        for missing_index in range(4):
-            values = list(professional)
-            values[missing_index] = None
-            cases.append((("KISYU", 1, *values), False))
-        for forbidden_index in (4, 5):
-            values = list(professional)
-            values[forbidden_index] = 1
-            cases.append((("KISYU", 1, *values), False))
-        for missing_index in (4, 5):
-            values = list(owner)
-            values[missing_index] = None
-            cases.append((("BANUSI", 1, *values), False))
-        for forbidden_index in range(4):
-            values = list(owner)
-            values[forbidden_index] = 1
-            cases.append((("BANUSI", 1, *values), False))
+        from itertools import product
+
+        cases = []
+        for entity in ("KISYU", "BANUSI", "INVALID"):
+            for period in (0, 1):
+                for values in product((None, 1), repeat=6):
+                    professional_shape = all(value is not None for value in values[:4]) and all(
+                        value is None for value in values[4:]
+                    )
+                    owner_shape = all(value is None for value in values[:4]) and all(
+                        value is not None for value in values[4:]
+                    )
+                    accepted = period == 1 and (
+                        (entity == "KISYU" and professional_shape)
+                        or (entity == "BANUSI" and owner_shape)
+                    )
+                    cases.append(((entity, period, *values), accepted))
         return columns, cases
 
     raise SchemaMigrationError(f"Unknown CK PostgreSQL CHECK constraint: {constraint_name}")
+
+
+def _ck_postgresql_expected_check_signature(
+    constraint_name: str,
+) -> tuple[dict[str, int], dict[str, int]]:
+    from collections import Counter
+
+    atoms: Counter[str] = Counter()
+    operators: Counter[str] = Counter()
+
+    def equality(column: str, value: Any) -> None:
+        atoms[f"eq:{column.lower()}:{str(value).lower()}"] += 1
+
+    def any_of(column: str, values: tuple[Any, ...]) -> None:
+        normalized = ",".join(str(value).lower() for value in values)
+        atoms[f"any:{column.lower()}:{normalized}"] += 1
+
+    def metric_family(metrics: tuple[tuple[str, int], ...]) -> None:
+        for metric, maximum in metrics:
+            equality("MetricKubun", metric)
+            atoms["ge:bucketnum:1"] += 1
+            atoms[f"le:bucketnum:{maximum}"] += 1
+            operators["and"] += 2
+        operators["or"] += len(metrics) - 1
+
+    if constraint_name == "ck_chaku_domain":
+        equality("EntityKubun", "UMA")
+        equality("PeriodNum", 0)
+        metric_family(_CK_HORSE_METRICS)
+        operators["and"] += 2
+
+        any_of("EntityKubun", ("KISYU", "CHOKYOSI"))
+        any_of("PeriodNum", (1, 2))
+        metric_family(_CK_PROFESSIONAL_METRICS)
+        operators["and"] += 2
+
+        any_of("EntityKubun", ("BANUSI", "BREEDER"))
+        any_of("PeriodNum", (1, 2))
+        equality("MetricKubun", "ChakuKaisu")
+        equality("BucketNum", 1)
+        operators["and"] += 3
+        operators["or"] += 2
+        return dict(atoms), dict(operators)
+
+    if constraint_name == "ck_chaku_count_shape":
+        equality("EntityKubun", "UMA")
+        equality("MetricKubun", "Kyakusitu")
+        atoms["null:count5"] += 1
+        atoms["null:count6"] += 1
+        equality("EntityKubun", "UMA")
+        equality("MetricKubun", "Kyakusitu")
+        atoms["notnull:count5"] += 1
+        atoms["notnull:count6"] += 1
+        operators.update({"and": 6, "or": 1, "not": 1})
+        return dict(atoms), dict(operators)
+
+    if constraint_name == "ck_ruikei_shape":
+        for entities, required, forbidden in (
+            (
+                ("KISYU", "CHOKYOSI"),
+                (
+                    "HonSyokinHeichi",
+                    "HonSyokinSyogai",
+                    "FukaSyokinHeichi",
+                    "FukaSyokinSyogai",
+                ),
+                ("HonSyokinTotal", "FukaSyokin"),
+            ),
+            (
+                ("BANUSI", "BREEDER"),
+                ("HonSyokinTotal", "FukaSyokin"),
+                (
+                    "HonSyokinHeichi",
+                    "HonSyokinSyogai",
+                    "FukaSyokinHeichi",
+                    "FukaSyokinSyogai",
+                ),
+            ),
+        ):
+            any_of("EntityKubun", entities)
+            any_of("PeriodNum", (1, 2))
+            for column in required:
+                atoms[f"notnull:{column.lower()}"] += 1
+            for column in forbidden:
+                atoms[f"null:{column.lower()}"] += 1
+            operators["and"] += 7
+        operators["or"] += 1
+        return dict(atoms), dict(operators)
+
+    raise SchemaMigrationError(f"Unknown CK PostgreSQL CHECK constraint: {constraint_name}")
+
+
+def _ck_postgresql_check_signature(
+    expression: str,
+) -> tuple[dict[str, int], dict[str, int]]:
+    import re
+    from collections import Counter
+
+    atoms: Counter[str] = Counter()
+    working = expression.lower()
+
+    def replace_any(match: Any) -> str:
+        column = match.group(1)
+        raw_values = match.group(2)
+        values = [
+            string_value if string_value else number_value
+            for string_value, number_value in re.findall(
+                r"'([^']*)'(?:\s*::\s*text)?|(-?\d+)", raw_values
+            )
+        ]
+        atoms[f"any:{column}:{','.join(values)}"] += 1
+        return " atom "
+
+    working = re.sub(
+        r"\b([a-z_][a-z0-9_]*)\s*=\s*any\s*\(\s*array\[(.*?)\]\s*\)",
+        replace_any,
+        working,
+        flags=re.DOTALL,
+    )
+
+    def replace_null(match: Any) -> str:
+        column = match.group(1)
+        qualifier = "notnull" if match.group(2) else "null"
+        atoms[f"{qualifier}:{column}"] += 1
+        return " atom "
+
+    working = re.sub(
+        r"\b([a-z_][a-z0-9_]*)\s+is\s+(not\s+)?null\b",
+        replace_null,
+        working,
+    )
+
+    def replace_text_equality(match: Any) -> str:
+        atoms[f"eq:{match.group(1)}:{match.group(2)}"] += 1
+        return " atom "
+
+    working = re.sub(
+        r"\b([a-z_][a-z0-9_]*)\s*=\s*'([^']*)'(?:\s*::\s*text)?",
+        replace_text_equality,
+        working,
+    )
+
+    def replace_numeric(match: Any) -> str:
+        operator = {"=": "eq", ">=": "ge", "<=": "le"}[match.group(2)]
+        atoms[f"{operator}:{match.group(1)}:{match.group(3)}"] += 1
+        return " atom "
+
+    working = re.sub(
+        r"\b([a-z_][a-z0-9_]*)\s*(>=|<=|=)\s*(-?\d+)\b",
+        replace_numeric,
+        working,
+    )
+    remaining_words = re.findall(r"[a-z_][a-z0-9_]*|>=|<=|=|-?\d+|'[^']*'|::", working)
+    operators: Counter[str] = Counter(
+        word for word in remaining_words if word in {"and", "or", "not"}
+    )
+    unrecognized = [
+        word for word in remaining_words if word not in {"atom", "and", "or", "not"}
+    ]
+    if unrecognized:
+        raise SchemaMigrationError(
+            f"CK PostgreSQL CHECK contains unrecognized structure: {unrecognized[:5]}"
+        )
+    return dict(atoms), dict(operators)
 
 
 def _verify_ck_postgresql_check_truth_table(
@@ -2547,6 +2700,13 @@ def _verify_ck_postgresql_check_truth_table(
     constraint_name: str,
     expression: str,
 ) -> None:
+    actual_signature = _ck_postgresql_check_signature(expression)
+    expected_signature = _ck_postgresql_expected_check_signature(constraint_name)
+    if actual_signature != expected_signature:
+        raise SchemaMigrationError(
+            f"CK child CHECK structure mismatch for {table_name}.{constraint_name}"
+        )
+
     columns, cases = _ck_postgresql_check_cases(constraint_name)
     value_rows = []
     parameters: list[Any] = []

--- a/src/importer/importer_optimized.py
+++ b/src/importer/importer_optimized.py
@@ -14,12 +14,14 @@ from src.database.migration import SchemaMigrationError
 from src.importer.importer import (
     _ORDERED_MASTER_STORAGE_TABLES,
     _PREPARED_CH_SEISEKI_ROWS_KEY,
+    _PREPARED_CK_ROWS_KEY,
     _PREPARED_KS_SEISEKI_ROWS_KEY,
     _RC_STORAGE_TABLES,
     _STANDARD_ODDS_CONFIG_BY_OWNER,
     _STANDARD_VOTE_CONFIG_BY_OWNER,
     _TK_CHILD_STORAGE_TABLES,
     _YS_STORAGE_TABLES,
+    _ck_child_tables,
     _delete_mining_race_rows,
     _delete_official_record,
     _expanded_record_fingerprint,
@@ -38,17 +40,20 @@ from src.importer.importer import (
     delete_standard_odds_record,
     delete_standard_vote_record,
     insert_ch_coupled_batch,
+    insert_ck_coupled_batch,
     insert_ks_coupled_batch,
     insert_standard_odds_batch,
     insert_standard_vote_batch,
     insert_tk_coupled_batch,
     prepare_ch_coupled_rows,
+    prepare_ck_coupled_rows,
     prepare_ks_coupled_rows,
     prepare_tk_coupled_record,
     replace_mining_native_snapshot,
     resolve_standard_storage_table_name,
     resolve_standard_table_name,
     verify_ch_coupled_table,
+    verify_ck_coupled_tables,
     verify_hy_storage_schema,
     verify_ks_coupled_table,
     verify_mining_native_schema,
@@ -91,6 +96,7 @@ class OptimizedDataImporter:
         self._jravan_tables_ready = not use_jravan_schema
         self._verified_mining_native_tables: set[str] = set()
         self._verified_hy_tables: set[str] = set()
+        self._verified_ck_child_tables: dict[str, tuple[str, str]] = {}
         self._verified_rc_tables: set[str] = set()
         self._verified_ys_tables: set[str] = set()
         self._verified_tk_header_tables: dict[str, str] = {}
@@ -528,6 +534,16 @@ class OptimizedDataImporter:
                             f"KS import could not resolve normalized table for {table_name}"
                         )
                     verified_ks_result_tables[table_name] = result_table
+                if (
+                    _ck_child_tables(table_name) is not None
+                    and table_name not in self._verified_ck_child_tables
+                ):
+                    child_tables = verify_ck_coupled_tables(self.database, table_name)
+                    if child_tables is None:
+                        raise SchemaMigrationError(
+                            f"CK import could not resolve normalized children for {table_name}"
+                        )
+                    self._verified_ck_child_tables[table_name] = child_tables
                 coupled = prepare_ch_coupled_rows(
                     self.database,
                     record,
@@ -544,6 +560,15 @@ class OptimizedDataImporter:
                 )
                 if ks_coupled is not None:
                     converted_record[_PREPARED_KS_SEISEKI_ROWS_KEY] = ks_coupled
+                ck_coupled = prepare_ck_coupled_rows(
+                    self.database,
+                    record,
+                    table_name,
+                    converted_record,
+                    verified_child_tables=self._verified_ck_child_tables.get(table_name),
+                )
+                if ck_coupled is not None:
+                    converted_record[_PREPARED_CK_ROWS_KEY] = ck_coupled
                 batch_buffers[table_name].append(converted_record)
 
                 # Check if any batch is full
@@ -692,6 +717,30 @@ class OptimizedDataImporter:
                 self.database,
                 table_name,
                 prepared_ch,
+                commit_batch=commit_batch,
+                optimized=True,
+            )
+            self._records_imported += succeeded
+            self._records_failed += failed
+            if succeeded:
+                self._batches_processed += 1
+            return
+
+        prepared_ck = []
+        for record in batch:
+            coupled = record.get(_PREPARED_CK_ROWS_KEY)
+            if coupled is None:
+                continue
+            chaku_table, chaku_rows, ruikei_table, ruikei_rows = coupled
+            main_row = {key: value for key, value in record.items() if key != _PREPARED_CK_ROWS_KEY}
+            prepared_ck.append((main_row, chaku_table, chaku_rows, ruikei_table, ruikei_rows))
+        if prepared_ck:
+            if len(prepared_ck) != len(batch):
+                raise SchemaMigrationError("CK batch lost its coupled child rows")
+            succeeded, failed = insert_ck_coupled_batch(
+                self.database,
+                table_name,
+                prepared_ck,
                 commit_batch=commit_batch,
                 optimized=True,
             )

--- a/src/parser/ck_parser.py
+++ b/src/parser/ck_parser.py
@@ -1,131 +1,382 @@
-"""Parser for CK record - JRA-VAN Standard compliant.
+#!/usr/bin/env python
+"""CK parser for the complete official current 6,870-byte layout."""
 
-This parser uses JRA-VAN standard field names and type conversions.
-Auto-generated from jv_data_formats.json.
-"""
+from __future__ import annotations
 
-from typing import List
+from typing import Any
 
-from src.parser.base import BaseParser, FieldDef
+from src.jvlink.constants import ENCODING_JVDATA
+from src.parser.base import validate_fixed_record
+from src.parser.converters import ConversionError, convert_value
+from src.utils.logger import get_logger
 
 
-class CKParser(BaseParser):
-    """Parser for CK record with JRA-VAN standard schema.
-
-    Uses English/Romanized field names matching JRA-VAN standard database.
-    """
+class CKParser:
+    """Parse one CK record into a compatibility parent and complete child rows."""
 
     record_type = "CK"
+    RECORD_TYPE = "CK"
     RECORD_LENGTH = 6870
 
-    def _define_fields(self) -> List[FieldDef]:
-        """Define field positions with JRA-VAN standard names and types.
+    _UMA_GROUPS = (
+        ("ChakuSogo", 100, 1),
+        ("ChakuChuo", 118, 1),
+        ("ChakuKaisuBa", 136, 7),
+        ("ChakuKaisuJyotai", 262, 12),
+        ("ChakuKaisuSibaKyori", 478, 9),
+        ("ChakuKaisuDirtKyori", 640, 9),
+        ("ChakuKaisuJyoSiba", 802, 10),
+        ("ChakuKaisuJyoDirt", 982, 10),
+        ("ChakuKaisuJyoSyogai", 1162, 10),
+    )
+    _COMPATIBILITY_COUNT_NAMES = (
+        "TotalChakuCount",
+        "ChuoChakuCount",
+        "SibaChoChaku",
+        "SibaMigiChaku",
+        "SibaHidariChaku",
+        "DirtChoChaku",
+        "DirtMigiChaku",
+        "DirtHidariChaku",
+        "SyogaiChaku",
+        "SibaRyoChaku",
+        "SibaYayaChaku",
+        "SibaOmoChaku",
+        "SibaFuChaku",
+        "DirtRyoChaku",
+        "DirtYayaChaku",
+        "DirtOmoChaku",
+        "DirtFuChaku",
+        "SyogaiRyoChaku",
+        "SyogaiYayaChaku",
+        "SyogaiOmoChaku",
+        "SyogaiFuChaku",
+        "Siba1200IkaChaku",
+        "Siba1201_1400Chaku",
+        "Siba1401_1600Chaku",
+        "Siba1601_1800Chaku",
+        "Siba1801_2000Chaku",
+        "Siba2001_2200Chaku",
+        "Siba2201_2400Chaku",
+        "Siba2401_2800Chaku",
+        "Siba2801OverChaku",
+        "Dirt1200IkaChaku",
+        "Dirt1201_1400Chaku",
+        "Dirt1401_1600Chaku",
+        "Dirt1601_1800Chaku",
+        "Dirt1801_2000Chaku",
+        "Dirt2001_2200Chaku",
+        "Dirt2201_2400Chaku",
+        "Dirt2401_2800Chaku",
+        "Dirt2801OverChaku",
+        "SapporoSibaChaku",
+        "HakodateSibaChaku",
+        "FukushimaSibaChaku",
+        "NiigataSibaChaku",
+        "TokyoSibaChaku",
+        "NakayamaSibaChaku",
+        "ChukyoSibaChaku",
+        "KyotoSibaChaku",
+        "HanshinSibaChaku",
+        "KokuraSibaChaku",
+        "SapporoDirtChaku",
+        "HakodateDirtChaku",
+        "FukushimaDirtChaku",
+        "NiigataDirtChaku",
+        "TokyoDirtChaku",
+        "NakayamaDirtChaku",
+        "ChukyoDirtChaku",
+        "KyotoDirtChaku",
+        "HanshinDirtChaku",
+        "KokuraDirtChaku",
+        "SapporoSyogaiChaku",
+        "HakodateSyogaiChaku",
+        "FukushimaSyogaiChaku",
+        "NiigataSyogaiChaku",
+        "TokyoSyogaiChaku",
+        "NakayamaSyogaiChaku",
+        "ChukyoSyogaiChaku",
+        "KyotoSyogaiChaku",
+        "HanshinSyogaiChaku",
+        "KokuraSyogaiChaku",
+    )
 
-        Returns:
-            List of FieldDef objects with type conversion settings
-        """
-        return [
-            FieldDef("RecordSpec", 0, 2, description="レコード種別ID"),
-            FieldDef("DataKubun", 2, 1, description="データ区分"),
-            FieldDef("MakeDate", 3, 8, convert_type="DATE", description="データ作成年月日"),
-            FieldDef("Year", 11, 4, convert_type="SMALLINT", description="開催年"),
-            FieldDef("MonthDay", 15, 4, convert_type="MONTH_DAY", description="開催月日"),
-            FieldDef("JyoCD", 19, 2, description="競馬場コード"),
-            FieldDef("Kaiji", 21, 2, convert_type="SMALLINT", description="開催回[第N回]"),
-            FieldDef("Nichiji", 23, 2, convert_type="SMALLINT", description="開催日目[N日目]"),
-            FieldDef("RaceNum", 25, 2, convert_type="SMALLINT", description="レース番号"),
-            FieldDef("KettoNum", 27, 10, description="血統登録番号"),
-            FieldDef("Bamei", 37, 36, description="馬名"),
-            FieldDef("HeichiHonsyokinTotal", 73, 9, description="平地本賞金累計"),
-            FieldDef("SyogaiHonsyokinTotal", 82, 9, description="障害本賞金累計"),
-            FieldDef("HeichiFukasyokinTotal", 91, 9, description="平地付加賞金累計"),
-            FieldDef("SyogaiFukasyokinTotal", 100, 9, description="障害付加賞金累計"),
-            FieldDef("HeichiSyutokuTotal", 109, 9, description="平地収得賞金累計"),
-            FieldDef("SyogaiSyutokuTotal", 118, 9, description="障害収得賞金累計"),
-            FieldDef("TotalChakuCount", 127, 3, description="総合着回数"),
-            FieldDef("ChuoChakuCount", 145, 3, description="中央合計着回数"),
-            FieldDef("SibaChoChaku", 163, 3, description="芝直・着回数"),
-            FieldDef("SibaMigiChaku", 181, 3, description="芝右・着回数"),
-            FieldDef("SibaHidariChaku", 199, 3, description="芝左・着回数"),
-            FieldDef("DirtChoChaku", 217, 3, description="ダ直・着回数"),
-            FieldDef("DirtMigiChaku", 235, 3, description="ダ右・着回数"),
-            FieldDef("DirtHidariChaku", 253, 3, description="ダ左・着回数"),
-            FieldDef("SyogaiChaku", 271, 3, description="障害・着回数"),
-            FieldDef("SibaRyoChaku", 289, 3, description="芝良・着回数"),
-            FieldDef("SibaYayaChaku", 307, 3, description="芝稍・着回数"),
-            FieldDef("SibaOmoChaku", 325, 3, description="芝重・着回数"),
-            FieldDef("SibaFuChaku", 343, 3, description="芝不・着回数"),
-            FieldDef("DirtRyoChaku", 361, 3, description="ダ良・着回数"),
-            FieldDef("DirtYayaChaku", 379, 3, description="ダ稍・着回数"),
-            FieldDef("DirtOmoChaku", 397, 3, description="ダ重・着回数"),
-            FieldDef("DirtFuChaku", 415, 3, description="ダ不・着回数"),
-            FieldDef("SyogaiRyoChaku", 433, 3, description="障良・着回数"),
-            FieldDef("SyogaiYayaChaku", 451, 3, description="障稍・着回数"),
-            FieldDef("SyogaiOmoChaku", 469, 3, description="障重・着回数"),
-            FieldDef("SyogaiFuChaku", 487, 3, description="障不・着回数"),
-            FieldDef("Siba1200IkaChaku", 505, 3, description="芝1200以下・着回数"),
-            FieldDef("Siba1201_1400Chaku", 523, 3, description="芝1201-1400・着回数"),
-            FieldDef("Siba1401_1600Chaku", 541, 3, description="芝1401-1600・着回数"),
-            FieldDef("Siba1601_1800Chaku", 559, 3, description="芝1601-1800・着回数"),
-            FieldDef("Siba1801_2000Chaku", 577, 3, description="芝1801-2000・着回数"),
-            FieldDef("Siba2001_2200Chaku", 595, 3, description="芝2001-2200・着回数"),
-            FieldDef("Siba2201_2400Chaku", 613, 3, description="芝2201-2400・着回数"),
-            FieldDef("Siba2401_2800Chaku", 631, 3, description="芝2401-2800・着回数"),
-            FieldDef("Siba2801OverChaku", 649, 3, description="芝2801以上・着回数"),
-            FieldDef("Dirt1200IkaChaku", 667, 3, description="ダ1200以下・着回数"),
-            FieldDef("Dirt1201_1400Chaku", 685, 3, description="ダ1201-1400・着回数"),
-            FieldDef("Dirt1401_1600Chaku", 703, 3, description="ダ1401-1600・着回数"),
-            FieldDef("Dirt1601_1800Chaku", 721, 3, description="ダ1601-1800・着回数"),
-            FieldDef("Dirt1801_2000Chaku", 739, 3, description="ダ1801-2000・着回数"),
-            FieldDef("Dirt2001_2200Chaku", 757, 3, description="ダ2001-2200・着回数"),
-            FieldDef("Dirt2201_2400Chaku", 775, 3, description="ダ2201-2400・着回数"),
-            FieldDef("Dirt2401_2800Chaku", 793, 3, description="ダ2401-2800・着回数"),
-            FieldDef("Dirt2801OverChaku", 811, 3, description="ダ2801以上・着回数"),
-            FieldDef("SapporoSibaChaku", 829, 3, description="札幌芝・着回数"),
-            FieldDef("HakodateSibaChaku", 847, 3, description="函館芝・着回数"),
-            FieldDef("FukushimaSibaChaku", 865, 3, description="福島芝・着回数"),
-            FieldDef("NiigataSibaChaku", 883, 3, description="新潟芝・着回数"),
-            FieldDef("TokyoSibaChaku", 901, 3, description="東京芝・着回数"),
-            FieldDef("NakayamaSibaChaku", 919, 3, description="中山芝・着回数"),
-            FieldDef("ChukyoSibaChaku", 937, 3, description="中京芝・着回数"),
-            FieldDef("KyotoSibaChaku", 955, 3, description="京都芝・着回数"),
-            FieldDef("HanshinSibaChaku", 973, 3, description="阪神芝・着回数"),
-            FieldDef("KokuraSibaChaku", 991, 3, description="小倉芝・着回数"),
-            FieldDef("SapporoDirtChaku", 1009, 3, description="札幌ダ・着回数"),
-            FieldDef("HakodateDirtChaku", 1027, 3, description="函館ダ・着回数"),
-            FieldDef("FukushimaDirtChaku", 1045, 3, description="福島ダ・着回数"),
-            FieldDef("NiigataDirtChaku", 1063, 3, description="新潟ダ・着回数"),
-            FieldDef("TokyoDirtChaku", 1081, 3, description="東京ダ・着回数"),
-            FieldDef("NakayamaDirtChaku", 1099, 3, description="中山ダ・着回数"),
-            FieldDef("ChukyoDirtChaku", 1117, 3, description="中京ダ・着回数"),
-            FieldDef("KyotoDirtChaku", 1135, 3, description="京都ダ・着回数"),
-            FieldDef("HanshinDirtChaku", 1153, 3, description="阪神ダ・着回数"),
-            FieldDef("KokuraDirtChaku", 1171, 3, description="小倉ダ・着回数"),
-            FieldDef("SapporoSyogaiChaku", 1189, 3, description="札幌障・着回数"),
-            FieldDef("HakodateSyogaiChaku", 1207, 3, description="函館障・着回数"),
-            FieldDef("FukushimaSyogaiChaku", 1225, 3, description="福島障・着回数"),
-            FieldDef("NiigataSyogaiChaku", 1243, 3, description="新潟障・着回数"),
-            FieldDef("TokyoSyogaiChaku", 1261, 3, description="東京障・着回数"),
-            FieldDef("NakayamaSyogaiChaku", 1279, 3, description="中山障・着回数"),
-            FieldDef("ChukyoSyogaiChaku", 1297, 3, description="中京障・着回数"),
-            FieldDef("KyotoSyogaiChaku", 1315, 3, description="京都障・着回数"),
-            FieldDef("HanshinSyogaiChaku", 1333, 3, description="阪神障・着回数"),
-            FieldDef("KokuraSyogaiChaku", 1351, 3, description="小倉障・着回数"),
-            FieldDef("KyakusituKeiko", 1369, 3, description="脚質傾向"),
-            FieldDef("RegisteredRaceCount", 1381, 3, description="登録レース数"),
-            FieldDef("KisyuCode", 1384, 5, description="騎手コード"),
-            FieldDef("KisyuName", 1389, 34, description="騎手名"),
-            FieldDef("KisyuResultsInfo", 1423, 1220, description="<騎手本年･累計成績情報>"),
-            FieldDef("ChokyosiCode", 3863, 5, description="調教師コード"),
-            FieldDef("ChokyosiName", 3868, 34, description="調教師名"),
-            FieldDef("ChokyosiResultsInfo", 3902, 1220, description="<調教師本年･累計成績情報>"),
-            FieldDef("BanusiCode", 6342, 6, description="馬主コード"),
-            FieldDef("BanusiName", 6348, 64, description="馬主名(法人格有)"),
-            FieldDef("BanusiName_Co", 6412, 64, description="馬主名(法人格無)"),
-            FieldDef("BanusiResultsInfo", 6476, 60, description="<本年･累計成績情報>"),
-            FieldDef("BreederCode", 6596, 8, description="生産者コード"),
-            FieldDef("BreederName", 6604, 72, description="生産者名(法人格有)"),
-            FieldDef("BreederName_Co", 6676, 72, description="生産者名(法人格無)"),
-            FieldDef("BreederResultsInfo", 6748, 60, description="<本年･累計成績情報>"),
-            FieldDef("RecordDelimiter", 6868, 2, description="レコード区切"),
-        ]
+    def __init__(self) -> None:
+        self.logger = get_logger(__name__)
+
+    @staticmethod
+    def decode_field(data: bytes) -> str:
+        return data.decode(ENCODING_JVDATA, errors="strict").strip()
+
+    @staticmethod
+    def _require_digits(name: str, value: str) -> None:
+        if not value.isascii() or not value.isdigit():
+            raise ValueError(f"{name} must contain only ASCII digits")
+
+    def _parent_key(self, data: bytes) -> dict[str, str]:
+        return {
+            "Year": self.decode_field(data[11:15]),
+            "MonthDay": self.decode_field(data[15:19]),
+            "JyoCD": self.decode_field(data[19:21]),
+            "Kaiji": self.decode_field(data[21:23]),
+            "Nichiji": self.decode_field(data[23:25]),
+            "RaceNum": self.decode_field(data[25:27]),
+            "KettoNum": self.decode_field(data[27:37]),
+        }
+
+    def _parse_uma_rows(self, data: bytes, key: dict[str, str]) -> list[dict[str, str]]:
+        rows: list[dict[str, str]] = []
+        uma_start = 27
+        for group_name, relative_start, count in self._UMA_GROUPS:
+            for number in range(1, count + 1):
+                start = uma_start + relative_start + 18 * (number - 1)
+                row = {
+                    **key,
+                    "EntityKubun": "UMA",
+                    "PeriodNum": "0",
+                    "MetricKubun": group_name,
+                    "BucketNum": str(number),
+                }
+                for rank in range(1, 7):
+                    offset = start + 3 * (rank - 1)
+                    row[f"Count{rank}"] = self.decode_field(data[offset : offset + 3])
+                rows.append(row)
+
+        row = {
+            **key,
+            "EntityKubun": "UMA",
+            "PeriodNum": "0",
+            "MetricKubun": "Kyakusitu",
+            "BucketNum": "1",
+        }
+        for rank in range(1, 5):
+            offset = 1369 + 3 * (rank - 1)
+            row[f"Count{rank}"] = self.decode_field(data[offset : offset + 3])
+        row["Count5"] = ""
+        row["Count6"] = ""
+        rows.append(row)
+        return rows
+
+    def _parse_hon_ruikei(
+        self,
+        data: bytes,
+        *,
+        start: int,
+        key: dict[str, str],
+        actor_type: str,
+        number: int,
+    ) -> tuple[dict[str, str], list[dict[str, str]]]:
+        summary = {
+            **key,
+            "EntityKubun": actor_type,
+            "PeriodNum": str(number),
+            "HonSyokinTotal": "",
+            "FukaSyokin": "",
+        }
+        count_rows: list[dict[str, str]] = []
+        cursor = start
+        for name, width in (
+            ("SetYear", 4),
+            ("HonSyokinHeichi", 10),
+            ("HonSyokinSyogai", 10),
+            ("FukaSyokinHeichi", 10),
+            ("FukaSyokinSyogai", 10),
+        ):
+            summary[name] = self.decode_field(data[cursor : cursor + width])
+            cursor += width
+        for group, count, width in (
+            ("ChakuKaisuSiba", 1, 5),
+            ("ChakuKaisuDirt", 1, 5),
+            ("ChakuKaisuSyogai", 1, 4),
+            ("ChakuKaisuSibaKyori", 9, 4),
+            ("ChakuKaisuDirtKyori", 9, 4),
+            ("ChakuKaisuJyoSiba", 10, 4),
+            ("ChakuKaisuJyoDirt", 10, 4),
+            ("ChakuKaisuJyoSyogai", 10, 3),
+        ):
+            for index in range(1, count + 1):
+                row = {
+                    **key,
+                    "EntityKubun": actor_type,
+                    "PeriodNum": str(number),
+                    "MetricKubun": group,
+                    "BucketNum": str(index),
+                }
+                for rank in range(1, 7):
+                    row[f"Count{rank}"] = self.decode_field(data[cursor : cursor + width])
+                    cursor += width
+                count_rows.append(row)
+        if cursor != start + 1220:
+            raise ValueError("CK professional result block width mismatch")
+        if len(count_rows) != 51:
+            raise ValueError("CK professional count row cardinality mismatch")
+        return summary, count_rows
+
+    def _parse_sei_ruikei(
+        self,
+        data: bytes,
+        *,
+        start: int,
+        key: dict[str, str],
+        actor_type: str,
+        number: int,
+    ) -> tuple[dict[str, str], dict[str, str]]:
+        summary = {
+            **key,
+            "EntityKubun": actor_type,
+            "PeriodNum": str(number),
+            "HonSyokinHeichi": "",
+            "HonSyokinSyogai": "",
+            "FukaSyokinHeichi": "",
+            "FukaSyokinSyogai": "",
+        }
+        cursor = start
+        for name, width in (("SetYear", 4), ("HonSyokinTotal", 10), ("FukaSyokin", 10)):
+            summary[name] = self.decode_field(data[cursor : cursor + width])
+            cursor += width
+        row = {
+            **key,
+            "EntityKubun": actor_type,
+            "PeriodNum": str(number),
+            "MetricKubun": "ChakuKaisu",
+            "BucketNum": "1",
+        }
+        for rank in range(1, 7):
+            row[f"Count{rank}"] = self.decode_field(data[cursor : cursor + 6])
+            cursor += 6
+        if cursor != start + 60:
+            raise ValueError("CK owner/breeder result block width mismatch")
+        return summary, row
+
+    def parse(self, data: bytes) -> dict[str, Any] | None:
+        """Return the compatibility parent plus all official normalized rows."""
+        try:
+            validate_fixed_record(data, self.RECORD_TYPE, self.RECORD_LENGTH)
+            result: dict[str, Any] = {
+                "RecordSpec": self.decode_field(data[0:2]),
+                "DataKubun": self.decode_field(data[2:3]),
+                "MakeDate": convert_value(self.decode_field(data[3:11]), "DATE"),
+                "Year": convert_value(self.decode_field(data[11:15]), "SMALLINT"),
+                "MonthDay": convert_value(self.decode_field(data[15:19]), "MONTH_DAY"),
+                "JyoCD": self.decode_field(data[19:21]),
+                "Kaiji": convert_value(self.decode_field(data[21:23]), "SMALLINT"),
+                "Nichiji": convert_value(self.decode_field(data[23:25]), "SMALLINT"),
+                "RaceNum": convert_value(self.decode_field(data[25:27]), "SMALLINT"),
+                "KettoNum": self.decode_field(data[27:37]),
+                "Bamei": self.decode_field(data[37:73]),
+                "HeichiHonsyokinTotal": self.decode_field(data[73:82]),
+                "SyogaiHonsyokinTotal": self.decode_field(data[82:91]),
+                "HeichiFukasyokinTotal": self.decode_field(data[91:100]),
+                "SyogaiFukasyokinTotal": self.decode_field(data[100:109]),
+                "HeichiSyutokuTotal": self.decode_field(data[109:118]),
+                "SyogaiSyutokuTotal": self.decode_field(data[118:127]),
+            }
+            if result["DataKubun"] not in {"0", "1", "2"}:
+                raise ValueError("CK DataKubun must be 0, 1, or 2")
+
+            key = self._parent_key(data)
+            for name, value in key.items():
+                self._require_digits(name, value)
+            if result["DataKubun"] == "0":
+                result["_ck_chaku_rows"] = []
+                result["_ck_ruikei_rows"] = []
+                return result
+
+            for name in (
+                "HeichiHonsyokinTotal",
+                "SyogaiHonsyokinTotal",
+                "HeichiFukasyokinTotal",
+                "SyogaiFukasyokinTotal",
+                "HeichiSyutokuTotal",
+                "SyogaiSyutokuTotal",
+            ):
+                self._require_digits(name, str(result[name]))
+            uma_rows = self._parse_uma_rows(data, key)
+            if len(uma_rows) != 70:
+                raise ValueError("CK horse count row cardinality mismatch")
+            for name, row in zip(self._COMPATIBILITY_COUNT_NAMES, uma_rows[:-1], strict=True):
+                result[name] = row["Count1"]
+            result["KyakusituKeiko"] = uma_rows[-1]["Count1"]
+            result["RegisteredRaceCount"] = self.decode_field(data[1381:1384])
+            self._require_digits("RegisteredRaceCount", result["RegisteredRaceCount"])
+
+            result.update(
+                {
+                    "KisyuCode": self.decode_field(data[1384:1389]),
+                    "KisyuName": self.decode_field(data[1389:1423]),
+                    "KisyuResultsInfo": self.decode_field(data[1423:2643]),
+                    "ChokyosiCode": self.decode_field(data[3863:3868]),
+                    "ChokyosiName": self.decode_field(data[3868:3902]),
+                    "ChokyosiResultsInfo": self.decode_field(data[3902:5122]),
+                    "BanusiCode": self.decode_field(data[6342:6348]),
+                    "BanusiName": self.decode_field(data[6348:6412]),
+                    "BanusiName_Co": self.decode_field(data[6412:6476]),
+                    "BanusiResultsInfo": self.decode_field(data[6476:6536]),
+                    "BreederCode": self.decode_field(data[6596:6604]),
+                    "BreederName": self.decode_field(data[6604:6676]),
+                    "BreederName_Co": self.decode_field(data[6676:6748]),
+                    "BreederResultsInfo": self.decode_field(data[6748:6808]),
+                    "RecordDelimiter": self.decode_field(data[6868:6870]),
+                }
+            )
+            professional = [
+                self._parse_hon_ruikei(
+                    data,
+                    start=start + 1220 * (number - 1),
+                    key=key,
+                    actor_type=actor_type,
+                    number=number,
+                )
+                for actor_type, start in (("KISYU", 1423), ("CHOKYOSI", 3902))
+                for number in range(1, 3)
+            ]
+            owners = [
+                self._parse_sei_ruikei(
+                    data,
+                    start=start + 60 * (number - 1),
+                    key=key,
+                    actor_type=actor_type,
+                    number=number,
+                )
+                for actor_type, start in (("BANUSI", 6476), ("BREEDER", 6748))
+                for number in range(1, 3)
+            ]
+            result["_ck_chaku_rows"] = [
+                *uma_rows,
+                *(row for _, rows in professional for row in rows),
+                *(row for _, row in owners),
+            ]
+            result["_ck_ruikei_rows"] = [
+                *(summary for summary, _ in professional),
+                *(summary for summary, _ in owners),
+            ]
+            if len(result["_ck_chaku_rows"]) != 278:
+                raise ValueError("CK normalized count row cardinality mismatch")
+            if len(result["_ck_ruikei_rows"]) != 8:
+                raise ValueError("CK normalized summary row cardinality mismatch")
+            for row_number, row in enumerate(result["_ck_chaku_rows"], start=1):
+                last_rank = (
+                    4 if row["EntityKubun"] == "UMA" and row["MetricKubun"] == "Kyakusitu" else 6
+                )
+                for rank in range(1, last_rank + 1):
+                    self._require_digits(
+                        f"CK count row {row_number} rank {rank}",
+                        row[f"Count{rank}"],
+                    )
+            for row_number, row in enumerate(result["_ck_ruikei_rows"], start=1):
+                for name in (
+                    "SetYear",
+                    "HonSyokinHeichi",
+                    "HonSyokinSyogai",
+                    "FukaSyokinHeichi",
+                    "FukaSyokinSyogai",
+                    "HonSyokinTotal",
+                    "FukaSyokin",
+                ):
+                    value = row[name]
+                    if value:
+                        self._require_digits(f"CK summary row {row_number} {name}", value)
+            return result
+        except (ConversionError, UnicodeDecodeError, ValueError, TypeError) as error:
+            self.logger.error(f"CKレコードパース中にエラー: {error}")
+            return None

--- a/tests/test_ck_official_contract.py
+++ b/tests/test_ck_official_contract.py
@@ -542,6 +542,13 @@ def _weaken_ck_chaku_schema(defect: str) -> str:
         end = schema.index(",\n            CONSTRAINT ck_chaku_count_shape", start)
         constraint = schema[start:end].replace("CHECK (", "CHECK (TRUE OR (", 1) + ")"
         return schema[:start] + constraint + schema[end:]
+    if defect == "extra-domain-value":
+        start = schema.index("CONSTRAINT ck_chaku_domain")
+        end = schema.index(",\n            CONSTRAINT ck_chaku_count_shape", start)
+        constraint = (
+            schema[start:end].replace("CHECK (", "CHECK ((", 1) + " OR EntityKubun = 'EVIL')"
+        )
+        return schema[:start] + constraint + schema[end:]
     if defect == "weak-count-shape":
         start = schema.index("CONSTRAINT ck_chaku_count_shape")
         end = schema.index(",\n            PRIMARY KEY", start)
@@ -552,6 +559,12 @@ def _weaken_ck_chaku_schema(defect: str) -> str:
         return schema[:start] + constraint + schema[end:]
     if defect == "restrict-fk":
         return schema.replace("ON DELETE CASCADE", "ON DELETE RESTRICT", 1)
+    if defect == "deferrable-fk":
+        return schema.replace(
+            "ON DELETE CASCADE",
+            "ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED",
+            1,
+        )
     if defect == "wrong-fk-order":
         return schema.replace(
             "FOREIGN KEY (Year, MonthDay,",
@@ -721,9 +734,11 @@ def test_ck_postgresql_complete_roundtrip_reconnect_update_delete(
     [
         "check-true",
         "token-tautology",
+        "extra-domain-value",
         "weak-count-shape",
         "not-validated",
         "restrict-fk",
+        "deferrable-fk",
         "wrong-fk-order",
     ],
 )

--- a/tests/test_ck_official_contract.py
+++ b/tests/test_ck_official_contract.py
@@ -531,7 +531,7 @@ def test_ck_metadata_defects_fail_before_replacing_a_complete_row(
 
 def _weaken_ck_chaku_schema(defect: str) -> str:
     schema = SCHEMAS["NL_CK_CHAKU"]
-    if defect == "not-validated":
+    if defect in {"not-validated", "disabled-fk-triggers", "replica-trigger-mode"}:
         return schema
     if defect == "check-true":
         start = schema.index("CONSTRAINT ck_chaku_domain")
@@ -549,6 +549,18 @@ def _weaken_ck_chaku_schema(defect: str) -> str:
             schema[start:end].replace("CHECK (", "CHECK ((", 1) + " OR EntityKubun = 'EVIL')"
         )
         return schema[:start] + constraint + schema[end:]
+    if defect == "computed-any-member":
+        return schema.replace(
+            "IN ('KISYU', 'CHOKYOSI')",
+            "IN ('KISYU', reverse('CHOKYOSI'))",
+            1,
+        )
+    if defect == "wrong-any-case":
+        return schema.replace(
+            "IN ('KISYU', 'CHOKYOSI')",
+            "IN ('KISYU', 'chokyosi')",
+            1,
+        )
     if defect == "weak-count-shape":
         start = schema.index("CONSTRAINT ck_chaku_count_shape")
         end = schema.index(",\n            PRIMARY KEY", start)
@@ -623,6 +635,29 @@ def test_ck_create_all_tables_reports_malformed_child_contract(tmp_path) -> None
         results = SchemaManager(database).create_all_tables()
         assert results["NL_CK_CHAKU"] is False
         assert results["NL_CK_RUIKEI"] is False
+
+
+@pytest.mark.parametrize("importer_class", [DataImporter, OptimizedDataImporter])
+def test_ck_sqlite_disabled_foreign_keys_fail_before_parent_mutation(
+    tmp_path, importer_class
+) -> None:
+    database = SQLiteDatabase({"path": str(tmp_path / "disabled-foreign-keys.db")})
+    with database:
+        _create_ck_tables(database)
+        database.execute(
+            "INSERT INTO NL_CK "
+            "(Year, MonthDay, JyoCD, Kaiji, Nichiji, RaceNum, KettoNum, Bamei) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+            (2025, 101, "05", 1, 1, 1, "2025000001", "preserve"),
+        )
+        database.commit()
+        database.execute("PRAGMA foreign_keys = OFF")
+        assert database.fetch_one("PRAGMA foreign_keys") == {"foreign_keys": 0}
+        with pytest.raises(SchemaMigrationError):
+            importer_class(database).import_records(iter([CKParser().parse(build_record()[0])]))
+        assert database.fetch_all("SELECT Bamei, CKStorageVersion FROM NL_CK") == [
+            {"Bamei": "preserve", "CKStorageVersion": None}
+        ]
 
 
 @pytest.mark.parametrize("importer_class", [DataImporter, OptimizedDataImporter])
@@ -735,10 +770,14 @@ def test_ck_postgresql_complete_roundtrip_reconnect_update_delete(
         "check-true",
         "token-tautology",
         "extra-domain-value",
+        "computed-any-member",
+        "wrong-any-case",
         "weak-count-shape",
         "not-validated",
         "restrict-fk",
         "deferrable-fk",
+        "disabled-fk-triggers",
+        "replica-trigger-mode",
         "wrong-fk-order",
     ],
 )
@@ -748,6 +787,10 @@ def test_ck_postgresql_malformed_constraints_fail_before_parent_mutation(
     database, _ = postgresql_db
     database.execute(SCHEMAS["NL_CK"])
     database.execute(_weaken_ck_chaku_schema(defect))
+    if defect == "disabled-fk-triggers":
+        database.execute("ALTER TABLE NL_CK_CHAKU DISABLE TRIGGER ALL")
+    if defect == "replica-trigger-mode":
+        database.execute("SET session_replication_role = replica")
     if defect == "not-validated":
         schema = SCHEMAS["NL_CK_CHAKU"]
         start = schema.index("CONSTRAINT ck_chaku_domain")

--- a/tests/test_ck_official_contract.py
+++ b/tests/test_ck_official_contract.py
@@ -531,12 +531,33 @@ def test_ck_metadata_defects_fail_before_replacing_a_complete_row(
 
 def _weaken_ck_chaku_schema(defect: str) -> str:
     schema = SCHEMAS["NL_CK_CHAKU"]
+    if defect == "not-validated":
+        return schema
     if defect == "check-true":
         start = schema.index("CONSTRAINT ck_chaku_domain")
         end = schema.index(",\n            CONSTRAINT ck_chaku_count_shape", start)
         return schema[:start] + "CONSTRAINT ck_chaku_domain CHECK (TRUE)" + schema[end:]
+    if defect == "token-tautology":
+        start = schema.index("CONSTRAINT ck_chaku_domain")
+        end = schema.index(",\n            CONSTRAINT ck_chaku_count_shape", start)
+        constraint = schema[start:end].replace("CHECK (", "CHECK (TRUE OR (", 1) + ")"
+        return schema[:start] + constraint + schema[end:]
+    if defect == "weak-count-shape":
+        start = schema.index("CONSTRAINT ck_chaku_count_shape")
+        end = schema.index(",\n            PRIMARY KEY", start)
+        constraint = (
+            "CONSTRAINT ck_chaku_count_shape CHECK "
+            "(Count5 IS NULL OR Count6 IS NULL OR MetricKubun = 'Kyakusitu')"
+        )
+        return schema[:start] + constraint + schema[end:]
     if defect == "restrict-fk":
         return schema.replace("ON DELETE CASCADE", "ON DELETE RESTRICT", 1)
+    if defect == "wrong-fk-order":
+        return schema.replace(
+            "FOREIGN KEY (Year, MonthDay,",
+            "FOREIGN KEY (MonthDay, Year,",
+            1,
+        )
     if defect == "nullable-dimension":
         return schema.replace("EntityKubun TEXT NOT NULL", "EntityKubun TEXT", 1)
     if defect == "wrong-pk":
@@ -570,6 +591,14 @@ def test_ck_child_schema_is_never_additively_repaired(tmp_path) -> None:
         assert SchemaManager(database).create_table("NL_CK_CHAKU") is False
         columns = {row["name"] for row in database.fetch_all('PRAGMA table_info("NL_CK_CHAKU")')}
         assert "Count6" not in columns
+
+
+def test_ck_single_child_creation_rejects_tautological_check(tmp_path) -> None:
+    database = SQLiteDatabase({"path": str(tmp_path / "single-child-check.db")})
+    with database:
+        database.create_table("NL_CK", SCHEMAS["NL_CK"])
+        database.create_table("NL_CK_CHAKU", _weaken_ck_chaku_schema("check-true"))
+        assert SchemaManager(database).create_table("NL_CK_CHAKU") is False
 
 
 def test_ck_create_all_tables_reports_malformed_child_contract(tmp_path) -> None:
@@ -687,13 +716,30 @@ def test_ck_postgresql_complete_roundtrip_reconnect_update_delete(
 
 
 @pytest.mark.parametrize("importer_class", [DataImporter, OptimizedDataImporter])
-@pytest.mark.parametrize("defect", ["check-true", "restrict-fk"])
+@pytest.mark.parametrize(
+    "defect",
+    [
+        "check-true",
+        "token-tautology",
+        "weak-count-shape",
+        "not-validated",
+        "restrict-fk",
+        "wrong-fk-order",
+    ],
+)
 def test_ck_postgresql_malformed_constraints_fail_before_parent_mutation(
     postgresql_db, importer_class, defect
 ) -> None:
     database, _ = postgresql_db
     database.execute(SCHEMAS["NL_CK"])
     database.execute(_weaken_ck_chaku_schema(defect))
+    if defect == "not-validated":
+        schema = SCHEMAS["NL_CK_CHAKU"]
+        start = schema.index("CONSTRAINT ck_chaku_domain")
+        end = schema.index(",\n            CONSTRAINT ck_chaku_count_shape", start)
+        domain_constraint = schema[start:end]
+        database.execute("ALTER TABLE NL_CK_CHAKU DROP CONSTRAINT ck_chaku_domain")
+        database.execute(f"ALTER TABLE NL_CK_CHAKU ADD {domain_constraint} NOT VALID")
     database.execute(SCHEMAS["NL_CK_RUIKEI"])
     database.execute(
         "INSERT INTO NL_CK "

--- a/tests/test_ck_official_contract.py
+++ b/tests/test_ck_official_contract.py
@@ -1,0 +1,709 @@
+#!/usr/bin/env python
+"""CK current-layout parsing and normalized native-storage contract."""
+
+from __future__ import annotations
+
+import os
+from copy import deepcopy
+from dataclasses import dataclass
+from datetime import date
+from uuid import uuid4
+
+import pytest
+
+from src.database.base import DatabaseError
+from src.database.migration import SchemaMigrationError, migrate_table_if_needed
+from src.database.schema import SCHEMAS, SchemaManager
+from src.database.schema_types import (
+    get_table_column_types,
+    get_table_primary_key_columns,
+)
+from src.database.sqlite_handler import SQLiteDatabase
+from src.importer.importer import DataImporter
+from src.importer.importer_optimized import OptimizedDataImporter
+from src.parser.ck_parser import CKParser
+
+
+@pytest.fixture
+def postgresql_db():
+    if os.getenv("JLTSQL_RUN_POSTGRESQL_INTEGRATION") != "1":
+        pytest.skip("Set JLTSQL_RUN_POSTGRESQL_INTEGRATION=1 to run PostgreSQL tests")
+
+    from src.database.postgresql_handler import PostgreSQLDatabase
+
+    database = PostgreSQLDatabase(
+        {
+            "host": os.getenv("POSTGRES_HOST") or os.getenv("PGHOST", "localhost"),
+            "port": int(os.getenv("POSTGRES_PORT") or os.getenv("PGPORT", "5432")),
+            "database": os.getenv("POSTGRES_DB") or os.getenv("PGDATABASE", "jltsql_test"),
+            "user": os.getenv("POSTGRES_USER") or os.getenv("PGUSER", "jltsql"),
+            "password": os.getenv("POSTGRES_PASSWORD") or os.getenv("PGPASSWORD", ""),
+            "connect_timeout": 5,
+        }
+    )
+    schema_name = f"jlt_ck_{uuid4().hex[:12]}"
+    database.connect()
+    try:
+        database.execute(f"CREATE SCHEMA {schema_name}")
+        database.execute(f"SET search_path TO {schema_name}")
+        database.commit()
+        yield database, schema_name
+    finally:
+        if not database.is_connected():
+            database.connect()
+        try:
+            database.execute(f"DROP SCHEMA IF EXISTS {schema_name} CASCADE")
+            database.commit()
+        finally:
+            database.disconnect()
+
+
+PARENT_KEY = ("Year", "MonthDay", "JyoCD", "Kaiji", "Nichiji", "RaceNum", "KettoNum")
+CHILD_TABLES = (
+    "NL_CK_CHAKU",
+    "NL_CK_RUIKEI",
+)
+UMA_GROUPS = (
+    ("ChakuSogo", 100, 1),
+    ("ChakuChuo", 118, 1),
+    ("ChakuKaisuBa", 136, 7),
+    ("ChakuKaisuJyotai", 262, 12),
+    ("ChakuKaisuSibaKyori", 478, 9),
+    ("ChakuKaisuDirtKyori", 640, 9),
+    ("ChakuKaisuJyoSiba", 802, 10),
+    ("ChakuKaisuJyoDirt", 982, 10),
+    ("ChakuKaisuJyoSyogai", 1162, 10),
+)
+
+
+@dataclass
+class _Sequence:
+    value: int = 1
+
+    def take(self, width: int) -> str:
+        value = str(self.value % (10**width)).zfill(width)
+        self.value += 1
+        return value
+
+
+def _pad(value: str, width: int) -> bytes:
+    encoded = value.encode("cp932")
+    assert len(encoded) <= width
+    return encoded.ljust(width, b" ")
+
+
+def _put(record: bytearray, start: int, width: int, value: str | bytes) -> str:
+    encoded = value if isinstance(value, bytes) else _pad(value, width)
+    assert len(encoded) == width
+    assert record[start : start + width] == b" " * width
+    record[start : start + width] = encoded
+    return encoded.decode("cp932").strip()
+
+
+def _parent_key() -> dict[str, str]:
+    return {
+        "Year": "2026",
+        "MonthDay": "0817",
+        "JyoCD": "05",
+        "Kaiji": "01",
+        "Nichiji": "02",
+        "RaceNum": "03",
+        "KettoNum": "2026000001",
+    }
+
+
+def _put_hon_ruikei(
+    record: bytearray,
+    start: int,
+    actor_type: str,
+    number: int,
+    sequence: _Sequence,
+) -> tuple[dict[str, str], list[dict[str, str]]]:
+    summary = {
+        **_parent_key(),
+        "EntityKubun": actor_type,
+        "PeriodNum": str(number),
+        "HonSyokinTotal": "",
+        "FukaSyokin": "",
+    }
+    count_rows = []
+    cursor = start
+    scalar_fields = (
+        ("SetYear", 4),
+        ("HonSyokinHeichi", 10),
+        ("HonSyokinSyogai", 10),
+        ("FukaSyokinHeichi", 10),
+        ("FukaSyokinSyogai", 10),
+    )
+    for name, width in scalar_fields:
+        value = "2026" if name == "SetYear" else sequence.take(width)
+        summary[name] = _put(record, cursor, width, value)
+        cursor += width
+
+    groups = (
+        ("ChakuKaisuSiba", 1, 5),
+        ("ChakuKaisuDirt", 1, 5),
+        ("ChakuKaisuSyogai", 1, 4),
+        ("ChakuKaisuSibaKyori", 9, 4),
+        ("ChakuKaisuDirtKyori", 9, 4),
+        ("ChakuKaisuJyoSiba", 10, 4),
+        ("ChakuKaisuJyoDirt", 10, 4),
+        ("ChakuKaisuJyoSyogai", 10, 3),
+    )
+    for group, count, width in groups:
+        for index in range(1, count + 1):
+            row = {
+                **_parent_key(),
+                "EntityKubun": actor_type,
+                "PeriodNum": str(number),
+                "MetricKubun": group,
+                "BucketNum": str(index),
+            }
+            for rank in range(1, 7):
+                value = sequence.take(width)
+                row[f"Count{rank}"] = _put(record, cursor, width, value)
+                cursor += width
+            count_rows.append(row)
+    assert cursor == start + 1220
+    assert len(count_rows) == 51
+    return summary, count_rows
+
+
+def _put_sei_ruikei(
+    record: bytearray,
+    start: int,
+    actor_type: str,
+    number: int,
+    sequence: _Sequence,
+) -> tuple[dict[str, str], dict[str, str]]:
+    summary = {
+        **_parent_key(),
+        "EntityKubun": actor_type,
+        "PeriodNum": str(number),
+        "HonSyokinHeichi": "",
+        "HonSyokinSyogai": "",
+        "FukaSyokinHeichi": "",
+        "FukaSyokinSyogai": "",
+    }
+    cursor = start
+    for name, width in (
+        ("SetYear", 4),
+        ("HonSyokinTotal", 10),
+        ("FukaSyokin", 10),
+    ):
+        value = "2026" if name == "SetYear" else sequence.take(width)
+        summary[name] = _put(record, cursor, width, value)
+        cursor += width
+    row = {
+        **_parent_key(),
+        "EntityKubun": actor_type,
+        "PeriodNum": str(number),
+        "MetricKubun": "ChakuKaisu",
+        "BucketNum": "1",
+    }
+    for rank in range(1, 7):
+        value = sequence.take(6)
+        row[f"Count{rank}"] = _put(record, cursor, 6, value)
+        cursor += 6
+    assert cursor == start + 60
+    return summary, row
+
+
+def build_record(
+    *,
+    data_kubun: str = "1",
+    horse_name: str = "完全展開馬",
+    sequence_start: int = 1,
+):
+    record = bytearray(b" " * 6870)
+    expected_parent = {
+        "RecordSpec": _put(record, 0, 2, "CK"),
+        "DataKubun": _put(record, 2, 1, data_kubun),
+        "MakeDate": date(2026, 8, 17),
+        "Year": 2026,
+        "MonthDay": 817,
+        "JyoCD": _put(record, 19, 2, "05"),
+        "Kaiji": 1,
+        "Nichiji": 2,
+        "RaceNum": 3,
+        "KettoNum": _put(record, 27, 10, "2026000001"),
+        "Bamei": _put(record, 37, 36, horse_name),
+    }
+    _put(record, 3, 8, "20260817")
+    _put(record, 11, 4, "2026")
+    _put(record, 15, 4, "0817")
+    _put(record, 21, 2, "01")
+    _put(record, 23, 2, "02")
+    _put(record, 25, 2, "03")
+    for name, start in (
+        ("HeichiHonsyokinTotal", 73),
+        ("SyogaiHonsyokinTotal", 82),
+        ("HeichiFukasyokinTotal", 91),
+        ("SyogaiFukasyokinTotal", 100),
+        ("HeichiSyutokuTotal", 109),
+        ("SyogaiSyutokuTotal", 118),
+    ):
+        expected_parent[name] = _put(record, start, 9, str(start).zfill(9))
+
+    sequence = _Sequence(sequence_start)
+    expected_chaku_rows = []
+    uma_start = 27
+    for group, relative_start, count in UMA_GROUPS:
+        for number in range(1, count + 1):
+            row = {
+                **_parent_key(),
+                "EntityKubun": "UMA",
+                "PeriodNum": "0",
+                "MetricKubun": group,
+                "BucketNum": str(number),
+            }
+            cursor = uma_start + relative_start + 18 * (number - 1)
+            for rank in range(1, 7):
+                value = sequence.take(3)
+                row[f"Count{rank}"] = _put(record, cursor, 3, value)
+                cursor += 3
+            expected_chaku_rows.append(row)
+
+    kyakusitu = {
+        **_parent_key(),
+        "EntityKubun": "UMA",
+        "PeriodNum": "0",
+        "MetricKubun": "Kyakusitu",
+        "BucketNum": "1",
+    }
+    for rank in range(1, 5):
+        value = sequence.take(3)
+        kyakusitu[f"Count{rank}"] = _put(record, 1369 + 3 * (rank - 1), 3, value)
+    kyakusitu["Count5"] = ""
+    kyakusitu["Count6"] = ""
+    expected_chaku_rows.append(kyakusitu)
+    expected_parent["RegisteredRaceCount"] = _put(record, 1381, 3, sequence.take(3))
+
+    expected_parent["KisyuCode"] = _put(record, 1384, 5, "01234")
+    expected_parent["KisyuName"] = _put(record, 1389, 34, "騎手 完全")
+    professional = [
+        _put_hon_ruikei(record, 1423 + 1220 * (number - 1), "KISYU", number, sequence)
+        for number in range(1, 3)
+    ]
+    expected_parent["ChokyosiCode"] = _put(record, 3863, 5, "05678")
+    expected_parent["ChokyosiName"] = _put(record, 3868, 34, "調教師 完全")
+    professional.extend(
+        _put_hon_ruikei(record, 3902 + 1220 * (number - 1), "CHOKYOSI", number, sequence)
+        for number in range(1, 3)
+    )
+
+    expected_parent["BanusiCode"] = _put(record, 6342, 6, "123456")
+    expected_parent["BanusiName"] = _put(record, 6348, 64, "株式会社馬主")
+    expected_parent["BanusiName_Co"] = _put(record, 6412, 64, "馬主法人格なし")
+    owners = [
+        _put_sei_ruikei(record, 6476 + 60 * (number - 1), "BANUSI", number, sequence)
+        for number in range(1, 3)
+    ]
+    expected_parent["BreederCode"] = _put(record, 6596, 8, "12345678")
+    expected_parent["BreederName"] = _put(record, 6604, 72, "株式会社生産者")
+    expected_parent["BreederName_Co"] = _put(record, 6676, 72, "生産者法人格なし")
+    owners.extend(
+        _put_sei_ruikei(record, 6748 + 60 * (number - 1), "BREEDER", number, sequence)
+        for number in range(1, 3)
+    )
+    record[6868:6870] = b"\r\n"
+    expected_chaku_rows.extend(row for _, rows in professional for row in rows)
+    expected_chaku_rows.extend(row for _, row in owners)
+    expected_ruikei_rows = [
+        *(summary for summary, _ in professional),
+        *(summary for summary, _ in owners),
+    ]
+    return bytes(record), expected_parent, expected_chaku_rows, expected_ruikei_rows
+
+
+def _rejects(record: bytes) -> bool:
+    try:
+        return CKParser().parse(record) is None
+    except (UnicodeDecodeError, ValueError):
+        return True
+
+
+def test_ck_parser_expands_all_1698_child_leaves_without_opaque_substitution() -> None:
+    record, parent, chaku_rows, ruikei_rows = build_record()
+    parsed = CKParser().parse(record)
+
+    assert parsed is not None
+    assert {name: parsed[name] for name in parent} == parent
+    assert parsed["_ck_chaku_rows"] == chaku_rows
+    assert parsed["_ck_ruikei_rows"] == ruikei_rows
+    assert len(chaku_rows) == 278
+    assert len(ruikei_rows) == 8
+    # 277 complete six-count blocks plus four running-style counts make
+    # 1,666 count leaves. Eight summaries hold another 32 leaves. The remaining
+    # 31 official leaves are in
+    # the parent or are the strictly validated CRLF delimiter.
+    assert 277 * 6 + 4 + 32 == 1698
+    assert 1698 + 31 == 1729
+
+
+@pytest.mark.parametrize("data_kubun", ["", "3", "9"])
+def test_ck_rejects_undefined_data_kubun(data_kubun: str) -> None:
+    assert _rejects(build_record(data_kubun=data_kubun)[0])
+
+
+def test_ck_rejects_previous_6864_byte_layout() -> None:
+    assert _rejects(build_record()[0][:6862] + b"\r\n")
+
+
+def test_ck_rejects_non_numeric_official_count_leaf() -> None:
+    record = bytearray(build_record()[0])
+    record[127:130] = b"0X1"
+    assert CKParser().parse(bytes(record)) is None
+
+
+def test_ck_normalized_native_schemas_fit_postgresql_and_have_exact_keys() -> None:
+    assert set(CHILD_TABLES) <= set(SCHEMAS)
+    assert get_table_primary_key_columns("NL_CK") == list(PARENT_KEY)
+    assert get_table_primary_key_columns("NL_CK_CHAKU") == [
+        *PARENT_KEY,
+        "EntityKubun",
+        "PeriodNum",
+        "MetricKubun",
+        "BucketNum",
+    ]
+    assert get_table_primary_key_columns("NL_CK_RUIKEI") == [
+        *PARENT_KEY,
+        "EntityKubun",
+        "PeriodNum",
+    ]
+    assert len(get_table_column_types("NL_CK_CHAKU")) == 17
+    assert len(get_table_column_types("NL_CK_RUIKEI")) == 16
+    assert max(len(get_table_column_types(name)) for name in ("NL_CK", *CHILD_TABLES)) < 1600
+
+
+def _create_ck_tables(database: SQLiteDatabase) -> None:
+    database.create_table("NL_CK", SCHEMAS["NL_CK"])
+    for table_name in CHILD_TABLES:
+        database.create_table(table_name, SCHEMAS[table_name])
+
+
+@pytest.mark.parametrize("importer_class", [DataImporter, OptimizedDataImporter])
+def test_ck_importers_store_update_delete_in_provider_order_and_reconnect(
+    tmp_path, importer_class
+) -> None:
+    path = tmp_path / f"{importer_class.__name__}.db"
+    initial = CKParser().parse(build_record()[0])
+    updated_record = build_record(
+        data_kubun="2",
+        horse_name="更新完全馬",
+        sequence_start=4000,
+    )
+    updated = CKParser().parse(updated_record[0])
+    deletion = CKParser().parse(build_record(data_kubun="0")[0])
+    database = SQLiteDatabase({"path": str(path)})
+    with database:
+        _create_ck_tables(database)
+        stats = importer_class(database).import_records(iter([initial, deletion, updated]))
+    assert stats["records_imported"] == 3
+    assert stats["records_failed"] == 0
+
+    with SQLiteDatabase({"path": str(path)}) as reopened:
+        parent = reopened.fetch_one("SELECT Bamei, CKStorageVersion FROM NL_CK")
+        counts = reopened.fetch_one("SELECT COUNT(*) AS count FROM NL_CK_CHAKU")
+        summaries = reopened.fetch_one("SELECT COUNT(*) AS count FROM NL_CK_RUIKEI")
+        count_sentinel = reopened.fetch_one(
+            "SELECT Count1 FROM NL_CK_CHAKU WHERE EntityKubun = ? "
+            "AND PeriodNum = ? AND MetricKubun = ? AND BucketNum = ?",
+            ("UMA", 0, "ChakuSogo", 1),
+        )
+        summary_sentinel = reopened.fetch_one(
+            "SELECT HonSyokinHeichi FROM NL_CK_RUIKEI " "WHERE EntityKubun = ? AND PeriodNum = ?",
+            ("KISYU", 1),
+        )
+        assert parent == {"Bamei": "更新完全馬", "CKStorageVersion": 1}
+        assert counts["count"] == 278
+        assert summaries["count"] == 8
+        assert count_sentinel == {"Count1": int(updated_record[2][0]["Count1"])}
+        assert summary_sentinel == {"HonSyokinHeichi": int(updated_record[3][0]["HonSyokinHeichi"])}
+        deleted = importer_class(reopened).import_records(iter([deletion]))
+        assert deleted["records_imported"] == 1
+        for table_name in ("NL_CK", *CHILD_TABLES):
+            assert reopened.fetch_one(f"SELECT COUNT(*) AS count FROM {table_name}")["count"] == 0
+
+
+@pytest.mark.parametrize("importer_class", [DataImporter, OptimizedDataImporter])
+def test_ck_import_refuses_missing_child_before_parent_mutation(tmp_path, importer_class) -> None:
+    database = SQLiteDatabase({"path": str(tmp_path / "missing-child.db")})
+    with database:
+        database.create_table("NL_CK", SCHEMAS["NL_CK"])
+        with pytest.raises(SchemaMigrationError, match="NL_CK_CHAKU"):
+            importer_class(database).import_records(iter([CKParser().parse(build_record()[0])]))
+        assert database.fetch_one("SELECT COUNT(*) AS count FROM NL_CK")["count"] == 0
+
+
+def test_ck_parent_migration_marks_legacy_rows_incomplete_until_reimport(tmp_path) -> None:
+    database = SQLiteDatabase({"path": str(tmp_path / "legacy-marker.db")})
+    legacy_schema = SCHEMAS["NL_CK"].replace("            CKStorageVersion INTEGER,\n", "")
+    with database:
+        database.create_table("NL_CK", legacy_schema)
+        database.execute(
+            "INSERT INTO NL_CK "
+            "(Year, MonthDay, JyoCD, Kaiji, Nichiji, RaceNum, KettoNum, Bamei) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+            (2025, 101, "05", 1, 1, 1, "2025000001", "legacy"),
+        )
+        database.commit()
+        assert migrate_table_if_needed(database, "NL_CK", SCHEMAS["NL_CK"])
+        assert database.fetch_one("SELECT Bamei, CKStorageVersion FROM NL_CK") == {
+            "Bamei": "legacy",
+            "CKStorageVersion": None,
+        }
+
+
+def test_ck_single_record_api_uses_the_same_coupled_contract(tmp_path) -> None:
+    database = SQLiteDatabase({"path": str(tmp_path / "single.db")})
+    parsed = CKParser().parse(build_record()[0])
+    deletion = CKParser().parse(build_record(data_kubun="0")[0])
+    with database:
+        _create_ck_tables(database)
+        importer = DataImporter(database)
+        assert importer.import_single_record(parsed)
+        assert database.fetch_one("SELECT CKStorageVersion FROM NL_CK") == {"CKStorageVersion": 1}
+        assert database.fetch_one("SELECT COUNT(*) AS count FROM NL_CK_CHAKU")["count"] == 278
+        assert database.fetch_one("SELECT COUNT(*) AS count FROM NL_CK_RUIKEI")["count"] == 8
+        assert importer.import_single_record(deletion)
+        assert database.fetch_one("SELECT COUNT(*) AS count FROM NL_CK")["count"] == 0
+
+
+@pytest.mark.parametrize("importer_class", [DataImporter, OptimizedDataImporter])
+def test_ck_standard_schema_mode_is_explicitly_unsupported(tmp_path, importer_class) -> None:
+    database = SQLiteDatabase({"path": str(tmp_path / "standard.db")})
+    with database:
+        with pytest.raises(SchemaMigrationError, match="CHOKYO_DETAIL"):
+            importer_class(database, use_jravan_schema=True).import_records(
+                iter([CKParser().parse(build_record()[0])])
+            )
+        assert not database.table_exists("CHOKYO_DETAIL")
+
+
+@pytest.mark.parametrize("importer_class", [DataImporter, OptimizedDataImporter])
+def test_ck_delete_rejects_forged_child_payload_before_mutation(tmp_path, importer_class) -> None:
+    database = SQLiteDatabase({"path": str(tmp_path / "delete-payload.db")})
+    initial = CKParser().parse(build_record()[0])
+    deletion = CKParser().parse(build_record(data_kubun="0")[0])
+    deletion["_ck_chaku_rows"] = deepcopy(initial["_ck_chaku_rows"])
+    with database:
+        _create_ck_tables(database)
+        importer_class(database).import_records(iter([initial]))
+        with pytest.raises(SchemaMigrationError, match="must not carry"):
+            importer_class(database).import_records(iter([deletion]))
+        assert database.fetch_one("SELECT CKStorageVersion FROM NL_CK") == {"CKStorageVersion": 1}
+
+
+@pytest.mark.parametrize("importer_class", [DataImporter, OptimizedDataImporter])
+@pytest.mark.parametrize("defect", ["reordered", "missing", "parent-key"])
+def test_ck_metadata_defects_fail_before_replacing_a_complete_row(
+    tmp_path, importer_class, defect
+) -> None:
+    database = SQLiteDatabase({"path": str(tmp_path / f"metadata-{defect}.db")})
+    initial = CKParser().parse(build_record()[0])
+    broken = deepcopy(CKParser().parse(build_record(data_kubun="2", sequence_start=5000)[0]))
+    if defect == "reordered":
+        broken["_ck_chaku_rows"][0], broken["_ck_chaku_rows"][1] = (
+            broken["_ck_chaku_rows"][1],
+            broken["_ck_chaku_rows"][0],
+        )
+    elif defect == "missing":
+        broken["_ck_ruikei_rows"].pop()
+    else:
+        broken["_ck_chaku_rows"][0]["Year"] = "2025"
+    with database:
+        _create_ck_tables(database)
+        importer_class(database).import_records(iter([initial]))
+        before = database.fetch_one(
+            "SELECT Count1 FROM NL_CK_CHAKU WHERE EntityKubun = 'UMA' "
+            "AND MetricKubun = 'ChakuSogo'"
+        )
+        with pytest.raises(SchemaMigrationError):
+            importer_class(database).import_records(iter([broken]))
+        after = database.fetch_one(
+            "SELECT Count1 FROM NL_CK_CHAKU WHERE EntityKubun = 'UMA' "
+            "AND MetricKubun = 'ChakuSogo'"
+        )
+        assert after == before
+        assert database.fetch_one("SELECT CKStorageVersion FROM NL_CK") == {"CKStorageVersion": 1}
+
+
+def _weaken_ck_chaku_schema(defect: str) -> str:
+    schema = SCHEMAS["NL_CK_CHAKU"]
+    if defect == "check-true":
+        start = schema.index("CONSTRAINT ck_chaku_domain")
+        end = schema.index(",\n            CONSTRAINT ck_chaku_count_shape", start)
+        return schema[:start] + "CONSTRAINT ck_chaku_domain CHECK (TRUE)" + schema[end:]
+    if defect == "restrict-fk":
+        return schema.replace("ON DELETE CASCADE", "ON DELETE RESTRICT", 1)
+    if defect == "nullable-dimension":
+        return schema.replace("EntityKubun TEXT NOT NULL", "EntityKubun TEXT", 1)
+    if defect == "wrong-pk":
+        return schema.replace(
+            ", MetricKubun, BucketNum)",
+            ", MetricKubun)",
+            1,
+        )
+    return schema.replace(
+        ",\n            CONSTRAINT ck_chaku_parent_fk",
+        ",\n            Unexpected INTEGER,\n            CONSTRAINT ck_chaku_parent_fk",
+        1,
+    )
+
+
+def _ck_chaku_schema_without_count6_or_shape_check() -> str:
+    schema = SCHEMAS["NL_CK_CHAKU"].replace("            Count6 INTEGER,\n", "")
+    start = schema.index(",\n            CONSTRAINT ck_chaku_count_shape")
+    end = schema.index(",\n            PRIMARY KEY", start)
+    return schema[:start] + schema[end:]
+
+
+def test_ck_child_schema_is_never_additively_repaired(tmp_path) -> None:
+    database = SQLiteDatabase({"path": str(tmp_path / "no-additive-child.db")})
+    with database:
+        database.create_table("NL_CK", SCHEMAS["NL_CK"])
+        database.create_table(
+            "NL_CK_CHAKU",
+            _ck_chaku_schema_without_count6_or_shape_check(),
+        )
+        assert SchemaManager(database).create_table("NL_CK_CHAKU") is False
+        columns = {row["name"] for row in database.fetch_all('PRAGMA table_info("NL_CK_CHAKU")')}
+        assert "Count6" not in columns
+
+
+def test_ck_create_all_tables_reports_malformed_child_contract(tmp_path) -> None:
+    database = SQLiteDatabase({"path": str(tmp_path / "create-all-malformed.db")})
+    with database:
+        database.create_table("NL_CK", SCHEMAS["NL_CK"])
+        database.create_table("NL_CK_CHAKU", _weaken_ck_chaku_schema("check-true"))
+        database.create_table("NL_CK_RUIKEI", SCHEMAS["NL_CK_RUIKEI"])
+        results = SchemaManager(database).create_all_tables()
+        assert results["NL_CK_CHAKU"] is False
+        assert results["NL_CK_RUIKEI"] is False
+
+
+@pytest.mark.parametrize("importer_class", [DataImporter, OptimizedDataImporter])
+@pytest.mark.parametrize(
+    "defect",
+    ["check-true", "restrict-fk", "nullable-dimension", "wrong-pk", "extra-column"],
+)
+def test_ck_malformed_child_schema_fails_closed_and_preserves_legacy_parent(
+    tmp_path, importer_class, defect
+) -> None:
+    database = SQLiteDatabase({"path": str(tmp_path / f"schema-{defect}.db")})
+    with database:
+        database.create_table("NL_CK", SCHEMAS["NL_CK"])
+        database.create_table("NL_CK_CHAKU", _weaken_ck_chaku_schema(defect))
+        database.create_table("NL_CK_RUIKEI", SCHEMAS["NL_CK_RUIKEI"])
+        database.execute(
+            "INSERT INTO NL_CK "
+            "(Year, MonthDay, JyoCD, Kaiji, Nichiji, RaceNum, KettoNum, Bamei) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+            (2025, 101, "05", 1, 1, 1, "2025000001", "preserve"),
+        )
+        database.commit()
+        with pytest.raises(SchemaMigrationError):
+            importer_class(database).import_records(iter([CKParser().parse(build_record()[0])]))
+        assert database.fetch_all("SELECT Bamei, CKStorageVersion FROM NL_CK") == [
+            {"Bamei": "preserve", "CKStorageVersion": None}
+        ]
+
+
+def test_ck_database_constraints_reject_orphan_invalid_dimension_and_null_count(tmp_path) -> None:
+    database = SQLiteDatabase({"path": str(tmp_path / "constraints.db")})
+    parsed = CKParser().parse(build_record()[0])
+    with database:
+        _create_ck_tables(database)
+        DataImporter(database).import_records(iter([parsed]))
+        stored = database.fetch_one("SELECT * FROM NL_CK_CHAKU LIMIT 1")
+        invalid_rows = []
+        orphan = dict(stored)
+        orphan["KettoNum"] = "9999999999"
+        invalid_rows.append(orphan)
+        invalid_dimension = dict(stored)
+        invalid_dimension["MetricKubun"] = "InventedMetric"
+        invalid_rows.append(invalid_dimension)
+        missing_count = dict(stored)
+        missing_count["Count5"] = None
+        invalid_rows.append(missing_count)
+        for row in invalid_rows:
+            with pytest.raises(DatabaseError):
+                database.insert("NL_CK_CHAKU", row)
+            database.rollback()
+        assert database.fetch_one("SELECT COUNT(*) AS count FROM NL_CK_CHAKU")["count"] == 278
+
+
+@pytest.mark.parametrize("importer_class", [DataImporter, OptimizedDataImporter])
+def test_ck_postgresql_complete_roundtrip_reconnect_update_delete(
+    postgresql_db, importer_class
+) -> None:
+    database, schema_name = postgresql_db
+    database.execute(SCHEMAS["NL_CK"])
+    database.execute(SCHEMAS["NL_CK_CHAKU"])
+    database.execute(SCHEMAS["NL_CK_RUIKEI"])
+    database.commit()
+    initial = CKParser().parse(build_record()[0])
+    updated_record = build_record(
+        data_kubun="2",
+        horse_name="PG更新完全馬",
+        sequence_start=7000,
+    )
+    updated = CKParser().parse(updated_record[0])
+    deletion = CKParser().parse(build_record(data_kubun="0")[0])
+    stats = importer_class(database).import_records(iter([initial, deletion, updated]))
+    assert stats["records_imported"] == 3
+    assert stats["records_failed"] == 0
+
+    database.disconnect()
+    database.connect()
+    database.execute(f"SET search_path TO {schema_name}")
+    database.commit()
+    assert database.fetch_one(
+        'SELECT Bamei AS "Bamei", CKStorageVersion AS "CKStorageVersion" FROM NL_CK'
+    ) == {"Bamei": "PG更新完全馬", "CKStorageVersion": 1}
+    assert database.fetch_one("SELECT COUNT(*) AS count FROM NL_CK_CHAKU")["count"] == 278
+    assert database.fetch_one("SELECT COUNT(*) AS count FROM NL_CK_RUIKEI")["count"] == 8
+    assert database.fetch_one(
+        'SELECT Count1 AS "Count1" FROM NL_CK_CHAKU '
+        "WHERE EntityKubun = ? AND PeriodNum = ? AND MetricKubun = ? AND BucketNum = ?",
+        ("UMA", 0, "ChakuSogo", 1),
+    ) == {"Count1": int(updated_record[2][0]["Count1"])}
+    stored = database.fetch_one("SELECT * FROM NL_CK_CHAKU LIMIT 1")
+    invalid_dimension = dict(stored)
+    invalid_dimension["metrickubun"] = "InventedMetric"
+    with pytest.raises(DatabaseError):
+        database.insert("NL_CK_CHAKU", invalid_dimension)
+    database.rollback()
+    orphan = dict(stored)
+    orphan["kettonum"] = "9999999999"
+    with pytest.raises(DatabaseError):
+        database.insert("NL_CK_CHAKU", orphan)
+    database.rollback()
+    deleted = importer_class(database).import_records(iter([deletion]))
+    assert deleted["records_imported"] == 1
+    for table_name in ("NL_CK", *CHILD_TABLES):
+        assert database.fetch_one(f"SELECT COUNT(*) AS count FROM {table_name}")["count"] == 0
+
+
+@pytest.mark.parametrize("importer_class", [DataImporter, OptimizedDataImporter])
+@pytest.mark.parametrize("defect", ["check-true", "restrict-fk"])
+def test_ck_postgresql_malformed_constraints_fail_before_parent_mutation(
+    postgresql_db, importer_class, defect
+) -> None:
+    database, _ = postgresql_db
+    database.execute(SCHEMAS["NL_CK"])
+    database.execute(_weaken_ck_chaku_schema(defect))
+    database.execute(SCHEMAS["NL_CK_RUIKEI"])
+    database.execute(
+        "INSERT INTO NL_CK "
+        "(Year, MonthDay, JyoCD, Kaiji, Nichiji, RaceNum, KettoNum, Bamei) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+        (2025, 101, "05", 1, 1, 1, "2025000001", "preserve"),
+    )
+    database.commit()
+    with pytest.raises(SchemaMigrationError):
+        importer_class(database).import_records(iter([CKParser().parse(build_record()[0])]))
+    assert database.fetch_one(
+        'SELECT Bamei AS "Bamei", CKStorageVersion AS "CKStorageVersion" FROM NL_CK'
+    ) == {"Bamei": "preserve", "CKStorageVersion": None}

--- a/tests/test_current_record_validation.py
+++ b/tests/test_current_record_validation.py
@@ -27,7 +27,7 @@ PREVIOUS_OFFICIAL_LENGTHS = tuple(
 # These parsers also require populated domain-specific arrays or master fields.
 # Their valid payloads are covered by dedicated official-contract tests; this
 # module limits their positive case to the shared physical-record envelope.
-DOMAIN_PAYLOAD_REQUIRED = {"DM", "KS", "TK", "TM", "WH"}
+DOMAIN_PAYLOAD_REQUIRED = {"CK", "DM", "KS", "TK", "TM", "WH"}
 
 
 def test_declared_current_lengths_match_every_factory_parser():

--- a/tests/test_e2e_comprehensive.py
+++ b/tests/test_e2e_comprehensive.py
@@ -7,11 +7,11 @@ Tests data storage across:
 - PostgreSQL (if available)
 
 Schema Status:
-- Total defined: 78 tables (45 NL_* + 21 RT_* + 12 TS_*)
+- Total defined: 80 tables (47 NL_* + 21 RT_* + 12 TS_*)
 - All tables should be created successfully with the current schema
 
 Note: The schema has been fully implemented with proper SQL syntax.
-All 78 tables should create successfully across all database backends.
+All 80 tables should create successfully across all database backends.
 DuckDB is outside this project's supported database matrix.
 """
 

--- a/tests/test_e2e_comprehensive.py
+++ b/tests/test_e2e_comprehensive.py
@@ -47,9 +47,9 @@ class TestAllTablesCreation(unittest.TestCase):
         nl_tables = [name for name in SCHEMAS.keys() if name.startswith('NL_')]
         rt_tables = [name for name in SCHEMAS.keys() if name.startswith('RT_')]
 
-        self.assertEqual(len(nl_tables), 45, "Should have 45 NL_* tables")
+        self.assertEqual(len(nl_tables), 47, "Should have 47 NL_* tables")
         self.assertEqual(len(rt_tables), 21, "Should have 21 RT_* tables")
-        self.assertEqual(len(SCHEMAS), 78, "Should have 78 total tables")
+        self.assertEqual(len(SCHEMAS), 80, "Should have 80 total tables")
 
     def test_realtime_tables_subset(self):
         """Verify RT tables are only for real-time record types."""
@@ -83,7 +83,7 @@ class TestSQLiteAllTables(unittest.TestCase):
         self.temp_dir.cleanup()
 
     def test_create_all_nl_tables(self):
-        """Test creating NL_* tables (all 44 should succeed)."""
+        """Test creating NL_* tables (all 47 should succeed)."""
         nl_tables = [name for name in SCHEMAS.keys() if name.startswith('NL_')]
 
         created_count = 0
@@ -95,8 +95,8 @@ class TestSQLiteAllTables(unittest.TestCase):
             else:
                 failed_tables.append(table_name)
 
-        # All 45 NL tables should create successfully
-        self.assertEqual(created_count, 45, f"Should create all 45 NL_* tables, failed: {failed_tables}")
+        # All 47 NL tables should create successfully
+        self.assertEqual(created_count, 47, f"Should create all 47 NL_* tables, failed: {failed_tables}")
 
         # Verify all tables exist
         for table_name in nl_tables:
@@ -135,8 +135,8 @@ class TestSQLiteAllTables(unittest.TestCase):
         failed = sum(1 for success in results.values() if not success)
         failed_tables = [name for name, success in results.items() if not success]
 
-        # All 78 tables should create successfully (45 NL + 21 RT + 12 TS)
-        self.assertEqual(successful, 78, f"Should create all 78 tables, failed: {failed_tables}")
+        # All 80 tables should create successfully (47 NL + 21 RT + 12 TS)
+        self.assertEqual(successful, 80, f"Should create all 80 tables, failed: {failed_tables}")
         self.assertEqual(failed, 0, "Should have 0 failing tables")
 
         # Verify all tables exist

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -121,6 +121,24 @@ class TestIndividualParsers:
                     mutable[start : start + size] = b"0" * size
                 mutable[1015:4171] = b"0" * 3156
                 data = bytes(mutable)
+            if record_type == "CK":
+                mutable = bytearray(data)
+                mutable[11:15] = b"2024"
+                mutable[15:19] = b"0601"
+                mutable[19:21] = b"05"
+                mutable[21:23] = b"01"
+                mutable[23:25] = b"01"
+                mutable[25:27] = b"01"
+                mutable[27:37] = b"2024000001"
+                for start, end in (
+                    (73, 1384),
+                    (1423, 3863),
+                    (3902, 6342),
+                    (6476, 6596),
+                    (6748, 6868),
+                ):
+                    mutable[start:end] = b"0" * (end - start)
+                data = bytes(mutable)
             if record_type == "TK":
                 mutable = bytearray(data)
                 mutable[11:15] = b"2024"


### PR DESCRIPTION
## Summary

This PR completes native storage for the official current CK record layout.

- parses and validates the complete 6,870-byte / 1,729-leaf CK record
- preserves the existing `NL_CK` compatibility projection and adds normalized `NL_CK_CHAKU` (278 rows) and `NL_CK_RUIKEI` (8 rows)
- writes the parent and both child sets atomically for both importers, with an importer-owned completion marker
- applies official `DataKubun=0` exact-key deletion with FK cascade and preserves provider order
- rejects the previous 6,864-byte layout instead of guessing between layouts
- keeps standard-name CK storage explicitly fail-closed until its separate canonical schema iteration
- verifies exact child columns, keys, CHECK constraints, FK definitions, and active FK enforcement on SQLite and PostgreSQL
- documents the migration/reimport boundary; tracked `specs/` remains excluded from wheel and sdist

## Compatibility and migration

Existing `NL_CK` rows remain readable but have `CKStorageVersion=NULL`; they are not misrepresented as complete because the former projection did not retain 988 official leaves. A complete current-layout reimport is required before consumers rely on marker `1` plus 278/8 child cardinalities. Existing native owner/breeder column meanings and current parser value types are preserved.

This change does not make or imply a 64-bit SDK support claim.

## Red-first evidence

The grouped base contract failed `9` tests before implementation. Subsequent validator regressions were also demonstrated against the prior candidates before repair:

- SQLite FK enforcement disabled: `2 failed` (`DID NOT RAISE`)
- PostgreSQL computed/case-changed `ANY` members: `4 failed`
- PostgreSQL internal FK triggers disabled: `2 failed`
- PostgreSQL non-enforcing session trigger mode: `2 failed`

The final implementation rejects all of these before parent mutation and retains paired canonical positive cases.

## Exact candidate evidence

Candidate: `5c0d86c1b4097a5636ef3cd2960ff9891b2868f2`

- full local suite: `2431 passed, 112 skipped, 15 subtests passed`
- disposable PostgreSQL 16 CK contract: `65 passed`
- independent PostgreSQL all-table setup: `2 passed`
- repository test-gate validator: pass
- fatal Ruff, changed-file Ruff/Black, compileall, and `git diff --check`: pass
- strict MkDocs build: pass
- wheel and sdist build/content gate: pass; `specs/` and oracle inputs absent, new runtime module present
- retired audit documents absent and public-document disclosure scan: pass
- final worktree: clean; disposable PostgreSQL container removed

## Review

An independent Codex critical review first returned `NEEDS_CHANGES` with reproducible PostgreSQL constraint and FK-enforcement findings. After one aggregated red-first repair, the same reviewer rechecked the exact candidate SHA and returned `GREEN`: no correctness, data-integrity, or release blocker remained.

Thank you very much for reviewing this relatively large but intentionally self-contained data-integrity change. Please let me know if any evidence would be easier to inspect in a different form.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added complete support for current-format CK records.
  * CK data is now stored across dedicated parent and detail tables.
  * Added transactional import, update, deletion, and rollback handling.
  * Added validation for record structure, storage versions, keys, numeric values, and table relationships.
  * Added support across standard and optimized import workflows.

* **Documentation**
  * Documented CK format, storage behavior, validation rules, and unsupported legacy imports.

* **Tests**
  * Added comprehensive coverage for parsing, schema constraints, imports, deletions, and database compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->