### PR TITLE
Close migration test SQLite fixture deterministically

### DIFF
--- a/specs/operations/20260816_release_readiness_worklog.md
+++ b/specs/operations/20260816_release_readiness_worklog.md
@@ -1427,7 +1427,7 @@
   SQLite connection leak which makes the complete release suite fail
   nondeterministically under Python 3.13 warning enforcement. Repository:
   `miyamamoto/jrvltsql`; dedicated worktree:
-  `/home/keiba/scratch/20260817_jrvltsql_test_resource`; branch:
+  `$WORKSPACE/20260817_jrvltsql_test_resource`; branch:
   `agent/test-resource-cleanup-20260817`; base and initial HEAD:
   `1b66f45629b9ede51fc2f4415e688784b2f55a2c`.
 - The leak is independent of the in-progress BT standard-schema iteration and
@@ -1444,3 +1444,15 @@
   clean committed full SHA; then open and merge this prerequisite before
   rebasing the BT work. STOP if any resource warning remains, migration behavior
   changes, or the finalizer does not execute after a test assertion failure.
+- Clean code candidate `25c02ebcc233ba7e6d515f4d09649c487781d9d4`
+  passed the exact red-first HR-to-HY sequence with the ResourceWarning promoted
+  to an error (`25 passed, 1 skipped`) and the complete local suite (`2,431
+  passed, 112 skipped, 15 subtests passed`). Fatal lint, compileall, the
+  fail-closed test-gate validator, strict MkDocs, and `git diff --check` passed.
+- An independent Codex read-only review of the same exact candidate returned
+  GREEN with no P0/P1/P2 finding. It reproduced the parent leak, confirmed that
+  explicit close removes it, and deliberately failed the test body to prove the
+  registered finalizer runs exactly once even on failure. It found no warning
+  filter, exception suppression, forced collection, production-code change, or
+  migration behavior change. The final worklog-only commit will be recorded in
+  PR metadata rather than adding a self-referential SHA commit.

--- a/specs/operations/20260816_release_readiness_worklog.md
+++ b/specs/operations/20260816_release_readiness_worklog.md
@@ -1420,3 +1420,27 @@
   documentation and open-PR audit, actual fresh acquisition, and SQLite plus
   PostgreSQL persistence/readback gates are complete. No 64-bit SDK support
   claim is made without an installed-SDK end-to-end run.
+
+### 2026-08-17 — deterministic SQLite test cleanup iteration
+
+- Objective and minimum scope: repair one independently traced test-only
+  SQLite connection leak which makes the complete release suite fail
+  nondeterministically under Python 3.13 warning enforcement. Repository:
+  `miyamamoto/jrvltsql`; dedicated worktree:
+  `/home/keiba/scratch/20260817_jrvltsql_test_resource`; branch:
+  `agent/test-resource-cleanup-20260817`; base and initial HEAD:
+  `1b66f45629b9ede51fc2f4415e688784b2f55a2c`.
+- The leak is independent of the in-progress BT standard-schema iteration and
+  is therefore isolated in this smaller prerequisite PR. Claude Code first
+  identified `tests/test_hr_schema_migration.py` as the likely allocation;
+  Codex then reproduced it with tracemalloc. Running that test immediately
+  before the HY official contract with `-W error::ResourceWarning` failed in
+  HY while the allocation traceback pointed exactly to `_SqliteDB.__init__`
+  line 21. The complete BT candidate suite likewise failed once after 2,463
+  passes when the same connection was garbage-collected.
+- The minimal repair gives the test wrapper an explicit `close` method and
+  registers it immediately as a pytest finalizer. Next safe action: rerun the
+  same red command, the focused migration test, and the complete suite on a
+  clean committed full SHA; then open and merge this prerequisite before
+  rebasing the BT work. STOP if any resource warning remains, migration behavior
+  changes, or the finalizer does not execute after a test assertion failure.

--- a/tests/test_hr_schema_migration.py
+++ b/tests/test_hr_schema_migration.py
@@ -40,6 +40,9 @@ class _SqliteDB:
     def commit(self):
         self.conn.commit()
 
+    def close(self):
+        self.conn.close()
+
 
 def _old_nl_hr_schema() -> str:
     """numbered 列追加前の旧 NL_HR 定義 (1件目のみ) を再現。"""
@@ -65,8 +68,9 @@ def _old_nl_hr_schema() -> str:
     return "\n".join(lines)
 
 
-def test_numbered_payout_columns_added_by_migration(tmp_path):
+def test_numbered_payout_columns_added_by_migration(tmp_path, request):
     db = _SqliteDB(tmp_path / "old.db")
+    request.addfinalizer(db.close)
     db.execute(_old_nl_hr_schema())
     db.execute(
         "INSERT INTO NL_HR (Year, MonthDay, JyoCD, Kaiji, Nichiji, RaceNum, FukuUmaban, FukuPay)"


### PR DESCRIPTION
## Summary

- close the test-only SQLite migration wrapper through a pytest finalizer
- keep the existing migration assertions unchanged
- record red-first, full-suite, and independent-review evidence in the tracked release worklog

## Root cause

`tests/test_hr_schema_migration.py` created a raw SQLite connection without a deterministic close. Under Python 3.13, later garbage collection could surface an unclosed-database `ResourceWarning` in an unrelated test and make the full release suite nondeterministic.

## Impact

This changes test resource cleanup only. Production code and migration behavior are unchanged.

## Validation

Final head: `fc2b06c1beae190ee695b9e07b5e4708a618e4cc`

- red-first HR→HY sequence reproduced the warning and traced allocation to the test wrapper
- repaired HR→HY sequence with `ResourceWarning` promoted to error: 25 passed, 1 skipped
- complete local suite on code candidate `25c02ebcc233ba7e6d515f4d09649c487781d9d4`: 2,431 passed, 112 skipped, 15 subtests
- fail-closed test-gate validator: pass
- strict MkDocs: pass
- fatal lint, compileall, and diff check: pass
- independent Codex review of the exact code candidate: GREEN, including an intentional test-body failure proving the finalizer runs exactly once

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved test database cleanup to ensure SQLite connections are closed reliably, including when assertions fail.
  * Eliminated connection-leak warnings during migration test execution.

* **Tests**
  * Verified the updated cleanup behavior with warnings enabled.
  * Confirmed the complete test suite passes without changes to production or migration behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->