### PR TITLE
Preserve the official WC storage contract

### DIFF
--- a/docs/data_support.md
+++ b/docs/data_support.md
@@ -54,7 +54,7 @@ jrvltsql は JRA / 中央競馬専用です。NAR / 地方競馬はこのリポ�
 | `BLDN` | `BLOD` | 血統情報 | `HN`, `SK`, `BT` | `NL_HN`, `NL_SK`, `NL_BT` | はい | いいえ | はい | 旧名 `BLOD` は受け付けません（下記参照）。 |
 | `MING` | - | データマイニング予想 | `DM`, `TM` | `NL_DM`, `NL_TM` | はい | いいえ | はい | full quickstart に含めています。 |
 | `SLOP` | - | 坂路調教関連 | `HC` | `NL_HC` | はい | いいえ | はい | standard / full quickstart に含めています。 |
-| `WOOD` | - | ウッドチップ調教関連 | `WC` | `NL_WC` | はい | いいえ | はい | standard / full quickstart に含めています。 |
+| `WOOD` | - | ウッドチップ調教関連 | `WC` | `NL_WC`（native）、`WOOD`（標準名モード） | はい | いいえ | はい | 現行105バイトを全項目保存します。公式キーはトレセン区分・調教年月日・調教時刻・血統登録番号の4項目で、`0` は同じキーの削除です。standard / full quickstart に含めています。 |
 | `YSCH` | - | 開催スケジュール | `YS` | `NL_YS` | はい | いいえ | はい | 開催カレンダー保守に使います。 |
 | `HOSN` | `HOSE` | 競走馬市場取引価格 | `HS` | `NL_HS` | はい | いいえ | はい | 旧名 `HOSE` は受け付けません（下記参照）。 |
 | `HOYU` | - | 馬名の意味由来 | `HY` | `NL_HY` | はい | いいえ | はい | standard / full quickstart に含めています。 |
@@ -179,6 +179,17 @@ jrvltsql は現在、以下 38 種類の JRA レコード種別に対してパ�
 対応済みの速報系レコードは `RT_*` にも保存できます。公式時系列オッズは
 `TS_O1` / `TS_O2`、開催週速報オッズは `TS_SOKUHO_O1`〜`TS_SOKUHO_O6`
 に保存します。
+
+`WC`はJV-Data 4.9.0.1とSDK 5.0.0の105バイト配置を使用し、10ハロンから
+1ハロンまでの合計・ラップを保存します。4.7.0.1で追記されたのは美浦・栗東の
+提供開始時期と計測距離の説明であり、別の物理レイアウトではありません。
+`Course`（コース）や馬場周りは公式キーではありません。旧版jrvltsqlが作成した
+`Course`入り・トレセン区分なしの主キーは自動修復せず、取込前に拒否します。
+`WOOD`はデータ種別名とSDK構造に対応させたjrvltsqlの標準名モード上の
+canonical table名であり、提供元がSQL DDLやテーブル名を規定しているという意味ではありません。
+4項目キーは[JRA-VANソフトサポートの回答](https://developer.jra-van.jp/t/topic/99)とも一致します。
+タイムが全桁9のデータは規定内として配信されるため、欠損へ置換せず数値sentinelとして保存します
+（[スタッフ回答](https://developer.jra-van.jp/t/topic/367)）。
 
 `KS`は公式4173バイトを1物理レコードとして扱い、nativeでは`NL_KS`と
 `NL_KS_SEISEKI`、JRA-VAN標準名モードでは`KISYU`と`KISYU_SEISEKI`へ

--- a/specs/operations/20260816_release_readiness_worklog.md
+++ b/specs/operations/20260816_release_readiness_worklog.md
@@ -2074,3 +2074,30 @@
   configured GitHub-native review, and aggregate Actions/threads once. STOP on
   any production delta after the GREEN parent, remote-head mismatch, executed
   CI failure, or actionable unresolved review.
+- PR [#200](https://github.com/miyamamoto/jrvltsql/pull/200) was opened from
+  exact clean head `6f1e886b014f0fb1a150223d20029740901e1a68` with the official
+  workbook/SDK/community basis, all three red-first stages, PostgreSQL/full-
+  suite/distribution evidence, and explicit non-release/non-64-bit/fresh-
+  acquisition boundaries. Copilot was requested exactly once through the
+  documented GitHub API reviewer identity and reported quota exhaustion; it
+  will not be re-requested. Actions run `31977128107` completed `test`,
+  `windows-batch-syntax`, and `lint` successfully; only the branch-only
+  performance job was intentionally skipped. The lint job retains its known
+  advisory type-debt failure annotation (mypy 76 errors) plus the Node.js
+  20-to-24 deprecation warning, but its fatal syntax/undefined-name gate and all
+  executed jobs succeeded.
+- CodeRabbit completed with Minimal merge risk and a passing status. Its two
+  review-body-only nitpicks are non-blocking after independent assessment. The
+  obsolete-WOOD fixture fallback is used only to preserve the original
+  red-first setup; canonical schema presence and field/key completeness are
+  already direct earlier assertions, so deleting WOOD cannot make the suite
+  green. Narrowing only WC's outer `Exception` catch would diverge from the
+  shared fail-closed parser contract and the suggested text is internally
+  inconsistent about `KeyError`; changing that public error boundary belongs
+  in a separate cross-parser iteration, not this verified storage repair.
+  Thread-aware GraphQL reports zero unresolved review threads. Next safe
+  action: commit/push this worklog-only GitHub evidence, carry the GREEN verdict
+  forward, let required Actions complete once on the final head, then post a
+  polite final evidence comment and squash-merge #200. STOP on any non-worklog
+  delta, remote-head mismatch, executed CI failure, new actionable thread, or
+  loss of mergeability.

--- a/specs/operations/20260816_release_readiness_worklog.md
+++ b/specs/operations/20260816_release_readiness_worklog.md
@@ -1865,3 +1865,123 @@
   evidence, carry the reviewed production verdict forward, confirm the final
   Actions/head/thread gate once, then squash-merge PR #199. STOP on any
   non-worklog delta, failed executed job, actionable review, or head mismatch.
+- PR [#199](https://github.com/miyamamoto/jrvltsql/pull/199) passed its final
+  gate on exact head `9ab32b05a34a47c258e8b2c5bc18a0449897ab7d`.
+  GitHub Actions run `31973856450` completed `test`, `lint`, and
+  `windows-batch-syntax` successfully, with only the intentionally conditional
+  `performance-test` skipped. Thread-aware GraphQL returned zero unresolved
+  threads, the PR was `MERGEABLE` / `CLEAN`, and independent Codex
+  carry-forward review returned P0/P1/P2=0. The iteration was squash-merged as
+  `b4369f74d2ba236c8b33dbb1e45882ffa7c9aa0f`; the merged worktree and local
+  branch were removed. This is an iteration merge, not a repository release.
+- WC official-storage iteration started from current `origin/master` full SHA
+  `b4369f74d2ba236c8b33dbb1e45882ffa7c9aa0f`. Repository:
+  `miyamamoto/jrvltsql`; dedicated worktree:
+  `/home/keiba/scratch/20260817_jrvltsql_wc_standard`; branch:
+  `agent/wc-standard-storage-20260817`. Minimal scope is WC only: reconcile the
+  current 105-byte official/SDK layout, the historical 4.7.0.1 key correction,
+  native `NL_WC` and canonical `WOOD` ownership, status/delete semantics,
+  migration fail-closed behavior, tests, public support documentation, and the
+  official-history oracle. JG is already merged; WF remains a separate later
+  iteration. Dependency order remains jrvltsql specification/storage fixes,
+  final repository audit plus fresh provider acquisition/storage and release,
+  then jrvltsql-nar alignment/release, then jvlink-mcp-server alignment/release.
+  STOP if official sources do not establish the WC key/history, if the
+  canonical owner cannot losslessly store all fields, if a legacy mismatch is
+  mutated before rejection, or if a current PR already owns the same scope.
+- Implementation is assigned to Claude Code `2.1.233` with `--model fable`,
+  session `08bd10b4-8b1b-4e04-97df-2a55addde642`. Fable is selected because WC
+  changes an official-key/schema validator and ordered delete behavior in both
+  importers, where a partial repair can silently overwrite or erase the wrong
+  training record. The session must first preserve grouped red-first evidence
+  on this exact base, and any repair review in this worktree must resume the
+  same session. Codex remains responsible for official-source reconciliation,
+  test execution, independent critical review, GitHub gates, and merge.
+- Claude Code session `08bd10b4-8b1b-4e04-97df-2a55addde642` stopped before
+  reading or editing the candidate because its account session limit had been
+  reached (`resets 08:40 Asia/Tokyo`). The CLI also printed local permission-
+  rule syntax warnings, but no tool action or repository change occurred.
+  Per the operator-approved fallback, Codex will implement the same aggregate
+  red-first contract rather than waiting idle; Claude output is not counted as
+  review or implementation evidence for this iteration. Current dirty state is
+  still this worklog entry only. Next safe action: add the grouped WC contract,
+  run it on unchanged production code, and record the red result before any
+  source/schema change. STOP if the red probe does not expose the known key,
+  deletion, standard-owner, or validator gaps.
+- The grouped WC regression contract was added before any production/schema
+  change and executed on exact code base
+  `b4369f74d2ba236c8b33dbb1e45882ffa7c9aa0f` with
+  `python3 -m pytest -q tests/test_wc_official_contract.py --no-cov
+  --basetemp=/home/keiba/scratch/20260817_wc_red_pytest`. It produced the
+  required red evidence: `42 failed, 1 passed, 1 PostgreSQL opt-in skip`.
+  Failures independently exposed the generic parser raising or accepting
+  corrupt fields, DATE/delimiter representation drift, the wrong native key,
+  missing canonical `WOOD` schema, missing 4.7.0.1 documentation-history
+  entry, collapse across training centres, Course-driven duplication, status-0
+  tombstones, absent caller-dictionary validation, obsolete-schema mutation,
+  and single-record divergence. The sole green was the official delete body
+  remaining readable with its complete four-part key, proving the test fixture
+  itself can express the provider contract. Next safe action: implement the
+  bounded WC parser/storage/importer/history repair, then rerun this same
+  contract. STOP if a new rejector makes the official all-nine sentinel or a
+  nonblank status-0 body fail.
+- The bounded WC repair is implemented without touching another record type's
+  storage contract. `WCParser` now validates the exact 105-byte/type/CP932/CRLF
+  envelope, explicit status 0/1, four fixed-width key values, current code
+  domains, and all 19 status-1 timing fields while accepting official zero and
+  all-nine sentinels. Native `NL_WC` now uses the official four-part key;
+  canonical `WOOD` stores the SDK field names losslessly. Both importers and
+  the single-record path share a schema verifier and caller-dictionary
+  validator, reject native/canonical alias conflicts, and apply status 0 as an
+  exact provider-ordered delete. Existing wrong-key tables are rejected rather
+  than migrated. The 4.7.0.1 ledger entry is explicitly documentation-only,
+  and public support docs distinguish the project canonical table name from a
+  provider-prescribed SQL DDL.
+- Community evidence was rechecked rather than inferred from current data.
+  JRA-VAN software support explicitly confirms the four recommended WC key
+  fields and reports no observed same-key BabaAround variant in [topic
+  99](https://developer.jra-van.jp/t/topic/99). Staff also confirms that all-nine
+  lap/total values are provider-valid overflow measurement sentinels, not a
+  parse error, in [topic 367](https://developer.jra-van.jp/t/topic/367). A 2023
+  report of malformed course/hill/WC data was acknowledged and re-provided by
+  support in [topic 237](https://developer.jra-van.jp/t/topic/237); this supports
+  fail-closed field validation and reacquisition, not accepting malformed
+  values or changing the documented key. These links and the official workbook
+  rows are independent sources for the test contract.
+- The original grouped contract is now green: `43 passed, 1 PostgreSQL opt-in
+  skip`. Its first affected selection exposed four old generic fixture
+  failures: the shared length test and parser sample used blank WC keys and
+  payload despite the current official domain. Those fixtures were corrected
+  (or delegated to the dedicated official-contract positive) rather than
+  weakening the parser; the affected parser/schema/importer/oracle selection
+  then completed `763 passed, 1 skip`. A disposable PostgreSQL 16 container
+  completed the expanded contract `44 passed`, covering both importers,
+  native/canonical create/update/delete, the two-centre collision direction,
+  Course non-key updates, and wrong-key schema rejection with catalog and rows
+  unchanged. One initial PostgreSQL assertion failed only because unquoted
+  identifiers are returned lowercase; the query now uses an explicit lowercase
+  alias and the production path was unchanged. The disposable container was
+  stopped and removed. Next safe action: inspect the aggregate diff, run the
+  official/static/document gates and CI-equivalent full suite, then freeze one
+  candidate for independent exact-SHA review. STOP on any non-WC behavior
+  regression, ledger hash drift, PostgreSQL schema mutation, or stale container.
+- Pre-candidate gates are complete under Python 3.12.11. The CI-equivalent
+  suite completed `2553 passed, 109 skipped, 14 deselected, 15 subtests passed`
+  with coverage. The same interpreter and a fresh PostgreSQL 16 container
+  repeated the WC contract `44 passed`; the container was stopped and removed.
+  `TEST GATE PASS`, `OFFICIAL ORACLE PASS`, full fatal flake8, Black/Ruff for
+  the new WC parser/contract, compileall, `git diff --check`, and strict MkDocs
+  all pass. Fresh
+  sdist and wheel for package version 1.6.10 built successfully and the two-
+  artifact distribution-content gate passed, including exclusion of tracked
+  `specs/` from release artifacts. Setuptools emitted only its pre-existing
+  future license-metadata deprecation. The pinned official workbook hashes were
+  rechecked as `23bafd375f704acbdd696b5032ac1619f17d47e882587d6e7954b610527a8234`
+  (4.9.0.1) and
+  `6a567f10b601115eca350571f36d27d9d28bd2d3835ea72b5bc057711155d4a7`
+  (4.8.0.2). Changed scope is the WC parser, native/canonical schemas, shared
+  importer plus optimized wiring, WC tests and corrected generic fixtures,
+  official-history fixture/oracle, data-support docs, and this worklog. Next
+  safe action: commit one candidate, confirm exact SHA/clean state, then request
+  one independent Codex critical review of that immutable SHA. STOP on any
+  worktree drift, failed exact-SHA replay, or data-integrity finding.

--- a/specs/operations/20260816_release_readiness_worklog.md
+++ b/specs/operations/20260816_release_readiness_worklog.md
@@ -2060,3 +2060,17 @@
   unchanged, and request one final carry-forward review rather than restarting
   the full review loop. STOP on a non-test/non-worklog delta, false-green
   mutation probe, failed PostgreSQL path, or unresolved reviewer finding.
+- Final Codex carry-forward review of exact clean candidate
+  `b9a1335579652fd56b0a8d837692fc2485b61517` returned GREEN with
+  `P0=0 / P1=0 / P2=0`. It confirmed that the delta from the reviewed
+  production parent is only the official-contract test and this tracked
+  worklog; directly recomputed all 30 parser/alias/SDK tuples; exercised the
+  offset-drift negative; and independently passed WC focused `51 passed, 1
+  skip`, the broader WC/metadata/current-validation selection `182 passed, 5
+  skipped`, and fresh PostgreSQL 16 `52 passed`. SHA and worktree stayed clean
+  and the review container was removed. Next safe action: commit this
+  worklog-only verdict, verify the carry-forward delta, push the branch, open a
+  scoped PR with the exact candidate and red-first evidence, request the one
+  configured GitHub-native review, and aggregate Actions/threads once. STOP on
+  any production delta after the GREEN parent, remote-head mismatch, executed
+  CI failure, or actionable unresolved review.

--- a/specs/operations/20260816_release_readiness_worklog.md
+++ b/specs/operations/20260816_release_readiness_worklog.md
@@ -2031,3 +2031,32 @@
   CI-equivalent full suite, and resume the same Codex reviewer for one
   aggregated delta review. STOP on a failed full test, post-commit drift, or a
   remaining correctness/data-integrity finding.
+- Repaired candidate `56a86301a89cfe5382c1d5d4f167d0e744c79bb2` was clean and
+  completed the exact Python 3.12 CI-equivalent full suite: `2560 passed, 109
+  skipped, 14 deselected, 15 subtests passed` with coverage. Fresh wheel and
+  sdist 1.6.10 built successfully and the two-artifact distribution-content
+  gate passed, retaining the required exclusion of tracked `specs/` and oracle
+  materials. The only build output was the existing future setuptools license-
+  metadata deprecation. Open PR inspection still returned zero PRs.
+- The resumed Codex delta review of exact `56a86301...` closed both prior P1s
+  and the worklog correction, and found no new production correctness blocker,
+  but returned `P0=0 / P1=0 / P2=2` NEEDS_CHANGES for test-oracle gaps. It
+  independently demonstrated that swapping two equal-width production parser
+  offsets escaped the manifest test, and noted that all tracked status-0 bodies
+  were also valid status-1 bodies while official measurement-failure zero
+  values lacked storage readback. Before repairing the oracle, a minimal
+  monkeypatch regression on unchanged production produced the required red
+  result: `1 failed, 50 passed, 1 PostgreSQL opt-in skip`. The repaired test now
+  compares all 30 tuples from `WCParser()._fields`, after applying the
+  production WOOD alias map, directly with the compact pinned SDK structure;
+  the same injected offset drift must raise. Existing parameterized paths now
+  use a physically decodable but status-1-invalid status-0 body, include a
+  caller-built over-width body for exact delete, and read back first/middle/last
+  official zero measurements as `0.0`. Focused SQLite is `51 passed, 1 skip`
+  (`74 passed, 5 skipped` with metadata tests), and a fresh disposable
+  PostgreSQL 16 run is `52 passed`; the container was removed. Test gate,
+  official oracle, focused Black/Ruff, and `diff --check` pass. Next safe
+  action: commit this test/worklog-only delta, confirm the production parent is
+  unchanged, and request one final carry-forward review rather than restarting
+  the full review loop. STOP on a non-test/non-worklog delta, false-green
+  mutation probe, failed PostgreSQL path, or unresolved reviewer finding.

--- a/specs/operations/20260816_release_readiness_worklog.md
+++ b/specs/operations/20260816_release_readiness_worklog.md
@@ -1879,7 +1879,8 @@
   `miyamamoto/jrvltsql`; dedicated worktree:
   `/home/keiba/scratch/20260817_jrvltsql_wc_standard`; branch:
   `agent/wc-standard-storage-20260817`. Minimal scope is WC only: reconcile the
-  current 105-byte official/SDK layout, the historical 4.7.0.1 key correction,
+  current 105-byte official/SDK layout, the documentation-only 4.7.0.1
+  availability/measured-distance clarification,
   native `NL_WC` and canonical `WOOD` ownership, status/delete semantics,
   migration fail-closed behavior, tests, public support documentation, and the
   official-history oracle. JG is already merged; WF remains a separate later
@@ -1928,8 +1929,9 @@
 - The bounded WC repair is implemented without touching another record type's
   storage contract. `WCParser` now validates the exact 105-byte/type/CP932/CRLF
   envelope, explicit status 0/1, four fixed-width key values, current code
-  domains, and all 19 status-1 timing fields while accepting official zero and
-  all-nine sentinels. Native `NL_WC` now uses the official four-part key;
+  domains, and all 19 status-1 timing fields while accepting documented
+  zero-valued measurement fields and all-nine timing sentinels. Native `NL_WC`
+  now uses the official four-part key;
   canonical `WOOD` stores the SDK field names losslessly. Both importers and
   the single-record path share a schema verifier and caller-dictionary
   validator, reject native/canonical alias conflicts, and apply status 0 as an
@@ -1944,10 +1946,10 @@
   lap/total values are provider-valid overflow measurement sentinels, not a
   parse error, in [topic 367](https://developer.jra-van.jp/t/topic/367). A 2023
   report of malformed course/hill/WC data was acknowledged and re-provided by
-  support in [topic 237](https://developer.jra-van.jp/t/topic/237); this supports
-  fail-closed field validation and reacquisition, not accepting malformed
-  values or changing the documented key. These links and the official workbook
-  rows are independent sources for the test contract.
+  support in [topic 237](https://developer.jra-van.jp/t/topic/237); this is the
+  basis for adding semantic date/time rejection and reacquisition rather than
+  accepting malformed values or changing the documented key. These links and
+  the official workbook rows are independent sources for the test contract.
 - The original grouped contract is now green: `43 passed, 1 PostgreSQL opt-in
   skip`. Its first affected selection exposed four old generic fixture
   failures: the shared length test and parser sample used blank WC keys and
@@ -1985,3 +1987,47 @@
   safe action: commit one candidate, confirm exact SHA/clean state, then request
   one independent Codex critical review of that immutable SHA. STOP on any
   worktree drift, failed exact-SHA replay, or data-integrity finding.
+- Exact candidate `4be96d1f3ad1f88c47894c7337ee7dcd28f094d8` was clean and
+  completed an exact-SHA no-coverage full replay (`2553 passed, 109 skipped,
+  14 deselected, 15 subtests passed`) plus a fresh disposable PostgreSQL 16 WC
+  contract (`44 passed`). Independent Codex critical review then returned
+  `P0=0 / P1=2 / P2=2` and NEEDS_CHANGES. The two P1 findings were semantic
+  fail-open acceptance of impossible Gregorian dates, invalid HHMM values such
+  as the provider-confirmed bad `1160`, and over-width caller `reserved`
+  values; and stale Japanese-name `NL_WC` metadata whose physical-column
+  intersection was zero. The P2 findings were lack of a tracked-manifest bind
+  for all WC fields/aliases and the earlier worklog's incorrect description of
+  4.7.0.1 as a key change. No release or fresh-provider claim was made, and the
+  review did not use a 64-bit SDK runtime. The Claude Fable session remains
+  quota-blocked, so this aggregated repair continues under the operator-
+  approved Codex fallback.
+- Before changing production code, the grouped WC contract was extended on
+  exact candidate `4be96d1f3ad1f88c47894c7337ee7dcd28f094d8` and produced the
+  required red result: `14 failed, 36 passed, 1 PostgreSQL opt-in skip`.
+  Failures covered parser calendar/HHMM semantics, both batch importers and
+  native/canonical caller dictionaries, `DataImporter.import_single_record`,
+  over-width/CP932-multibyte `reserved`, and exact metadata column/key drift.
+  The paired valid leap-day/midnight case, all-nine timing payload, blank
+  reserved field, and nonblank status-0 body remained green. The test now also
+  binds all 30 logical parser fields and every WOOD alias to the pinned SDK
+  5.0.0 manifest. The bounded repair shares Gregorian/HHMM/CP932-width helpers
+  between parser and importer validation, keeps status-0 body opaque, and
+  derives `NL_WC` metadata from the executable schema. The same contract is
+  now green (`50 passed, 1 PostgreSQL opt-in skip`). Next safe action: run the
+  affected SQLite/metadata/oracle selection, repeat the real PostgreSQL WC and
+  metadata application paths, then freeze a repaired exact SHA for one
+  aggregated delta review. STOP if any valid official zero/all-nine payload is
+  rejected, metadata application fails, a wrong schema or row mutates, or a
+  non-WC regression appears.
+- The repaired affected selection completed `556 passed, 5 skipped`. A fresh
+  disposable PostgreSQL 16 instance then completed the expanded WC contract
+  `51 passed`, including both importers/native/canonical storage and actual
+  `COMMENT ON COLUMN` metadata application; the container was stopped and
+  removed. `TEST GATE PASS`, `OFFICIAL ORACLE PASS`, compileall, fatal flake8,
+  focused Black/Ruff, strict MkDocs, and `git diff --check` also pass. Full-file
+  Black/Ruff still report the repository's pre-existing formatting/typing debt
+  in `importer.py` and `schema_metadata.py`; no unrelated mechanical rewrite
+  was made. Next safe action: commit the repaired candidate, run one exact-SHA
+  CI-equivalent full suite, and resume the same Codex reviewer for one
+  aggregated delta review. STOP on a failed full test, post-commit drift, or a
+  remaining correctness/data-integrity finding.

--- a/src/database/schema.py
+++ b/src/database/schema.py
@@ -82,7 +82,7 @@ Scratch/Exclusion Tables:
     NL_AV, RT_AV: PRIMARY KEY (Year, MonthDay, JyoCD, Kaiji, Nichiji, RaceNum, Umaban)
 
 Workout/Training Tables:
-    NL_WC: PRIMARY KEY (ChokyoDate, ChokyoTime, KettoNum, Course)
+    NL_WC: PRIMARY KEY (TresenKubun, ChokyoDate, ChokyoTime, KettoNum)
 
 Horse Name Table:
     NL_HY: PRIMARY KEY (KettoNum)
@@ -1464,7 +1464,7 @@ SCHEMAS = {
             LapTime_400M_200M REAL,
             LapTime_200M_0M REAL,
             RecordDelimiter TEXT,
-            PRIMARY KEY (ChokyoDate, ChokyoTime, KettoNum, Course)
+            PRIMARY KEY (TresenKubun, ChokyoDate, ChokyoTime, KettoNum)
         )
     """,
 

--- a/src/database/schema_jravan.py
+++ b/src/database/schema_jravan.py
@@ -210,6 +210,40 @@ JRAVAN_SCHEMAS: Dict[str, str] = {
             LapTime1                       DECIMAL(4,1)          -- ラップタイム1(秒)
         )
     """,
+    "WOOD": """
+        CREATE TABLE IF NOT EXISTS WOOD (
+            RecordSpec                     CHAR(2)             ,  -- レコード種別ID
+            DataKubun                      CHAR(1)             ,  -- 0:削除 1:初期値
+            MakeDate                       DATE                ,  -- データ作成年月日
+            TresenKubun                    CHAR(1)             ,  -- 0:美浦 1:栗東
+            ChokyoDate                     VARCHAR(8)          ,  -- 調教年月日
+            ChokyoTime                     VARCHAR(4)          ,  -- 調教時刻
+            KettoNum                       VARCHAR(10)         ,  -- 血統登録番号
+            Course                         CHAR(1)             ,  -- 0:A 1:B 2:C 3:D 4:E
+            BabaAround                     CHAR(1)             ,  -- 0:右 1:左
+            reserved                       CHAR(1)             ,  -- 予備
+            HaronTime10                    DECIMAL(4,1)        ,
+            LapTime10                      DECIMAL(3,1)        ,
+            HaronTime9                     DECIMAL(4,1)        ,
+            LapTime9                       DECIMAL(3,1)        ,
+            HaronTime8                     DECIMAL(4,1)        ,
+            LapTime8                       DECIMAL(3,1)        ,
+            HaronTime7                     DECIMAL(4,1)        ,
+            LapTime7                       DECIMAL(3,1)        ,
+            HaronTime6                     DECIMAL(4,1)        ,
+            LapTime6                       DECIMAL(3,1)        ,
+            HaronTime5                     DECIMAL(4,1)        ,
+            LapTime5                       DECIMAL(3,1)        ,
+            HaronTime4                     DECIMAL(4,1)        ,
+            LapTime4                       DECIMAL(3,1)        ,
+            HaronTime3                     DECIMAL(4,1)        ,
+            LapTime3                       DECIMAL(3,1)        ,
+            HaronTime2                     DECIMAL(4,1)        ,
+            LapTime2                       DECIMAL(3,1)        ,
+            LapTime1                       DECIMAL(3,1)        ,
+            PRIMARY KEY (TresenKubun, ChokyoDate, ChokyoTime, KettoNum)
+        )
+    """,
     "HANSYOKU": """
         CREATE TABLE IF NOT EXISTS HANSYOKU (
             RecordSpec                     CHAR(2)             ,  -- レコード種別ID

--- a/src/database/schema_metadata.py
+++ b/src/database/schema_metadata.py
@@ -1165,24 +1165,16 @@ TABLE_METADATA: Dict[str, TableMetadata] = {
         "indexes": ["開催年月日"]
     },
 
-    "NL_WC": {
-        "table_name": "NL_WC",
-        "record_type": "WC",
-        "description": "調教詳細タイム情報",
-        "purpose": "調教時の詳細ラップタイム（200m刻み）を格納",
-        "columns": [
-            {"name": "レコード種別ID", "type": "TEXT", "description": "レコード種別識別子（'WC'）", "example": "WC", "nullable": False},
-            {"name": "トレセン区分", "type": "TEXT", "description": "トレーニングセンター", "example": "1", "nullable": False},
-            {"name": "調教年月日", "type": "TEXT", "description": "調教実施日", "example": "20240525", "nullable": False},
-            {"name": "調教時刻", "type": "TEXT", "description": "調教実施時刻", "example": "0630", "nullable": False},
-            {"name": "血統登録番号", "type": "TEXT", "description": "馬の血統登録番号", "example": "2020123456", "nullable": False},
-            {"name": "2000M通過タイム", "type": "TEXT", "description": "2000m地点通過タイム", "example": "120.5", "nullable": True},
-            {"name": "1800M通過タイム", "type": "TEXT", "description": "1800m地点通過タイム", "example": "108.2", "nullable": True},
-            {"name": "200M通過タイム", "type": "TEXT", "description": "200m地点通過タイム", "example": "12.1", "nullable": True}
-        ],
-        "primary_key": ["トレセン区分", "調教年月日", "調教時刻", "血統登録番号"],
-        "indexes": ["血統登録番号", "調教年月日"]
-    },
+    "NL_WC": _schema_backed_metadata(
+        "NL_WC",
+        record_type="WC",
+        description="ウッドチップ調教詳細タイム情報",
+        purpose=(
+            "トレセン・調教日時・血統登録番号を公式キーとして、200m刻みの"
+            "全ラップタイムを格納"
+        ),
+        indexes=["KettoNum", "ChokyoDate"],
+    ),
 
     "NL_WF": {
         "table_name": "NL_WF",

--- a/src/importer/importer.py
+++ b/src/importer/importer.py
@@ -161,6 +161,28 @@ _STANDARD_FIELD_ALIASES = {
         "SyussoKubun": "ShussoKubun",
         "JyogaiStateKubun": "JogaiJotaiKubun",
     },
+    "WOOD": {
+        "BabaMawari": "BabaAround",
+        "HaronTime10Total": "HaronTime10",
+        "LapTime_2000M_1800M": "LapTime10",
+        "HaronTime9Total": "HaronTime9",
+        "LapTime_1800M_1600M": "LapTime9",
+        "HaronTime8Total": "HaronTime8",
+        "LapTime_1600M_1400M": "LapTime8",
+        "HaronTime7Total": "HaronTime7",
+        "LapTime_1400M_1200M": "LapTime7",
+        "HaronTime6Total": "HaronTime6",
+        "LapTime_1200M_1000M": "LapTime6",
+        "HaronTime5Total": "HaronTime5",
+        "LapTime_1000M_800M": "LapTime5",
+        "HaronTime4Total": "HaronTime4",
+        "LapTime_800M_600M": "LapTime4",
+        "HaronTime3Total": "HaronTime3",
+        "LapTime_600M_400M": "LapTime3",
+        "HaronTime2Total": "HaronTime2",
+        "LapTime_400M_200M": "LapTime2",
+        "LapTime_200M_0M": "LapTime1",
+    },
     "TOKU_RACE": {
         "RaceRyakusyo10": "Ryakusyo10",
         "RaceRyakusyo6": "Ryakusyo6",
@@ -223,7 +245,9 @@ _JG_KEY_COLUMNS = (
     "KettoNum",
     "Num",
 )
-_STRICT_NONADDITIVE_STANDARD_TABLES = frozenset({"KEITO", "JOGAIBA"})
+_WC_STORAGE_TABLES = frozenset({"NL_WC", "WOOD"})
+_WC_KEY_COLUMNS = ("TresenKubun", "ChokyoDate", "ChokyoTime", "KettoNum")
+_STRICT_NONADDITIVE_STANDARD_TABLES = frozenset({"KEITO", "JOGAIBA", "WOOD"})
 _LEGACY_STANDARD_PREFLIGHT_NATIVE_TABLES = (
     "NL_BT",
     "NL_JG",
@@ -358,6 +382,89 @@ def validate_jg_record(record: dict, table_name: str) -> bool:
         raise SchemaMigrationError(
             f"JG record JyogaiStateKubun has unsupported code: {jyogai!r}"
         )
+    return True
+
+
+def verify_wc_storage_schema(database: BaseDatabase, table_name: str) -> bool:
+    """Fail closed unless WC storage preserves every field and official key."""
+    if table_name not in _WC_STORAGE_TABLES:
+        return False
+
+    from src.database.migration import verify_table_schema
+    from src.database.schema import SCHEMAS
+    from src.database.schema_jravan import JRAVAN_SCHEMAS
+
+    schema_sql = SCHEMAS.get(table_name) or JRAVAN_SCHEMAS.get(table_name)
+    if schema_sql is None:
+        raise SchemaMigrationError(f"WC storage schema is undefined: {table_name}")
+    verify_table_schema(database, table_name, schema_sql)
+    return True
+
+
+def validate_wc_record(record: dict, table_name: str) -> bool:
+    """Revalidate a caller-built WC row before any insert, update, or delete."""
+    if table_name not in _WC_STORAGE_TABLES:
+        return False
+    if _record_type_from_record(record) != "WC":
+        raise SchemaMigrationError(f"{table_name} received a non-WC record")
+
+    from src.parser.wc_parser import WCParser
+
+    if record.get("DataKubun") in (None, "") and record.get("headDataKubun") in (
+        None,
+        "",
+    ):
+        raise SchemaMigrationError("WC DataKubun is required")
+    try:
+        data_kubun = resolve_record_data_kubun(record)
+    except ValueError as error:
+        raise SchemaMigrationError(str(error)) from error
+    if data_kubun not in WCParser.DATA_KUBUN_VALUES:
+        raise SchemaMigrationError(f"WC record has unsupported DataKubun: {data_kubun!r}")
+
+    aliases = _STANDARD_FIELD_ALIASES.get(table_name, {})
+    conflicts = [
+        (native_name, standard_name)
+        for native_name, standard_name in aliases.items()
+        if native_name in record
+        and standard_name in record
+        and record[native_name] != record[standard_name]
+    ]
+    if conflicts:
+        raise SchemaMigrationError(f"conflicting WC alias values: {conflicts}")
+
+    def value_for(native_name: str):
+        if native_name in record:
+            return record[native_name]
+        return record.get(aliases.get(native_name, native_name))
+
+    def require_digits(name: str, width: int) -> None:
+        value = value_for(name)
+        if (
+            not isinstance(value, str)
+            or len(value) != width
+            or not value.isascii()
+            or not value.isdigit()
+        ):
+            raise SchemaMigrationError(
+                f"WC record {name} must be exactly {width} ASCII digits"
+            )
+
+    for field_name, width in WCParser.KEY_FIXED_FIELDS:
+        require_digits(field_name, width)
+    if value_for("TresenKubun") not in WCParser.TRESEN_KUBUN_VALUES:
+        raise SchemaMigrationError("WC record TresenKubun must be 0 or 1")
+
+    # DataKubun=0 is a keyed command; the provider does not define a blank-body
+    # requirement. Status 1 owns the payload and therefore validates all codes
+    # and every fixed-width timing value.
+    if data_kubun == "1":
+        if value_for("Course") not in WCParser.COURSE_VALUES:
+            raise SchemaMigrationError("WC record Course must be in 0..4")
+        if value_for("BabaMawari") not in WCParser.BABA_MAWARI_VALUES:
+            raise SchemaMigrationError("WC record BabaMawari must be 0 or 1")
+        for field_name, width in WCParser.TIME_FIXED_FIELDS:
+            require_digits(field_name, width)
     return True
 
 
@@ -877,6 +984,7 @@ _OFFICIAL_ERASE_KEY_COLUMNS = {
     "HY": ("KettoNum",),
     "BT": ("HansyokuNum",),
     "JG": _JG_KEY_COLUMNS,
+    "WC": _WC_KEY_COLUMNS,
 }
 
 _OFFICIAL_ERASE_STORAGE_TABLES = {
@@ -895,6 +1003,7 @@ _OFFICIAL_ERASE_STORAGE_TABLES = {
     "HY": {"NL_HY", "BAMEIORIGIN"},
     "BT": {"NL_BT", "KEITO"},
     "JG": {"NL_JG", "JOGAIBA"},
+    "WC": {"NL_WC", "WOOD"},
 }
 
 _STANDARD_ODDS_RACE_KEY_COLUMNS = _MINING_RACE_KEY_COLUMNS
@@ -3509,6 +3618,7 @@ class DataImporter:
         self._verified_hy_tables: set[str] = set()
         self._verified_bt_tables: set[str] = set()
         self._verified_jg_tables: set[str] = set()
+        self._verified_wc_tables: set[str] = set()
         self._verified_ck_child_tables: dict[str, tuple[str, str]] = {}
         self._verified_rc_tables: set[str] = set()
         self._verified_ys_tables: set[str] = set()
@@ -3775,6 +3885,10 @@ class DataImporter:
                     if verify_jg_storage_schema(self.database, table_name):
                         self._verified_jg_tables.add(table_name)
                 validate_jg_record(record, table_name)
+                if table_name not in self._verified_wc_tables:
+                    if verify_wc_storage_schema(self.database, table_name):
+                        self._verified_wc_tables.add(table_name)
+                validate_wc_record(record, table_name)
 
                 if table_name not in self._verified_mining_native_tables:
                     if verify_mining_native_schema(self.database, record, table_name):
@@ -4324,6 +4438,10 @@ class DataImporter:
                 if verify_jg_storage_schema(self.database, table_name):
                     self._verified_jg_tables.add(table_name)
             validate_jg_record(record, table_name)
+            if table_name not in self._verified_wc_tables:
+                if verify_wc_storage_schema(self.database, table_name):
+                    self._verified_wc_tables.add(table_name)
+            validate_wc_record(record, table_name)
             if table_name not in self._verified_rc_tables:
                 if verify_rc_storage_schema(self.database, table_name):
                     self._verified_rc_tables.add(table_name)

--- a/src/importer/importer.py
+++ b/src/importer/importer.py
@@ -452,6 +452,12 @@ def validate_wc_record(record: dict, table_name: str) -> bool:
 
     for field_name, width in WCParser.KEY_FIXED_FIELDS:
         require_digits(field_name, width)
+    try:
+        WCParser._require_yyyymmdd("MakeDate", value_for("MakeDate"))
+        WCParser._require_yyyymmdd("ChokyoDate", value_for("ChokyoDate"))
+        WCParser._require_hhmm("ChokyoTime", value_for("ChokyoTime"))
+    except ValueError as error:
+        raise SchemaMigrationError(str(error)) from error
     if value_for("TresenKubun") not in WCParser.TRESEN_KUBUN_VALUES:
         raise SchemaMigrationError("WC record TresenKubun must be 0 or 1")
 
@@ -463,6 +469,10 @@ def validate_wc_record(record: dict, table_name: str) -> bool:
             raise SchemaMigrationError("WC record Course must be in 0..4")
         if value_for("BabaMawari") not in WCParser.BABA_MAWARI_VALUES:
             raise SchemaMigrationError("WC record BabaMawari must be 0 or 1")
+        try:
+            WCParser._require_cp932_width("reserved", value_for("reserved"), 1)
+        except ValueError as error:
+            raise SchemaMigrationError(str(error)) from error
         for field_name, width in WCParser.TIME_FIXED_FIELDS:
             require_digits(field_name, width)
     return True

--- a/src/importer/importer_optimized.py
+++ b/src/importer/importer_optimized.py
@@ -55,6 +55,7 @@ from src.importer.importer import (
     resolve_standard_storage_table_name,
     resolve_standard_table_name,
     validate_jg_record,
+    validate_wc_record,
     verify_bt_storage_schema,
     verify_ch_coupled_table,
     verify_ck_coupled_tables,
@@ -64,6 +65,7 @@ from src.importer.importer import (
     verify_mining_native_schema,
     verify_rc_storage_schema,
     verify_tk_coupled_tables,
+    verify_wc_storage_schema,
     verify_ys_storage_schema,
 )
 from src.utils.logger import get_logger
@@ -103,6 +105,7 @@ class OptimizedDataImporter:
         self._verified_hy_tables: set[str] = set()
         self._verified_bt_tables: set[str] = set()
         self._verified_jg_tables: set[str] = set()
+        self._verified_wc_tables: set[str] = set()
         self._verified_ck_child_tables: dict[str, tuple[str, str]] = {}
         self._verified_rc_tables: set[str] = set()
         self._verified_ys_tables: set[str] = set()
@@ -327,6 +330,10 @@ class OptimizedDataImporter:
                     if verify_jg_storage_schema(self.database, table_name):
                         self._verified_jg_tables.add(table_name)
                 validate_jg_record(record, table_name)
+                if table_name not in self._verified_wc_tables:
+                    if verify_wc_storage_schema(self.database, table_name):
+                        self._verified_wc_tables.add(table_name)
+                validate_wc_record(record, table_name)
 
                 if table_name not in self._verified_rc_tables:
                     if verify_rc_storage_schema(self.database, table_name):

--- a/src/parser/wc_parser.py
+++ b/src/parser/wc_parser.py
@@ -1,24 +1,93 @@
-"""Parser for WC record - JRA-VAN Standard compliant.
+"""Parser for the official current 105-byte WC woodchip-training record.
 
-This parser uses JRA-VAN standard field names and type conversions.
-Auto-generated from jv_data_formats.json.
+The layout is pinned to JV-Data 4.9.0.1 and SDK 5.0.0 ``JV_WC_WOOD``.
+JV-Data 4.7.0.1 added availability notes but did not change this layout.
 """
 
-from typing import List
-
 from src.parser.base import BaseParser, FieldDef
+from src.utils.logger import get_logger
+
+logger = get_logger(__name__)
 
 
 class WCParser(BaseParser):
-    """Parser for WC record with JRA-VAN standard schema.
-
-    Uses English/Romanized field names matching JRA-VAN standard database.
-    """
+    """Parse every field and reject malformed current WC physical records."""
 
     record_type = "WC"
     RECORD_LENGTH = 105
+    DATA_KUBUN_VALUES = frozenset({"0", "1"})
+    TRESEN_KUBUN_VALUES = frozenset({"0", "1"})
+    COURSE_VALUES = frozenset({"0", "1", "2", "3", "4"})
+    BABA_MAWARI_VALUES = frozenset({"0", "1"})
+    KEY_FIXED_FIELDS = (
+        ("MakeDate", 8),
+        ("ChokyoDate", 8),
+        ("ChokyoTime", 4),
+        ("KettoNum", 10),
+    )
+    TIME_FIXED_FIELDS = (
+        ("HaronTime10Total", 4),
+        ("LapTime_2000M_1800M", 3),
+        ("HaronTime9Total", 4),
+        ("LapTime_1800M_1600M", 3),
+        ("HaronTime8Total", 4),
+        ("LapTime_1600M_1400M", 3),
+        ("HaronTime7Total", 4),
+        ("LapTime_1400M_1200M", 3),
+        ("HaronTime6Total", 4),
+        ("LapTime_1200M_1000M", 3),
+        ("HaronTime5Total", 4),
+        ("LapTime_1000M_800M", 3),
+        ("HaronTime4Total", 4),
+        ("LapTime_800M_600M", 3),
+        ("HaronTime3Total", 4),
+        ("LapTime_600M_400M", 3),
+        ("HaronTime2Total", 4),
+        ("LapTime_400M_200M", 3),
+        ("LapTime_200M_0M", 3),
+    )
 
-    def _define_fields(self) -> List[FieldDef]:
+    @staticmethod
+    def _require_ascii_digits(name: str, value: object, width: int) -> None:
+        if (
+            not isinstance(value, str)
+            or len(value) != width
+            or not value.isascii()
+            or not value.isdigit()
+        ):
+            raise ValueError(f"WC {name} must be exactly {width} ASCII digits")
+
+    def parse(self, record: bytes) -> dict[str, str] | None:
+        """Return a validated current WC row, or ``None`` for invalid input."""
+        try:
+            result = super().parse(record)
+            # CRLF is a structural field. BaseParser strips it to None after the
+            # fixed-record validator has already proved the exact bytes.
+            result["RecordDelimiter"] = ""
+            data_kubun = result["DataKubun"]
+            if data_kubun not in self.DATA_KUBUN_VALUES:
+                raise ValueError("WC DataKubun must be 0 or 1")
+            for name, width in self.KEY_FIXED_FIELDS:
+                self._require_ascii_digits(name, result[name], width)
+            if result["TresenKubun"] not in self.TRESEN_KUBUN_VALUES:
+                raise ValueError("WC TresenKubun must be 0 or 1")
+
+            # A status-0 row is an exact-key delete instruction. The provider
+            # does not require its unused body to be blank, so do not interpret
+            # or reject that body beyond the physical CP932/CRLF boundary.
+            if data_kubun == "1":
+                if result["Course"] not in self.COURSE_VALUES:
+                    raise ValueError("WC Course must be in 0..4")
+                if result["BabaMawari"] not in self.BABA_MAWARI_VALUES:
+                    raise ValueError("WC BabaMawari must be 0 or 1")
+                for name, width in self.TIME_FIXED_FIELDS:
+                    self._require_ascii_digits(name, result[name], width)
+            return result
+        except Exception as error:
+            logger.error(f"WC record parse failed: {error}")
+            return None
+
+    def _define_fields(self) -> list[FieldDef]:
         """Define field positions with JRA-VAN standard names and types.
 
         Returns:
@@ -27,7 +96,7 @@ class WCParser(BaseParser):
         return [
             FieldDef("RecordSpec", 0, 2, description="レコード種別ID"),
             FieldDef("DataKubun", 2, 1, description="データ区分"),
-            FieldDef("MakeDate", 3, 8, convert_type="DATE", description="データ作成年月日"),
+            FieldDef("MakeDate", 3, 8, description="データ作成年月日"),
             FieldDef("TresenKubun", 11, 1, description="トレセン区分"),
             FieldDef("ChokyoDate", 12, 8, description="調教年月日"),
             FieldDef("ChokyoTime", 20, 4, description="調教時刻"),

--- a/src/parser/wc_parser.py
+++ b/src/parser/wc_parser.py
@@ -4,6 +4,8 @@ The layout is pinned to JV-Data 4.9.0.1 and SDK 5.0.0 ``JV_WC_WOOD``.
 JV-Data 4.7.0.1 added availability notes but did not change this layout.
 """
 
+from datetime import date, time
+
 from src.parser.base import BaseParser, FieldDef
 from src.utils.logger import get_logger
 
@@ -57,6 +59,40 @@ class WCParser(BaseParser):
         ):
             raise ValueError(f"WC {name} must be exactly {width} ASCII digits")
 
+    @classmethod
+    def _require_yyyymmdd(cls, name: str, value: object) -> None:
+        """Require an actual Gregorian date, not merely eight digits."""
+        cls._require_ascii_digits(name, value, 8)
+        assert isinstance(value, str)
+        try:
+            date(int(value[:4]), int(value[4:6]), int(value[6:8]))
+        except ValueError as error:
+            raise ValueError(f"WC {name} must be a real yyyymmdd date") from error
+
+    @classmethod
+    def _require_hhmm(cls, name: str, value: object) -> None:
+        """Require a real 24-hour time; payload all-nine rules do not apply."""
+        cls._require_ascii_digits(name, value, 4)
+        assert isinstance(value, str)
+        try:
+            time(int(value[:2]), int(value[2:4]))
+        except ValueError as error:
+            raise ValueError(f"WC {name} must be a real HHMM time") from error
+
+    @staticmethod
+    def _require_cp932_width(name: str, value: object, width: int) -> None:
+        """Require an optional caller value to fit its physical CP932 field."""
+        if value in (None, ""):
+            return
+        if not isinstance(value, str):
+            raise ValueError(f"WC {name} must be text or blank")
+        try:
+            encoded = value.encode("cp932", errors="strict")
+        except UnicodeEncodeError as error:
+            raise ValueError(f"WC {name} must be valid CP932 text") from error
+        if len(encoded) > width:
+            raise ValueError(f"WC {name} must fit in {width} CP932 byte(s)")
+
     def parse(self, record: bytes) -> dict[str, str] | None:
         """Return a validated current WC row, or ``None`` for invalid input."""
         try:
@@ -69,6 +105,9 @@ class WCParser(BaseParser):
                 raise ValueError("WC DataKubun must be 0 or 1")
             for name, width in self.KEY_FIXED_FIELDS:
                 self._require_ascii_digits(name, result[name], width)
+            self._require_yyyymmdd("MakeDate", result["MakeDate"])
+            self._require_yyyymmdd("ChokyoDate", result["ChokyoDate"])
+            self._require_hhmm("ChokyoTime", result["ChokyoTime"])
             if result["TresenKubun"] not in self.TRESEN_KUBUN_VALUES:
                 raise ValueError("WC TresenKubun must be 0 or 1")
 
@@ -80,6 +119,7 @@ class WCParser(BaseParser):
                     raise ValueError("WC Course must be in 0..4")
                 if result["BabaMawari"] not in self.BABA_MAWARI_VALUES:
                     raise ValueError("WC BabaMawari must be 0 or 1")
+                self._require_cp932_width("reserved", result["reserved"], 1)
                 for name, width in self.TIME_FIXED_FIELDS:
                     self._require_ascii_digits(name, result[name], width)
             return result

--- a/tests/fixtures/official_layout/jvdata_layout_history.json
+++ b/tests/fixtures/official_layout/jvdata_layout_history.json
@@ -155,6 +155,17 @@
       "provenance_required": false,
       "reason": "Ver.4.1.1 only appended the initial value 0 for item 10 KettoNum. The 80-byte layout introduced in Ver.4.1.0 is unchanged, so no distinct pre-change byte layout is documented or recorded.",
       "source": "JV-Data4901.xlsx:変更履歴:110"
+    },
+    {
+      "record_type": "WC",
+      "announced_date": "2022-02-22",
+      "official_spec_version": "4.7.0.1",
+      "length_unchanged": true,
+      "layout_unchanged": true,
+      "change_kind": "availability_documentation_clarification",
+      "provenance_required": false,
+      "reason": "The specification added availability and measured-distance notes for Miho/Ritto woodchip training without changing the 105-byte layout.",
+      "source": "JV-Data4901.xlsx:変更履歴:56;特記事項:237-240"
     }
   ]
 }

--- a/tests/test_current_record_validation.py
+++ b/tests/test_current_record_validation.py
@@ -27,9 +27,9 @@ PREVIOUS_OFFICIAL_LENGTHS = tuple(
 # These parsers also require populated domain-specific arrays or master fields.
 # Their valid payloads are covered by dedicated official-contract tests; this
 # module limits their positive case to the shared physical-record envelope.
-# JG additionally requires its numeric eight-part official key (KettoNum and
-# ShutsubaTohyoJun) and current status codes.
-DOMAIN_PAYLOAD_REQUIRED = {"CK", "DM", "JG", "KS", "TK", "TM", "WH"}
+# JG and WC additionally require their official fixed-width keys and current
+# status/code domains, so a generic space-filled envelope is not valid.
+DOMAIN_PAYLOAD_REQUIRED = {"CK", "DM", "JG", "KS", "TK", "TM", "WC", "WH"}
 
 
 def test_declared_current_lengths_match_every_factory_parser():

--- a/tests/test_official_jvdata_oracle.py
+++ b/tests/test_official_jvdata_oracle.py
@@ -25,7 +25,7 @@ OFFICIAL_MANIFEST_CONTRACT_SHA256 = (
     "f35859d252fd20e4d7e38ee8d0a224deae87a62bae9db1995ed897bdccef6c45"
 )
 OFFICIAL_HISTORY_CONTRACT_SHA256 = (
-    "9f275d4c35714464cfd8737bd14fae08cf473388a725a31507f52ceb99ce4a80"
+    "aee4f1e36d5f8cedfc2c61f53c8a8eb8f131387010e0e9070360dbeceed9ee90"
 )
 
 
@@ -721,7 +721,7 @@ def test_official_hy_and_ck_sentinels_cannot_follow_current_implementation_drift
 def _assert_history_cardinality(history):
     assert len(history["sources"]) == 2
     assert len(history["physical_length_changes"]) == 10
-    assert len(history["same_length_semantic_changes"]) == 2
+    assert len(history["same_length_semantic_changes"]) == 3
 
 
 def _assert_history_truth_contract(history):
@@ -790,6 +790,18 @@ def _assert_history_truth_contract(history):
     assert jg_change["provenance_required"] is False
     assert jg_change["source"] == "JV-Data4901.xlsx:変更履歴:110"
 
+    # Ver.4.7.0.1 documented when Miho/Ritto WC data became available and the
+    # measured distances. It did not introduce another 105-byte generation.
+    wc_change = history["same_length_semantic_changes"][2]
+    assert wc_change["record_type"] == "WC"
+    assert wc_change["official_spec_version"] == "4.7.0.1"
+    assert wc_change["announced_date"] == "2022-02-22"
+    assert wc_change["length_unchanged"] is True
+    assert wc_change["layout_unchanged"] is True
+    assert wc_change["change_kind"] == "availability_documentation_clarification"
+    assert wc_change["provenance_required"] is False
+    assert wc_change["source"] == "JV-Data4901.xlsx:変更履歴:56;特記事項:237-240"
+
 
 def test_official_layout_history_is_provenanced_and_continuous_to_current():
     history = json.loads(HISTORY_PATH.read_text(encoding="utf-8"))
@@ -839,6 +851,8 @@ def test_official_layout_history_is_provenanced_and_continuous_to_current():
         (("same_length_semantic_changes", 1, "layout_unchanged"), False),
         (("same_length_semantic_changes", 1, "provenance_required"), True),
         (("same_length_semantic_changes", 1, "source"), "wrong:999"),
+        (("same_length_semantic_changes", 2, "layout_unchanged"), False),
+        (("same_length_semantic_changes", 2, "source"), "wrong:999"),
     ),
 )
 def test_history_truth_contract_rejects_content_and_provenance_drift(path, value):
@@ -854,7 +868,7 @@ def test_history_truth_contract_rejects_content_and_provenance_drift(path, value
     (
         ("sources", 2),
         ("physical_length_changes", 10),
-        ("same_length_semantic_changes", 2),
+        ("same_length_semantic_changes", 3),
     ),
 )
 def test_history_contract_rejects_duplicate_entries(collection, expected_count):

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -155,6 +155,19 @@ class TestIndividualParsers:
                 mutable[76:77] = b"1"
                 mutable[77:78] = b"0"
                 data = bytes(mutable)
+            if record_type == "WC":
+                # WC has a four-part fixed-width key, code domains, and 19
+                # numeric timing fields; blanks are not a positive fixture.
+                mutable = bytearray(data)
+                mutable[11:12] = b"0"
+                mutable[12:20] = b"20240601"
+                mutable[20:24] = b"0630"
+                mutable[24:34] = b"2020000001"
+                mutable[34:35] = b"0"
+                mutable[35:36] = b"0"
+                mutable[36:37] = b"0"
+                mutable[37:103] = b"0" * 66
+                data = bytes(mutable)
             if record_type == "TK":
                 mutable = bytearray(data)
                 mutable[11:15] = b"2024"

--- a/tests/test_wc_official_contract.py
+++ b/tests/test_wc_official_contract.py
@@ -1,0 +1,584 @@
+"""WC parser and storage contract for the official current 105-byte layout."""
+
+import json
+import os
+from itertools import pairwise
+from pathlib import Path
+from uuid import uuid4
+
+import pytest
+
+from src.database.migration import SchemaMigrationError
+from src.database.schema import SCHEMAS
+from src.database.schema_jravan import JRAVAN_SCHEMAS
+from src.database.schema_types import (
+    get_table_column_types,
+    get_table_primary_key_columns,
+)
+from src.database.sqlite_handler import SQLiteDatabase
+from src.database.table_mappings import JLTSQL_TO_JRAVAN, JRAVAN_TO_JLTSQL
+from src.importer.importer import DataImporter
+from src.importer.importer_optimized import OptimizedDataImporter
+from src.parser.wc_parser import WCParser
+
+
+def _pad(value: str, width: int) -> bytes:
+    encoded = value.encode("cp932")
+    assert len(encoded) <= width
+    return encoded.ljust(width, b" ")
+
+
+FIELDS = (
+    ("RecordSpec", 1, 2, b"WC"),
+    ("DataKubun", 3, 1, b"1"),
+    ("MakeDate", 4, 8, b"20260817"),
+    ("TresenKubun", 12, 1, b"0"),
+    ("ChokyoDate", 13, 8, b"20260816"),
+    ("ChokyoTime", 21, 4, b"0630"),
+    ("KettoNum", 25, 10, b"2020100001"),
+    ("Course", 35, 1, b"0"),
+    ("BabaMawari", 36, 1, b"0"),
+    ("reserved", 37, 1, b"0"),
+    ("HaronTime10Total", 38, 4, b"1200"),
+    ("LapTime_2000M_1800M", 42, 3, b"120"),
+    ("HaronTime9Total", 45, 4, b"1080"),
+    ("LapTime_1800M_1600M", 49, 3, b"120"),
+    ("HaronTime8Total", 52, 4, b"0960"),
+    ("LapTime_1600M_1400M", 56, 3, b"120"),
+    ("HaronTime7Total", 59, 4, b"0840"),
+    ("LapTime_1400M_1200M", 63, 3, b"120"),
+    ("HaronTime6Total", 66, 4, b"0720"),
+    ("LapTime_1200M_1000M", 70, 3, b"120"),
+    ("HaronTime5Total", 73, 4, b"0600"),
+    ("LapTime_1000M_800M", 77, 3, b"120"),
+    ("HaronTime4Total", 80, 4, b"0480"),
+    ("LapTime_800M_600M", 84, 3, b"120"),
+    ("HaronTime3Total", 87, 4, b"0360"),
+    ("LapTime_600M_400M", 91, 3, b"120"),
+    ("HaronTime2Total", 94, 4, b"0240"),
+    ("LapTime_400M_200M", 98, 3, b"120"),
+    ("LapTime_200M_0M", 101, 3, b"120"),
+    ("RecordDelimiter", 104, 2, b"\r\n"),
+)
+
+TIME_FIELDS = tuple(
+    (name, width) for name, _, width, _ in FIELDS if name.startswith(("HaronTime", "LapTime"))
+)
+STANDARD_ALIASES = {
+    "BabaMawari": "BabaAround",
+    "HaronTime10Total": "HaronTime10",
+    "LapTime_2000M_1800M": "LapTime10",
+    "HaronTime9Total": "HaronTime9",
+    "LapTime_1800M_1600M": "LapTime9",
+    "HaronTime8Total": "HaronTime8",
+    "LapTime_1600M_1400M": "LapTime8",
+    "HaronTime7Total": "HaronTime7",
+    "LapTime_1400M_1200M": "LapTime7",
+    "HaronTime6Total": "HaronTime6",
+    "LapTime_1200M_1000M": "LapTime6",
+    "HaronTime5Total": "HaronTime5",
+    "LapTime_1000M_800M": "LapTime5",
+    "HaronTime4Total": "HaronTime4",
+    "LapTime_800M_600M": "LapTime4",
+    "HaronTime3Total": "HaronTime3",
+    "LapTime_600M_400M": "LapTime3",
+    "HaronTime2Total": "HaronTime2",
+    "LapTime_400M_200M": "LapTime2",
+    "LapTime_200M_0M": "LapTime1",
+}
+EXPECTED = {name: value.decode("cp932").strip() for name, _, _, value in FIELDS}
+NATIVE_FIELDS = set(EXPECTED)
+STANDARD_FIELDS = NATIVE_FIELDS - {"RecordDelimiter", *STANDARD_ALIASES} | set(
+    STANDARD_ALIASES.values()
+)
+OFFICIAL_KEY = ["TresenKubun", "ChokyoDate", "ChokyoTime", "KettoNum"]
+
+
+def build_record(
+    *,
+    data_kubun: str = "1",
+    make_date: str = "20260817",
+    tresen_kubun: str = "0",
+    chokyo_date: str = "20260816",
+    chokyo_time: str = "0630",
+    ketto_num: str = "2020100001",
+    course: str = "0",
+    baba_mawari: str = "0",
+    all_nines: bool = False,
+    field_overrides: dict[str, str] | None = None,
+) -> bytes:
+    values = {
+        "DataKubun": data_kubun,
+        "MakeDate": make_date,
+        "TresenKubun": tresen_kubun,
+        "ChokyoDate": chokyo_date,
+        "ChokyoTime": chokyo_time,
+        "KettoNum": ketto_num,
+        "Course": course,
+        "BabaMawari": baba_mawari,
+    }
+    if all_nines:
+        values.update({name: "9" * width for name, width in TIME_FIELDS})
+    if field_overrides:
+        values.update(field_overrides)
+
+    record = bytearray()
+    for name, position, width, default in FIELDS:
+        value = _pad(values[name], width) if name in values else default
+        assert len(record) == position - 1
+        assert len(value) == width
+        record += value
+    assert len(record) == WCParser.RECORD_LENGTH == 105
+    return bytes(record)
+
+
+def parsed_record(**kwargs) -> dict:
+    record = WCParser().parse(build_record(**kwargs))
+    assert record is not None
+    return record
+
+
+def _split_cp932_at_field_boundary() -> bytes:
+    record = bytearray(build_record())
+    record[10] = 0x82
+    record[11] = 0xA0
+    bytes(record).decode("cp932", errors="strict")
+    return bytes(record)
+
+
+@pytest.fixture
+def postgresql_db():
+    if os.getenv("JLTSQL_RUN_POSTGRESQL_INTEGRATION") != "1":
+        pytest.skip("Set JLTSQL_RUN_POSTGRESQL_INTEGRATION=1 to run PostgreSQL tests")
+
+    from src.database.postgresql_handler import PostgreSQLDatabase
+
+    database = PostgreSQLDatabase(
+        {
+            "host": os.getenv("POSTGRES_HOST") or os.getenv("PGHOST", "localhost"),
+            "port": int(os.getenv("POSTGRES_PORT") or os.getenv("PGPORT", "5432")),
+            "database": os.getenv("POSTGRES_DB") or os.getenv("PGDATABASE", "jltsql_test"),
+            "user": os.getenv("POSTGRES_USER") or os.getenv("PGUSER", "jltsql"),
+            "password": os.getenv("POSTGRES_PASSWORD") or os.getenv("PGPASSWORD", ""),
+            "connect_timeout": 5,
+        }
+    )
+    schema_name = f"jlt_wc_{uuid4().hex[:12]}"
+    database.connect()
+    try:
+        database.execute(f"CREATE SCHEMA {schema_name}")
+        database.execute(f"SET search_path TO {schema_name}")
+        database.commit()
+        yield database
+    finally:
+        try:
+            database.execute(f"DROP SCHEMA IF EXISTS {schema_name} CASCADE")
+            database.commit()
+        finally:
+            database.disconnect()
+
+
+def test_wc_layout_is_gap_free_and_reads_every_official_field() -> None:
+    assert all(
+        position + width == next_position
+        for (_, position, width, _), (_, next_position, _, _) in pairwise(FIELDS)
+    )
+    assert WCParser().parse(build_record()) == EXPECTED
+    all_nines = WCParser().parse(build_record(all_nines=True))
+    assert all_nines is not None
+    assert all(all_nines[name] == "9" * width for name, width in TIME_FIELDS)
+
+
+@pytest.mark.parametrize(
+    "record",
+    (
+        build_record()[:-1],
+        build_record() + b" ",
+        b"XX" + build_record()[2:],
+        build_record()[:-2] + b"  ",
+        _split_cp932_at_field_boundary(),
+        build_record(data_kubun=""),
+        build_record(data_kubun="8"),
+        build_record(make_date="20A60817"),
+        build_record(tresen_kubun="8"),
+        build_record(chokyo_date="202A0816"),
+        build_record(chokyo_time="06A0"),
+        build_record(ketto_num="20201A0001"),
+        build_record(course="8"),
+        build_record(baba_mawari="8"),
+        build_record(field_overrides={"HaronTime10Total": "12A0"}),
+    ),
+)
+def test_wc_rejects_noncurrent_or_corrupt_records(record: bytes) -> None:
+    assert WCParser().parse(record) is None
+
+
+def test_wc_delete_record_keeps_the_exact_official_key_without_blank_body_rule() -> None:
+    deleted = WCParser().parse(build_record(data_kubun="0", course="4", all_nines=True))
+    assert deleted is not None
+    assert deleted["DataKubun"] == "0"
+    assert [deleted[name] for name in OFFICIAL_KEY] == [
+        "0",
+        "20260816",
+        "0630",
+        "2020100001",
+    ]
+
+
+def test_wc_native_and_canonical_schemas_match_the_official_key_and_fields() -> None:
+    assert set(get_table_column_types("NL_WC")) == NATIVE_FIELDS
+    assert get_table_primary_key_columns("NL_WC") == OFFICIAL_KEY
+    assert set(get_table_column_types("WOOD")) == STANDARD_FIELDS
+    assert get_table_primary_key_columns("WOOD") == OFFICIAL_KEY
+    assert JRAVAN_TO_JLTSQL["WOOD"] == "NL_WC"
+    assert JLTSQL_TO_JRAVAN["NL_WC"] == "WOOD"
+
+
+def test_wc_4701_history_is_documentation_only_not_a_physical_layout() -> None:
+    history = json.loads(
+        Path("tests/fixtures/official_layout/jvdata_layout_history.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    assert not any(item["record_type"] == "WC" for item in history["physical_length_changes"])
+    wc_change = next(
+        item for item in history["same_length_semantic_changes"] if item["record_type"] == "WC"
+    )
+    assert wc_change == {
+        "record_type": "WC",
+        "announced_date": "2022-02-22",
+        "official_spec_version": "4.7.0.1",
+        "length_unchanged": True,
+        "layout_unchanged": True,
+        "change_kind": "availability_documentation_clarification",
+        "provenance_required": False,
+        "reason": (
+            "The specification added availability and measured-distance notes for "
+            "Miho/Ritto woodchip training without changing the 105-byte layout."
+        ),
+        "source": "JV-Data4901.xlsx:変更履歴:56;特記事項:237-240",
+    }
+
+
+@pytest.mark.parametrize(
+    ("importer_class", "table_name", "standard", "auto_commit"),
+    [
+        pytest.param(
+            importer_class,
+            table_name,
+            standard,
+            auto_commit,
+            id=f"{importer_class.__name__}-{table_name}-commit-{auto_commit}",
+        )
+        for importer_class in (DataImporter, OptimizedDataImporter)
+        for table_name, standard in (("NL_WC", False), ("WOOD", True))
+        for auto_commit in (True, False)
+    ],
+)
+def test_wc_official_key_coexistence_course_update_and_provider_ordered_delete(
+    tmp_path,
+    importer_class,
+    table_name: str,
+    standard: bool,
+    auto_commit: bool,
+) -> None:
+    database = SQLiteDatabase({"path": str(tmp_path / f"ordered-{table_name}.db")})
+    schema = JRAVAN_SCHEMAS[table_name] if standard else SCHEMAS[table_name]
+    haron_column = "HaronTime10" if standard else "HaronTime10Total"
+    with database:
+        database.create_table(table_name, schema)
+        importer = importer_class(database, use_jravan_schema=standard)
+        created = importer.import_records(
+            iter([parsed_record(tresen_kubun="0"), parsed_record(tresen_kubun="1")]),
+            auto_commit=auto_commit,
+        )
+        rows_after_create = database.fetch_all(
+            f"SELECT TresenKubun, Course FROM {table_name} ORDER BY TresenKubun"
+        )
+        updated = importer.import_records(
+            iter([parsed_record(tresen_kubun="0", course="1", all_nines=True)]),
+            auto_commit=auto_commit,
+        )
+        rows_after_update = database.fetch_all(
+            f"SELECT TresenKubun, Course, {haron_column} AS haron "
+            f"FROM {table_name} ORDER BY TresenKubun"
+        )
+        ordered = importer.import_records(
+            iter(
+                [
+                    parsed_record(data_kubun="0", tresen_kubun="0", course="4"),
+                    parsed_record(tresen_kubun="0", course="2"),
+                ]
+            ),
+            auto_commit=auto_commit,
+        )
+        rows_after_ordered_delete = database.fetch_all(
+            f"SELECT DataKubun, TresenKubun, Course FROM {table_name} ORDER BY TresenKubun"
+        )
+
+    assert created["records_imported"] == 2
+    assert created["records_failed"] == 0
+    assert updated["records_imported"] == 1
+    assert updated["records_failed"] == 0
+    assert ordered["records_imported"] == 2
+    assert ordered["records_failed"] == 0
+    assert rows_after_create == [
+        {"TresenKubun": "0", "Course": "0"},
+        {"TresenKubun": "1", "Course": "0"},
+    ]
+    assert rows_after_update == [
+        {"TresenKubun": "0", "Course": "1", "haron": 999.9},
+        {"TresenKubun": "1", "Course": "0", "haron": 120.0},
+    ]
+    assert rows_after_ordered_delete == [
+        {"DataKubun": "1", "TresenKubun": "0", "Course": "2"},
+        {"DataKubun": "1", "TresenKubun": "1", "Course": "0"},
+    ]
+
+
+def _canonical_only(record: dict) -> dict:
+    canonical = dict(record)
+    for native, standard in STANDARD_ALIASES.items():
+        canonical[standard] = canonical.pop(native)
+    return canonical
+
+
+@pytest.mark.parametrize(
+    ("importer_class", "table_name", "standard"),
+    [
+        pytest.param(
+            importer_class,
+            table_name,
+            standard,
+            id=f"{importer_class.__name__}-{table_name}",
+        )
+        for importer_class in (DataImporter, OptimizedDataImporter)
+        for table_name, standard in (("NL_WC", False), ("WOOD", True))
+    ],
+)
+def test_wc_caller_built_rows_are_revalidated_before_mutation(
+    tmp_path,
+    importer_class,
+    table_name: str,
+    standard: bool,
+) -> None:
+    database = SQLiteDatabase({"path": str(tmp_path / f"caller-{table_name}.db")})
+    schema = JRAVAN_SCHEMAS[table_name] if standard else SCHEMAS[table_name]
+    with database:
+        database.create_table(table_name, schema)
+        importer = importer_class(database, use_jravan_schema=standard)
+        importer.import_records(iter([parsed_record()]))
+
+        legacy_headers = parsed_record(chokyo_time="0631")
+        legacy_headers["headRecordSpec"] = legacy_headers.pop("RecordSpec")
+        legacy_headers["headDataKubun"] = legacy_headers.pop("DataKubun")
+        assert importer.import_records(iter([legacy_headers]))["records_imported"] == 1
+
+        if standard:
+            canonical = _canonical_only(parsed_record(chokyo_time="0632", all_nines=True))
+            assert importer.import_records(iter([canonical]))["records_imported"] == 1
+            assert database.fetch_one(
+                "SELECT BabaAround, HaronTime10, LapTime1 FROM WOOD WHERE ChokyoTime = ?",
+                ("0632",),
+            ) == {"BabaAround": "0", "HaronTime10": 999.9, "LapTime1": 99.9}
+
+        before = database.fetch_all(f"SELECT * FROM {table_name}")
+        invalid_records = []
+
+        missing_status = parsed_record()
+        missing_status.pop("DataKubun")
+        invalid_records.append(missing_status)
+        blank_status = parsed_record()
+        blank_status["DataKubun"] = ""
+        invalid_records.append(blank_status)
+        conflicting_status = parsed_record()
+        conflicting_status["headDataKubun"] = "0"
+        invalid_records.append(conflicting_status)
+        invalid_status = parsed_record()
+        invalid_status["DataKubun"] = "8"
+        invalid_records.append(invalid_status)
+
+        for field_name, invalid_value in (
+            ("TresenKubun", "8"),
+            ("ChokyoDate", "202A0816"),
+            ("ChokyoTime", "06A0"),
+            ("KettoNum", "20201A0001"),
+            ("Course", "8"),
+            ("BabaMawari", "8"),
+            ("HaronTime10Total", "12A0"),
+        ):
+            invalid = parsed_record()
+            invalid[field_name] = invalid_value
+            invalid_records.append(invalid)
+
+        incomplete = parsed_record(data_kubun="0")
+        incomplete["KettoNum"] = ""
+        invalid_records.append(incomplete)
+
+        if standard:
+            conflict = parsed_record()
+            conflict["BabaAround"] = "1"
+            invalid_records.append(conflict)
+
+        for invalid in invalid_records:
+            with pytest.raises(SchemaMigrationError):
+                importer.import_records(iter([invalid]))
+        after = database.fetch_all(f"SELECT * FROM {table_name}")
+
+    assert after == before
+
+
+def _obsolete_schema(table_name: str, *, standard: bool) -> str:
+    if standard:
+        schema = JRAVAN_SCHEMAS.get("WOOD")
+        if schema is None:
+            schema = SCHEMAS["NL_WC"].replace("NL_WC", "WOOD")
+    else:
+        schema = SCHEMAS["NL_WC"]
+    return schema.replace(
+        "PRIMARY KEY (TresenKubun, ChokyoDate, ChokyoTime, KettoNum)",
+        "PRIMARY KEY (ChokyoDate, ChokyoTime, KettoNum, Course)",
+    )
+
+
+@pytest.mark.parametrize(
+    ("importer_class", "table_name", "standard", "auto_commit"),
+    [
+        pytest.param(
+            importer_class,
+            table_name,
+            standard,
+            auto_commit,
+            id=f"{importer_class.__name__}-{table_name}-commit-{auto_commit}",
+        )
+        for importer_class in (DataImporter, OptimizedDataImporter)
+        for table_name, standard in (("NL_WC", False), ("WOOD", True))
+        for auto_commit in (True, False)
+    ],
+)
+def test_wc_obsolete_wrong_key_is_rejected_before_schema_or_row_mutation(
+    tmp_path,
+    importer_class,
+    table_name: str,
+    standard: bool,
+    auto_commit: bool,
+) -> None:
+    database = SQLiteDatabase({"path": str(tmp_path / f"obsolete-{table_name}.db")})
+    with database:
+        database.execute(_obsolete_schema(table_name, standard=standard))
+        database.execute(
+            f"INSERT INTO {table_name} "
+            "(RecordSpec, DataKubun, TresenKubun, ChokyoDate, ChokyoTime, KettoNum, Course) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?)",
+            ("WC", "1", "0", "20260815", "0600", "2020100999", "0"),
+        )
+        database.commit()
+        before_schema = database.fetch_one(
+            "SELECT sql FROM sqlite_master WHERE type='table' AND name=?", (table_name,)
+        )
+        before_rows = database.fetch_all(f"SELECT * FROM {table_name}")
+
+        with pytest.raises(SchemaMigrationError, match="primary key"):
+            importer_class(database, use_jravan_schema=standard).import_records(
+                iter([parsed_record()]), auto_commit=auto_commit
+            )
+
+        after_schema = database.fetch_one(
+            "SELECT sql FROM sqlite_master WHERE type='table' AND name=?", (table_name,)
+        )
+        after_rows = database.fetch_all(f"SELECT * FROM {table_name}")
+
+    assert after_schema == before_schema
+    assert after_rows == before_rows
+
+
+@pytest.mark.parametrize(
+    ("table_name", "standard", "auto_commit"),
+    [
+        pytest.param(table_name, standard, auto_commit, id=f"{table_name}-{auto_commit}")
+        for table_name, standard in (("NL_WC", False), ("WOOD", True))
+        for auto_commit in (True, False)
+    ],
+)
+def test_wc_single_record_uses_the_same_validation_and_exact_delete(
+    tmp_path,
+    table_name: str,
+    standard: bool,
+    auto_commit: bool,
+) -> None:
+    database = SQLiteDatabase({"path": str(tmp_path / f"single-{table_name}.db")})
+    schema = JRAVAN_SCHEMAS[table_name] if standard else SCHEMAS[table_name]
+    with database:
+        database.create_table(table_name, schema)
+        importer = DataImporter(database, use_jravan_schema=standard)
+        importer.import_records(iter([parsed_record()]))
+        missing_status = parsed_record()
+        missing_status.pop("DataKubun")
+        with pytest.raises(SchemaMigrationError):
+            importer.import_single_record(missing_status, auto_commit=auto_commit)
+        assert importer.import_single_record(
+            parsed_record(data_kubun="0", course="4", all_nines=True),
+            auto_commit=auto_commit,
+        )
+        assert database.fetch_one(f"SELECT COUNT(*) AS count FROM {table_name}")["count"] == 0
+
+
+def test_wc_postgresql_native_and_standard_key_update_delete(postgresql_db) -> None:
+    postgresql_db.execute(SCHEMAS["NL_WC"])
+    postgresql_db.execute(JRAVAN_SCHEMAS["WOOD"])
+    postgresql_db.commit()
+
+    for importer_class in (DataImporter, OptimizedDataImporter):
+        for table_name, standard in (("NL_WC", False), ("WOOD", True)):
+            importer = importer_class(postgresql_db, use_jravan_schema=standard)
+            stats = importer.import_records(
+                iter([parsed_record(tresen_kubun="0"), parsed_record(tresen_kubun="1")])
+            )
+            assert stats["records_imported"] == 2
+            assert postgresql_db.fetch_one(f"SELECT COUNT(*) AS count FROM {table_name}") == {
+                "count": 2
+            }
+            importer.import_records(iter([parsed_record(tresen_kubun="0", course="2")]))
+            assert postgresql_db.fetch_one(f"SELECT COUNT(*) AS count FROM {table_name}") == {
+                "count": 2
+            }
+            importer.import_records(
+                iter([parsed_record(data_kubun="0", tresen_kubun="0", course="4")])
+            )
+            assert postgresql_db.fetch_all(
+                f"SELECT TresenKubun AS tresen FROM {table_name} ORDER BY TresenKubun"
+            ) == [{"tresen": "1"}]
+            postgresql_db.execute(f"DELETE FROM {table_name}")
+            postgresql_db.commit()
+
+    primary_key_query = (
+        "SELECT pg_get_constraintdef(c.oid) AS definition "
+        "FROM pg_constraint c WHERE c.conrelid = to_regclass(?) AND c.contype = 'p'"
+    )
+    for table_name, standard in (("NL_WC", False), ("WOOD", True)):
+        postgresql_db.execute(f"DROP TABLE {table_name}")
+        postgresql_db.execute(_obsolete_schema(table_name, standard=standard))
+        postgresql_db.execute(
+            f"INSERT INTO {table_name} "
+            "(RecordSpec, DataKubun, TresenKubun, ChokyoDate, ChokyoTime, KettoNum, Course) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?)",
+            ("WC", "1", "0", "20260815", "0600", "2020100999", "0"),
+        )
+        postgresql_db.commit()
+        before_key = postgresql_db.fetch_one(primary_key_query, (table_name.lower(),))
+        before_rows = postgresql_db.fetch_all(f"SELECT * FROM {table_name}")
+
+        for importer_class, auto_commit in (
+            (DataImporter, True),
+            (OptimizedDataImporter, False),
+        ):
+            with pytest.raises(SchemaMigrationError, match="primary key"):
+                importer_class(postgresql_db, use_jravan_schema=standard).import_records(
+                    iter([parsed_record()]), auto_commit=auto_commit
+                )
+            assert postgresql_db.fetch_one(primary_key_query, (table_name.lower(),)) == before_key
+            assert postgresql_db.fetch_all(f"SELECT * FROM {table_name}") == before_rows
+            postgresql_db.rollback()
+
+        postgresql_db.execute(f"DROP TABLE {table_name}")
+        postgresql_db.commit()

--- a/tests/test_wc_official_contract.py
+++ b/tests/test_wc_official_contract.py
@@ -9,15 +9,16 @@ from uuid import uuid4
 import pytest
 
 from src.database.migration import SchemaMigrationError
-from src.database.schema import SCHEMAS
+from src.database.schema import SCHEMAS, SchemaManager
 from src.database.schema_jravan import JRAVAN_SCHEMAS
+from src.database.schema_metadata import TABLE_METADATA
 from src.database.schema_types import (
     get_table_column_types,
     get_table_primary_key_columns,
 )
 from src.database.sqlite_handler import SQLiteDatabase
 from src.database.table_mappings import JLTSQL_TO_JRAVAN, JRAVAN_TO_JLTSQL
-from src.importer.importer import DataImporter
+from src.importer.importer import _STANDARD_FIELD_ALIASES, DataImporter
 from src.importer.importer_optimized import OptimizedDataImporter
 from src.parser.wc_parser import WCParser
 
@@ -189,6 +190,74 @@ def test_wc_layout_is_gap_free_and_reads_every_official_field() -> None:
     assert all(all_nines[name] == "9" * width for name, width in TIME_FIELDS)
 
 
+def test_wc_layout_is_bound_to_the_pinned_sdk_manifest() -> None:
+    manifest = json.loads(
+        Path("tests/fixtures/official_layout/jvdata_sdk500_manifest.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    structures = manifest["structures"]
+    actual = []
+    for field in structures["JV_WC_WOOD"]["fields"]:
+        if field["name"] == "head":
+            for header_field in structures[field["struct"]]["fields"]:
+                actual.append(
+                    (
+                        header_field["name"],
+                        field["start"] + header_field["start"] - 1,
+                        header_field["width"],
+                    )
+                )
+        else:
+            actual.append(
+                (
+                    {
+                        "BabaAround": "BabaMawari",
+                        "HaronTime10": "HaronTime10Total",
+                        "LapTime10": "LapTime_2000M_1800M",
+                        "HaronTime9": "HaronTime9Total",
+                        "LapTime9": "LapTime_1800M_1600M",
+                        "HaronTime8": "HaronTime8Total",
+                        "LapTime8": "LapTime_1600M_1400M",
+                        "HaronTime7": "HaronTime7Total",
+                        "LapTime7": "LapTime_1400M_1200M",
+                        "HaronTime6": "HaronTime6Total",
+                        "LapTime6": "LapTime_1200M_1000M",
+                        "HaronTime5": "HaronTime5Total",
+                        "LapTime5": "LapTime_1000M_800M",
+                        "HaronTime4": "HaronTime4Total",
+                        "LapTime4": "LapTime_800M_600M",
+                        "HaronTime3": "HaronTime3Total",
+                        "LapTime3": "LapTime_600M_400M",
+                        "HaronTime2": "HaronTime2Total",
+                        "LapTime2": "LapTime_400M_200M",
+                        "LapTime1": "LapTime_200M_0M",
+                        "crlf": "RecordDelimiter",
+                    }.get(field["name"], field["name"]),
+                    field["start"],
+                    field["width"],
+                )
+            )
+
+    expected = [(name, position, width) for name, position, width, _ in FIELDS]
+    assert actual == expected
+    assert _STANDARD_FIELD_ALIASES["WOOD"] == STANDARD_ALIASES
+
+
+def test_wc_accepts_real_calendar_dates_and_midnight() -> None:
+    parsed = WCParser().parse(
+        build_record(
+            make_date="20260228",
+            chokyo_date="20240229",
+            chokyo_time="0000",
+        )
+    )
+    assert parsed is not None
+    assert parsed["MakeDate"] == "20260228"
+    assert parsed["ChokyoDate"] == "20240229"
+    assert parsed["ChokyoTime"] == "0000"
+
+
 @pytest.mark.parametrize(
     "record",
     (
@@ -200,9 +269,14 @@ def test_wc_layout_is_gap_free_and_reads_every_official_field() -> None:
         build_record(data_kubun=""),
         build_record(data_kubun="8"),
         build_record(make_date="20A60817"),
+        build_record(make_date="20260230"),
         build_record(tresen_kubun="8"),
         build_record(chokyo_date="202A0816"),
+        build_record(chokyo_date="20260230"),
         build_record(chokyo_time="06A0"),
+        build_record(chokyo_time="1160"),
+        build_record(chokyo_time="2400"),
+        build_record(chokyo_time="9999"),
         build_record(ketto_num="20201A0001"),
         build_record(course="8"),
         build_record(baba_mawari="8"),
@@ -232,6 +306,11 @@ def test_wc_native_and_canonical_schemas_match_the_official_key_and_fields() -> 
     assert get_table_primary_key_columns("WOOD") == OFFICIAL_KEY
     assert JRAVAN_TO_JLTSQL["WOOD"] == "NL_WC"
     assert JLTSQL_TO_JRAVAN["NL_WC"] == "WOOD"
+    metadata = TABLE_METADATA["NL_WC"]
+    assert [(column["name"], column["type"]) for column in metadata["columns"]] == list(
+        get_table_column_types("NL_WC").items()
+    )
+    assert metadata["primary_key"] == OFFICIAL_KEY
 
 
 def test_wc_4701_history_is_documentation_only_not_a_physical_layout() -> None:
@@ -374,6 +453,9 @@ def test_wc_caller_built_rows_are_revalidated_before_mutation(
         legacy_headers["headDataKubun"] = legacy_headers.pop("DataKubun")
         assert importer.import_records(iter([legacy_headers]))["records_imported"] == 1
 
+        blank_reserved = parsed_record(chokyo_time="0633", field_overrides={"reserved": ""})
+        assert importer.import_records(iter([blank_reserved]))["records_imported"] == 1
+
         if standard:
             canonical = _canonical_only(parsed_record(chokyo_time="0632", all_nines=True))
             assert importer.import_records(iter([canonical]))["records_imported"] == 1
@@ -400,11 +482,17 @@ def test_wc_caller_built_rows_are_revalidated_before_mutation(
 
         for field_name, invalid_value in (
             ("TresenKubun", "8"),
+            ("MakeDate", "20260230"),
             ("ChokyoDate", "202A0816"),
+            ("ChokyoDate", "20260230"),
             ("ChokyoTime", "06A0"),
+            ("ChokyoTime", "1160"),
+            ("ChokyoTime", "2400"),
             ("KettoNum", "20201A0001"),
             ("Course", "8"),
             ("BabaMawari", "8"),
+            ("reserved", "OVERSIZED"),
+            ("reserved", "馬"),
             ("HaronTime10Total", "12A0"),
         ):
             invalid = parsed_record()
@@ -516,6 +604,10 @@ def test_wc_single_record_uses_the_same_validation_and_exact_delete(
         missing_status.pop("DataKubun")
         with pytest.raises(SchemaMigrationError):
             importer.import_single_record(missing_status, auto_commit=auto_commit)
+        invalid_time = parsed_record()
+        invalid_time["ChokyoTime"] = "1160"
+        with pytest.raises(SchemaMigrationError):
+            importer.import_single_record(invalid_time, auto_commit=auto_commit)
         assert importer.import_single_record(
             parsed_record(data_kubun="0", course="4", all_nines=True),
             auto_commit=auto_commit,
@@ -526,6 +618,8 @@ def test_wc_single_record_uses_the_same_validation_and_exact_delete(
 def test_wc_postgresql_native_and_standard_key_update_delete(postgresql_db) -> None:
     postgresql_db.execute(SCHEMAS["NL_WC"])
     postgresql_db.execute(JRAVAN_SCHEMAS["WOOD"])
+    postgresql_db.commit()
+    assert SchemaManager(postgresql_db).apply_metadata_to_table("NL_WC") is True
     postgresql_db.commit()
 
     for importer_class in (DataImporter, OptimizedDataImporter):

--- a/tests/test_wc_official_contract.py
+++ b/tests/test_wc_official_contract.py
@@ -197,11 +197,11 @@ def test_wc_layout_is_bound_to_the_pinned_sdk_manifest() -> None:
         )
     )
     structures = manifest["structures"]
-    actual = []
+    sdk_compact_contract = []
     for field in structures["JV_WC_WOOD"]["fields"]:
         if field["name"] == "head":
             for header_field in structures[field["struct"]]["fields"]:
-                actual.append(
+                sdk_compact_contract.append(
                     (
                         header_field["name"],
                         field["start"] + header_field["start"] - 1,
@@ -209,39 +209,43 @@ def test_wc_layout_is_bound_to_the_pinned_sdk_manifest() -> None:
                     )
                 )
         else:
-            actual.append(
-                (
-                    {
-                        "BabaAround": "BabaMawari",
-                        "HaronTime10": "HaronTime10Total",
-                        "LapTime10": "LapTime_2000M_1800M",
-                        "HaronTime9": "HaronTime9Total",
-                        "LapTime9": "LapTime_1800M_1600M",
-                        "HaronTime8": "HaronTime8Total",
-                        "LapTime8": "LapTime_1600M_1400M",
-                        "HaronTime7": "HaronTime7Total",
-                        "LapTime7": "LapTime_1400M_1200M",
-                        "HaronTime6": "HaronTime6Total",
-                        "LapTime6": "LapTime_1200M_1000M",
-                        "HaronTime5": "HaronTime5Total",
-                        "LapTime5": "LapTime_1000M_800M",
-                        "HaronTime4": "HaronTime4Total",
-                        "LapTime4": "LapTime_800M_600M",
-                        "HaronTime3": "HaronTime3Total",
-                        "LapTime3": "LapTime_600M_400M",
-                        "HaronTime2": "HaronTime2Total",
-                        "LapTime2": "LapTime_400M_200M",
-                        "LapTime1": "LapTime_200M_0M",
-                        "crlf": "RecordDelimiter",
-                    }.get(field["name"], field["name"]),
-                    field["start"],
-                    field["width"],
-                )
-            )
+            sdk_compact_contract.append((field["name"], field["start"], field["width"]))
 
-    expected = [(name, position, width) for name, position, width, _ in FIELDS]
-    assert actual == expected
+    parser_fields = WCParser()._fields
+    fixture_contract = [(name, position, width) for name, position, width, _ in FIELDS]
+    assert [
+        (field.name, field.start + 1, field.length) for field in parser_fields
+    ] == fixture_contract
     assert _STANDARD_FIELD_ALIASES["WOOD"] == STANDARD_ALIASES
+    parser_canonical_contract = [
+        (
+            (
+                "crlf"
+                if field.name == "RecordDelimiter"
+                else _STANDARD_FIELD_ALIASES["WOOD"].get(field.name, field.name)
+            ),
+            field.start + 1,
+            field.length,
+        )
+        for field in parser_fields
+    ]
+    assert parser_canonical_contract == sdk_compact_contract
+
+
+def test_wc_manifest_oracle_rejects_production_parser_offset_drift(monkeypatch) -> None:
+    original_define_fields = WCParser._define_fields
+
+    def swapped_equal_width_fields(self):
+        fields = original_define_fields(self)
+        by_name = {field.name: field for field in fields}
+        first = by_name["LapTime_2000M_1800M"]
+        second = by_name["LapTime_1800M_1600M"]
+        first.start, second.start = second.start, first.start
+        return fields
+
+    monkeypatch.setattr(WCParser, "_define_fields", swapped_equal_width_fields)
+    with pytest.raises(AssertionError):
+        test_wc_layout_is_bound_to_the_pinned_sdk_manifest()
 
 
 def test_wc_accepts_real_calendar_dates_and_midnight() -> None:
@@ -288,7 +292,18 @@ def test_wc_rejects_noncurrent_or_corrupt_records(record: bytes) -> None:
 
 
 def test_wc_delete_record_keeps_the_exact_official_key_without_blank_body_rule() -> None:
-    deleted = WCParser().parse(build_record(data_kubun="0", course="4", all_nines=True))
+    deleted = WCParser().parse(
+        build_record(
+            data_kubun="0",
+            course="8",
+            baba_mawari="8",
+            field_overrides={
+                "reserved": "A",
+                "HaronTime10Total": "ABCD",
+                "LapTime_1000M_800M": "A1B",
+            },
+        )
+    )
     assert deleted is not None
     assert deleted["DataKubun"] == "0"
     assert [deleted[name] for name in OFFICIAL_KEY] == [
@@ -385,7 +400,13 @@ def test_wc_official_key_coexistence_course_update_and_provider_ordered_delete(
         ordered = importer.import_records(
             iter(
                 [
-                    parsed_record(data_kubun="0", tresen_kubun="0", course="4"),
+                    parsed_record(
+                        data_kubun="0",
+                        tresen_kubun="0",
+                        course="8",
+                        baba_mawari="8",
+                        field_overrides={"HaronTime10Total": "ABCD"},
+                    ),
                     parsed_record(tresen_kubun="0", course="2"),
                 ]
             ),
@@ -455,6 +476,37 @@ def test_wc_caller_built_rows_are_revalidated_before_mutation(
 
         blank_reserved = parsed_record(chokyo_time="0633", field_overrides={"reserved": ""})
         assert importer.import_records(iter([blank_reserved]))["records_imported"] == 1
+
+        zero_measurements = parsed_record(
+            chokyo_time="0634",
+            field_overrides={name: "0" * width for name, width in TIME_FIELDS},
+        )
+        assert importer.import_records(iter([zero_measurements]))["records_imported"] == 1
+        if standard:
+            zero_columns = ("HaronTime10", "LapTime5", "LapTime1")
+        else:
+            zero_columns = (
+                "HaronTime10Total",
+                "LapTime_1000M_800M",
+                "LapTime_200M_0M",
+            )
+        zero_row = database.fetch_one(
+            f"SELECT {zero_columns[0]} AS first_value, "
+            f"{zero_columns[1]} AS middle_value, {zero_columns[2]} AS last_value "
+            f"FROM {table_name} WHERE ChokyoTime = ?",
+            ("0634",),
+        )
+        assert zero_row == {"first_value": 0.0, "middle_value": 0.0, "last_value": 0.0}
+
+        opaque_delete = parsed_record(
+            data_kubun="0",
+            course="8",
+            baba_mawari="8",
+            field_overrides={"HaronTime10Total": "ABCD"},
+        )
+        opaque_delete["reserved"] = "OVERSIZED"
+        assert importer.import_records(iter([opaque_delete]))["records_imported"] == 1
+        assert importer.import_records(iter([parsed_record()]))["records_imported"] == 1
 
         if standard:
             canonical = _canonical_only(parsed_record(chokyo_time="0632", all_nines=True))
@@ -608,10 +660,14 @@ def test_wc_single_record_uses_the_same_validation_and_exact_delete(
         invalid_time["ChokyoTime"] = "1160"
         with pytest.raises(SchemaMigrationError):
             importer.import_single_record(invalid_time, auto_commit=auto_commit)
-        assert importer.import_single_record(
-            parsed_record(data_kubun="0", course="4", all_nines=True),
-            auto_commit=auto_commit,
+        opaque_delete = parsed_record(
+            data_kubun="0",
+            course="8",
+            baba_mawari="8",
+            field_overrides={"HaronTime10Total": "ABCD"},
         )
+        opaque_delete["reserved"] = "OVERSIZED"
+        assert importer.import_single_record(opaque_delete, auto_commit=auto_commit)
         assert database.fetch_one(f"SELECT COUNT(*) AS count FROM {table_name}")["count"] == 0
 
 


### PR DESCRIPTION
## 概要

WC（ウッドチップ調教）を、JV-Data 4.9.0.1 / SDK 5.0.0 の現行仕様と、4.7.0.1 の説明追記、JRA-VAN開発者コミュニティ上の公式回答に照合して修正しました。

- 105-byte / 30 logical fieldsを現行SDK manifestへ直接固定
- 公式4項目キー `TresenKubun, ChokyoDate, ChokyoTime, KettoNum` をnative `NL_WC` とcanonical `WOOD` の双方へ適用
- DataKubun 0をprovider順のexact deleteとして処理し、tombstoneを残さない
- 実在Gregorian日・HHMMを検証し、再提供対象となった `11:60` 型の不正値を保存前に拒否
- 19 timing payloadのzero / all-nine sentinelは保持
- caller-built辞書、両batch importer、single-record、native/canonicalを同じ契約で検証
- 旧wrong-key schemaはmutation前に拒否
- `NL_WC` metadataを実schema 30列と正しいPKから生成
- tracked `specs/` と公式oracle素材は引き続きwheel/sdistから除外

## 公式根拠

- JV-Data 4.9.0.1 workbook rows 1357–1409
- JV-Data SDK 5.0.0 `JV_WC_WOOD`
- 4.7.0.1変更履歴は物理/key変更ではなくavailability / measured-distanceの説明追記
- 推奨4項目キー: https://developer.jra-van.jp/t/topic/99
- all-nine timingの正規データ扱い: https://developer.jra-van.jp/t/topic/367
- 不正 `11:60` 等のデータ不備・再提供: https://developer.jra-van.jp/t/topic/237

## Red-first evidence

- 初期base `b4369f74d2ba236c8b33dbb1e45882ffa7c9aa0f`: `42 failed, 1 passed, 1 PostgreSQL opt-in skip`
- review findingの意味検証/metadata追加前 `4be96d1f3ad1f88c47894c7337ee7dcd28f094d8`: `14 failed, 36 passed, 1 skip`
- manifest oracle修正前 `56a86301a89cfe5382c1d5d4f167d0e744c79bb2`: 同幅offset drift注入で `1 failed, 50 passed, 1 skip`

正常な閏日・00:00、status-0 opaque body、zero/all-nine timingを対になるgreenとして固定しています。

## 検証

- production candidate `56a86301a89cfe5382c1d5d4f167d0e744c79bb2` CI相当full: `2560 passed, 109 skipped, 14 deselected, 15 subtests passed`（Python 3.12.11、coverage付き）
- final test/worklog head `6f1e886b014f0fb1a150223d20029740901e1a68` focused: `74 passed, 5 skipped`
- fresh PostgreSQL 16: `52 passed`
  - 両importer × `NL_WC` / `WOOD`
  - create/update/delete、provider順、zero/all-nine、invalid値のmutation前拒否
  - obsolete PKのcatalog/row不変
  - 実 `COMMENT ON COLUMN` metadata適用
- `TEST GATE PASS` / `OFFICIAL ORACLE PASS`
- fatal flake8 / focused Black・Ruff / compileall / `git diff --check`
- strict MkDocs build
- fresh wheel/sdist 1.6.10 build + distribution content gate（2 artifacts）
- 独立Codex最終レビュー: `P0=0 / P1=0 / P2=0` GREEN
- worktree clean、open PR重複なし

## リリース境界

本PRはWCの1イテレーションであり、リリースそのものではありません。リリース前の必須条件である最終統合監査と、最終コードによるfresh provider取得・実DB格納確認は別途実施します。また、実SDKを導入した64-bit環境での動作確認は行っていないため、64-bit対応済みとは主張しません。

お手数ですが、公式契約、delete順序、migrationの無変更保証、日時/sentinel境界を中心にご確認いただけますと幸いです。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for storing WC records in native `NL_WC` and standard `WOOD` formats.
  * Added validation for the current 105-byte WC record format, including fields, dates, times, and character widths.
  * Added WC import, deletion, schema verification, and PostgreSQL compatibility support.
  * Added official WC layout history and storage documentation.

* **Bug Fixes**
  * Updated `NL_WC` key handling to use the official four-field key.
  * Rejected obsolete schemas and invalid records consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->