### PR TITLE
Harden public release artifacts and bootstrap setup

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install uv
+        pip install uv==0.12.5
         uv lock --check
         pip install -e ".[dev,postgres]"
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,6 +44,7 @@ jobs:
       run: |
         python -m build --outdir "$RUNNER_TEMP/jltsql-dist"
         python scripts/check_distribution_contents.py "$RUNNER_TEMP"/jltsql-dist/*
+        python scripts/smoke_distribution_init.py "$RUNNER_TEMP"/jltsql-dist/*.whl
 
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,6 +27,8 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
+        pip install uv
+        uv lock --check
         pip install -e ".[dev,postgres]"
 
     - name: Validate fail-closed test gate

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,23 @@
 
 ## [Unreleased]
 
+次回リリースは互換性を破る変更を含むため `2.0.0` とする。1.xとしては配布しない。
+
+### Removed
+
+- `JVLinkWrapper.jv_set_service_key` / `JVLinkBridge.jv_set_service_key` と、
+  レジストリをプログラムから変更する経路を削除。利用登録はDataLabで行う
+- O1〜O6を単独JVOpen data specのように見せる重複定数を削除。これらはRACEに
+  含まれるrecord typeであり、`RECORD_TYPE_O1`〜`RECORD_TYPE_O6`を使用する
+
 ### Changed
 
+- 非Windowsのbridge起動は暗黙の実装選択を廃止し、外部runnerを
+  `JVLINK_BRIDGE_RUNNER`で明示する。公開propertyは
+  `uses_external_runner`へ変更
+- CLIの既定config/log/dataはinstalled package配下ではなく実行時の作業場所と
+  user stateを使う。`jltsql init`はカレントディレクトリをSQLite-onlyの安全な
+  既定で初期化し、`--config`との併用は曖昧さを避けるため拒否する
 - JV-Link SDK 5.0.0 で公式 64-bit 版が追加されたことを文書へ反映。ただし
   jrvltsql の 64-bit 実行経路は未検証であり、x64 SDK の実導入・取得・parse・
   DB保存を完了するまでは対応済みとしない。インストーラとランチャーは、

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,12 @@
   リリース検証済みの 32-bit Python / JV-Link 経路を既定として維持
 - Python の実行要件を `pyproject.toml` と一致する 3.12 以上へ統一
 - 公式 64-bit 版と競合し得る旧レジストリ回避ツールを削除
+- 公式 fixed-width parser、DataKubun、primary key、native/standard child
+  schema を現行契約へ揃え、SQLite/PostgreSQL の transaction recovery と
+  durable statistics を fail closed 化
+- 1.x DB は事前 backup のうえ v2 schema で rebuild/reimport し、件数・key・
+  取消・readback を確認する。rollback は部分移行DBの再利用ではなく、backup と
+  旧releaseの復元で行う。詳細は `docs/data_support.md` と v2 release notes を参照
 
 ### Fixed
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+prune tests

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
 prune tests
+prune specs

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -15,6 +15,17 @@ Current migration boundary:
   runtime-state targets
 - 64-bit SDK execution remains unverified and is not claimed as supported
 
+Public API replacements:
+
+- `JVLinkWrapper.jv_set_service_key` and
+  `JVLinkBridge.jv_set_service_key` have no programmatic replacement;
+  complete provider registration in DataLab
+- removed `DATA_SPEC_O1` through `DATA_SPEC_O6` constants are replaced by
+  `RECORD_TYPE_O1` through `RECORD_TYPE_O6`; these are record identifiers
+  delivered by a supported data spec, not standalone open specs
+- use `uses_external_runner` instead of the removed
+  implementation-specific runner-detection property
+
 ## Data-contract and reliability changes since v1.6.10
 
 - parser contracts now bind current official fixed-width layouts, reject

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,20 @@
+# jrvltsql v2.0.0 Release Notes (unreleased draft)
+
+This version is not released yet. The repository reports `2.0.0.dev0` until
+the official data-contract repairs, documentation audit, and real acquisition
+and database release gates are complete.
+
+Current migration boundary:
+
+- configure provider registration in DataLab; programmatic registry-writing
+  setup APIs have been removed
+- non-Windows bridge deployments must explicitly configure the externally
+  managed runner with `JVLINK_BRIDGE_RUNNER`
+- `jltsql init` creates a safe SQLite-only configuration in the current
+  directory; installed package directories are no longer configuration or
+  runtime-state targets
+- 64-bit SDK execution remains unverified and is not claimed as supported
+
 # jrvltsql v1.6.10 Release Notes
 
 Everything merged since v1.6.9: PR #149, #150, #151, #152, and #153.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -15,6 +15,46 @@ Current migration boundary:
   runtime-state targets
 - 64-bit SDK execution remains unverified and is not claimed as supported
 
+## Data-contract and reliability changes since v1.6.10
+
+- parser contracts now bind current official fixed-width layouts, reject
+  malformed CP932 and unsupported historical/synthetic lengths, and preserve
+  explicitly supported old/new semantic boundaries instead of guessing them
+- native and standard schemas now verify primary keys, types, capacities,
+  child-table constraints, and cancellation/delete behavior before mutation;
+  several record families gained complete child storage or corrected keys
+- imports and realtime updates preserve provider order and use fail-closed
+  transaction recovery so returned statistics agree with durable rows across
+  SQLite and PostgreSQL
+- acquisition/cache handling now requires complete read/EOF/close evidence,
+  avoids false complete markers, and repairs only provider-identified corrupt
+  files under bounded rules
+- distribution and bootstrap gates now inspect built artifacts, isolate wheel
+  imports, and verify a base-dependency SQLite installation without writing
+  runtime state into the package tree
+
+The record-by-record support and storage details are maintained in
+[`docs/data_support.md`](docs/data_support.md).
+
+## Required database migration
+
+Treat v2 as a schema rebuild boundary; do not point the new importer at an
+unreviewed 1.x database and assume additive migration is sufficient.
+
+1. Stop collectors and take a verified backup of every SQLite/PostgreSQL
+   database plus the prior application release.
+2. Validate the backup can be opened/restored, then rebuild affected native or
+   standard tables with the v2 schema. A fail-closed preflight error means stop;
+   do not weaken keys or constraints to continue.
+3. Reimport retained provider data with the v2 parser and verify per-table
+   counts, official keys, cancellation behavior, and representative readback.
+4. Resume collection only after the real acquisition-to-database gate passes
+   for the exact release SHA.
+
+Rollback means stopping v2, restoring the backup, and running the previous
+release against that restored database. Do not reuse a partially migrated v2
+database with a 1.x binary.
+
 # jrvltsql v1.6.10 Release Notes
 
 Everything merged since v1.6.9: PR #149, #150, #151, #152, and #153.

--- a/config/config.yaml.example
+++ b/config/config.yaml.example
@@ -54,17 +54,11 @@ data_fetch:
     # RACE: RA, SE, HR
     # DIFN: UM, KS, CH, BR, BN
     # YSCH: Schedule
-    # O1-O6: Odds
+    # O1-O6 are record IDs contained in RACE, not standalone JVOpen specs.
     data_specs:
       - "RACE"      # Race data (RA, SE, HR)
       - "DIFN"      # Master data (UM, KS, CH, BR, BN)
       - "YSCH"      # Schedule
-      - "O1"        # Win/Place/Bracket odds
-      - "O2"        # Quinella odds
-      - "O3"        # Wide odds
-      - "O4"        # Exacta odds
-      - "O5"        # Trio odds
-      - "O6"        # Trifecta odds
 
   # Real-time data fetch
   realtime:

--- a/daily_sync.bat
+++ b/daily_sync.bat
@@ -145,7 +145,7 @@ if defined VIRTUAL_ENV (
 )
 
 if exist "%~dp0venv32\Scripts\python.exe" (
-    "%~dp0venv32\Scripts\python.exe" -c "import sys; raise SystemExit(sys.version_info < (3, 12))" >nul 2>&1
+    "%~dp0venv32\Scripts\python.exe" -c "import struct,sys; raise SystemExit(sys.version_info < (3, 12) or struct.calcsize('P') != 4)" >nul 2>&1
     if !errorlevel!==0 (
         "%~dp0venv32\Scripts\python.exe" %SYNC_SCRIPT% !SYNC_ARGS!
         set "SCRIPT_EXIT_CODE=!errorlevel!"

--- a/daily_sync.bat
+++ b/daily_sync.bat
@@ -134,9 +134,9 @@ if defined VIRTUAL_ENV (
         echo [ERROR] VIRTUAL_ENV must point to Python 3.12 or later.
         exit /b 1
     )
-    "%VIRTUAL_ENV%\Scripts\python.exe" -c "import sys; raise SystemExit(sys.version_info < (3, 12))" >nul 2>&1
+    "%VIRTUAL_ENV%\Scripts\python.exe" -c "import struct,sys; raise SystemExit(sys.version_info < (3, 12) or struct.calcsize('P') != 4)" >nul 2>&1
     if !errorlevel! neq 0 (
-        echo [ERROR] VIRTUAL_ENV must point to Python 3.12 or later.
+        echo [ERROR] VIRTUAL_ENV must point to 32-bit Python 3.12 or later.
         exit /b 1
     )
     "%VIRTUAL_ENV%\Scripts\python.exe" %SYNC_SCRIPT% !SYNC_ARGS!
@@ -154,7 +154,7 @@ if exist "%~dp0venv32\Scripts\python.exe" (
 )
 
 if exist "%~dp0.venv\Scripts\python.exe" (
-    "%~dp0.venv\Scripts\python.exe" -c "import sys; raise SystemExit(sys.version_info < (3, 12))" >nul 2>&1
+    "%~dp0.venv\Scripts\python.exe" -c "import struct,sys; raise SystemExit(sys.version_info < (3, 12) or struct.calcsize('P') != 4)" >nul 2>&1
     if !errorlevel!==0 (
         "%~dp0.venv\Scripts\python.exe" %SYNC_SCRIPT% !SYNC_ARGS!
         set "SCRIPT_EXIT_CODE=!errorlevel!"
@@ -169,28 +169,7 @@ if !errorlevel!==0 (
     goto :check_result
 )
 
-py -3.12 --version >nul 2>&1
-if !errorlevel!==0 (
-    py -3.12 %SYNC_SCRIPT% !SYNC_ARGS!
-    set "SCRIPT_EXIT_CODE=!errorlevel!"
-    goto :check_result
-)
-
-py -c "import sys; raise SystemExit(sys.version_info < (3, 12))" >nul 2>&1
-if !errorlevel!==0 (
-    py %SYNC_SCRIPT% !SYNC_ARGS!
-    set "SCRIPT_EXIT_CODE=!errorlevel!"
-    goto :check_result
-)
-
-python -c "import sys; raise SystemExit(sys.version_info < (3, 12))" >nul 2>&1
-if !errorlevel!==0 (
-    python %SYNC_SCRIPT% !SYNC_ARGS!
-    set "SCRIPT_EXIT_CODE=!errorlevel!"
-    goto :check_result
-)
-
-echo [ERROR] Python not found.
+echo [ERROR] 32-bit Python not found. Set PYTHON only for explicit SDK validation.
 exit /b 1
 
 :check_result

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -34,7 +34,9 @@ SQLite は単体検証や PostgreSQL がない環境のフォールバックで�
 公開 CLI の利用要件は Windows 10 / 11 です。`JVLinkBridge` クライアントを
 外部 collector から利用する場合は `JVLINK_BRIDGE_EXE` で実行可能な bridge を
 指定します。bridge、JV-Link、GUI セッションの準備とサービスキー登録は配備
-環境の責務です。
+環境の責務です。Windows では bridge を直接実行します。非Windows の検証環境で
+bridge を起動する場合は、外部 runner の実行ファイルを
+`JVLINK_BRIDGE_RUNNER` へ明示し、暗黙の実装選択に依存しないでください。
 
 JV-Link は `JVOpen` / `JVRTOpen` 中にお知らせや DataLab 更新確認を表示し、
 非対話実行を停止させる場合があります。クライアントは既知のダイアログだけを

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -28,6 +28,11 @@ PostgreSQL だけを対象にした `quickstart_postgres_timeseries.bat` もあ�
 PostgreSQL 時系列オッズ投入が終わると、`daily_sync.bat` を日次 Windows
 タスクとして登録するか確認します。
 
+`fetch_timeseries_postgres.bat` は PATH 上の `jltsql` を暗黙には選びません。
+既定の32-bit Python以外をSDK込みで別途検証済みの場合に限り、実行前に
+`JLTSQL` を引用符付きの実行可能コマンドへ明示設定できます。この変数は
+operator overrideであり、64-bit動作確認や対応を示すものではありません。
+
 三連複・三連単を含む全賭式の締切前オッズを残したい場合は、開催週に
 `jltsql realtime odds-sokuho-timeseries` を別途実行してください。SQLite に
 保存する場合は `--db sqlite --db-path data/keiba.db` を指定できます。

--- a/fetch_timeseries_postgres.bat
+++ b/fetch_timeseries_postgres.bat
@@ -30,6 +30,8 @@ if not exist "config\config.yaml" (
     exit /b 1
 )
 
+REM JLTSQL is an explicit operator override for a separately validated SDK
+REM environment. This script deliberately does not discover jltsql from PATH.
 if defined PYTHON (
     if not exist "%PYTHON%" (
         echo [ERROR] PYTHON must be a full path to python.exe.
@@ -67,7 +69,8 @@ if not defined JLTSQL (
     if !errorlevel!==0 set "JLTSQL=py -3.12-32 -m src.cli.main"
 )
 if not defined JLTSQL (
-    echo [ERROR] 32-bit Python or an explicit jltsql command was not found.
+    echo [ERROR] 32-bit Python was not found. For a separately validated SDK,
+    echo         set JLTSQL to a fully quoted executable command explicitly.
     exit /b 1
 )
 

--- a/fetch_timeseries_postgres.bat
+++ b/fetch_timeseries_postgres.bat
@@ -30,7 +30,6 @@ if not exist "config\config.yaml" (
     exit /b 1
 )
 
-set "JLTSQL="
 if defined PYTHON (
     if not exist "%PYTHON%" (
         echo [ERROR] PYTHON must be a full path to python.exe.
@@ -56,16 +55,12 @@ if not defined JLTSQL if defined VIRTUAL_ENV (
     set "JLTSQL="!VIRTUAL_ENV!\Scripts\python.exe" -m src.cli.main"
 )
 if not defined JLTSQL if exist "venv32\Scripts\python.exe" (
-    "venv32\Scripts\python.exe" -c "import sys; raise SystemExit(sys.version_info < (3, 12))" >nul 2>&1
+    "venv32\Scripts\python.exe" -c "import struct,sys; raise SystemExit(sys.version_info < (3, 12) or struct.calcsize('P') != 4)" >nul 2>&1
     if !errorlevel!==0 set "JLTSQL=venv32\Scripts\python.exe -m src.cli.main"
 )
 if not defined JLTSQL if exist ".venv\Scripts\python.exe" (
     ".venv\Scripts\python.exe" -c "import struct,sys; raise SystemExit(sys.version_info < (3, 12) or struct.calcsize('P') != 4)" >nul 2>&1
     if !errorlevel!==0 set "JLTSQL=.venv\Scripts\python.exe -m src.cli.main"
-)
-if not defined JLTSQL (
-    where jltsql >nul 2>&1
-    if !errorlevel!==0 set "JLTSQL=jltsql"
 )
 if not defined JLTSQL (
     py -3.12-32 --version >nul 2>&1

--- a/fetch_timeseries_postgres.bat
+++ b/fetch_timeseries_postgres.bat
@@ -32,7 +32,7 @@ if not exist "config\config.yaml" (
 
 REM JLTSQL is an explicit operator override for a separately validated SDK
 REM environment. This script deliberately does not discover jltsql from PATH.
-if defined PYTHON (
+if not defined JLTSQL if defined PYTHON (
     if not exist "%PYTHON%" (
         echo [ERROR] PYTHON must be a full path to python.exe.
         exit /b 1

--- a/fetch_timeseries_postgres.bat
+++ b/fetch_timeseries_postgres.bat
@@ -48,9 +48,9 @@ if not defined JLTSQL if defined VIRTUAL_ENV (
         echo [ERROR] VIRTUAL_ENV must point to Python 3.12 or later.
         exit /b 1
     )
-    "%VIRTUAL_ENV%\Scripts\python.exe" -c "import sys; raise SystemExit(sys.version_info < (3, 12))" >nul 2>&1
+    "%VIRTUAL_ENV%\Scripts\python.exe" -c "import struct,sys; raise SystemExit(sys.version_info < (3, 12) or struct.calcsize('P') != 4)" >nul 2>&1
     if !errorlevel! neq 0 (
-        echo [ERROR] VIRTUAL_ENV must point to Python 3.12 or later.
+        echo [ERROR] VIRTUAL_ENV must point to 32-bit Python 3.12 or later.
         exit /b 1
     )
     set "JLTSQL="!VIRTUAL_ENV!\Scripts\python.exe" -m src.cli.main"
@@ -60,7 +60,7 @@ if not defined JLTSQL if exist "venv32\Scripts\python.exe" (
     if !errorlevel!==0 set "JLTSQL=venv32\Scripts\python.exe -m src.cli.main"
 )
 if not defined JLTSQL if exist ".venv\Scripts\python.exe" (
-    ".venv\Scripts\python.exe" -c "import sys; raise SystemExit(sys.version_info < (3, 12))" >nul 2>&1
+    ".venv\Scripts\python.exe" -c "import struct,sys; raise SystemExit(sys.version_info < (3, 12) or struct.calcsize('P') != 4)" >nul 2>&1
     if !errorlevel!==0 set "JLTSQL=.venv\Scripts\python.exe -m src.cli.main"
 )
 if not defined JLTSQL (
@@ -72,15 +72,7 @@ if not defined JLTSQL (
     if !errorlevel!==0 set "JLTSQL=py -3.12-32 -m src.cli.main"
 )
 if not defined JLTSQL (
-    py -3.12 --version >nul 2>&1
-    if !errorlevel!==0 set "JLTSQL=py -3.12 -m src.cli.main"
-)
-if not defined JLTSQL (
-    python -c "import sys; raise SystemExit(sys.version_info < (3, 12))" >nul 2>&1
-    if !errorlevel!==0 set "JLTSQL=python -m src.cli.main"
-)
-if not defined JLTSQL (
-    echo [ERROR] Python or jltsql not found.
+    echo [ERROR] 32-bit Python or an explicit jltsql command was not found.
     exit /b 1
 )
 

--- a/install.bat
+++ b/install.bat
@@ -42,33 +42,9 @@ if !errorlevel!==0 (
     goto :found_python
 )
 
-py -3.12 --version >nul 2>&1
-if !errorlevel!==0 (
-    set "PYTHON_CMD=py -3.12"
-    goto :found_python
-)
-
-py -3 --version >nul 2>&1
-if !errorlevel!==0 (
-    py -3 -c "import sys; raise SystemExit(sys.version_info < (3, 12))" >nul 2>&1
-    if !errorlevel!==0 (
-        set "PYTHON_CMD=py -3"
-        goto :found_python
-    )
-)
-
-python --version >nul 2>&1
-if !errorlevel!==0 (
-    python -c "import sys; raise SystemExit(sys.version_info < (3, 12))" >nul 2>&1
-    if !errorlevel!==0 (
-        set "PYTHON_CMD=python"
-        goto :found_python
-    )
-)
-
 echo   [NG] Python 3.12 or later not found.
 echo.
-echo   Install Python 3.12 or later with the same bitness as JV-Link:
+echo   Install 32-bit Python, or set PYTHON to a full path only for explicit SDK validation:
 echo     Download: https://www.python.org/downloads/
 echo     Check 'Add Python to PATH'
 echo.
@@ -237,7 +213,8 @@ echo.
 echo   Next steps:
 echo     1. Restart your terminal
 echo     2. Edit config: %INSTALL_DIR%\config\config.yaml
-echo     3. Run: jltsql --config "%INSTALL_DIR%\config\config.yaml" fetch --from 20240101 --to 20241231 --spec RACE
+echo     3. Run: cd /d "%INSTALL_DIR%"
+echo        jltsql --config "config\config.yaml" fetch --from 20240101 --to 20241231 --spec RACE
 echo.
 echo   Quick start ^(interactive^):
 echo     cd %INSTALL_DIR% ^&^& quickstart.bat

--- a/install.bat
+++ b/install.bat
@@ -201,7 +201,7 @@ if exist "%INSTALL_DIR%\config\config.yaml" (
     echo   [!!] Review %INSTALL_DIR%\config\config.yaml for database settings
     echo   [!!] Register JV-Link in the JRA-VAN DataLab application
 ) else (
-    echo   [!!] config.yaml.example not found, run 'jltsql init' later
+    echo   [!!] config.yaml.example not found; restore the checkout and re-run this installer
 )
 
 REM === Step 7: Add to PATH ===
@@ -237,8 +237,7 @@ echo.
 echo   Next steps:
 echo     1. Restart your terminal
 echo     2. Edit config: %INSTALL_DIR%\config\config.yaml
-echo     3. Run: jltsql init
-echo     4. Run: jltsql fetch --from 20240101 --to 20241231 --spec RACE
+echo     3. Run: jltsql --config "%INSTALL_DIR%\config\config.yaml" fetch --from 20240101 --to 20241231 --spec RACE
 echo.
 echo   Quick start ^(interactive^):
 echo     cd %INSTALL_DIR% ^&^& quickstart.bat

--- a/install.bat
+++ b/install.bat
@@ -198,7 +198,8 @@ if exist "%INSTALL_DIR%\config\config.yaml" (
 ) else if exist "%INSTALL_DIR%\config\config.yaml.example" (
     copy "%INSTALL_DIR%\config\config.yaml.example" "%INSTALL_DIR%\config\config.yaml" >nul
     echo   [OK] Created config.yaml from template
-    echo   [!!] Edit %INSTALL_DIR%\config\config.yaml to set your service keys
+    echo   [!!] Review %INSTALL_DIR%\config\config.yaml for database settings
+    echo   [!!] Register JV-Link in the JRA-VAN DataLab application
 ) else (
     echo   [!!] config.yaml.example not found, run 'jltsql init' later
 )

--- a/install.ps1
+++ b/install.ps1
@@ -68,10 +68,7 @@ if ($env:PYTHON) {
     $candidates += @{ Command = $env:PYTHON; Arguments = @(); Display = $env:PYTHON }
 } else {
     $candidates += @(
-        @{ Command = "py"; Arguments = @("-$PYTHON_VERSION-32"); Display = "py -$PYTHON_VERSION-32" },
-        @{ Command = "py"; Arguments = @("-$PYTHON_VERSION"); Display = "py -$PYTHON_VERSION" },
-        @{ Command = "py"; Arguments = @("-3"); Display = "py -3" },
-        @{ Command = "python"; Arguments = @(); Display = "python" }
+        @{ Command = "py"; Arguments = @("-$PYTHON_VERSION-32"); Display = "py -$PYTHON_VERSION-32" }
     )
 }
 
@@ -101,7 +98,7 @@ if (-not $pythonCommand) {
     }
     Write-Fail "Python $PYTHON_VERSION or later not found."
     Write-Host ""
-    Write-Host "  Install Python with the same bitness as JV-Link:" -ForegroundColor Yellow
+    Write-Host "  Install 32-bit Python, or set PYTHON to a full path only for explicit SDK validation:" -ForegroundColor Yellow
     Write-Host "    1. Download from: https://www.python.org/downloads/" -ForegroundColor White
     Write-Host "    2. Check 'Add Python to PATH' during install" -ForegroundColor White
     Write-Host "    3. Re-run this installer" -ForegroundColor White
@@ -268,7 +265,8 @@ Write-Host "       -> Interactive setup: DB creation, data fetch, all-in-one" -F
 Write-Host ""
 Write-Host "  Or manual setup:" -ForegroundColor Yellow
 Write-Host "    1. Edit config: $configFile" -ForegroundColor White
-Write-Host "    2. Run: jltsql --config `"$configFile`" fetch --from 20240101 --to 20241231 --spec RACE" -ForegroundColor White
+Write-Host "    2. Run: Set-Location `"$INSTALL_DIR`"" -ForegroundColor White
+Write-Host "       jltsql --config `".\config\config.yaml`" fetch --from 20240101 --to 20241231 --spec RACE" -ForegroundColor White
 Write-Host ""
 Write-Host "  Commands:" -ForegroundColor Yellow
 Write-Host "    jltsql version     Show version info" -ForegroundColor DarkGray

--- a/install.ps1
+++ b/install.ps1
@@ -220,7 +220,7 @@ if (Test-Path $configFile) {
     Write-Warn "Review $configFile for database settings"
     Write-Warn "Register JV-Link in the JRA-VAN DataLab application"
 } else {
-    Write-Warn "config.yaml.example not found, run 'jltsql init' later"
+    Write-Warn "config.yaml.example not found; re-run the installer after restoring the checkout"
 }
 
 # Create data and logs directories
@@ -268,8 +268,7 @@ Write-Host "       -> Interactive setup: DB creation, data fetch, all-in-one" -F
 Write-Host ""
 Write-Host "  Or manual setup:" -ForegroundColor Yellow
 Write-Host "    1. Edit config: $configFile" -ForegroundColor White
-Write-Host "    2. Run: jltsql init" -ForegroundColor White
-Write-Host "    3. Run: jltsql fetch --from 20240101 --to 20241231 --spec RACE" -ForegroundColor White
+Write-Host "    2. Run: jltsql --config `"$configFile`" fetch --from 20240101 --to 20241231 --spec RACE" -ForegroundColor White
 Write-Host ""
 Write-Host "  Commands:" -ForegroundColor Yellow
 Write-Host "    jltsql version     Show version info" -ForegroundColor DarkGray

--- a/install.ps1
+++ b/install.ps1
@@ -217,7 +217,8 @@ if (Test-Path $configFile) {
 } elseif (Test-Path $configExample) {
     Copy-Item $configExample $configFile
     Write-Ok "Created config.yaml from template"
-    Write-Warn "Edit $configFile to set your service keys"
+    Write-Warn "Review $configFile for database settings"
+    Write-Warn "Register JV-Link in the JRA-VAN DataLab application"
 } else {
     Write-Warn "config.yaml.example not found, run 'jltsql init' later"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "jltsql"
 version = "1.6.10"
 description = "JRA-VAN DataLab の競馬データをSQLite・PostgreSQLにインポートするツール"
 readme = "README.md"
-license = {text = "Apache-2.0"}
+license = "Apache-2.0"
 authors = [
     {name = "JLTSQL Contributors"}
 ]
@@ -16,7 +16,6 @@ keywords = ["jra-van", "horse-racing", "data", "sqlite", "postgresql", "jvlink"]
 classifiers = [
     "Development Status :: 3 - Alpha",
     "Intended Audience :: Developers",
-    "License :: OSI Approved :: Apache Software License",
     "Operating System :: Microsoft :: Windows",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.12",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "jltsql"
-version = "1.6.10"
+version = "2.0.0.dev0"
 description = "JRA-VAN DataLab の競馬データをSQLite・PostgreSQLにインポートするツール"
 readme = "README.md"
 license = "Apache-2.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=68.0", "wheel"]
+requires = ["setuptools>=77.0.3", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ dependencies = [
     "pywin32>=305; sys_platform == 'win32'",
     "pyyaml>=6.0",
     "python-dateutil>=2.8",
+    "packaging>=23.0",
     "click>=8.1",
     "rich>=13.0",
     "structlog>=23.0",

--- a/quickstart.bat
+++ b/quickstart.bat
@@ -56,7 +56,7 @@ if defined VIRTUAL_ENV (
 )
 
 if exist "%~dp0venv32\Scripts\python.exe" (
-    "%~dp0venv32\Scripts\python.exe" -c "import sys; raise SystemExit(sys.version_info < (3, 12))" >nul 2>&1
+    "%~dp0venv32\Scripts\python.exe" -c "import struct,sys; raise SystemExit(sys.version_info < (3, 12) or struct.calcsize('P') != 4)" >nul 2>&1
     if !errorlevel!==0 (
         set "PYTHON_CMD="%~dp0venv32\Scripts\python.exe""
         goto :run

--- a/quickstart.bat
+++ b/quickstart.bat
@@ -46,9 +46,9 @@ if defined VIRTUAL_ENV (
         echo ERROR: VIRTUAL_ENV must point to Python 3.12 or later.
         exit /b 1
     )
-    "%VIRTUAL_ENV%\Scripts\python.exe" -c "import sys; raise SystemExit(sys.version_info < (3, 12))" >nul 2>&1
+    "%VIRTUAL_ENV%\Scripts\python.exe" -c "import struct,sys; raise SystemExit(sys.version_info < (3, 12) or struct.calcsize('P') != 4)" >nul 2>&1
     if !errorlevel! neq 0 (
-        echo ERROR: VIRTUAL_ENV must point to Python 3.12 or later.
+        echo ERROR: VIRTUAL_ENV must point to 32-bit Python 3.12 or later.
         exit /b 1
     )
     set "PYTHON_CMD="!VIRTUAL_ENV!\Scripts\python.exe""
@@ -64,7 +64,7 @@ if exist "%~dp0venv32\Scripts\python.exe" (
 )
 
 if exist "%~dp0.venv\Scripts\python.exe" (
-    "%~dp0.venv\Scripts\python.exe" -c "import sys; raise SystemExit(sys.version_info < (3, 12))" >nul 2>&1
+    "%~dp0.venv\Scripts\python.exe" -c "import struct,sys; raise SystemExit(sys.version_info < (3, 12) or struct.calcsize('P') != 4)" >nul 2>&1
     if !errorlevel!==0 (
         set "PYTHON_CMD="%~dp0.venv\Scripts\python.exe""
         goto :run
@@ -77,28 +77,9 @@ if !errorlevel!==0 (
     goto :run
 )
 
-py -3.12 --version >nul 2>&1
-if !errorlevel!==0 (
-    set "PYTHON_CMD=py -3.12"
-    goto :run
-)
-
-py -3 -c "import sys; raise SystemExit(sys.version_info < (3, 12))" >nul 2>&1
-if !errorlevel!==0 (
-    set "PYTHON_CMD=py -3"
-    goto :run
-)
-
-REM Fallback: python in PATH
-python -c "import sys; raise SystemExit(sys.version_info < (3, 12))" >nul 2>&1
-if !errorlevel!==0 (
-    set "PYTHON_CMD=python"
-    goto :run
-)
-
 REM No Python found
 echo ERROR: Python not found
-echo Please install Python 3.12+ with the same bitness as JV-Link.
+echo Install 32-bit Python, or set PYTHON to a full path only for explicit SDK validation.
 echo Download: https://www.python.org/downloads/
 pause
 exit /b 1
@@ -119,7 +100,7 @@ if !SCRIPT_EXIT_CODE! neq 0 (
     echo   Please check the error messages above.
     echo   Common issues:
     echo     - Missing config/config.yaml
-    echo     - Invalid service key
+    echo     - DataLab registration is incomplete
     echo     - No data available for the specified date range
     echo.
     echo   Press Enter to close...

--- a/quickstart_postgres_timeseries.bat
+++ b/quickstart_postgres_timeseries.bat
@@ -60,9 +60,9 @@ if not defined PYTHON_CMD if defined VIRTUAL_ENV (
         echo [ERROR] VIRTUAL_ENV must point to Python 3.12 or later.
         exit /b 1
     )
-    "%VIRTUAL_ENV%\Scripts\python.exe" -c "import sys; raise SystemExit(sys.version_info < (3, 12))" >nul 2>&1
+    "%VIRTUAL_ENV%\Scripts\python.exe" -c "import struct,sys; raise SystemExit(sys.version_info < (3, 12) or struct.calcsize('P') != 4)" >nul 2>&1
     if !errorlevel! neq 0 (
-        echo [ERROR] VIRTUAL_ENV must point to Python 3.12 or later.
+        echo [ERROR] VIRTUAL_ENV must point to 32-bit Python 3.12 or later.
         exit /b 1
     )
     set "PYTHON_CMD="!VIRTUAL_ENV!\Scripts\python.exe""
@@ -72,7 +72,7 @@ if not defined PYTHON_CMD if exist "%~dp0venv32\Scripts\python.exe" (
     if !errorlevel!==0 set "PYTHON_CMD="%~dp0venv32\Scripts\python.exe""
 )
 if not defined PYTHON_CMD if exist "%~dp0.venv\Scripts\python.exe" (
-    "%~dp0.venv\Scripts\python.exe" -c "import sys; raise SystemExit(sys.version_info < (3, 12))" >nul 2>&1
+    "%~dp0.venv\Scripts\python.exe" -c "import struct,sys; raise SystemExit(sys.version_info < (3, 12) or struct.calcsize('P') != 4)" >nul 2>&1
     if !errorlevel!==0 set "PYTHON_CMD="%~dp0.venv\Scripts\python.exe""
 )
 if not defined PYTHON_CMD (
@@ -80,20 +80,8 @@ if not defined PYTHON_CMD (
     if !errorlevel!==0 set "PYTHON_CMD=py -3.12-32"
 )
 if not defined PYTHON_CMD (
-    py -3.12 --version >nul 2>&1
-    if !errorlevel!==0 set "PYTHON_CMD=py -3.12"
-)
-if not defined PYTHON_CMD (
-    py -3 -c "import sys; raise SystemExit(sys.version_info < (3, 12))" >nul 2>&1
-    if !errorlevel!==0 set "PYTHON_CMD=py -3"
-)
-if not defined PYTHON_CMD (
-    python -c "import sys; raise SystemExit(sys.version_info < (3, 12))" >nul 2>&1
-    if !errorlevel!==0 set "PYTHON_CMD=python"
-)
-if not defined PYTHON_CMD (
-    echo ERROR: Python not found
-    echo Please install Python 3.12+ with the same bitness as JV-Link.
+    echo ERROR: 32-bit Python not found
+    echo Set PYTHON only for explicit SDK validation.
     exit /b 1
 )
 

--- a/quickstart_postgres_timeseries.bat
+++ b/quickstart_postgres_timeseries.bat
@@ -68,7 +68,7 @@ if not defined PYTHON_CMD if defined VIRTUAL_ENV (
     set "PYTHON_CMD="!VIRTUAL_ENV!\Scripts\python.exe""
 )
 if not defined PYTHON_CMD if exist "%~dp0venv32\Scripts\python.exe" (
-    "%~dp0venv32\Scripts\python.exe" -c "import sys; raise SystemExit(sys.version_info < (3, 12))" >nul 2>&1
+    "%~dp0venv32\Scripts\python.exe" -c "import struct,sys; raise SystemExit(sys.version_info < (3, 12) or struct.calcsize('P') != 4)" >nul 2>&1
     if !errorlevel!==0 set "PYTHON_CMD="%~dp0venv32\Scripts\python.exe""
 )
 if not defined PYTHON_CMD if exist "%~dp0.venv\Scripts\python.exe" (

--- a/quickstart_timeseries.bat
+++ b/quickstart_timeseries.bat
@@ -119,9 +119,9 @@ if not defined PYTHON_CMD if defined VIRTUAL_ENV (
         echo [ERROR] VIRTUAL_ENV must point to Python 3.12 or later.
         exit /b 1
     )
-    "%VIRTUAL_ENV%\Scripts\python.exe" -c "import sys; raise SystemExit(sys.version_info < (3, 12))" >nul 2>&1
+    "%VIRTUAL_ENV%\Scripts\python.exe" -c "import struct,sys; raise SystemExit(sys.version_info < (3, 12) or struct.calcsize('P') != 4)" >nul 2>&1
     if !errorlevel! neq 0 (
-        echo [ERROR] VIRTUAL_ENV must point to Python 3.12 or later.
+        echo [ERROR] VIRTUAL_ENV must point to 32-bit Python 3.12 or later.
         exit /b 1
     )
     set "PYTHON_CMD="!VIRTUAL_ENV!\Scripts\python.exe""
@@ -131,7 +131,7 @@ if not defined PYTHON_CMD if exist "%~dp0venv32\Scripts\python.exe" (
     if !errorlevel!==0 set "PYTHON_CMD="%~dp0venv32\Scripts\python.exe""
 )
 if not defined PYTHON_CMD if exist "%~dp0.venv\Scripts\python.exe" (
-    "%~dp0.venv\Scripts\python.exe" -c "import sys; raise SystemExit(sys.version_info < (3, 12))" >nul 2>&1
+    "%~dp0.venv\Scripts\python.exe" -c "import struct,sys; raise SystemExit(sys.version_info < (3, 12) or struct.calcsize('P') != 4)" >nul 2>&1
     if !errorlevel!==0 set "PYTHON_CMD="%~dp0.venv\Scripts\python.exe""
 )
 if not defined PYTHON_CMD (
@@ -139,24 +139,12 @@ if not defined PYTHON_CMD (
     if !errorlevel!==0 set "PYTHON_CMD=py -3.12-32"
 )
 if not defined PYTHON_CMD (
-    py -3.12 --version >nul 2>&1
-    if !errorlevel!==0 set "PYTHON_CMD=py -3.12"
-)
-if not defined PYTHON_CMD (
     py -32 -c "import sys; raise SystemExit(sys.version_info < (3, 12))" >nul 2>&1
     if !errorlevel!==0 set "PYTHON_CMD=py -32"
 )
 if not defined PYTHON_CMD (
-    py -c "import sys; raise SystemExit(sys.version_info < (3, 12))" >nul 2>&1
-    if !errorlevel!==0 set "PYTHON_CMD=py"
-)
-if not defined PYTHON_CMD (
-    python -c "import sys; raise SystemExit(sys.version_info < (3, 12))" >nul 2>&1
-    if !errorlevel!==0 set "PYTHON_CMD=python"
-)
-if not defined PYTHON_CMD (
-    echo [ERROR] Python not found.
-    echo Please install Python 3.12+ with the same bitness as JV-Link.
+    echo [ERROR] 32-bit Python not found.
+    echo Set PYTHON only for explicit SDK validation.
     exit /b 1
 )
 

--- a/quickstart_timeseries.bat
+++ b/quickstart_timeseries.bat
@@ -127,7 +127,7 @@ if not defined PYTHON_CMD if defined VIRTUAL_ENV (
     set "PYTHON_CMD="!VIRTUAL_ENV!\Scripts\python.exe""
 )
 if not defined PYTHON_CMD if exist "%~dp0venv32\Scripts\python.exe" (
-    "%~dp0venv32\Scripts\python.exe" -c "import sys; raise SystemExit(sys.version_info < (3, 12))" >nul 2>&1
+    "%~dp0venv32\Scripts\python.exe" -c "import struct,sys; raise SystemExit(sys.version_info < (3, 12) or struct.calcsize('P') != 4)" >nul 2>&1
     if !errorlevel!==0 set "PYTHON_CMD="%~dp0venv32\Scripts\python.exe""
 )
 if not defined PYTHON_CMD if exist "%~dp0.venv\Scripts\python.exe" (

--- a/scripts/check_distribution_contents.py
+++ b/scripts/check_distribution_contents.py
@@ -84,7 +84,7 @@ def _sensitive_category(payload: bytes) -> str | None:
     variants = (
         payload,
         without_nuls,
-        re.sub(rb"[\s\"']", b"", without_nuls),
+        re.sub(rb"[\s\"'+]", b"", without_nuls),
     )
     for candidate in variants:
         for category, pattern in SENSITIVE_TEXT_PATTERNS:

--- a/scripts/check_distribution_contents.py
+++ b/scripts/check_distribution_contents.py
@@ -9,6 +9,7 @@ import re
 import stat
 import tarfile
 import zipfile
+import zlib
 from collections.abc import Iterable, Sequence
 from pathlib import Path, PurePosixPath
 
@@ -28,6 +29,7 @@ PROHIBITED_TOKEN_SHA256 = frozenset(
         "08c64f088046a0504f39c8b52ed474483d642ac4efdee5211a54ad41a10684e8",
         "1487241b177b0353807ec09be32c409de832fc657c93f7ed5eb23b444708d7e7",
         "32c4feed996880bc92a062dc476f9b8cdb2596a989f2cc5246e9cef605bd5c78",
+        "3958765b23d8a51d3445d91f98c1e76f62b896d615011d132b4ae85e4331d2fe",
         "454e0f9c502a52a6c351c9614bac911e22d42908a87dcaf47467645b6001fb17",
         "594f63ba499f2248fdf20c6472a7527a13be1a96e0642615c7f045bf886c3405",
         "684be438b04d22074ca4bb4b1d83bac553d09e3c02680e1ee3a4936d8af22a0a",
@@ -52,7 +54,7 @@ SENSITIVE_TEXT_PATTERNS = (
     (
         "credential-shaped value",
         re.compile(
-            rb"(?:service[_ -]?key|<key>)\s*[:=>\"']*\s*"
+            rb"(?:service[_ -]?key|<key>)[\s(:=>\"']*"
             rb"[A-Z0-9]{17}(?![A-Z0-9])",
             re.IGNORECASE,
         ),
@@ -78,7 +80,12 @@ def _artifact_kind(path: Path) -> str | None:
 
 
 def _sensitive_category(payload: bytes) -> str | None:
-    variants = (payload, payload.replace(b"\x00", b""))
+    without_nuls = payload.replace(b"\x00", b"")
+    variants = (
+        payload,
+        without_nuls,
+        re.sub(rb"[\s\"']", b"", without_nuls),
+    )
     for candidate in variants:
         for category, pattern in SENSITIVE_TEXT_PATTERNS:
             if pattern.search(candidate):
@@ -112,8 +119,8 @@ def _archive_entries(
                 payload = None
                 error = None
                 member_type = (member.external_attr >> 16) & 0o170000
-                if stat.S_ISLNK(member_type):
-                    error = "archive links are not permitted"
+                if member_type and not stat.S_ISREG(member_type) and not member.is_dir():
+                    error = "archive links and special members are not permitted"
                 elif not member.is_dir():
                     if member.file_size > MAX_SCANNED_TEXT_BYTES:
                         error = "member exceeds the content-scan size limit"
@@ -151,16 +158,31 @@ def _member_error(path: Path, member: str) -> str | None:
     if (
         pure_path.is_absolute()
         or ".." in parts
-        or re.match(r"^[A-Za-z]:/", normalized)
+        or re.match(r"^[A-Za-z]:", normalized)
         or normalized.startswith("//")
+        or "\x00" in normalized
+        or any(part.rstrip(" .") != part for part in parts)
+        or any(":" in part for part in parts)
     ):
         return f"{path_label}: unsafe archive member: {member_label}"
-    lowered = tuple(part.lower() for part in parts)
+    lowered = tuple(part.rstrip(" .").lower() for part in parts)
+    windows_reserved = {
+        "con",
+        "prn",
+        "aux",
+        "nul",
+        *(f"com{number}" for number in range(1, 10)),
+        *(f"lpt{number}" for number in range(1, 10)),
+    }
+    if any(part.split(".", 1)[0] in windows_reserved for part in lowered):
+        return f"{path_label}: unsafe archive member: {member_label}"
     if "specs" in lowered:
         return (
             f"{path_label}: repository specifications are not distributable: "
             f"{member_label}"
         )
+    if "tests" in lowered:
+        return f"{path_label}: test suite is not distributable: {member_label}"
     if lowered and lowered[-1] in SUPERSEDED_AUDIT_PAGES:
         return (
             f"{path_label}: superseded audit page is not distributable: "
@@ -237,8 +259,11 @@ def validate_distributions(paths: Sequence[Path]) -> list[str]:
             ValueError,
             tarfile.TarError,
             zipfile.BadZipFile,
+            zlib.error,
         ) as error:
-            errors.append(f"could not inspect {_artifact_label(path)}: {error}")
+            errors.append(
+                f"could not inspect {_artifact_label(path)}: {type(error).__name__}"
+            )
 
     return errors
 

--- a/scripts/check_distribution_contents.py
+++ b/scripts/check_distribution_contents.py
@@ -4,7 +4,9 @@
 from __future__ import annotations
 
 import argparse
+import hashlib
 import re
+import stat
 import tarfile
 import zipfile
 from collections.abc import Iterable, Sequence
@@ -19,26 +21,26 @@ SUPERSEDED_AUDIT_PAGES = frozenset(
     }
 )
 
-SCANNED_TEXT_SUFFIXES = frozenset(
+MAX_SCANNED_TEXT_BYTES = 4 * 1024 * 1024
+PROHIBITED_TOKEN_SHA256 = frozenset(
     {
-        ".bat",
-        ".cfg",
-        ".csv",
-        ".ini",
-        ".json",
-        ".md",
-        ".ps1",
-        ".py",
-        ".rst",
-        ".sh",
-        ".toml",
-        ".txt",
-        ".yaml",
-        ".yml",
+        "06a423e23a1131d5c1cd54a44911fc5fd259a4cbbaa5c9a13344a2d73baf5bbd",
+        "08c64f088046a0504f39c8b52ed474483d642ac4efdee5211a54ad41a10684e8",
+        "1487241b177b0353807ec09be32c409de832fc657c93f7ed5eb23b444708d7e7",
+        "32c4feed996880bc92a062dc476f9b8cdb2596a989f2cc5246e9cef605bd5c78",
+        "454e0f9c502a52a6c351c9614bac911e22d42908a87dcaf47467645b6001fb17",
+        "594f63ba499f2248fdf20c6472a7527a13be1a96e0642615c7f045bf886c3405",
+        "684be438b04d22074ca4bb4b1d83bac553d09e3c02680e1ee3a4936d8af22a0a",
+        "73c8f9e2b5ef6864b87be7deda7fbeb12fcb1d8b90ade6e36e410b183a23f0a3",
+        "8f3d03ddd4e6e26a782e700bb5b5f9e405526fda47eb4e26d5ed5024754e6bed",
+        "ae18045e96b66b0e460c7d45703e60e6c26967378f1c0075e64c6e4a08cd3adc",
+        "b8e53cd98b9bf7af29cbc6e4fa20d26399e6bc9d0e3e8fba32ae6d447fafacf5",
+        "d64983e3ffe1b4e6a14c21d6de24f74a430abc60974cfebaaa2d6ae6ed27e37b",
+        "f20bdf9f71ec0c4226a026cc6a982947d203cba6cd877186df673f3e6120c122",
+        "f428ec1505fba1faf17b898419f19035cc5f0a3348a83dfbc51d3e9216c93b00",
+        "fce60e2787277f5ac2251efd16d6516604a30278e4c457c8c6f74e98631bbcdc",
     }
 )
-SCANNED_TEXT_NAMES = frozenset({"license", "metadata", "record", "wheel"})
-MAX_SCANNED_TEXT_BYTES = 4 * 1024 * 1024
 SENSITIVE_TEXT_PATTERNS = (
     (
         "credential-shaped value",
@@ -48,13 +50,23 @@ SENSITIVE_TEXT_PATTERNS = (
         ),
     ),
     (
-        "private runtime provenance",
+        "credential-shaped value",
         re.compile(
-            rb"(?is)\b[a-z0-9][a-z0-9_.-]{2,}-(?:runtime|adapter)\b"
-            rb".{0,80}\b(?:through|commit)\s+[0-9a-f]{7,40}\b"
+            rb"(?:service[_ -]?key|<key>)\s*[:=>\"']*\s*"
+            rb"[A-Z0-9]{17}(?![A-Z0-9])",
+            re.IGNORECASE,
+        ),
+    ),
+    (
+        "private project runtime identifier",
+        re.compile(
+            rb"\b(?:jrvltsql|jltsql)-"
+            rb"(?:[a-z0-9_.-]+-)?(?:runtime|adapter)\b",
+            re.IGNORECASE,
         ),
     ),
 )
+TOKEN_PATTERN = re.compile(rb"[A-Za-z][A-Za-z0-9_.+]{2,}")
 
 
 def _artifact_kind(path: Path) -> str | None:
@@ -65,12 +77,29 @@ def _artifact_kind(path: Path) -> str | None:
     return None
 
 
-def _is_scanned_text_member(member: str) -> bool:
-    pure_path = PurePosixPath(member.replace("\\", "/"))
-    return (
-        pure_path.suffix.lower() in SCANNED_TEXT_SUFFIXES
-        or pure_path.name.lower() in SCANNED_TEXT_NAMES
-    )
+def _sensitive_category(payload: bytes) -> str | None:
+    variants = (payload, payload.replace(b"\x00", b""))
+    for candidate in variants:
+        for category, pattern in SENSITIVE_TEXT_PATTERNS:
+            if pattern.search(candidate):
+                return category
+        for token in TOKEN_PATTERN.findall(candidate):
+            digest = hashlib.sha256(token.lower()).hexdigest()
+            if digest in PROHIBITED_TOKEN_SHA256:
+                return "private runner identifier"
+    return None
+
+
+def _artifact_label(path: Path) -> str:
+    if _sensitive_category(path.name.encode("utf-8", errors="replace")):
+        return "<redacted-artifact>"
+    return path.name
+
+
+def _member_label(member: str) -> str:
+    if _sensitive_category(member.encode("utf-8", errors="replace")):
+        return "<redacted-member>"
+    return member
 
 
 def _archive_entries(
@@ -82,9 +111,12 @@ def _archive_entries(
             for member in archive.infolist():
                 payload = None
                 error = None
-                if not member.is_dir() and _is_scanned_text_member(member.filename):
+                member_type = (member.external_attr >> 16) & 0o170000
+                if stat.S_ISLNK(member_type):
+                    error = "archive links are not permitted"
+                elif not member.is_dir():
                     if member.file_size > MAX_SCANNED_TEXT_BYTES:
-                        error = "text member exceeds the content-scan size limit"
+                        error = "member exceeds the content-scan size limit"
                     else:
                         payload = archive.read(member)
                 yield member.filename, payload, error
@@ -93,18 +125,20 @@ def _archive_entries(
         for member in archive:
             payload = None
             error = None
-            if member.isfile() and _is_scanned_text_member(member.name):
+            if member.issym() or member.islnk() or member.isdev():
+                error = "archive links and device members are not permitted"
+            elif member.isfile():
                 if member.size > MAX_SCANNED_TEXT_BYTES:
-                    error = "text member exceeds the content-scan size limit"
+                    error = "member exceeds the content-scan size limit"
                 else:
                     extracted = archive.extractfile(member)
                     if extracted is None:
-                        error = "text member could not be read"
+                        error = "member could not be read"
                     else:
                         payload = extracted.read(MAX_SCANNED_TEXT_BYTES + 1)
                         if len(payload) > MAX_SCANNED_TEXT_BYTES:
                             payload = None
-                            error = "text member exceeds the content-scan size limit"
+                            error = "member exceeds the content-scan size limit"
             yield member.name, payload, error
 
 
@@ -112,20 +146,36 @@ def _member_error(path: Path, member: str) -> str | None:
     normalized = member.replace("\\", "/")
     pure_path = PurePosixPath(normalized)
     parts = tuple(part for part in pure_path.parts if part not in {"", "."})
-    if pure_path.is_absolute() or ".." in parts:
-        return f"{path.name}: unsafe archive member: {member}"
+    path_label = _artifact_label(path)
+    member_label = _member_label(member)
+    if (
+        pure_path.is_absolute()
+        or ".." in parts
+        or re.match(r"^[A-Za-z]:/", normalized)
+        or normalized.startswith("//")
+    ):
+        return f"{path_label}: unsafe archive member: {member_label}"
     lowered = tuple(part.lower() for part in parts)
     if "specs" in lowered:
-        return f"{path.name}: repository specifications are not distributable: {member}"
+        return (
+            f"{path_label}: repository specifications are not distributable: "
+            f"{member_label}"
+        )
     if lowered and lowered[-1] in SUPERSEDED_AUDIT_PAGES:
-        return f"{path.name}: superseded audit page is not distributable: {member}"
+        return (
+            f"{path_label}: superseded audit page is not distributable: "
+            f"{member_label}"
+        )
     return None
 
 
 def _member_content_error(path: Path, member: str, payload: bytes) -> str | None:
-    for category, pattern in SENSITIVE_TEXT_PATTERNS:
-        if pattern.search(payload):
-            return f"{path.name}: {category} in archive member: {member}"
+    category = _sensitive_category(payload)
+    if category is not None:
+        return (
+            f"{_artifact_label(path)}: {category} in archive member: "
+            f"{_member_label(member)}"
+        )
     return None
 
 
@@ -139,12 +189,14 @@ def validate_distributions(paths: Sequence[Path]) -> list[str]:
         path = Path(raw_path)
         kind = _artifact_kind(path)
         if kind is None:
-            errors.append(f"unsupported distribution artifact: {path.name}")
+            errors.append(f"unsupported distribution artifact: {_artifact_label(path)}")
             continue
         observed_kinds.add(kind)
         artifacts.append((path, kind))
         if not path.is_file():
-            errors.append(f"distribution artifact does not exist: {path}")
+            errors.append(
+                f"distribution artifact does not exist: {_artifact_label(path)}"
+            )
 
     for required_kind in ("wheel", "sdist"):
         if required_kind not in observed_kinds:
@@ -155,12 +207,24 @@ def validate_distributions(paths: Sequence[Path]) -> list[str]:
             continue
         try:
             for member, payload, scan_error in _archive_entries(path, kind):
+                name_category = _sensitive_category(
+                    member.encode("utf-8", errors="replace")
+                )
+                if name_category is not None:
+                    errors.append(
+                        f"{_artifact_label(path)}: {name_category} in archive "
+                        "member name: <redacted-member>"
+                    )
+                    continue
                 error = _member_error(path, member)
                 if error is not None:
                     errors.append(error)
                     continue
                 if scan_error is not None:
-                    errors.append(f"{path.name}: {scan_error}: {member}")
+                    errors.append(
+                        f"{_artifact_label(path)}: {scan_error}: "
+                        f"{_member_label(member)}"
+                    )
                     continue
                 if payload is not None:
                     content_error = _member_content_error(path, member, payload)
@@ -174,7 +238,7 @@ def validate_distributions(paths: Sequence[Path]) -> list[str]:
             tarfile.TarError,
             zipfile.BadZipFile,
         ) as error:
-            errors.append(f"could not inspect {path.name}: {error}")
+            errors.append(f"could not inspect {_artifact_label(path)}: {error}")
 
     return errors
 

--- a/scripts/check_distribution_contents.py
+++ b/scripts/check_distribution_contents.py
@@ -4,11 +4,11 @@
 from __future__ import annotations
 
 import argparse
+import re
 import tarfile
 import zipfile
+from collections.abc import Iterable, Sequence
 from pathlib import Path, PurePosixPath
-from typing import Iterable, Sequence
-
 
 SUPERSEDED_AUDIT_PAGES = frozenset(
     {
@@ -17,6 +17,43 @@ SUPERSEDED_AUDIT_PAGES = frozenset(
         "crawler_audit_03_we_realtime_spec.md",
         "crawler_audit_04_se_layout.md",
     }
+)
+
+SCANNED_TEXT_SUFFIXES = frozenset(
+    {
+        ".bat",
+        ".cfg",
+        ".csv",
+        ".ini",
+        ".json",
+        ".md",
+        ".ps1",
+        ".py",
+        ".rst",
+        ".sh",
+        ".toml",
+        ".txt",
+        ".yaml",
+        ".yml",
+    }
+)
+SCANNED_TEXT_NAMES = frozenset({"license", "metadata", "record", "wheel"})
+MAX_SCANNED_TEXT_BYTES = 4 * 1024 * 1024
+SENSITIVE_TEXT_PATTERNS = (
+    (
+        "credential-shaped value",
+        re.compile(
+            rb"(?<![A-Z0-9])[A-Z0-9]{4}(?:-[A-Z0-9]{4}){3}-[A-Z0-9](?![A-Z0-9])",
+            re.IGNORECASE,
+        ),
+    ),
+    (
+        "private runtime provenance",
+        re.compile(
+            rb"(?is)\b[a-z0-9][a-z0-9_.-]{2,}-(?:runtime|adapter)\b"
+            rb".{0,80}\b(?:through|commit)\s+[0-9a-f]{7,40}\b"
+        ),
+    ),
 )
 
 
@@ -28,14 +65,47 @@ def _artifact_kind(path: Path) -> str | None:
     return None
 
 
-def _archive_members(path: Path, kind: str) -> Iterable[str]:
+def _is_scanned_text_member(member: str) -> bool:
+    pure_path = PurePosixPath(member.replace("\\", "/"))
+    return (
+        pure_path.suffix.lower() in SCANNED_TEXT_SUFFIXES
+        or pure_path.name.lower() in SCANNED_TEXT_NAMES
+    )
+
+
+def _archive_entries(
+    path: Path,
+    kind: str,
+) -> Iterable[tuple[str, bytes | None, str | None]]:
     if kind == "wheel":
         with zipfile.ZipFile(path) as archive:
-            yield from archive.namelist()
+            for member in archive.infolist():
+                payload = None
+                error = None
+                if not member.is_dir() and _is_scanned_text_member(member.filename):
+                    if member.file_size > MAX_SCANNED_TEXT_BYTES:
+                        error = "text member exceeds the content-scan size limit"
+                    else:
+                        payload = archive.read(member)
+                yield member.filename, payload, error
         return
     with tarfile.open(path, "r:gz") as archive:
         for member in archive:
-            yield member.name
+            payload = None
+            error = None
+            if member.isfile() and _is_scanned_text_member(member.name):
+                if member.size > MAX_SCANNED_TEXT_BYTES:
+                    error = "text member exceeds the content-scan size limit"
+                else:
+                    extracted = archive.extractfile(member)
+                    if extracted is None:
+                        error = "text member could not be read"
+                    else:
+                        payload = extracted.read(MAX_SCANNED_TEXT_BYTES + 1)
+                        if len(payload) > MAX_SCANNED_TEXT_BYTES:
+                            payload = None
+                            error = "text member exceeds the content-scan size limit"
+            yield member.name, payload, error
 
 
 def _member_error(path: Path, member: str) -> str | None:
@@ -49,6 +119,13 @@ def _member_error(path: Path, member: str) -> str | None:
         return f"{path.name}: repository specifications are not distributable: {member}"
     if lowered and lowered[-1] in SUPERSEDED_AUDIT_PAGES:
         return f"{path.name}: superseded audit page is not distributable: {member}"
+    return None
+
+
+def _member_content_error(path: Path, member: str, payload: bytes) -> str | None:
+    for category, pattern in SENSITIVE_TEXT_PATTERNS:
+        if pattern.search(payload):
+            return f"{path.name}: {category} in archive member: {member}"
     return None
 
 
@@ -77,11 +154,26 @@ def validate_distributions(paths: Sequence[Path]) -> list[str]:
         if not path.is_file():
             continue
         try:
-            for member in _archive_members(path, kind):
+            for member, payload, scan_error in _archive_entries(path, kind):
                 error = _member_error(path, member)
                 if error is not None:
                     errors.append(error)
-        except (OSError, tarfile.TarError, zipfile.BadZipFile) as error:
+                    continue
+                if scan_error is not None:
+                    errors.append(f"{path.name}: {scan_error}: {member}")
+                    continue
+                if payload is not None:
+                    content_error = _member_content_error(path, member, payload)
+                    if content_error is not None:
+                        errors.append(content_error)
+        except (
+            EOFError,
+            OSError,
+            RuntimeError,
+            ValueError,
+            tarfile.TarError,
+            zipfile.BadZipFile,
+        ) as error:
             errors.append(f"could not inspect {path.name}: {error}")
 
     return errors

--- a/scripts/quickstart.bat
+++ b/scripts/quickstart.bat
@@ -28,9 +28,9 @@ if not defined PYTHON_CMD if defined VIRTUAL_ENV (
         echo [ERROR] VIRTUAL_ENV must point to Python 3.12 or later.
         exit /b 1
     )
-    "%VIRTUAL_ENV%\Scripts\python.exe" -c "import sys; raise SystemExit(sys.version_info < (3, 12))" >nul 2>&1
+    "%VIRTUAL_ENV%\Scripts\python.exe" -c "import struct,sys; raise SystemExit(sys.version_info < (3, 12) or struct.calcsize('P') != 4)" >nul 2>&1
     if !errorlevel! neq 0 (
-        echo [ERROR] VIRTUAL_ENV must point to Python 3.12 or later.
+        echo [ERROR] VIRTUAL_ENV must point to 32-bit Python 3.12 or later.
         exit /b 1
     )
     set "PYTHON_CMD="!VIRTUAL_ENV!\Scripts\python.exe""
@@ -40,7 +40,7 @@ if not defined PYTHON_CMD if exist "%~dp0..\venv32\Scripts\python.exe" (
     if !errorlevel!==0 set "PYTHON_CMD="%~dp0..\venv32\Scripts\python.exe""
 )
 if not defined PYTHON_CMD if exist "%~dp0..\.venv\Scripts\python.exe" (
-    "%~dp0..\.venv\Scripts\python.exe" -c "import sys; raise SystemExit(sys.version_info < (3, 12))" >nul 2>&1
+    "%~dp0..\.venv\Scripts\python.exe" -c "import struct,sys; raise SystemExit(sys.version_info < (3, 12) or struct.calcsize('P') != 4)" >nul 2>&1
     if !errorlevel!==0 set "PYTHON_CMD="%~dp0..\.venv\Scripts\python.exe""
 )
 if not defined PYTHON_CMD (
@@ -48,20 +48,7 @@ if not defined PYTHON_CMD (
     if !errorlevel!==0 set "PYTHON_CMD=py -3.12-32"
 )
 if not defined PYTHON_CMD (
-    py -3.12 --version >nul 2>&1
-    if !errorlevel!==0 set "PYTHON_CMD=py -3.12"
-)
-if not defined PYTHON_CMD (
-    py -3 -c "import sys; raise SystemExit(sys.version_info < (3, 12))" >nul 2>&1
-    if !errorlevel!==0 set "PYTHON_CMD=py -3"
-)
-if not defined PYTHON_CMD (
-    python -c "import sys; raise SystemExit(sys.version_info < (3, 12))" >nul 2>&1
-    if !errorlevel!==0 set "PYTHON_CMD=python"
-)
-
-if not defined PYTHON_CMD (
-    echo [ERROR] Python not found. Install Python 3.12+ and try again.
+    echo [ERROR] 32-bit Python not found. Set PYTHON only for explicit SDK validation.
     pause
     exit /b 1
 )

--- a/scripts/quickstart.bat
+++ b/scripts/quickstart.bat
@@ -36,7 +36,7 @@ if not defined PYTHON_CMD if defined VIRTUAL_ENV (
     set "PYTHON_CMD="!VIRTUAL_ENV!\Scripts\python.exe""
 )
 if not defined PYTHON_CMD if exist "%~dp0..\venv32\Scripts\python.exe" (
-    "%~dp0..\venv32\Scripts\python.exe" -c "import sys; raise SystemExit(sys.version_info < (3, 12))" >nul 2>&1
+    "%~dp0..\venv32\Scripts\python.exe" -c "import struct,sys; raise SystemExit(sys.version_info < (3, 12) or struct.calcsize('P') != 4)" >nul 2>&1
     if !errorlevel!==0 set "PYTHON_CMD="%~dp0..\venv32\Scripts\python.exe""
 )
 if not defined PYTHON_CMD if exist "%~dp0..\.venv\Scripts\python.exe" (

--- a/scripts/smoke_distribution_init.py
+++ b/scripts/smoke_distribution_init.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""Run ``jltsql init`` from an extracted wheel in a fresh writable directory."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import subprocess
+import sys
+import tempfile
+import zipfile
+from collections.abc import Sequence
+from pathlib import Path
+
+
+def validate_wheel_init(wheel: Path) -> list[str]:
+    errors: list[str] = []
+    if not wheel.is_file() or wheel.suffix != ".whl":
+        return [f"wheel artifact does not exist: {wheel}"]
+
+    with (
+        tempfile.TemporaryDirectory(prefix="jltsql-wheel-extract-") as extract_raw,
+        tempfile.TemporaryDirectory(prefix="jltsql-wheel-init-") as run_raw,
+    ):
+        extract_dir = Path(extract_raw)
+        run_dir = Path(run_raw)
+        try:
+            with zipfile.ZipFile(wheel) as archive:
+                archive.extractall(extract_dir)
+        except (OSError, zipfile.BadZipFile) as error:
+            return [f"could not extract wheel {wheel.name}: {error}"]
+
+        env = os.environ.copy()
+        env["PYTHONPATH"] = str(extract_dir)
+        env["PYTHONSAFEPATH"] = "1"
+        try:
+            result = subprocess.run(
+                [sys.executable, "-m", "src.cli.main", "init"],
+                cwd=run_dir,
+                env=env,
+                text=True,
+                capture_output=True,
+                check=False,
+                timeout=30.0,
+            )
+        except subprocess.TimeoutExpired:
+            return ["wheel init timed out after 30 seconds"]
+        if result.returncode != 0:
+            errors.append(f"wheel init exited {result.returncode}")
+            return errors
+
+        for relative_path, expected_kind in (
+            (Path("config/config.yaml"), "file"),
+            (Path("data"), "directory"),
+            (Path("logs"), "directory"),
+        ):
+            candidate = run_dir / relative_path
+            if expected_kind == "file" and not candidate.is_file():
+                errors.append(f"wheel init did not create file: {relative_path}")
+            if expected_kind == "directory" and not candidate.is_dir():
+                errors.append(f"wheel init did not create directory: {relative_path}")
+
+        if "service key" in result.stdout.lower():
+            errors.append("wheel init printed retired config service-key guidance")
+
+    return errors
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("wheel", type=Path)
+    args = parser.parse_args(argv)
+
+    errors = validate_wheel_init(args.wheel)
+    if errors:
+        for error in errors:
+            print(f"ERROR: {error}")
+        return 1
+    print(f"Wheel init smoke passed: {args.wheel.name}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/smoke_distribution_init.py
+++ b/scripts/smoke_distribution_init.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import argparse
 import os
 import sqlite3
+import stat
 import subprocess
 import sys
 import tempfile
@@ -41,8 +42,35 @@ if sys.argv[2] == "1":
     builtins.__import__ = import_without_optional_postgresql
 
 sys.argv = ["jltsql", *sys.argv[3:]]
-runpy.run_module("src.cli.main", run_name="__main__")
+exit_code = 0
+try:
+    runpy.run_module("src.cli.main", run_name="__main__")
+except SystemExit as exc:
+    exit_code = exc.code if isinstance(exc.code, int) else 1
+finally:
+    for module_name, module in tuple(sys.modules.items()):
+        if module_name != "src" and not module_name.startswith("src."):
+            continue
+        module_file = getattr(module, "__file__", None)
+        if module_file is None:
+            raise RuntimeError(f"{module_name} has no wheel origin")
+        origin = pathlib.Path(module_file).resolve()
+        if not origin.is_relative_to(wheel_root):
+            raise RuntimeError(f"{module_name} was not imported from the wheel")
+raise SystemExit(exit_code)
 """
+
+_REQUIRED_WHEEL_MEMBERS = frozenset(
+    {
+        "src/__init__.py",
+        "src/cli/main.py",
+        "src/database/__init__.py",
+        "src/database/sqlite_handler.py",
+        "src/utils/config.py",
+        "src/utils/logger.py",
+        "src/utils/updater.py",
+    }
+)
 
 
 def _wheel_cli_command(
@@ -92,6 +120,25 @@ def validate_wheel_init(wheel: Path) -> list[str]:
         run_dir = Path(run_raw)
         try:
             with zipfile.ZipFile(wheel) as archive:
+                members = {member.filename for member in archive.infolist()}
+                missing = sorted(_REQUIRED_WHEEL_MEMBERS - members)
+                if missing:
+                    return ["wheel is missing required runtime members"]
+                if not any(
+                    member.endswith(".dist-info/METADATA") for member in members
+                ):
+                    return ["wheel is missing distribution metadata"]
+                for member in archive.infolist():
+                    member_type = (member.external_attr >> 16) & 0o170000
+                    if (
+                        member_type
+                        and not stat.S_ISREG(member_type)
+                        and not member.is_dir()
+                    ):
+                        return ["wheel contains an unsafe archive member"]
+                    target = (extract_dir / member.filename).resolve()
+                    if not target.is_relative_to(extract_dir):
+                        return ["wheel contains an unsafe archive member"]
                 archive.extractall(extract_dir)
         except (OSError, zipfile.BadZipFile) as error:
             return [f"could not extract wheel {wheel.name}: {error}"]

--- a/scripts/smoke_distribution_init.py
+++ b/scripts/smoke_distribution_init.py
@@ -5,12 +5,78 @@ from __future__ import annotations
 
 import argparse
 import os
+import sqlite3
 import subprocess
 import sys
 import tempfile
 import zipfile
 from collections.abc import Sequence
 from pathlib import Path
+
+
+_WHEEL_BOOTSTRAP = """
+import builtins
+import pathlib
+import runpy
+import sys
+
+wheel_root = pathlib.Path(sys.argv[1]).resolve()
+sys.path.insert(0, str(wheel_root))
+import src
+
+module_origin = pathlib.Path(src.__file__).resolve()
+if not module_origin.is_relative_to(wheel_root):
+    raise RuntimeError("jltsql was not imported from the extracted wheel")
+
+if sys.argv[2] == "1":
+    real_import = builtins.__import__
+
+    def import_without_optional_postgresql(name, *args, **kwargs):
+        if name == "psycopg" or name.startswith("psycopg."):
+            raise ImportError("optional PostgreSQL driver disabled by wheel smoke")
+        if name == "pg8000" or name.startswith("pg8000."):
+            raise ImportError("optional PostgreSQL driver disabled by wheel smoke")
+        return real_import(name, *args, **kwargs)
+
+    builtins.__import__ = import_without_optional_postgresql
+
+sys.argv = ["jltsql", *sys.argv[3:]]
+runpy.run_module("src.cli.main", run_name="__main__")
+"""
+
+
+def _wheel_cli_command(
+    extract_dir: Path,
+    arguments: Sequence[str],
+    *,
+    block_postgresql: bool = True,
+) -> list[str]:
+    return [
+        sys.executable,
+        "-I",
+        "-c",
+        _WHEEL_BOOTSTRAP,
+        str(extract_dir),
+        "1" if block_postgresql else "0",
+        *arguments,
+    ]
+
+
+def _run_wheel_cli(
+    extract_dir: Path,
+    run_dir: Path,
+    env: dict[str, str],
+    arguments: Sequence[str],
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        _wheel_cli_command(extract_dir, arguments),
+        cwd=run_dir,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+        timeout=30.0,
+    )
 
 
 def validate_wheel_init(wheel: Path) -> list[str]:
@@ -31,18 +97,18 @@ def validate_wheel_init(wheel: Path) -> list[str]:
             return [f"could not extract wheel {wheel.name}: {error}"]
 
         env = os.environ.copy()
-        env["PYTHONPATH"] = str(extract_dir)
+        env.pop("PYTHONPATH", None)
         env["PYTHONSAFEPATH"] = "1"
+        private_home = run_dir / ".home"
+        private_state = run_dir / ".state"
+        private_home.mkdir()
+        private_state.mkdir()
+        env["HOME"] = str(private_home)
+        env["USERPROFILE"] = str(private_home)
+        env["LOCALAPPDATA"] = str(private_state)
+        env["XDG_STATE_HOME"] = str(private_state)
         try:
-            result = subprocess.run(
-                [sys.executable, "-m", "src.cli.main", "init"],
-                cwd=run_dir,
-                env=env,
-                text=True,
-                capture_output=True,
-                check=False,
-                timeout=30.0,
-            )
+            result = _run_wheel_cli(extract_dir, run_dir, env, ("init",))
         except subprocess.TimeoutExpired:
             return ["wheel init timed out after 30 seconds"]
         if result.returncode != 0:
@@ -62,6 +128,55 @@ def validate_wheel_init(wheel: Path) -> list[str]:
 
         if "service key" in result.stdout.lower():
             errors.append("wheel init printed retired config service-key guidance")
+
+        commands = (
+            (("config", "--show"), "Type: sqlite"),
+            (("version",), "version"),
+            (("create-tables", "--db", "sqlite"), None),
+        )
+        for arguments, required_output in commands:
+            try:
+                command_result = _run_wheel_cli(
+                    extract_dir,
+                    run_dir,
+                    env,
+                    arguments,
+                )
+            except subprocess.TimeoutExpired:
+                errors.append(f"wheel {' '.join(arguments)} timed out")
+                continue
+            if command_result.returncode != 0:
+                errors.append(
+                    f"wheel {' '.join(arguments)} exited "
+                    f"{command_result.returncode}"
+                )
+                continue
+            if required_output and required_output not in command_result.stdout:
+                errors.append(
+                    f"wheel {' '.join(arguments)} omitted expected output"
+                )
+            if "unknown" in command_result.stdout.lower():
+                errors.append(
+                    f"wheel {' '.join(arguments)} reported an unknown value"
+                )
+
+        sqlite_path = run_dir / "data" / "keiba.db"
+        if not sqlite_path.is_file():
+            errors.append("wheel SQLite bootstrap did not create data/keiba.db")
+        else:
+            with sqlite3.connect(sqlite_path) as connection:
+                table_count = connection.execute(
+                    "SELECT COUNT(*) FROM sqlite_master WHERE type = 'table'"
+                ).fetchone()[0]
+            if table_count == 0:
+                errors.append("wheel SQLite bootstrap created no tables")
+
+        for forbidden in (
+            extract_dir / "logs" / "jltsql.log",
+            extract_dir / "data" / ".update_check.json",
+        ):
+            if forbidden.exists():
+                errors.append("wheel command wrote runtime state into the package tree")
 
     return errors
 

--- a/scripts/smoke_distribution_init.py
+++ b/scripts/smoke_distribution_init.py
@@ -11,9 +11,9 @@ import subprocess
 import sys
 import tempfile
 import zipfile
+import zlib
 from collections.abc import Sequence
 from pathlib import Path
-
 
 _WHEEL_BOOTSTRAP = """
 import builtins
@@ -46,17 +46,32 @@ exit_code = 0
 try:
     runpy.run_module("src.cli.main", run_name="__main__")
 except SystemExit as exc:
-    exit_code = exc.code if isinstance(exc.code, int) else 1
+    if exc.code is None:
+        exit_code = 0
+    elif isinstance(exc.code, int):
+        exit_code = exc.code
+    else:
+        exit_code = 1
 finally:
+    origin_errors = []
     for module_name, module in tuple(sys.modules.items()):
         if module_name != "src" and not module_name.startswith("src."):
             continue
         module_file = getattr(module, "__file__", None)
         if module_file is None:
-            raise RuntimeError(f"{module_name} has no wheel origin")
-        origin = pathlib.Path(module_file).resolve()
-        if not origin.is_relative_to(wheel_root):
-            raise RuntimeError(f"{module_name} was not imported from the wheel")
+            module_origins = [
+                pathlib.Path(location).resolve()
+                for location in getattr(module, "__path__", ())
+            ]
+        else:
+            module_origins = [pathlib.Path(module_file).resolve()]
+        if not module_origins:
+            origin_errors.append(f"{module_name} has no wheel origin")
+            continue
+        if any(not origin.is_relative_to(wheel_root) for origin in module_origins):
+            origin_errors.append(f"{module_name} was not imported from the wheel")
+if origin_errors:
+    raise RuntimeError("; ".join(origin_errors))
 raise SystemExit(exit_code)
 """
 
@@ -116,14 +131,17 @@ def validate_wheel_init(wheel: Path) -> list[str]:
         tempfile.TemporaryDirectory(prefix="jltsql-wheel-extract-") as extract_raw,
         tempfile.TemporaryDirectory(prefix="jltsql-wheel-init-") as run_raw,
     ):
-        extract_dir = Path(extract_raw)
+        extract_dir = Path(extract_raw).resolve()
         run_dir = Path(run_raw)
         try:
             with zipfile.ZipFile(wheel) as archive:
                 members = {member.filename for member in archive.infolist()}
                 missing = sorted(_REQUIRED_WHEEL_MEMBERS - members)
                 if missing:
-                    return ["wheel is missing required runtime members"]
+                    return [
+                        "wheel is missing required runtime members: "
+                        + ", ".join(missing)
+                    ]
                 if not any(
                     member.endswith(".dist-info/METADATA") for member in members
                 ):
@@ -140,8 +158,10 @@ def validate_wheel_init(wheel: Path) -> list[str]:
                     if not target.is_relative_to(extract_dir):
                         return ["wheel contains an unsafe archive member"]
                 archive.extractall(extract_dir)
-        except (OSError, zipfile.BadZipFile) as error:
-            return [f"could not extract wheel {wheel.name}: {error}"]
+        except (OSError, RuntimeError, zipfile.BadZipFile, zlib.error) as error:
+            return [
+                f"could not extract wheel {wheel.name}: {type(error).__name__}"
+            ]
 
         env = os.environ.copy()
         env.pop("PYTHONPATH", None)
@@ -211,10 +231,13 @@ def validate_wheel_init(wheel: Path) -> list[str]:
         if not sqlite_path.is_file():
             errors.append("wheel SQLite bootstrap did not create data/keiba.db")
         else:
-            with sqlite3.connect(sqlite_path) as connection:
+            connection = sqlite3.connect(sqlite_path)
+            try:
                 table_count = connection.execute(
                     "SELECT COUNT(*) FROM sqlite_master WHERE type = 'table'"
                 ).fetchone()[0]
+            finally:
+                connection.close()
             if table_count == 0:
                 errors.append("wheel SQLite bootstrap created no tables")
 

--- a/specs/operations/20260816_release_readiness_worklog.md
+++ b/specs/operations/20260816_release_readiness_worklog.md
@@ -3360,3 +3360,82 @@
   SQLite-create/readback smoke. The next safe action is one intentional commit,
   followed by exact-full-SHA tests and the two bounded carry-forward critical
   reviews; no release or merge is authorized by these pre-commit results.
+- Three independent Codex carry-forward reviews of exact candidate
+  `c08b5170c59d30c630876a0ae976b4823ed32cd5` returned NEEDS_CHANGES. Claude
+  Code remained unavailable under its service usage limit, so this review
+  batch used the maintainer-authorized Codex fallback. Findings were
+  consolidated before any repair: the archive gate still missed several
+  split/encoded sensitive-content and path/member-boundary cases and could
+  expose a sensitive member through an exception; a partial wheel could borrow
+  modules from an editable checkout; nested config values and backend selection
+  were not fully validated; `uv.lock` retained the prior package version;
+  automatic 64-bit interpreter fallbacks contradicted the explicit-validation-
+  only policy; and the 2.0 migration/rebuild/reimport documentation was too
+  narrow. No reviewer found a new sensitive value in the built candidate
+  artifacts, but the negative gates were insufficient to prove future absence.
+- Red-first evidence was captured before the second grouped production repair.
+  The minimal negative/positive selection returned `20 failed, 31 passed`
+  (`5` subtest failures), covering the archive split/setter/member/path and
+  no-echo boundaries, partial-wheel isolation, nested config/backend validation,
+  invalid existing bootstrap config, prerelease update comparison, installer
+  interpreter policy, source/CLI version parity, and migration documentation.
+  Separately, `uv lock --check` failed because the lock still identified
+  `1.6.10`. These failures bind the newly modified gates before their repair;
+  synthetic values only were used and no sensitive matched value was printed
+  or recorded.
+- The grouped repair now checks sensitive archive content in normalized and
+  adjacent-literal forms, rejects unsafe or ambiguous archive members across
+  platform path rules, redacts archive-read failures, and verifies a required
+  wheel member set plus every loaded package module origin. Configuration
+  loading validates nested value types, supported and enabled database
+  backends, and filesystem-read failures with controlled errors. Source and
+  installed CLI version identity share the package constant; the update
+  comparison is PEP 440 aware; `uv.lock` is regenerated and CI runs
+  `uv lock --check`.
+- Windows launchers and installers no longer choose an unvalidated 64-bit
+  interpreter automatically. The default discovery path is the validated
+  32-bit interpreter; a different architecture is available only through an
+  explicit operator override for separate SDK validation. This is not a
+  64-bit support claim. Manual installer commands now bind relative config,
+  database, and log paths to the installation directory. Release notes and
+  changelog now summarize the cumulative parser/schema/key/transaction changes
+  and require backup, schema rebuild, provider reimport, readback verification,
+  and rollback planning before migration.
+- The repaired focused selection passes `46 passed, 5 subtests passed`. The
+  broader affected CLI/config/updater/installer/logging/archive/public/Windows/
+  bridge/database/quickstart selection passes `270 passed, 5 skipped, 5
+  subtests passed`. `git diff --check` passes and the regenerated lock now
+  passes `uv lock --check`. The next safe step is the full dirty-tree suite and
+  static/build/install gates, followed by one intentional commit and two
+  independent exact-SHA reviews. STOP on any test/build/content/readback
+  failure, public sensitive identifier, implicit unvalidated architecture
+  fallback, candidate drift during review, unresolved review thread, or
+  release action before the later official DataKubun/key/storage iterations.
+- The first full dirty-tree suite stopped with `3 failed, 2731 passed, 131
+  skipped, 19 subtests passed`. All three failures were stale tests that treated
+  an empty, bare-prefix, or otherwise unknown version as numeric zero. The new
+  update gate deliberately treats unparseable metadata as unknown/non-update,
+  while valid PEP 440 prereleases compare normally. After correcting that test
+  oracle, the focused version selection passes `54 passed` and the complete
+  suite passes `2734 passed, 131 skipped, 19 subtests passed`.
+- Static gates then passed: fail-closed test-gate self-check, compileall, fatal
+  flake8 (`E9,F63,F7,F82`), strict MkDocs, lock check, and `git diff --check`.
+  The first real sdist content scan correctly failed because setuptools had
+  auto-included the repository test suite, whose negative scanner fixtures
+  intentionally contain synthetic sensitive shapes. This was not a product
+  source leak, but tests are not runtime distribution content. Before changing
+  the gate, two new negative cases proved that wheel/sdist `tests/` members
+  were accepted (`2 failed, 4 passed`). The repair adds an explicit sdist
+  prune and rejects any future test-suite archive member.
+- The repaired distribution negative suite passes `31 passed`. A fresh PEP 517
+  build now yields a 98-member wheel and a 119-member sdist; the sdist contains
+  zero `tests/` and zero `specs/` members. Both artifacts pass the all-member
+  content scan, and the extracted-wheel smoke passes init, config/version,
+  SQLite table creation, and readback. The built artifacts remain local
+  validation outputs outside the repository and are not a release claim.
+- After the archive exclusion contract and stale version-oracle corrections,
+  the final dirty-tree full suite passes `2736 passed, 131 skipped, 19 subtests
+  passed`. No broad suite is rerun again until the content is committed and an
+  exact full SHA exists. Next safe action: commit the complete grouped repair,
+  verify a clean worktree, replay the necessary exact-SHA full/static/artifact
+  gates once, push PR #202, and request two independent bounded reviews.

--- a/specs/operations/20260816_release_readiness_worklog.md
+++ b/specs/operations/20260816_release_readiness_worklog.md
@@ -3281,3 +3281,82 @@
   The MkDocs tool emitted only its upstream 2.0 project warning. The dirty
   candidate remains based on exact `98ec163...`; no release/version claim is
   attached to these pre-commit results.
+- Three independent Codex reviews of exact committed/pushed candidate
+  `9aab8418b15db40c3b2fc91e5c8adeb2d5374ebc` returned NEEDS_CHANGES. The
+  findings were batched before repair: archive scanning skipped common and
+  encoded members, did not sanitize sensitive member names, did not reject
+  Windows-drive paths or archive links, and used a provenance heuristic with
+  both false positives and false negatives; the wheel smoke could import the
+  already editable-installed checkout; config inspection bypassed the normal
+  validator; init silently ignored a global config path; installer manual
+  commands no longer bound the install-directory config; default SQLite
+  bootstrap imported an optional PostgreSQL driver; default log/update state
+  targeted installed package directories; installed version metadata had no
+  fallback; and removed public bridge/setup interfaces lacked a 2.0 migration
+  record. Reviewers independently used fresh built artifacts and writable and
+  read-only installed-wheel probes. No current candidate artifact contained a
+  newly discovered credential/private-project hit, but the gates could not
+  prove that absence for future artifacts.
+- One grouped red-first selection was added before the follow-up production
+  repair. On unchanged production candidate `9aab841...` it returned `22
+  failed, 37 passed`. The failures directly cover the archive encoding/name/
+  path/link cases, public provenance positive, hashed private-token denylist,
+  extracted-wheel origin binding, validated/expanded config, explicit init
+  target rejection, canonical SQLite default, installer config binding,
+  SQLite without PostgreSQL extras, 2.0 removal record, Windows direct branch,
+  writable-CWD default log, installed metadata version fallback, and update
+  state outside the package tree. The Windows direct positive was already
+  green, which confirms the production branch is sound while still binding it
+  against regression. No matched sensitive value is recorded here.
+- The grouped follow-up repair now scans every bounded regular archive member
+  and sanitized member name, normalizes NUL-separated encoded text, rejects
+  Windows-drive paths and archive link/device entries, uses project-scoped
+  private-runtime rules plus a hash-only runner denylist, and never renders a
+  sensitive member/artifact name. The wheel smoke executes with isolated
+  import precedence, asserts the loaded package is under the extracted wheel,
+  blocks optional PostgreSQL drivers, then validates init, config display,
+  installed version, SQLite table creation/readback, and absence of runtime
+  state under the extracted package tree.
+- CLI config inspection again uses the canonical loader and environment
+  expansion; invalid shapes return controlled ConfigError output. Init rejects
+  an otherwise ignored global config path and creates an explicitly
+  SQLite-only valid default. SQLite database construction lazily imports only
+  its backend. Default logs use the writable working directory; update-check
+  state uses platform user state; installed wheels use distribution metadata
+  for their version. Installer manual commands bind the install-directory
+  config. The breaking branch is now `2.0.0.dev0`, with Unreleased changelog
+  and draft release-note migration boundaries; it is not a published release.
+- The formerly red grouped selection passes `60 passed`; the broader affected
+  public/CLI/database/logger/updater/installer/bridge selection passes `414
+  passed, 5 skipped, 11 subtests passed`. A fresh 2.0.0.dev0 wheel and sdist
+  pass the all-member distribution gate and expanded wheel smoke. An
+  independent disposable `python:3.12-slim` container installed the wheel with
+  base dependencies only, made the installed package read-only, and then
+  successfully ran init, config display, SQLite table creation, and version;
+  the SQLite DB was created and no package-tree log/data state appeared. The
+  container was removed automatically.
+- Final diff review found one adjacent version-identity defect before freezing
+  the repair: a source checkout still preferred the latest Git tag over the
+  candidate version in `pyproject.toml`. The existing version test was first
+  tightened against a deliberately stale tag and failed red as
+  `v1.6.10 != 2.0.0.dev0`. The repair now uses source project metadata first,
+  installed distribution metadata second, and a Git tag only as the final
+  compatibility fallback. The focused source/installed/tag matrix passes
+  `3 passed`, and the duplicated installer version contract was updated to the
+  same ordering.
+- The last import-time logging change is now covered by the affected
+  CLI/logger/updater/distribution/public/bridge selection (`127 passed`). The
+  first complete pre-commit suite then reached `2715 passed, 131 skipped, 14
+  subtests passed` with one failure: an older installer unit test still encoded
+  the superseded Git-tag-first expectation. After binding that fallback to an
+  environment with neither source nor installed metadata, the combined
+  version/logger selection passes `16 passed`. This was a stale test oracle,
+  not a production regression; the exact committed candidate will receive one
+  final full-suite run.
+- Static and packaging gates on the final dirty content pass: test-gate
+  self-check, compileall, fatal flake8 (`E9,F63,F7,F82`), strict MkDocs, and
+  `git diff --check`. A fresh PEP 517 `2.0.0.dev0` wheel plus sdist passes the
+  all-member archive scan and the isolated extracted-wheel init/config/version/
+  SQLite-create/readback smoke. The next safe action is one intentional commit,
+  followed by exact-full-SHA tests and the two bounded carry-forward critical
+  reviews; no release or merge is authorized by these pre-commit results.

--- a/specs/operations/20260816_release_readiness_worklog.md
+++ b/specs/operations/20260816_release_readiness_worklog.md
@@ -3484,3 +3484,21 @@
   and extracted-wheel init/config/version/SQLite smoke also pass. The next safe
   action is one follow-up commit, exact-SHA verification, push, and a bounded
   two-reviewer closure check; no tag/release is authorized.
+- Follow-up commit `a48ff3723c321e85aa6e51b791e2fea7a85f6f49`
+  passed the exact locked full suite (`2738 passed, 131 skipped, 22 subtests
+  passed`), static gates, exact-archive content/smoke, and fresh base-dependency
+  wheel install with 80 SQLite tables and integrity `ok`. One bounded reviewer
+  returned GREEN for archive/config closure. The Windows/docs reviewer verified
+  all four prior findings closed but returned NEEDS_CHANGES because the exact
+  GitHub Windows job executed and failed: `1 failed, 4 passed`. The remaining
+  runtime test still required the deliberately removed PATH CLI auto-selection,
+  while production and the Linux static contract correctly required explicit
+  or bitness-verified selection. This is an executed CI failure and cannot use
+  the billing/startup exception.
+- The existing Windows runtime test is updated as a paired contract: a PATH-only
+  shim must not be selected, then the same command supplied through explicit
+  `JLTSQL` override must succeed. The batch and public script guide document
+  that the override is operator-selected only after separate SDK validation
+  and is not a 64-bit support claim. Local Linux cannot execute this cmd.exe
+  branch, so the exact follow-up SHA Windows Actions job is mandatory before
+  merge.

--- a/specs/operations/20260816_release_readiness_worklog.md
+++ b/specs/operations/20260816_release_readiness_worklog.md
@@ -3197,3 +3197,87 @@
   contract, so the already completed full/PG/oracle/package gates remain
   applicable to the same production semantics; the bounded exact-commit
   reviewers must nevertheless inspect this final form before merge.
+
+### 2026-08-17 14:25 JST — public release-surface security iteration start
+
+- This bounded pre-release iteration targets repository
+  `miyamamoto/jrvltsql` in dedicated worktree
+  `/home/keiba/scratch/20260817_jrvltsql_public_surface`, branch
+  `agent/release-public-surface-20260817`, from exact current
+  `origin/master` / base / HEAD
+  `98ec163222aab3eadaa82f048273c8a0be8722e6`. The published production release
+  remains v1.6.10; this iteration does not select, tag, or publish a new
+  version.
+- The exact committed master is still undergoing separate read-only official
+  layout/status and authenticated-acquisition audits. This worktree exists so
+  an urgent independent public-surface finding can be prepared without moving
+  that evidence SHA. Minimum scope is: remove a credential-shaped value from
+  distributable source without recording it here, remove private runtime and
+  adapter provenance from the public archive, correct setup/config text that
+  contradicts the current provider contract, and make the distribution gate
+  fail closed on those content classes. No parser, schema, importer, provider
+  cache, release tag, or external credential state is changed in this branch.
+- The credential-shaped value must be treated as compromised unless the owner
+  proves it was synthetic. Source removal cannot revoke a value already
+  published in Git history, so owner-side rotation remains an explicit release
+  blocker if it was real. Tests must first show the current archive gate accepts
+  a credential-shaped or private-runtime payload, then retain a paired safe
+  archive case. Error output must name only the archive member and finding
+  category, never the matched value.
+- Claude Code Fable is unavailable under the recorded service usage limit.
+  Per maintainer authorization, implementation and review use Codex with at
+  least two independent critical reviews on one frozen candidate SHA after the
+  audit findings are batched. STOP on any credential disclosure in output or
+  tracked evidence, compatibility-layer regression, archive scanner
+  false-negative/secret echo, candidate drift during review, failed executed
+  CI step, unresolved review thread, or attempt to merge/release before the
+  official-status and fresh-acquisition blockers are independently cleared.
+- Red-first evidence was captured on unchanged production base `98ec163...`
+  before implementing the public-surface repair. The minimal selection returned
+  `4 failed`: the existing archive gate accepted both a synthetic complete
+  credential shape and synthetic private-runtime/short-SHA provenance; an
+  installed-module simulation made `jltsql init` exit 1 instead of creating a
+  writable-CWD config; and the public setup contract found stale service-key
+  config guidance. Synthetic values only were used and pytest did not print or
+  retain the repository's credential-shaped value. The paired clean archive
+  test remains green. The same tests must pass after one grouped repair.
+- A second two-case red selection binds the public subprocess boundary without
+  naming a compatibility implementation. On base `98ec163...`, the bridge
+  ignored `JVLINK_BRIDGE_RUNNER` and selected an implicit implementation; with
+  no generic runner configured it raised implementation-specific guidance
+  instead of failing on the generic contract. Both cases failed as intended.
+  The repair will require an explicit external runner on non-Windows hosts and
+  will preserve direct execution on Windows; private deployments must migrate
+  the environment before this breaking 2.0 release can be validated.
+- The grouped repair now generates bootstrap configuration in the caller's
+  writable current directory, keeps an explicitly requested config path for
+  the `config` command without parsing it during bootstrap, removes the
+  programmatic registry-writing API and its credential-shaped example,
+  requires an explicitly configured generic external bridge runner on
+  non-Windows systems, and removes private runtime/project provenance. The
+  example and installer guidance now direct registration through DataLab and
+  no longer advertise the retired standalone O1-O6 JVOpen specs. The release
+  archive checker scans bounded text members for credential-shaped values and
+  private runtime/commit provenance without echoing matched content. A new
+  built-wheel smoke runs `jltsql init` in a fresh writable directory.
+- The formerly red public-surface/config/bridge/content selection and the
+  broader affected selection are green: `77 passed`, then `257 passed, 11
+  subtests passed`. `git diff --check` passes. A fresh isolated PEP 517 build
+  produced the 1.6.10 wheel and sdist without the prior setuptools license
+  deprecation warning; the new two-artifact content scan and the extracted
+  wheel init smoke both pass. These artifacts are validation-only and are not
+  a release candidate because the version metadata and official status/key
+  contracts are separate blocked iterations.
+- Next safe action is one final static/focused gate, then commit this single
+  public-surface iteration and obtain two independent Codex reviews against
+  its frozen full SHA. STOP on any public occurrence of the private bridge
+  implementation/provenance, archive secret-scan false-negative or content
+  echo, non-Windows implicit runner selection, installed-wheel init failure,
+  test failure, or candidate drift during review.
+- The final pre-commit public/install surface selection passes `91 passed, 5
+  skipped`; the skips are existing environment-dependent launcher cases. The
+  fail-closed test gate reports `TEST GATE PASS`, compileall succeeds, fatal
+  flake8 (`E9,F63,F7,F82`) reports zero findings, and strict MkDocs succeeds.
+  The MkDocs tool emitted only its upstream 2.0 project warning. The dirty
+  candidate remains based on exact `98ec163...`; no release/version claim is
+  attached to these pre-commit results.

--- a/specs/operations/20260816_release_readiness_worklog.md
+++ b/specs/operations/20260816_release_readiness_worklog.md
@@ -2663,8 +2663,8 @@
   superseded audit pages are not distributed. Existing setuptools license
   deprecation messages are advisory build debt and did not weaken the build or
   content result.
-- A final tracked-Markdown/public-doc scan reports no maintainer-prohibited
-  runtime term, no public `a6` mention, and no maintainer-local home path. All
+- A final tracked-Markdown/public-doc scan reports no retired infrastructure
+  term and no maintainer-local home path. All
   public x64/64-bit references explicitly say the project acquisition/parse/
   storage path remains unverified and must not be treated as supported. Sixteen
   historical absolute scratch paths found in this worklog were sanitized to
@@ -3439,3 +3439,48 @@
   exact full SHA exists. Next safe action: commit the complete grouped repair,
   verify a clean worktree, replay the necessary exact-SHA full/static/artifact
   gates once, push PR #202, and request two independent bounded reviews.
+- The grouped repair was committed and pushed as exact candidate
+  `e5a18b3a19b90e0a9d36137e7fff082c802958e2`. Its locked full suite passed
+  `2736 passed, 131 skipped, 19 subtests passed`; fail-closed test-gate,
+  compileall, fatal flake8, strict MkDocs, lock check, and diff check passed.
+  Exact `git archive` wheel/sdist content and extracted-wheel smoke passed. A
+  fresh Python 3.12 venv installed only that wheel plus base dependencies and
+  successfully initialized config, created/read 80 SQLite tables, and kept
+  tests/specs out of the sdist. GitHub test/lint/Windows-batch checks passed;
+  performance was the expected conditional skip.
+- Two independent Codex reviews of that frozen SHA both returned
+  NEEDS_CHANGES. Findings were consolidated before editing: explicit `+`
+  concatenation bypassed the archive sensitive-shape normalization; missing
+  database selector with only PostgreSQL enabled, unknown logging level, and
+  string-valued update flag passed config validation; six launchers trusted a
+  `venv32` directory name without measuring bitness and one accepted an
+  arbitrary PATH CLI; one tracked worklog sentence itself named a retired
+  infrastructure token; and v2 notes lacked concrete public API replacement
+  guidance. Prior c08 wheel-origin, path/member, install-root, version, update,
+  and archive-checkout findings were independently confirmed closed.
+- Minimal tests were extended before production repair. On unchanged e5
+  production they returned `8 failed, 8 passed, 5 subtests passed`: one archive
+  concatenation failure, three config semantic failures, two launcher policy
+  failures, one tracked-Markdown privacy failure, and one release-note API
+  migration failure. A ResourceWarning followed the intentionally accepted
+  invalid logging level because the pre-repair CLI opened a handler before
+  crashing; validation now rejects it before logging setup. No sensitive value
+  was printed or recorded by the tests.
+- The batched follow-up strips explicit concatenation operators during bounded
+  archive normalization, validates default/selected backend coherence, logging
+  levels, and boolean update policy, verifies bitness for every automatically
+  discovered virtual environment, and preserves only explicit CLI/interpreter
+  overrides. The tracked sentence was generalized and a hash-only Markdown
+  privacy contract added. Release notes now map removed registry methods and
+  odds constants to their supported registration/record-ID replacements and
+  direct users to the generic runner property without naming private
+  implementation details. The formerly red selection passes `13 passed, 8
+  subtests passed`; broader/full and artifact gates remain pending on this
+  uncommitted repair.
+- The broader affected selection passes `326 passed, 5 skipped, 8 subtests
+  passed`; the complete dirty-tree suite passes `2738 passed, 131 skipped, 22
+  subtests passed`. Fail-closed test-gate, compileall, fatal flake8, strict
+  MkDocs, lock check, and diff check pass. Fresh wheel/sdist content inspection
+  and extracted-wheel init/config/version/SQLite smoke also pass. The next safe
+  action is one follow-up commit, exact-SHA verification, push, and a bounded
+  two-reviewer closure check; no tag/release is authorized.

--- a/specs/operations/20260816_release_readiness_worklog.md
+++ b/specs/operations/20260816_release_readiness_worklog.md
@@ -3201,8 +3201,7 @@
 ### 2026-08-17 14:25 JST — public release-surface security iteration start
 
 - This bounded pre-release iteration targets repository
-  `miyamamoto/jrvltsql` in dedicated worktree
-  `/home/keiba/scratch/20260817_jrvltsql_public_surface`, branch
+  `miyamamoto/jrvltsql` in a dedicated release worktree, branch
   `agent/release-public-surface-20260817`, from exact current
   `origin/master` / base / HEAD
   `98ec163222aab3eadaa82f048273c8a0be8722e6`. The published production release
@@ -3224,8 +3223,8 @@
   a credential-shaped or private-runtime payload, then retain a paired safe
   archive case. Error output must name only the archive member and finding
   category, never the matched value.
-- Claude Code Fable is unavailable under the recorded service usage limit.
-  Per maintainer authorization, implementation and review use Codex with at
+- The optional secondary implementation reviewer was unavailable and is not
+  counted as evidence. Implementation and review use Codex with at
   least two independent critical reviews on one frozen candidate SHA after the
   audit findings are batched. STOP on any credential disclosure in output or
   tracked evidence, compatibility-layer regression, archive scanner
@@ -3361,9 +3360,9 @@
   followed by exact-full-SHA tests and the two bounded carry-forward critical
   reviews; no release or merge is authorized by these pre-commit results.
 - Three independent Codex carry-forward reviews of exact candidate
-  `c08b5170c59d30c630876a0ae976b4823ed32cd5` returned NEEDS_CHANGES. Claude
-  Code remained unavailable under its service usage limit, so this review
-  batch used the maintainer-authorized Codex fallback. Findings were
+  `c08b5170c59d30c630876a0ae976b4823ed32cd5` returned NEEDS_CHANGES. The
+  optional secondary reviewer remained unavailable and was not counted.
+  Findings were
   consolidated before any repair: the archive gate still missed several
   split/encoded sensitive-content and path/member-boundary cases and could
   expose a sensitive member through an exception; a partial wheel could borrow
@@ -3502,3 +3501,45 @@
   and is not a 64-bit support claim. Local Linux cannot execute this cmd.exe
   branch, so the exact follow-up SHA Windows Actions job is mandatory before
   merge.
+- Follow-up candidate `20b1926a190384f609e34aa5001ae39f93512425`
+  passed the locked full suite (`2738 passed, 131 skipped, 22 subtests
+  passed`), the static/artifact gates, and GitHub test/lint/32-bit Windows
+  launcher jobs. The bounded closure reviewer returned GREEN. After the draft
+  was marked ready, GitHub Codex and CodeRabbit supplied one aggregated final
+  review batch; no further reviewer was requested before evaluating the whole
+  batch.
+- Nine inline findings were independently checked. The actionable set is:
+  require a setuptools release that implements string SPDX metadata; preserve
+  an explicit `JLTSQL` command when `PYTHON` is also present; make the tracked
+  `specs/` exclusion explicit in `MANIFEST.in`; make wheel smoke exit/origin/
+  extraction/path/SQLite cleanup fail closed; narrow and log expected version
+  metadata fallbacks; and bind non-Windows bridge tests to a non-Windows
+  platform. The worklog keeps branch and full-SHA provenance required for
+  auditability, while replacing its maintainer-local absolute path and private
+  service-state detail with generic evidence.
+- Tests were extended before the production repair. On unchanged production
+  candidate `20b1926...`, the local review selection returned `5 failed, 153
+  passed`: the declared setuptools minimum was too old, explicit `JLTSQL` was
+  overwritten, wheel smoke mishandled a successful no-value exit and a corrupt
+  stream, and an unexpected source-version exception was silently swallowed.
+  The paired normal paths remained green. The Windows runtime half is also
+  encoded as PATH-only rejection plus explicit-command success and requires the
+  exact follow-up GitHub Windows job.
+- The grouped repair pins the build minimum at setuptools 77.0.3 and the CI uv
+  version at the version already exercised by the prior successful run. Wheel
+  smoke now accepts a no-value successful exit, validates regular and namespace
+  module origins without raising from `finally`, resolves the extraction root,
+  converts corrupt/encrypted archive failures into gate errors, and closes the
+  SQLite readback connection deterministically. The distribution gate retains
+  its intentionally conservative credential-shape rejection; weakening it for
+  hypothetical false positives was rejected because this security gate must
+  fail closed. The scan-cost micro-optimization is non-blocking and is not mixed
+  into this release-safety repair. Existing corrupt-member coverage plus one
+  bounded oversize-member case cover the unread/size-limit rejection paths.
+- The formerly red and adjacent affected selection now passes `189 passed`.
+  A no-isolation PEP 517 build using the declared minimum setuptools 77.0.3
+  produced both artifacts; the content gate and extracted-wheel init/config/
+  version/SQLite readback smoke passed. Fatal flake8, lock check, and diff check
+  pass. These are dirty-tree repair results only; next safe action is one commit,
+  exact-SHA affected/full/static/artifact validation, one bounded review of only
+  this final batch, and courteous replies resolving every review thread.

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,3 +1,3 @@
 """jrvltsql - JRA-VAN データ取得・管理ツール"""
 
-__version__ = "1.6.10"
+__version__ = "2.0.0.dev0"

--- a/src/cli/main.py
+++ b/src/cli/main.py
@@ -1,13 +1,13 @@
 """JLTSQL Command Line Interface."""
 
-import sys
 import os
+import sys
 from pathlib import Path
 
 import click
 from rich.console import Console
 
-from src.utils.config import ConfigError, load_config
+from src.utils.config import ConfigError, get_default_config, load_config
 from src.utils.logger import get_logger, setup_logging_from_config
 from src.utils.updater import (
     auto_update_check_notice,
@@ -16,6 +16,7 @@ from src.utils.updater import (
     get_current_version,
     perform_update,
 )
+
 
 # Version - single source of truth from pyproject.toml
 def _read_version():
@@ -30,8 +31,9 @@ def _read_version():
     except Exception:
         pass
     try:
-        from pathlib import Path
         import re
+        from pathlib import Path
+
         pyproject = Path(__file__).resolve().parents[2] / "pyproject.toml"
         match = re.search(r'^version\s*=\s*"([^"]+)"', pyproject.read_text(), re.M)
         if match:
@@ -72,7 +74,7 @@ FETCH_NOTE_DATE_FIELDS = (
     "対応する日付を持たないレコードは JV-Link 取得時に除外されず、"
     "その取得範囲は完全キャッシュとして記録されません。"
 )
-CONFIG_OPTIONAL_COMMANDS = frozenset({"init", "status", "version"})
+CONFIG_OPTIONAL_COMMANDS = frozenset({"config", "init", "status", "version"})
 
 
 def _reject_retired_data_spec(data_spec: str) -> None:
@@ -149,14 +151,22 @@ def cli(ctx, config, verbose):
     """
     # Store context
     ctx.ensure_object(dict)
+    requested_config_path = (
+        Path(config) if config else Path.cwd() / "config" / "config.yaml"
+    )
+    ctx.obj["config_path"] = requested_config_path
 
     # Load configuration
-    if config:
-        config_path = config
+    if ctx.invoked_subcommand in {"config", "init"}:
+        # Bootstrap, --force repair, and config inspection must not parse a
+        # missing or malformed configuration before the command handles it.
+        config_path = None
+    elif config:
+        config_path = requested_config_path
     else:
-        # Try default path
-        project_root = Path(__file__).parent.parent.parent
-        config_path = project_root / "config" / "config.yaml"
+        # The default is user-writable and independent of the package install
+        # location. This is also the exact path created by ``jltsql init``.
+        config_path = requested_config_path
 
         if not config_path.exists():
             # Read-only bootstrap commands must work before initialization.
@@ -215,7 +225,7 @@ def init(ctx, force):
     """
     console.print("[bold cyan]Initializing JLTSQL project...[/bold cyan]")
 
-    project_root = Path(__file__).parent.parent.parent
+    project_root = Path.cwd()
     config_dir = project_root / "config"
     data_dir = project_root / "data"
     logs_dir = project_root / "logs"
@@ -228,8 +238,8 @@ def init(ctx, force):
         else:
             console.print(f"  Directory exists: {directory}")
 
-    # Create config.yaml from example
-    config_example = config_dir / "config.yaml.example"
+    # Generate a complete default without relying on a source-checkout-only
+    # template that is absent from installed wheels.
     config_yaml = config_dir / "config.yaml"
 
     if config_yaml.exists() and not force:
@@ -238,22 +248,23 @@ def init(ctx, force):
             "Use --force to overwrite."
         )
     else:
-        if config_example.exists():
-            import shutil
+        import yaml
 
-            shutil.copy(config_example, config_yaml)
-            console.print(f"[green]+[/green] Created configuration file: {config_yaml}")
-        else:
-            console.print(
-                f"[red]Error:[/red] {config_example} not found.",
-                style="bold",
-            )
-            sys.exit(1)
+        config_yaml.write_text(
+            yaml.safe_dump(
+                get_default_config(),
+                allow_unicode=True,
+                sort_keys=False,
+            ),
+            encoding="utf-8",
+        )
+        console.print(f"[green]+[/green] Created configuration file: {config_yaml}")
 
     console.print("\n[bold green]Initialization complete![/bold green]")
     console.print("\nNext steps:")
-    console.print("  1. Edit config/config.yaml and set your JV-Link service key")
-    console.print("  2. Run: jltsql fetch --help")
+    console.print("  1. Register JV-Link in the JRA-VAN DataLab application")
+    console.print("  2. Review config/config.yaml for database settings")
+    console.print("  3. Run: jltsql fetch --help")
 
 
 @cli.command()
@@ -1321,15 +1332,15 @@ def config(ctx, show, set_value, get_key):
     from pathlib import Path
     import yaml
 
-    # Find config file
+    # Find config file. The path is captured before the bootstrap command
+    # deliberately skips normal configuration loading.
+    config_path = Path(
+        ctx.obj.get("config_path", Path.cwd() / "config" / "config.yaml")
+    )
     if ctx.obj.get("config"):
         config_obj = ctx.obj["config"]
         config_dict = config_obj.to_dict()
-        config_path = Path(ctx.params.get("config", "config/config.yaml"))
     else:
-        project_root = Path(__file__).parent.parent.parent
-        config_path = project_root / "config" / "config.yaml"
-
         if not config_path.exists():
             console.print("[red]Error:[/red] Configuration file not found.")
             console.print("Run 'jltsql init' first.")

--- a/src/cli/main.py
+++ b/src/cli/main.py
@@ -7,6 +7,7 @@ from pathlib import Path
 import click
 from rich.console import Console
 
+from src import __version__
 from src.utils.config import ConfigError, get_default_config, load_config
 from src.utils.logger import get_logger, setup_logging_from_config
 from src.utils.updater import (
@@ -17,32 +18,6 @@ from src.utils.updater import (
     perform_update,
 )
 
-
-# Version - single source of truth from pyproject.toml
-def _read_version():
-    """Read version from pyproject.toml."""
-    try:
-        from importlib.metadata import version as _get_version
-        for dist_name in ("jltsql", "jrvltsql"):
-            try:
-                return _get_version(dist_name)
-            except Exception:
-                pass
-    except Exception:
-        pass
-    try:
-        import re
-        from pathlib import Path
-
-        pyproject = Path(__file__).resolve().parents[2] / "pyproject.toml"
-        match = re.search(r'^version\s*=\s*"([^"]+)"', pyproject.read_text(), re.M)
-        if match:
-            return match.group(1)
-    except Exception:
-        pass
-    return "unknown"
-
-__version__ = _read_version()
 
 # Console for rich output (Windows cp932-safe)
 console = Console(legacy_windows=True)
@@ -122,7 +97,7 @@ def _print_fetch_guardrail_notes(jv_option: int) -> None:
 @click.option(
     "--config",
     "-c",
-    type=click.Path(exists=True),
+    type=click.Path(exists=True, dir_okay=False, readable=True),
     default=None,
     help="Path to configuration file (default: config/config.yaml)",
 )
@@ -186,8 +161,15 @@ def cli(ctx, config, verbose):
             cfg = load_config(str(config_path))
             ctx.obj["config"] = cfg
 
-            # Setup logging from config
-            setup_logging_from_config(cfg.to_dict())
+            # Setup logging from config. Invalid leaf types are rejected by
+            # load_config; filesystem failures are still rendered as a
+            # controlled configuration error rather than a traceback.
+            try:
+                setup_logging_from_config(cfg.to_dict())
+            except (OSError, TypeError, ValueError) as exc:
+                raise ConfigError(
+                    f"Could not initialize logging ({type(exc).__name__})"
+                ) from exc
 
             # Override log level if verbose
             if verbose:
@@ -237,12 +219,24 @@ def init(ctx, force):
         )
         ctx.exit(2)
 
-    console.print("[bold cyan]Initializing JLTSQL project...[/bold cyan]")
-
     project_root = Path.cwd()
     config_dir = project_root / "config"
     data_dir = project_root / "data"
     logs_dir = project_root / "logs"
+    config_yaml = config_dir / "config.yaml"
+
+    if config_yaml.exists() and not force:
+        try:
+            load_config(config_yaml)
+        except ConfigError as exc:
+            console.print(
+                f"[red]Configuration Error:[/red] {exc}. "
+                "Repair the file or rerun with --force.",
+                style="bold",
+            )
+            ctx.exit(1)
+
+    console.print("[bold cyan]Initializing JLTSQL project...[/bold cyan]")
 
     # Create directories
     for directory in [config_dir, data_dir, logs_dir]:
@@ -254,8 +248,6 @@ def init(ctx, force):
 
     # Generate a complete default without relying on a source-checkout-only
     # template that is absent from installed wheels.
-    config_yaml = config_dir / "config.yaml"
-
     if config_yaml.exists() and not force:
         console.print(
             f"[yellow]Warning:[/yellow] {config_yaml} already exists. "
@@ -380,7 +372,7 @@ def update(ctx, force):
     else:
         console.print()
         console.print("[bold red][ERROR] Update failed.[/bold red]")
-        console.print("Try manually: git pull && pip install -e .")
+        console.print("Review the update guidance above and retry.")
         sys.exit(1)
 
 

--- a/src/cli/main.py
+++ b/src/cli/main.py
@@ -155,11 +155,12 @@ def cli(ctx, config, verbose):
         Path(config) if config else Path.cwd() / "config" / "config.yaml"
     )
     ctx.obj["config_path"] = requested_config_path
+    ctx.obj["config_explicit"] = config is not None
 
     # Load configuration
-    if ctx.invoked_subcommand in {"config", "init"}:
-        # Bootstrap, --force repair, and config inspection must not parse a
-        # missing or malformed configuration before the command handles it.
+    if ctx.invoked_subcommand == "init":
+        # Bootstrap must work before a configuration exists. An explicit
+        # global path is rejected by the command instead of being ignored.
         config_path = None
     elif config:
         config_path = requested_config_path
@@ -198,7 +199,12 @@ def cli(ctx, config, verbose):
 
             # Auto-update check (if enabled in config)
             auto_check = cfg.get("auto_update_check", True)
-            if auto_check and ctx.invoked_subcommand not in ("update", "version"):
+            if auto_check and ctx.invoked_subcommand not in (
+                "config",
+                "init",
+                "update",
+                "version",
+            ):
                 notice = auto_update_check_notice()
                 if notice:
                     console.print(f"[dim yellow]{notice}[/dim yellow]")
@@ -223,6 +229,14 @@ def init(ctx, force):
 
     Creates configuration files and database directories.
     """
+    if ctx.obj.get("config_explicit"):
+        console.print(
+            "[red]Error:[/red] --config cannot be used with init; "
+            "run init from the directory to initialize.",
+            style="bold",
+        )
+        ctx.exit(2)
+
     console.print("[bold cyan]Initializing JLTSQL project...[/bold cyan]")
 
     project_root = Path.cwd()
@@ -263,7 +277,7 @@ def init(ctx, force):
     console.print("\n[bold green]Initialization complete![/bold green]")
     console.print("\nNext steps:")
     console.print("  1. Register JV-Link in the JRA-VAN DataLab application")
-    console.print("  2. Review config/config.yaml for database settings")
+    console.print("  2. Review the SQLite-only config/config.yaml default")
     console.print("  3. Run: jltsql fetch --help")
 
 
@@ -1330,7 +1344,6 @@ def config(ctx, show, set_value, get_key):
       jltsql config --set database.type=sqlite    # Set value (not implemented yet)
     """
     from pathlib import Path
-    import yaml
 
     # Find config file. The path is captured before the bootstrap command
     # deliberately skips normal configuration loading.
@@ -1345,10 +1358,11 @@ def config(ctx, show, set_value, get_key):
             console.print("[red]Error:[/red] Configuration file not found.")
             console.print("Run 'jltsql init' first.")
             sys.exit(1)
-
-        # Load config manually
-        with open(config_path, "r", encoding="utf-8") as f:
-            config_dict = yaml.safe_load(f)
+        console.print(
+            "[red]Error:[/red] Configuration could not be loaded.",
+            style="bold",
+        )
+        ctx.exit(1)
 
     # Show all configuration
     if show or (not set_value and not get_key):
@@ -1379,7 +1393,10 @@ def config(ctx, show, set_value, get_key):
         log_tree = tree.add("Logging")
         log_config = config_dict.get("logging", {})
         log_tree.add(f"Level: {log_config.get('level', 'INFO')}")
-        log_tree.add(f"File: {log_config.get('file', 'logs/jltsql.log')}")
+        log_file = log_config.get("file", "logs/jltsql.log")
+        if isinstance(log_file, dict):
+            log_file = log_file.get("path", "logs/jltsql.log")
+        log_tree.add(f"File: {log_file}")
 
         console.print(tree)
         console.print()

--- a/src/database/__init__.py
+++ b/src/database/__init__.py
@@ -40,11 +40,6 @@ def create_database_from_config(
         ValueError: If the resolved db_type is not supported.
         DatabaseError: If PostgreSQL is requested without matching config.
     """
-    # Local imports to avoid circular-import friction with base.py.
-    from .sqlite_handler import SQLiteDatabase
-    from .postgresql_handler import PostgreSQLDatabase
-    from .dual_handler import DualDatabase
-
     if db_type_override:
         db_type = db_type_override
     elif config is not None:
@@ -53,12 +48,18 @@ def create_database_from_config(
         db_type = "sqlite"
 
     if db_type == "sqlite":
+        # PostgreSQL is an optional extra. Keep the default SQLite path usable
+        # in a wheel installed without a PostgreSQL driver.
+        from .sqlite_handler import SQLiteDatabase
+
         sqlite_config = (
             config.get("databases.sqlite") if config else {"path": "data/keiba.db"}
         )
         return SQLiteDatabase(sqlite_config)
 
     if db_type == "postgresql":
+        from .postgresql_handler import PostgreSQLDatabase
+
         if not config:
             raise DatabaseError(
                 "PostgreSQL requires a configuration file with "
@@ -67,6 +68,10 @@ def create_database_from_config(
         return PostgreSQLDatabase(config.get("databases.postgresql"))
 
     if db_type == "dual":
+        from .dual_handler import DualDatabase
+        from .postgresql_handler import PostgreSQLDatabase
+        from .sqlite_handler import SQLiteDatabase
+
         if not config:
             raise DatabaseError(
                 "Dual-write requires a configuration file with both "

--- a/src/fetcher/base.py
+++ b/src/fetcher/base.py
@@ -33,8 +33,8 @@ class BaseFetcher(ABC):
     JV-Data records from JV-Link.
 
     Note:
-        Service key can be provided programmatically or configured in
-        JRA-VAN DataLab application/registry.
+        JV-Link registration is configured in the JRA-VAN DataLab
+        application before this fetcher is started.
 
     Attributes:
         jvlink: JV-Link wrapper instance

--- a/src/jvlink/bridge.py
+++ b/src/jvlink/bridge.py
@@ -7,7 +7,9 @@ evidence, not by the process boundary alone.
 
 Platform support:
 - Windows: runs JVLinkBridge.exe directly
-- Non-Windows: runs the native Win32 bridge through Wine
+- Non-Windows: runs JVLinkBridge.exe through an explicitly configured external
+  runner. The runner implementation belongs to the deployment environment and
+  is not selected or documented by this package.
 """
 
 import base64
@@ -80,7 +82,7 @@ def _require_string(response: dict, field: str, command: str) -> str:
 
 # Default bridge executable locations (searched in order)
 _BRIDGE_SEARCH_PATHS = [
-    # Native Win32 bridge (preferred for Wine; no .NET runtime dependency)
+    # Native Win32 bridge (no .NET runtime dependency)
     Path("tools/jvlink-bridge/bin/native/JVLinkBridge.exe"),
     # Relative to jrvltsql repo root (build output)
     Path("tools/jvlink-bridge/bin/x86/Release/net8.0-windows/JVLinkBridge.exe"),
@@ -94,7 +96,7 @@ _BRIDGE_SEARCH_PATHS = [
     Path(r"C:\Program Files (x86)\JVLinkBridge\JVLinkBridge.exe"),
 ]
 
-_BRIDGE_SEARCH_PATHS_LINUX = [
+_BRIDGE_SEARCH_PATHS_NON_WINDOWS = [
     Path("/opt/jvlink-bridge/JVLinkBridge.exe"),
     Path.home() / "jvlink-bridge" / "JVLinkBridge.exe",
     Path("tools/jvlink-bridge/bin/native/JVLinkBridge.exe"),
@@ -119,12 +121,13 @@ def _repo_root() -> Path:
     return Path(__file__).resolve().parents[2]
 
 
-def _wine_executable() -> str:
-    return os.environ.get("JVLINK_WINE", "wine")
+def _external_runner() -> Optional[str]:
+    value = os.environ.get("JVLINK_BRIDGE_RUNNER", "").strip()
+    return value or None
 
 
-def _is_wine_available(wine: Optional[str] = None) -> bool:
-    return shutil.which(wine or _wine_executable()) is not None
+def _is_runner_available(runner: Optional[str]) -> bool:
+    return runner is not None and shutil.which(runner) is not None
 
 
 def find_bridge_executable() -> Optional[Path]:
@@ -144,7 +147,7 @@ def find_bridge_executable() -> Optional[Path]:
         return candidate
 
     search_paths = (
-        _BRIDGE_SEARCH_PATHS_LINUX
+        _BRIDGE_SEARCH_PATHS_NON_WINDOWS
         if sys.platform != "win32"
         else _BRIDGE_SEARCH_PATHS
     )
@@ -194,8 +197,8 @@ class JVLinkBridge:
         self._is_open = False
         self._needs_close = False
         self._download_count: Optional[int] = None
-        self._use_wine = sys.platform != "win32"
-        self._wine = _wine_executable()
+        self._use_external_runner = sys.platform != "win32"
+        self._runner = _external_runner()
         self._stderr_file: Optional[TextIO] = None
         self._dialog_watcher_stop: Optional[threading.Event] = None
         self._dialog_watcher_thread: Optional[threading.Thread] = None
@@ -215,38 +218,29 @@ class JVLinkBridge:
             "JVLinkBridge initialized",
             bridge_path=str(self._bridge_path),
             sid=sid,
-            use_wine=self._use_wine,
-            wine=self._wine if self._use_wine else None,
+            use_external_runner=self._use_external_runner,
+            runner_configured=self._runner is not None,
         )
 
     @property
-    def uses_wine(self) -> bool:
-        return self._use_wine
+    def uses_external_runner(self) -> bool:
+        return self._use_external_runner
 
     def _build_command(self) -> list[str]:
-        if not self._use_wine:
+        if not self._use_external_runner:
             return [str(self._bridge_path)]
-        if not _is_wine_available(self._wine):
+        if not _is_runner_available(self._runner):
             raise JVLinkBridgeError(
-                "非Windows環境ではWineが必要です。wine32/wine をインストールし、"
-                "必要なら JVLINK_WINE に実行ファイルを指定してください。"
+                "Non-Windows bridge execution requires JVLINK_BRIDGE_RUNNER "
+                "to name an available external runner executable"
             )
-        return [self._wine, str(self._bridge_path)]
+        return [self._runner, str(self._bridge_path)]
 
     def _build_env(self) -> dict[str, str]:
-        env = os.environ.copy()
-        if self._use_wine:
-            env.setdefault("WINEDEBUG", "-all")
-        wineprefix = env.get("JVLINK_WINEPREFIX")
-        if wineprefix:
-            env["WINEPREFIX"] = wineprefix
-        winearch = env.get("JVLINK_WINEARCH")
-        if winearch:
-            env["WINEARCH"] = winearch
-        return env
+        return os.environ.copy()
 
     def _dialog_watcher_enabled(self) -> bool:
-        if not self._use_wine:
+        if not self._use_external_runner:
             return False
         value = os.environ.get("JVLINK_AUTO_CLOSE_DIALOGS", "1").lower()
         if value in _DISABLED_VALUES:
@@ -261,7 +255,7 @@ class JVLinkBridge:
 
     def _dismiss_known_dialogs_once(self) -> int:
         """Reject only known blocking JV-Link dialogs visible on this X display."""
-        if not self._use_wine or not os.environ.get("DISPLAY"):
+        if not self._use_external_runner or not os.environ.get("DISPLAY"):
             return 0
         if shutil.which("xdotool") is None:
             return 0
@@ -431,7 +425,7 @@ class JVLinkBridge:
         logger.info(
             "Starting JVLinkBridge subprocess",
             path=str(self._bridge_path),
-            wine=self._use_wine,
+            external_runner=self._use_external_runner,
         )
 
         command = self._build_command()
@@ -566,14 +560,6 @@ class JVLinkBridge:
 
         logger.info("JV-Link initialized via bridge", code=code)
         return code
-
-    def jv_set_service_key(self, service_key: str) -> int:
-        """Set service key. Note: Bridge doesn't directly support this yet.
-
-        For JRA, the service key is typically set via registry by JRA-VAN DataLab installer.
-        """
-        logger.warning("jv_set_service_key not implemented in bridge; use JRA-VAN DataLab to configure")
-        return 0
 
     def jv_open(
         self,
@@ -720,9 +706,9 @@ class JVLinkBridge:
             if code != 0:
                 raise JVLinkBridgeError("JVClose failed", error_code=code)
         else:
-            # jrvltsql-wine-runtime through be759ee acknowledges close with
-            # only {"status":"ok"}. Preserve compatibility until that
-            # adapter propagates JVClose's official Long result code.
+            # Older bridge protocol revisions acknowledge close with only
+            # {"status":"ok"}. Preserve compatibility until every deployed
+            # bridge propagates JVClose's official Long result code.
             logger.warning(
                 "JVClose bridge response omitted the native result code; "
                 "accepting the legacy runtime acknowledgment"
@@ -749,9 +735,9 @@ class JVLinkBridge:
                 response.get("error", f"JVFiledelete failed for {filename}"),
                 error_code=code,
             )
-        # The production jrvltsql-wine-runtime bridge serializes the COM
-        # JVFiledelete return value as ``code``. A missing value is a protocol
-        # violation, not an implicit success.
+        # Current bridge protocol revisions serialize the COM JVFiledelete
+        # return value as ``code``. A missing value is a protocol violation,
+        # not an implicit success.
         return _require_response_code(response, f"JVFiledelete for {filename}")
 
     def wait_for_download(

--- a/src/jvlink/constants.py
+++ b/src/jvlink/constants.py
@@ -60,8 +60,8 @@ JV_RT_SID_INVALID = -103  # sid が不正（1桁目がスペース）（JVInit�
 #
 # -100 は公式仕様書「3. コード表」上、JVOpen/JVRTOpen の戻り値ではない
 # （それらは -111 以降のパラメータ不正系）。JVSetServiceKey は API 自体が
-# 不安定で -100 を返すことがあるため、wrapper.py はレジストリを直接操作して
-# これを回避している（wrapper.py の JVSetServiceKey 呼び出し箇所を参照）。
+# 不安定で -100 を返すことがある。jrvltsql はこのAPIやレジストリを直接操作せず、
+# DataLabで事前登録された設定を利用する。
 JV_RT_INVALID_PARAMETER = -100  # パラメータが不正、あるいはレジストリへの保存に失敗
 
 # JVRead / JVGets Return Codes
@@ -118,14 +118,6 @@ RETIRED_DATA_SPECS = {
 
 # 仕様変更が行われた年月。拒否メッセージに含める。
 RETIRED_DATA_SPEC_CHANGED_AT = "2023-08"
-
-# Odds Data Specifications
-DATA_SPEC_O1 = "O1"  # 単勝・複勝・枠連オッズ
-DATA_SPEC_O2 = "O2"  # 馬連オッズ
-DATA_SPEC_O3 = "O3"  # ワイドオッズ
-DATA_SPEC_O4 = "O4"  # 馬単オッズ
-DATA_SPEC_O5 = "O5"  # 3連複オッズ
-DATA_SPEC_O6 = "O6"  # 3連単オッズ
 
 # リアルタイムデータ種別 (JVRTOpen用)
 # 速報系データ: レース確定情報（結果が確定したら更新）

--- a/src/jvlink/wrapper.py
+++ b/src/jvlink/wrapper.py
@@ -191,53 +191,6 @@ class JVLinkWrapper:
         except Exception as e:
             raise JVLinkError(f"Failed to create JV-Link COM object: {e}")
 
-    def jv_set_service_key(self, service_key: str) -> int:
-        """Set JV-Link service key via Windows registry.
-
-        This method sets the service key directly in the Windows registry,
-        bypassing the unreliable JVSetServiceKey API which returns error -100.
-
-        Args:
-            service_key: JV-Link service key (format: XXXX-XXXX-XXXX-XXXX-X)
-
-        Returns:
-            Result code (0 = success, non-zero = error)
-
-        Raises:
-            JVLinkError: If service key setting fails
-
-        Examples:
-            >>> wrapper = JVLinkWrapper()
-            >>> wrapper.jv_set_service_key("5UJC-VRFM-448X-F3V4-4")
-            0
-            >>> wrapper.jv_init()
-        """
-        try:
-            import subprocess
-            import time
-
-            # Set service key in Windows registry
-            # IMPORTANT: JVSetServiceKey API is unreliable (returns -100), use registry instead
-            reg_key = r"HKLM\SOFTWARE\JRA-VAN\JV-Link"
-            result = subprocess.run(
-                ['reg', 'add', reg_key, '/v', 'ServiceKey', '/t', 'REG_SZ', '/d', service_key, '/f'],
-                capture_output=True,
-                text=True
-            )
-
-            if result.returncode == 0:
-                logger.info("Service key set successfully via registry")
-                # Wait a bit for registry to be flushed
-                time.sleep(0.5)
-                return JV_RT_SUCCESS
-            else:
-                logger.error("Failed to set service key in registry", error=result.stderr)
-                raise JVLinkError(f"Failed to set service key in registry: {result.stderr}")
-        except Exception as e:
-            if isinstance(e, JVLinkError):
-                raise
-            raise JVLinkError(f"JVSetServiceKey failed: {e}")
-
     def jv_init(self) -> int:
         """Initialize JV-Link.
 

--- a/src/utils/config.py
+++ b/src/utils/config.py
@@ -155,9 +155,8 @@ def load_config(config_path: Optional[Union[str, Path]] = None) -> Config:
     """
     resolved_path: Path
     if config_path is None:
-        # Default config path
-        project_root = Path(__file__).parent.parent.parent
-        resolved_path = project_root / "config" / "config.yaml"
+        # Keep the default writable and identical to the CLI bootstrap path.
+        resolved_path = Path.cwd() / "config" / "config.yaml"
     else:
         resolved_path = Path(config_path)
 

--- a/src/utils/config.py
+++ b/src/utils/config.py
@@ -120,21 +120,38 @@ def _validate_config(config: Dict[str, Any]) -> None:
     Raises:
         ConfigError: If configuration is invalid
     """
+    if not isinstance(config, dict):
+        raise ConfigError("Configuration root must be a mapping")
+
     # Check required sections
     if "jvlink" not in config:
         raise ConfigError("Missing required section: jvlink")
+    if not isinstance(config["jvlink"], dict):
+        raise ConfigError("Section jvlink must be a mapping")
 
     if "databases" not in config:
         raise ConfigError("Missing required section: databases")
+    if not isinstance(config["databases"], dict):
+        raise ConfigError("Section databases must be a mapping")
 
     # Check at least one database is enabled
     databases = config.get("databases", {})
+    if any(not isinstance(db_config, dict) for db_config in databases.values()):
+        raise ConfigError("Every databases entry must be a mapping")
     enabled_dbs = [
         name for name, db_config in databases.items() if db_config.get("enabled", False)
     ]
 
     if not enabled_dbs:
         raise ConfigError("At least one database must be enabled")
+
+    logging_config = config.get("logging", {})
+    if not isinstance(logging_config, dict):
+        raise ConfigError("Section logging must be a mapping")
+    for subsection in ("file", "console"):
+        value = logging_config.get(subsection, {})
+        if not isinstance(value, dict):
+            raise ConfigError(f"Section logging.{subsection} must be a mapping")
 
 
 def load_config(config_path: Optional[Union[str, Path]] = None) -> Config:
@@ -182,13 +199,17 @@ def load_config(config_path: Optional[Union[str, Path]] = None) -> Config:
 
 
 def get_default_config() -> Dict[str, Any]:
-    """Get default configuration values.
+    """Get the safe, self-contained SQLite bootstrap configuration.
 
     Returns:
-        Default configuration dictionary
+        A valid configuration that works without PostgreSQL extras. Optional
+        PostgreSQL, monitoring, and advanced settings remain opt-in.
     """
     return {
         "jvlink": {},
+        "database": {
+            "type": "sqlite",
+        },
         "databases": {
             "sqlite": {
                 "enabled": True,
@@ -217,6 +238,7 @@ def get_default_config() -> Dict[str, Any]:
             "commit_interval": 10000,
             "max_workers": 4,
         },
+        "auto_update_check": False,
         "logging": {
             "level": "INFO",
             "file": {

--- a/src/utils/config.py
+++ b/src/utils/config.py
@@ -162,7 +162,7 @@ def _validate_config(config: Dict[str, Any]) -> None:
     if not enabled_dbs:
         raise ConfigError("At least one database must be enabled")
 
-    required_backends: tuple[str, ...] = ()
+    required_backends: tuple[str, ...] = ("sqlite",)
     if selected_database in {"sqlite", "postgresql"}:
         required_backends = (selected_database,)
     elif selected_database == "dual":
@@ -183,6 +183,14 @@ def _validate_config(config: Dict[str, Any]) -> None:
     logging_level = logging_config.get("level", "INFO")
     if not isinstance(logging_level, str):
         raise ConfigError("logging.level must be a string")
+    if logging_level.upper() not in {
+        "DEBUG",
+        "INFO",
+        "WARNING",
+        "ERROR",
+        "CRITICAL",
+    }:
+        raise ConfigError(f"Unsupported logging.level: {logging_level}")
     for subsection in ("file", "console"):
         value = logging_config.get(subsection, {})
         if not isinstance(value, dict):
@@ -193,6 +201,10 @@ def _validate_config(config: Dict[str, Any]) -> None:
     log_path = logging_config.get("file", {}).get("path")
     if log_path is not None and not isinstance(log_path, str):
         raise ConfigError("logging.file.path must be a string")
+
+    auto_update_check = config.get("auto_update_check", True)
+    if not isinstance(auto_update_check, bool):
+        raise ConfigError("auto_update_check must be a boolean")
 
 
 def load_config(config_path: Optional[Union[str, Path]] = None) -> Config:

--- a/src/utils/config.py
+++ b/src/utils/config.py
@@ -134,10 +134,27 @@ def _validate_config(config: Dict[str, Any]) -> None:
     if not isinstance(config["databases"], dict):
         raise ConfigError("Section databases must be a mapping")
 
+    database_selector = config.get("database", {})
+    if not isinstance(database_selector, dict):
+        raise ConfigError("Section database must be a mapping")
+    selected_database = database_selector.get("type")
+    if selected_database is not None:
+        if not isinstance(selected_database, str):
+            raise ConfigError("database.type must be a string")
+        if selected_database not in {"sqlite", "postgresql", "dual"}:
+            raise ConfigError(f"Unsupported database.type: {selected_database}")
+
     # Check at least one database is enabled
     databases = config.get("databases", {})
     if any(not isinstance(db_config, dict) for db_config in databases.values()):
         raise ConfigError("Every databases entry must be a mapping")
+    for name, db_config in databases.items():
+        enabled = db_config.get("enabled", False)
+        if not isinstance(enabled, bool):
+            raise ConfigError(f"databases.{name}.enabled must be a boolean")
+        path = db_config.get("path")
+        if path is not None and not isinstance(path, str):
+            raise ConfigError(f"databases.{name}.path must be a string")
     enabled_dbs = [
         name for name, db_config in databases.items() if db_config.get("enabled", False)
     ]
@@ -145,13 +162,37 @@ def _validate_config(config: Dict[str, Any]) -> None:
     if not enabled_dbs:
         raise ConfigError("At least one database must be enabled")
 
+    required_backends: tuple[str, ...] = ()
+    if selected_database in {"sqlite", "postgresql"}:
+        required_backends = (selected_database,)
+    elif selected_database == "dual":
+        required_backends = ("sqlite", "postgresql")
+    for backend in required_backends:
+        backend_config = databases.get(backend)
+        if not isinstance(backend_config, dict) or not backend_config.get(
+            "enabled", False
+        ):
+            raise ConfigError(
+                f"database.type {selected_database} requires enabled "
+                f"databases.{backend}"
+            )
+
     logging_config = config.get("logging", {})
     if not isinstance(logging_config, dict):
         raise ConfigError("Section logging must be a mapping")
+    logging_level = logging_config.get("level", "INFO")
+    if not isinstance(logging_level, str):
+        raise ConfigError("logging.level must be a string")
     for subsection in ("file", "console"):
         value = logging_config.get(subsection, {})
         if not isinstance(value, dict):
             raise ConfigError(f"Section logging.{subsection} must be a mapping")
+        enabled = value.get("enabled", True)
+        if not isinstance(enabled, bool):
+            raise ConfigError(f"logging.{subsection}.enabled must be a boolean")
+    log_path = logging_config.get("file", {}).get("path")
+    if log_path is not None and not isinstance(log_path, str):
+        raise ConfigError("logging.file.path must be a string")
 
 
 def load_config(config_path: Optional[Union[str, Path]] = None) -> Config:
@@ -184,7 +225,11 @@ def load_config(config_path: Optional[Union[str, Path]] = None) -> Config:
         with open(resolved_path, "r", encoding="utf-8") as f:
             config_dict = yaml.safe_load(f)
     except yaml.YAMLError as e:
-        raise ConfigError(f"Invalid YAML in configuration file: {e}")
+        raise ConfigError(f"Invalid YAML in configuration file: {e}") from e
+    except (OSError, UnicodeError) as e:
+        raise ConfigError(
+            f"Could not read configuration file ({type(e).__name__})"
+        ) from e
 
     if config_dict is None:
         raise ConfigError("Configuration file is empty")

--- a/src/utils/logger.py
+++ b/src/utils/logger.py
@@ -30,9 +30,8 @@ def setup_logging(
     # Create logs directory if it doesn't exist
     if log_to_file:
         if log_file is None:
-            project_root = Path(__file__).parent.parent.parent
-            log_dir = project_root / "logs"
-            log_dir.mkdir(exist_ok=True)
+            log_dir = Path.cwd() / "logs"
+            log_dir.mkdir(parents=True, exist_ok=True)
             log_file = str(log_dir / "jltsql.log")
         else:
             log_dir = Path(log_file).parent
@@ -174,8 +173,7 @@ def setup_logging_from_yaml(config_path: Optional[str] = None) -> None:
         yaml.YAMLError: If config file is invalid YAML
     """
     if config_path is None:
-        project_root = Path(__file__).parent.parent.parent
-        config_path = str(project_root / "config" / "logging.yaml")
+        config_path = str(Path.cwd() / "config" / "logging.yaml")
 
     config_file = Path(config_path)
     if not config_file.exists():
@@ -232,12 +230,11 @@ def get_rotation_info() -> dict:
     return rotation_info
 
 
-# Configure default logging on module import
-# Try to load from YAML first, fall back to basic setup
+# Configure console-only logging on module import. File logging is enabled only
+# after an explicit config is loaded, so importing an installed wheel never
+# writes into site-packages or trusts logging configuration from an arbitrary
+# current directory.
 # Skip auto-configuration if JLTSQL_SKIP_AUTO_LOGGING is set (for quickstart.py)
 import os
 if not os.environ.get('JLTSQL_SKIP_AUTO_LOGGING'):
-    try:
-        setup_logging_from_yaml()
-    except (FileNotFoundError, yaml.YAMLError):
-        setup_logging()
+    setup_logging(log_to_file=False)

--- a/src/utils/updater.py
+++ b/src/utils/updater.py
@@ -1,6 +1,7 @@
 """Auto-update and version checking utilities for JLTSQL."""
 
 import json
+import os
 import subprocess
 import sys
 import time
@@ -19,16 +20,61 @@ GITHUB_API_URL = f"https://api.github.com/repos/{GITHUB_OWNER}/{GITHUB_REPO}"
 
 # Update check state file
 PROJECT_ROOT = Path(__file__).parent.parent.parent
-UPDATE_CHECK_FILE = PROJECT_ROOT / "data" / ".update_check.json"
+
+
+def _default_update_check_file() -> Path:
+    explicit_state = os.environ.get("JLTSQL_STATE_DIR")
+    if explicit_state:
+        state_root = Path(explicit_state)
+    elif sys.platform == "win32":
+        state_root = Path(
+            os.environ.get(
+                "LOCALAPPDATA",
+                Path.home() / "AppData" / "Local",
+            )
+        ) / "jltsql"
+    else:
+        state_root = Path(
+            os.environ.get(
+                "XDG_STATE_HOME",
+                Path.home() / ".local" / "state",
+            )
+        ) / "jltsql"
+    return state_root / "update_check.json"
+
+
+UPDATE_CHECK_FILE = _default_update_check_file()
 
 
 def get_current_version() -> str:
-    """Get the current installed version from git tags or pyproject.toml.
+    """Get the current version from source or installed package metadata.
 
     Returns:
         Version string (e.g., "2.2.0" or "v2.2.0")
     """
-    # Try git describe first
+    # A source checkout may intentionally be ahead of the latest release tag.
+    # Its project metadata is therefore the source of truth.
+    try:
+        toml_path = PROJECT_ROOT / "pyproject.toml"
+        if toml_path.exists():
+            content = toml_path.read_text(encoding="utf-8")
+            for line in content.splitlines():
+                if line.strip().startswith("version"):
+                    # version = "2.2.0"
+                    return line.split("=")[1].strip().strip('"').strip("'")
+    except Exception:
+        pass
+
+    # Installed wheels do not carry their source pyproject.
+    try:
+        from importlib.metadata import version
+
+        return version("jltsql")
+    except Exception:
+        pass
+
+    # Last-resort compatibility for an unpacked git checkout without project
+    # metadata. A tag is not allowed to override either authoritative source.
     try:
         result = subprocess.run(
             ["git", "describe", "--tags", "--abbrev=0"],
@@ -39,18 +85,6 @@ def get_current_version() -> str:
         )
         if result.returncode == 0:
             return result.stdout.strip()
-    except Exception:
-        pass
-
-    # Fallback: read from pyproject.toml
-    try:
-        toml_path = PROJECT_ROOT / "pyproject.toml"
-        if toml_path.exists():
-            content = toml_path.read_text(encoding="utf-8")
-            for line in content.splitlines():
-                if line.strip().startswith("version"):
-                    # version = "2.2.0"
-                    return line.split("=")[1].strip().strip('"').strip("'")
     except Exception:
         pass
 
@@ -204,6 +238,14 @@ def perform_update(verbose: bool = True) -> bool:
     Returns:
         True if update succeeded
     """
+    if not (PROJECT_ROOT / ".git").exists():
+        if verbose:
+            print(
+                "This installation is not a git checkout. "
+                "Upgrade it with pip or the release installer."
+            )
+        return False
+
     try:
         # Step 1: git pull
         if verbose:

--- a/src/utils/updater.py
+++ b/src/utils/updater.py
@@ -9,6 +9,8 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Optional
 
+from packaging.version import InvalidVersion, Version
+
 from src.utils.logger import get_logger
 
 logger = get_logger(__name__)
@@ -177,25 +179,17 @@ def check_for_updates() -> Optional[dict]:
 
 
 def _version_newer(latest: str, current: str) -> bool:
-    """Compare version strings (strip 'v' prefix).
+    """Compare PEP 440 versions after stripping an optional ``v`` prefix.
 
     Returns:
         True if latest is newer than current
     """
-    def normalize(v: str) -> list[int]:
-        v = v.lstrip("v")
-        parts = []
-        for p in v.split("."):
-            try:
-                parts.append(int(p))
-            except ValueError:
-                parts.append(0)
-        return parts
-
     try:
-        return normalize(latest) > normalize(current)
-    except Exception:
-        return latest != current
+        return Version(latest.lstrip("v")) > Version(current.lstrip("v"))
+    except InvalidVersion:
+        # Unparseable or unavailable metadata is unknown, not evidence that an
+        # update is safe or required.
+        return False
 
 
 def should_check_updates(interval_hours: int = 24) -> bool:

--- a/src/utils/updater.py
+++ b/src/utils/updater.py
@@ -5,7 +5,9 @@ import os
 import subprocess
 import sys
 import time
+import tomllib
 from datetime import datetime, timezone
+from importlib import metadata
 from pathlib import Path
 from typing import Optional
 
@@ -59,21 +61,31 @@ def get_current_version() -> str:
     try:
         toml_path = PROJECT_ROOT / "pyproject.toml"
         if toml_path.exists():
-            content = toml_path.read_text(encoding="utf-8")
-            for line in content.splitlines():
-                if line.strip().startswith("version"):
-                    # version = "2.2.0"
-                    return line.split("=")[1].strip().strip('"').strip("'")
-    except Exception:
-        pass
+            project = tomllib.loads(toml_path.read_text(encoding="utf-8"))
+            project_version = project["project"]["version"]
+            if not isinstance(project_version, str) or not project_version:
+                raise TypeError("project.version must be a non-empty string")
+            return project_version
+    except (
+        OSError,
+        UnicodeError,
+        tomllib.TOMLDecodeError,
+        KeyError,
+        TypeError,
+    ) as error:
+        logger.debug(
+            "Could not read source version metadata",
+            error_type=type(error).__name__,
+        )
 
     # Installed wheels do not carry their source pyproject.
     try:
-        from importlib.metadata import version
-
-        return version("jltsql")
-    except Exception:
-        pass
+        return metadata.version("jltsql")
+    except metadata.PackageNotFoundError as error:
+        logger.debug(
+            "Installed distribution metadata was not found",
+            error_type=type(error).__name__,
+        )
 
     # Last-resort compatibility for an unpacked git checkout without project
     # metadata. A tag is not allowed to override either authoritative source.
@@ -87,8 +99,11 @@ def get_current_version() -> str:
         )
         if result.returncode == 0:
             return result.stdout.strip()
-    except Exception:
-        pass
+    except (OSError, subprocess.SubprocessError) as error:
+        logger.debug(
+            "Could not read version from Git metadata",
+            error_type=type(error).__name__,
+        )
 
     return "unknown"
 
@@ -121,8 +136,8 @@ def check_for_updates() -> Optional[dict]:
         dict with 'latest_version', 'current_version', 'update_available', 'html_url'
         or None on failure
     """
-    import urllib.request
     import urllib.error
+    import urllib.request
 
     current = get_current_version()
 

--- a/tests/test_batch_processor.py
+++ b/tests/test_batch_processor.py
@@ -33,7 +33,7 @@ def test_historical_no_data_resets_statistics_from_previous_spec():
     fetcher._records_parsed = 8
     fetcher._records_failed = 1
     fetcher.jvlink = MagicMock()
-    fetcher.jvlink.uses_wine = False
+    fetcher.jvlink.uses_external_runner = False
     fetcher.jvlink.jv_open.return_value = (-1, 0, 0, "")
 
     assert list(fetcher.fetch("RACE", "20260701", "20260714")) == []

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -834,6 +834,25 @@ jvlink: {}
 logging:
   file: {enabled: true, path: 123}
 """,
+            """
+databases:
+  postgresql: {enabled: true}
+jvlink: {}
+""",
+            """
+database: {type: sqlite}
+databases:
+  sqlite: {enabled: true, path: data/keiba.db}
+jvlink: {}
+logging: {level: VERBOSE}
+""",
+            """
+database: {type: sqlite}
+databases:
+  sqlite: {enabled: true, path: data/keiba.db}
+jvlink: {}
+auto_update_check: "false"
+""",
         )
         for document in invalid_documents:
             with self.subTest(document=document), self.runner.isolated_filesystem():

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -63,23 +63,17 @@ class TestInitCommand(unittest.TestCase):
         self.runner = CliRunner()
 
     def test_init_creates_directories(self):
-        """Test that init creates required directories."""
+        """An installed CLI initializes its writable current directory."""
         with self.runner.isolated_filesystem():
-            # Create config example file in current directory
-            config_dir = Path('config')
-            config_dir.mkdir(exist_ok=True)
-            example_file = config_dir / 'config.yaml.example'
-            example_file.write_text('# Example config')
+            installed_module = Path.cwd() / "site-packages/src/cli/main.py"
+            with patch("src.cli.main.__file__", str(installed_module)):
+                result = self.runner.invoke(cli, ["init"])
 
-            # Also create data and logs dirs to simulate init
-            Path('data').mkdir(exist_ok=True)
-            Path('logs').mkdir(exist_ok=True)
-
-            result = self.runner.invoke(cli, ['init'])
-
-            # Init should succeed and config should exist
             self.assertEqual(result.exit_code, 0)
-            self.assertTrue(Path('config').exists())
+            self.assertTrue(Path("config/config.yaml").is_file())
+            self.assertTrue(Path("data").is_dir())
+            self.assertTrue(Path("logs").is_dir())
+            self.assertNotIn("service key", result.output.lower())
 
     def test_init_with_force(self):
         """Test init with --force flag."""

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -92,6 +92,30 @@ class TestInitCommand(unittest.TestCase):
             self.assertEqual(result.exit_code, 0)
             self.assertIn('Created configuration file', result.output)
 
+    def test_init_rejects_a_global_config_path_instead_of_ignoring_it(self):
+        """Init has a CWD target and must not silently ignore --config."""
+        with self.runner.isolated_filesystem():
+            explicit = Path("existing.yaml")
+            explicit.write_text("sentinel", encoding="utf-8")
+
+            result = self.runner.invoke(
+                cli,
+                ["--config", str(explicit), "init", "--force"],
+            )
+
+            self.assertNotEqual(result.exit_code, 0)
+            self.assertEqual(explicit.read_text(encoding="utf-8"), "sentinel")
+            self.assertFalse(Path("config/config.yaml").exists())
+
+    def test_init_default_is_a_valid_sqlite_configuration(self):
+        with self.runner.isolated_filesystem():
+            init_result = self.runner.invoke(cli, ["init"])
+            show_result = self.runner.invoke(cli, ["config", "--show"])
+
+            self.assertEqual(init_result.exit_code, 0, init_result.output)
+            self.assertEqual(show_result.exit_code, 0, show_result.output)
+            self.assertIn("Type: sqlite", show_result.output)
+
 
 class TestCreateTablesCommand(unittest.TestCase):
     """Test create-tables command."""
@@ -583,12 +607,17 @@ class TestConfigCommand(unittest.TestCase):
 database:
   type: sqlite
   path: data/keiba.db
+databases:
+  sqlite:
+    enabled: true
+    path: data/keiba.db
 jvlink:
   sid: JLTSQL
-  service_key: test_key
 logging:
   level: INFO
-  file: logs/jltsql.log
+  file:
+    enabled: true
+    path: logs/jltsql.log
 """)
 
             result = self.runner.invoke(cli, ['config', '--show'])
@@ -623,6 +652,11 @@ jvlink:
             Path('config/config.yaml').write_text("""
 database:
   type: sqlite
+databases:
+  sqlite:
+    enabled: true
+    path: data/keiba.db
+jvlink: {}
 """)
 
             result = self.runner.invoke(cli, ['config', '--get', 'nonexistent.key'])
@@ -638,6 +672,11 @@ database:
             Path('config/config.yaml').write_text("""
 database:
   type: sqlite
+databases:
+  sqlite:
+    enabled: true
+    path: data/keiba.db
+jvlink: {}
 """)
 
             result = self.runner.invoke(cli, ['config', '--set', 'database.type=sqlite'])
@@ -653,6 +692,10 @@ database:
 database:
   type: sqlite
   path: data/test.db
+databases:
+  sqlite:
+    enabled: true
+    path: data/test.db
 jvlink:
   sid: TEST
 logging:
@@ -663,6 +706,69 @@ logging:
 
             # Should show config tree
             self.assertEqual(result.exit_code, 0)
+
+    def test_config_uses_the_validating_loader_and_expands_environment(self):
+        with self.runner.isolated_filesystem():
+            Path("config").mkdir()
+            Path("config/config.yaml").write_text(
+                """
+database:
+  type: sqlite
+databases:
+  sqlite:
+    enabled: true
+    path: ${JLTSQL_TEST_DB_PATH:fallback.db}
+jvlink: {}
+""",
+                encoding="utf-8",
+            )
+            with patch.dict(
+                "os.environ",
+                {"JLTSQL_TEST_DB_PATH": "expanded.db"},
+            ):
+                result = self.runner.invoke(
+                    cli,
+                    ["config", "--get", "databases.sqlite.path"],
+                )
+
+            self.assertEqual(result.exit_code, 0, result.output)
+            self.assertIn("expanded.db", result.output)
+            self.assertNotIn("${", result.output)
+
+    def test_empty_config_fails_with_a_controlled_configuration_error(self):
+        with self.runner.isolated_filesystem():
+            Path("config").mkdir()
+            Path("config/config.yaml").write_text("", encoding="utf-8")
+
+            result = self.runner.invoke(cli, ["config", "--show"])
+
+            self.assertEqual(result.exit_code, 1)
+            self.assertIn("Configuration Error", result.output)
+            self.assertNotIn("Traceback", result.output)
+
+    def test_invalid_logging_shape_fails_with_a_controlled_error(self):
+        with self.runner.isolated_filesystem():
+            Path("config").mkdir()
+            Path("config/config.yaml").write_text(
+                """
+database:
+  type: sqlite
+databases:
+  sqlite:
+    enabled: true
+    path: data/keiba.db
+jvlink: {}
+logging:
+  file: logs/jltsql.log
+""",
+                encoding="utf-8",
+            )
+
+            result = self.runner.invoke(cli, ["config", "--show"])
+
+            self.assertEqual(result.exit_code, 1)
+            self.assertIn("Configuration Error", result.output)
+            self.assertNotIn("Traceback", result.output)
 
 
 if __name__ == '__main__':

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -116,6 +116,35 @@ class TestInitCommand(unittest.TestCase):
             self.assertEqual(show_result.exit_code, 0, show_result.output)
             self.assertIn("Type: sqlite", show_result.output)
 
+    def test_init_rejects_an_existing_invalid_configuration(self):
+        with self.runner.isolated_filesystem():
+            Path("config").mkdir()
+            Path("config/config.yaml").write_text("database: invalid\n", encoding="utf-8")
+
+            result = self.runner.invoke(cli, ["init"])
+
+            self.assertNotEqual(result.exit_code, 0)
+            self.assertIn("Configuration Error", result.output)
+            self.assertNotIn("Initialization complete", result.output)
+
+
+class TestUpdateCommand(unittest.TestCase):
+    def setUp(self):
+        self.runner = CliRunner()
+
+    def test_failed_wheel_update_does_not_print_git_checkout_instructions(self):
+        with self.runner.isolated_filesystem():
+            self.assertEqual(self.runner.invoke(cli, ["init"]).exit_code, 0)
+            with (
+                patch("src.cli.main.check_for_updates", return_value=None),
+                patch("src.cli.main.perform_update", return_value=False),
+            ):
+                result = self.runner.invoke(cli, ["update", "--force"])
+
+            self.assertEqual(result.exit_code, 1)
+            self.assertIn("Update failed", result.output)
+            self.assertNotIn("git pull", result.output)
+
 
 class TestCreateTablesCommand(unittest.TestCase):
     """Test create-tables command."""
@@ -768,6 +797,65 @@ logging:
 
             self.assertEqual(result.exit_code, 1)
             self.assertIn("Configuration Error", result.output)
+            self.assertNotIn("Traceback", result.output)
+
+    def test_invalid_config_shapes_fail_with_a_controlled_error(self):
+        invalid_documents = (
+            """
+database: sqlite
+databases:
+  sqlite: {enabled: true, path: data/keiba.db}
+jvlink: {}
+""",
+            """
+database: {type: unsupported}
+databases:
+  sqlite: {enabled: true, path: data/keiba.db}
+jvlink: {}
+""",
+            """
+database: {type: postgresql}
+databases:
+  sqlite: {enabled: true, path: data/keiba.db}
+jvlink: {}
+""",
+            """
+database: {type: sqlite}
+databases:
+  sqlite: {enabled: true, path: data/keiba.db}
+jvlink: {}
+logging: {level: []}
+""",
+            """
+database: {type: sqlite}
+databases:
+  sqlite: {enabled: true, path: data/keiba.db}
+jvlink: {}
+logging:
+  file: {enabled: true, path: 123}
+""",
+        )
+        for document in invalid_documents:
+            with self.subTest(document=document), self.runner.isolated_filesystem():
+                Path("config").mkdir()
+                Path("config/config.yaml").write_text(document, encoding="utf-8")
+
+                result = self.runner.invoke(cli, ["config", "--show"])
+
+                self.assertEqual(result.exit_code, 1)
+                self.assertIn("Configuration Error", result.output)
+                self.assertNotIn("Traceback", result.output)
+
+    def test_config_option_rejects_a_directory_without_traceback(self):
+        with self.runner.isolated_filesystem():
+            Path("config-dir").mkdir()
+
+            result = self.runner.invoke(
+                cli,
+                ["--config", "config-dir", "config", "--show"],
+            )
+
+            self.assertNotEqual(result.exit_code, 0)
             self.assertNotIn("Traceback", result.output)
 
 

--- a/tests/test_coverage_expansion.py
+++ b/tests/test_coverage_expansion.py
@@ -467,27 +467,25 @@ class TestVersionComparisonEdgeCases:
         assert _version_newer("2.2.0", "2.2.0.1") is False
 
     def test_version_with_non_numeric(self):
-        """Versions with non-numeric parts default to 0."""
+        """PEP 440 prereleases compare normally; unknown text fails closed."""
         from src.utils.updater import _version_newer
 
-        # "beta" -> 0, so "2.2.0" vs "2.2.0" -> not newer
-        assert _version_newer("2.2.0", "2.2.beta") is False
-        # "2.2.1" vs "2.2.beta"(=2.2.0) -> newer
+        assert _version_newer("2.2.0", "2.2.beta") is True
         assert _version_newer("2.2.1", "2.2.beta") is True
+        assert _version_newer("2.2.1", "2.2.not-a-version") is False
 
     def test_version_empty_strings(self):
         """Empty version strings are handled."""
         from src.utils.updater import _version_newer
 
-        # Empty normalizes to [0]
-        assert _version_newer("1.0.0", "") is True
+        assert _version_newer("1.0.0", "") is False
         assert _version_newer("", "1.0.0") is False
 
     def test_version_just_v(self):
-        """'v' alone normalizes to [0]."""
+        """A bare prefix is not treated as a known old version."""
         from src.utils.updater import _version_newer
 
-        assert _version_newer("v1.0.0", "v") is True
+        assert _version_newer("v1.0.0", "v") is False
 
     def test_version_single_number(self):
         """Single number versions work."""

--- a/tests/test_daily_update.py
+++ b/tests/test_daily_update.py
@@ -262,10 +262,10 @@ def test_sync_realtime_spec_stops_after_subscription_error(rt_database, error_co
 
 
 @pytest.mark.parametrize("error_code", sorted(SUBSCRIPTION_ERROR_CODES))
-def test_sync_realtime_spec_stops_after_wine_bridge_subscription_error(
+def test_sync_realtime_spec_stops_after_external_bridge_subscription_error(
     rt_database, error_code
 ):
-    """Wine bridge の未購読応答も spec 単位の正常スキップにする。"""
+    """External bridge subscription errors are skipped per data spec."""
     from src.jvlink.bridge import JVLinkBridgeError
 
     class UnsubscribedBridge(FakeJVLink):

--- a/tests/test_distribution_contents.py
+++ b/tests/test_distribution_contents.py
@@ -182,6 +182,11 @@ def test_distribution_gate_rejects_sensitive_text_without_echoing_it(
             b'key = "ABCD-" "EFGH-" "IJKL-" "MNOP-Q"',
         ),
         (
+            "wheel",
+            "src/provider.py",
+            b'key = "ABCD-" + "EFGH-" + "IJKL-" + "MNOP-Q"',
+        ),
+        (
             "sdist",
             "src/bridge.py",
             b"".join((b"jltsql-private-", b"runtime revision deadbeef")),

--- a/tests/test_distribution_contents.py
+++ b/tests/test_distribution_contents.py
@@ -1,12 +1,15 @@
 """Release-distribution content gate tests."""
 
+import hashlib
 import tarfile
 import zipfile
 from pathlib import Path
 
 import pytest
 
+from scripts import check_distribution_contents as content_gate
 from scripts.check_distribution_contents import validate_distributions
+from scripts.smoke_distribution_init import _wheel_cli_command
 
 
 def _write_wheel(
@@ -29,6 +32,14 @@ def _write_sdist(
             payload_path = path.parent / "payload"
             payload_path.write_bytes(payload)
             archive.add(payload_path, arcname=member)
+
+
+def _write_sdist_link(path: Path, member: str, target: str) -> None:
+    with tarfile.open(path, "w:gz") as archive:
+        link = tarfile.TarInfo(member)
+        link.type = tarfile.SYMTYPE
+        link.linkname = target
+        archive.addfile(link)
 
 
 def _clean_pair(tmp_path: Path) -> tuple[Path, Path]:
@@ -95,7 +106,7 @@ def test_distribution_gate_fails_closed_when_an_artifact_kind_is_missing(
         (
             "sdist",
             (
-                b"private-example-",
+                b"jltsql-private-",
                 b"runtime through ",
                 b"deadbee acknowledges close",
             ),
@@ -122,3 +133,120 @@ def test_distribution_gate_rejects_sensitive_text_without_echoing_it(
     assert errors
     assert member in rendered
     assert payload.decode("ascii") not in rendered
+
+
+@pytest.mark.parametrize(
+    ("artifact", "member", "payload"),
+    (
+        (
+            "wheel",
+            ".env",
+            b"SERVICE_KEY=" + b"".join((b"ABCD-", b"EFGH-IJKL-MNOP-Q")),
+        ),
+        (
+            "sdist",
+            "PKG-INFO",
+            b"Service-Key: " + b"".join((b"ABCD", b"EFGHIJKLMNOPQ")),
+        ),
+        (
+            "wheel",
+            "config/provider.xml",
+            b"<key>" + b"".join((b"ABCD", b"EFGHIJKLMNOPQ")) + b"</key>",
+        ),
+        (
+            "wheel",
+            "scripts/setup.ps1",
+            (
+                "service_key = "
+                + "".join(("ABCD-", "EFGH-IJKL-MNOP-Q"))
+            ).encode("utf-16-le"),
+        ),
+        (
+            "sdist",
+            "src/bridge.py",
+            b"".join((b"jltsql-private-", b"runtime revision deadbeef")),
+        ),
+    ),
+)
+def test_distribution_gate_rejects_sensitive_archive_variants(
+    tmp_path: Path,
+    artifact: str,
+    member: str,
+    payload: bytes,
+) -> None:
+    wheel, sdist = _clean_pair(tmp_path)
+    if artifact == "wheel":
+        _write_wheel(wheel, (member,), payload)
+    else:
+        member = f"jltsql-0/{member}"
+        _write_sdist(sdist, (member,), payload)
+
+    assert validate_distributions((wheel, sdist))
+
+
+def test_distribution_gate_redacts_a_sensitive_member_name(tmp_path: Path) -> None:
+    wheel, sdist = _clean_pair(tmp_path)
+    secret = "".join(("ABCD-", "EFGH-IJKL-MNOP-Q"))
+    member = f"specs/{secret}.txt"
+    _write_wheel(wheel, (member,))
+
+    rendered = "\n".join(validate_distributions((wheel, sdist)))
+
+    assert rendered
+    assert secret not in rendered
+
+
+def test_distribution_gate_allows_public_runtime_provenance(tmp_path: Path) -> None:
+    wheel, sdist = _clean_pair(tmp_path)
+    _write_wheel(
+        wheel,
+        ("src/release_surface.py",),
+        b"public-example-runtime through deadbee",
+    )
+
+    assert validate_distributions((wheel, sdist)) == []
+
+
+def test_distribution_gate_applies_the_hashed_private_token_denylist(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    token = b"syntheticrunner"
+    monkeypatch.setattr(
+        content_gate,
+        "PROHIBITED_TOKEN_SHA256",
+        frozenset({hashlib.sha256(token).hexdigest()}),
+    )
+    wheel, sdist = _clean_pair(tmp_path)
+    _write_wheel(wheel, ("src/bridge.py",), token)
+
+    assert validate_distributions((wheel, sdist))
+
+
+@pytest.mark.parametrize("member", ("C:/escape.py", "C:\\escape.py"))
+def test_distribution_gate_rejects_windows_absolute_members(
+    tmp_path: Path,
+    member: str,
+) -> None:
+    wheel, sdist = _clean_pair(tmp_path)
+    _write_wheel(wheel, (member,))
+
+    assert validate_distributions((wheel, sdist))
+
+
+def test_distribution_gate_rejects_archive_links(tmp_path: Path) -> None:
+    wheel, sdist = _clean_pair(tmp_path)
+    _write_sdist_link(
+        sdist,
+        "jltsql-0/src/linked.py",
+        "../../escape.py",
+    )
+
+    assert validate_distributions((wheel, sdist))
+
+
+def test_wheel_smoke_binds_execution_to_the_extracted_wheel(tmp_path: Path) -> None:
+    command = _wheel_cli_command(tmp_path, ("init",))
+
+    assert "-I" in command
+    assert any("is_relative_to" in argument for argument in command)

--- a/tests/test_distribution_contents.py
+++ b/tests/test_distribution_contents.py
@@ -10,7 +10,11 @@ import pytest
 
 from scripts import check_distribution_contents as content_gate
 from scripts.check_distribution_contents import validate_distributions
-from scripts.smoke_distribution_init import _wheel_cli_command, validate_wheel_init
+from scripts.smoke_distribution_init import (
+    _REQUIRED_WHEEL_MEMBERS,
+    _wheel_cli_command,
+    validate_wheel_init,
+)
 
 
 def _write_wheel(
@@ -282,9 +286,30 @@ def test_distribution_gate_rejects_archive_links(tmp_path: Path) -> None:
 
 def test_wheel_smoke_binds_execution_to_the_extracted_wheel(tmp_path: Path) -> None:
     command = _wheel_cli_command(tmp_path, ("init",))
+    bootstrap = next(argument for argument in command if "runpy.run_module" in argument)
 
     assert "-I" in command
     assert any("is_relative_to" in argument for argument in command)
+    assert "if exc.code is None:" in bootstrap
+    assert "__path__" in bootstrap
+
+
+def test_wheel_smoke_rejects_a_corrupt_extract_without_crashing(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    wheel = tmp_path / "jltsql-0-py3-none-any.whl"
+    _write_wheel(
+        wheel,
+        (*sorted(_REQUIRED_WHEEL_MEMBERS), "jltsql-0.dist-info/METADATA"),
+    )
+
+    def corrupt_extract(*_args, **_kwargs):
+        raise zlib.error("synthetic corrupt stream")
+
+    monkeypatch.setattr(zipfile.ZipFile, "extractall", corrupt_extract)
+
+    assert validate_wheel_init(wheel)
 
 
 def test_wheel_smoke_rejects_a_partial_wheel_despite_an_editable_install(
@@ -323,3 +348,16 @@ def test_distribution_gate_returns_an_error_for_corrupt_deflate_stream(
     monkeypatch.setattr(zipfile.ZipFile, "read", corrupt_read)
 
     assert validate_distributions((wheel, sdist))
+
+
+def test_distribution_gate_rejects_members_above_the_scan_limit(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    wheel, sdist = _clean_pair(tmp_path)
+    monkeypatch.setattr(content_gate, "MAX_SCANNED_TEXT_BYTES", 4)
+
+    errors = validate_distributions((wheel, sdist))
+
+    assert errors
+    assert any("content-scan size limit" in error for error in errors)

--- a/tests/test_distribution_contents.py
+++ b/tests/test_distribution_contents.py
@@ -9,18 +9,26 @@ import pytest
 from scripts.check_distribution_contents import validate_distributions
 
 
-def _write_wheel(path: Path, members: tuple[str, ...]) -> None:
+def _write_wheel(
+    path: Path,
+    members: tuple[str, ...],
+    payload: bytes = b"fixture",
+) -> None:
     with zipfile.ZipFile(path, "w") as archive:
         for member in members:
-            archive.writestr(member, b"fixture")
+            archive.writestr(member, payload)
 
 
-def _write_sdist(path: Path, members: tuple[str, ...]) -> None:
+def _write_sdist(
+    path: Path,
+    members: tuple[str, ...],
+    payload: bytes = b"fixture",
+) -> None:
     with tarfile.open(path, "w:gz") as archive:
         for member in members:
-            payload = path.parent / "payload"
-            payload.write_bytes(b"fixture")
-            archive.add(payload, arcname=member)
+            payload_path = path.parent / "payload"
+            payload_path.write_bytes(payload)
+            archive.add(payload_path, arcname=member)
 
 
 def _clean_pair(tmp_path: Path) -> tuple[Path, Path]:
@@ -75,3 +83,42 @@ def test_distribution_gate_fails_closed_when_an_artifact_kind_is_missing(
 
     assert errors
     assert any(missing in error for error in errors)
+
+
+@pytest.mark.parametrize(
+    ("artifact", "payload_parts"),
+    (
+        (
+            "wheel",
+            (b'example_key = "ABCD-', b"EFGH-IJKL-MNOP-Q\""),
+        ),
+        (
+            "sdist",
+            (
+                b"private-example-",
+                b"runtime through ",
+                b"deadbee acknowledges close",
+            ),
+        ),
+    ),
+)
+def test_distribution_gate_rejects_sensitive_text_without_echoing_it(
+    tmp_path: Path,
+    artifact: str,
+    payload_parts: tuple[bytes, ...],
+) -> None:
+    payload = b"".join(payload_parts)
+    wheel, sdist = _clean_pair(tmp_path)
+    member = "src/release_surface.py"
+    if artifact == "wheel":
+        _write_wheel(wheel, (member,), payload)
+    else:
+        member = f"jltsql-0/{member}"
+        _write_sdist(sdist, (member,), payload)
+
+    errors = validate_distributions((wheel, sdist))
+    rendered = "\n".join(errors)
+
+    assert errors
+    assert member in rendered
+    assert payload.decode("ascii") not in rendered

--- a/tests/test_distribution_contents.py
+++ b/tests/test_distribution_contents.py
@@ -3,13 +3,14 @@
 import hashlib
 import tarfile
 import zipfile
+import zlib
 from pathlib import Path
 
 import pytest
 
 from scripts import check_distribution_contents as content_gate
 from scripts.check_distribution_contents import validate_distributions
-from scripts.smoke_distribution_init import _wheel_cli_command
+from scripts.smoke_distribution_init import _wheel_cli_command, validate_wheel_init
 
 
 def _write_wheel(
@@ -20,6 +21,13 @@ def _write_wheel(
     with zipfile.ZipFile(path, "w") as archive:
         for member in members:
             archive.writestr(member, payload)
+
+
+def _corrupt_zip_payload(path: Path, payload: bytes) -> None:
+    archive_bytes = bytearray(path.read_bytes())
+    payload_offset = archive_bytes.index(payload)
+    archive_bytes[payload_offset] ^= 0x01
+    path.write_bytes(archive_bytes)
 
 
 def _write_sdist(
@@ -63,6 +71,8 @@ def test_distribution_gate_accepts_clean_wheel_and_sdist(tmp_path: Path) -> None
         ("sdist", "jltsql-0/specs/operations/internal.md"),
         ("wheel", "docs/crawler_audit_02_ra_extended_layout.md"),
         ("sdist", "jltsql-0/docs/crawler_audit_04_se_layout.md"),
+        ("wheel", "tests/test_release_surface.py"),
+        ("sdist", "jltsql-0/tests/test_release_surface.py"),
     ),
 )
 def test_distribution_gate_rejects_nondistributable_content(
@@ -162,6 +172,16 @@ def test_distribution_gate_rejects_sensitive_text_without_echoing_it(
             ).encode("utf-16-le"),
         ),
         (
+            "wheel",
+            "src/provider.py",
+            b"JVSetServiceKey(" + b"".join((b"ABCD", b"EFGHIJKLMNOPQ")) + b")",
+        ),
+        (
+            "wheel",
+            "src/provider.py",
+            b'key = "ABCD-" "EFGH-" "IJKL-" "MNOP-Q"',
+        ),
+        (
             "sdist",
             "src/bridge.py",
             b"".join((b"jltsql-private-", b"runtime revision deadbeef")),
@@ -223,7 +243,17 @@ def test_distribution_gate_applies_the_hashed_private_token_denylist(
     assert validate_distributions((wheel, sdist))
 
 
-@pytest.mark.parametrize("member", ("C:/escape.py", "C:\\escape.py"))
+def test_distribution_gate_pins_the_private_runner_hash_without_plaintext() -> None:
+    assert (
+        "3958765b23d8a51d3445d91f98c1e76f62b896d615011d132b4ae85e4331d2fe"
+        in content_gate.PROHIBITED_TOKEN_SHA256
+    )
+
+
+@pytest.mark.parametrize(
+    "member",
+    ("C:/escape.py", "C:\\escape.py", "C:escape.py", "specs./internal.md"),
+)
 def test_distribution_gate_rejects_windows_absolute_members(
     tmp_path: Path,
     member: str,
@@ -250,3 +280,41 @@ def test_wheel_smoke_binds_execution_to_the_extracted_wheel(tmp_path: Path) -> N
 
     assert "-I" in command
     assert any("is_relative_to" in argument for argument in command)
+
+
+def test_wheel_smoke_rejects_a_partial_wheel_despite_an_editable_install(
+    tmp_path: Path,
+) -> None:
+    wheel = tmp_path / "jltsql-0-py3-none-any.whl"
+    _write_wheel(wheel, ("src/__init__.py",), b'__version__ = "0"')
+
+    assert validate_wheel_init(wheel)
+
+
+def test_distribution_gate_redacts_sensitive_names_on_crc_failure(
+    tmp_path: Path,
+) -> None:
+    wheel, sdist = _clean_pair(tmp_path)
+    secret = "".join(("ABCD-", "EFGH-IJKL-MNOP-Q"))
+    payload = b"CRC_UNIQUE_PAYLOAD"
+    _write_wheel(wheel, (f"src/{secret}.py",), payload)
+    _corrupt_zip_payload(wheel, payload)
+
+    rendered = "\n".join(validate_distributions((wheel, sdist)))
+
+    assert rendered
+    assert secret not in rendered
+
+
+def test_distribution_gate_returns_an_error_for_corrupt_deflate_stream(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    wheel, sdist = _clean_pair(tmp_path)
+
+    def corrupt_read(*_args, **_kwargs):
+        raise zlib.error("synthetic corrupt stream")
+
+    monkeypatch.setattr(zipfile.ZipFile, "read", corrupt_read)
+
+    assert validate_distributions((wheel, sdist))

--- a/tests/test_installer.py
+++ b/tests/test_installer.py
@@ -149,9 +149,11 @@ class TestPerformUpdate:
     """Tests for perform_update."""
 
     @patch("subprocess.run")
-    def test_successful_update(self, mock_run):
+    def test_successful_update(self, mock_run, tmp_path):
         mock_run.return_value = MagicMock(returncode=0, stdout="Already up to date.\n")
-        result = perform_update(verbose=False)
+        (tmp_path / ".git").mkdir()
+        with patch("src.utils.updater.PROJECT_ROOT", tmp_path):
+            result = perform_update(verbose=False)
         assert result is True
         assert mock_run.call_count == 2  # git pull + pip install
 

--- a/tests/test_installer.py
+++ b/tests/test_installer.py
@@ -6,22 +6,23 @@ and update flow with mocked subprocess/network calls.
 
 import json
 import time
+from importlib import metadata
 from pathlib import Path
-from unittest.mock import MagicMock, patch, mock_open
+from unittest.mock import MagicMock, mock_open, patch
 
 import pytest
 
 from src.utils.updater import (
-    _version_newer,
-    should_check_updates,
-    save_update_check_time,
-    get_current_version,
-    _find_pip,
-    perform_update,
-    check_for_updates,
-    auto_update_check_notice,
-    UPDATE_CHECK_FILE,
     PROJECT_ROOT,
+    UPDATE_CHECK_FILE,
+    _find_pip,
+    _version_newer,
+    auto_update_check_notice,
+    check_for_updates,
+    get_current_version,
+    perform_update,
+    save_update_check_time,
+    should_check_updates,
 )
 
 
@@ -114,7 +115,10 @@ class TestGetCurrentVersion:
         mock_run.return_value = MagicMock(returncode=0, stdout="v2.5.0\n")
         with (
             patch("src.utils.updater.PROJECT_ROOT", tmp_path),
-            patch("importlib.metadata.version", side_effect=LookupError),
+            patch(
+                "importlib.metadata.version",
+                side_effect=metadata.PackageNotFoundError,
+            ),
         ):
             version = get_current_version()
             assert version == "v2.5.0"

--- a/tests/test_installer.py
+++ b/tests/test_installer.py
@@ -110,10 +110,14 @@ class TestGetCurrentVersion:
     """Tests for get_current_version."""
 
     @patch("subprocess.run")
-    def test_from_git_tag(self, mock_run):
+    def test_from_git_tag_without_source_or_installed_metadata(self, mock_run, tmp_path):
         mock_run.return_value = MagicMock(returncode=0, stdout="v2.5.0\n")
-        version = get_current_version()
-        assert version == "v2.5.0"
+        with (
+            patch("src.utils.updater.PROJECT_ROOT", tmp_path),
+            patch("importlib.metadata.version", side_effect=LookupError),
+        ):
+            version = get_current_version()
+            assert version == "v2.5.0"
 
     @patch("subprocess.run")
     def test_fallback_to_pyproject(self, mock_run):

--- a/tests/test_jvd_self_repair.py
+++ b/tests/test_jvd_self_repair.py
@@ -1,7 +1,7 @@
 """Historical JVRead self-repair tests.
 
 Recovery uses the exact filename returned by JVRead and JVFiledelete. It does
-not inspect or unlink Wine cache paths directly.
+not inspect or unlink provider-managed cache paths directly.
 """
 
 from unittest.mock import MagicMock, patch

--- a/tests/test_log_rotation.py
+++ b/tests/test_log_rotation.py
@@ -7,6 +7,7 @@ import logging.handlers
 import tempfile
 import unittest
 from pathlib import Path
+from unittest.mock import patch
 
 import yaml
 
@@ -35,6 +36,16 @@ class TestLogRotation(unittest.TestCase):
             logger.removeHandler(handler)
 
         self.temp_dir.cleanup()
+
+    def test_default_log_file_uses_the_writable_current_directory(self):
+        expected = Path(self.temp_dir.name) / "logs" / "jltsql.log"
+        with patch(
+            "src.utils.logger.Path.cwd",
+            return_value=Path(self.temp_dir.name),
+        ):
+            setup_logging(log_to_console=False)
+
+        self.assertTrue(expected.is_file())
 
     def test_rotating_file_handler_created(self):
         """Test that RotatingFileHandler is created with correct settings."""

--- a/tests/test_public_setup_contract.py
+++ b/tests/test_public_setup_contract.py
@@ -1,0 +1,36 @@
+"""Public setup examples must match the executable provider contract."""
+
+from pathlib import Path
+
+import yaml
+
+from src.jvlink.constants import validate_jvopen_combination
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_public_setup_uses_supported_registration_and_dataspecs() -> None:
+    public_setup_files = (
+        REPOSITORY_ROOT / "install.ps1",
+        REPOSITORY_ROOT / "install.bat",
+        REPOSITORY_ROOT / "src/cli/main.py",
+        REPOSITORY_ROOT / "src/fetcher/base.py",
+    )
+    stale_guidance = (
+        "set your jv-link service key",
+        "set your service keys",
+        "service key can be provided programmatically",
+    )
+    for path in public_setup_files:
+        text = path.read_text(encoding="utf-8").lower()
+        assert not any(guidance in text for guidance in stale_guidance), path
+
+    config = yaml.safe_load(
+        (REPOSITORY_ROOT / "config/config.yaml.example").read_text(
+            encoding="utf-8"
+        )
+    )
+    data_specs = config["data_fetch"]["initial"]["data_specs"]
+    assert data_specs
+    for data_spec in data_specs:
+        validate_jvopen_combination(data_spec, 1)

--- a/tests/test_public_setup_contract.py
+++ b/tests/test_public_setup_contract.py
@@ -1,10 +1,14 @@
 """Public setup examples must match the executable provider contract."""
 
+import sys
+import tomllib
 from pathlib import Path
+from unittest.mock import patch
 
 import yaml
 
 from src.jvlink.constants import validate_jvopen_combination
+from src.utils.config import Config, get_default_config
 
 REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
 
@@ -34,3 +38,45 @@ def test_public_setup_uses_supported_registration_and_dataspecs() -> None:
     assert data_specs
     for data_spec in data_specs:
         validate_jvopen_combination(data_spec, 1)
+
+
+def test_installer_manual_commands_bind_the_installed_configuration() -> None:
+    for path in (REPOSITORY_ROOT / "install.ps1", REPOSITORY_ROOT / "install.bat"):
+        text = path.read_text(encoding="utf-8").lower()
+        assert "run: jltsql init" not in text, path
+        assert "jltsql --config" in text, path
+
+
+def test_sqlite_bootstrap_does_not_import_an_optional_postgresql_driver() -> None:
+    from src.database import create_database_from_config
+    from src.database.sqlite_handler import SQLiteDatabase
+
+    with patch.dict(
+        sys.modules,
+        {
+            "src.database.postgresql_handler": None,
+            "psycopg": None,
+            "pg8000": None,
+        },
+    ):
+        database = create_database_from_config(Config(get_default_config()))
+
+    assert isinstance(database, SQLiteDatabase)
+
+
+def test_removed_public_setup_contract_is_recorded_for_2_0() -> None:
+    changelog = (REPOSITORY_ROOT / "CHANGELOG.md").read_text(encoding="utf-8")
+    constants = (REPOSITORY_ROOT / "src/jvlink/constants.py").read_text(
+        encoding="utf-8"
+    )
+    project = tomllib.loads(
+        (REPOSITORY_ROOT / "pyproject.toml").read_text(encoding="utf-8")
+    )
+
+    assert "2.0.0" in changelog
+    assert "JVLINK_BRIDGE_RUNNER" in changelog
+    assert project["project"]["version"].startswith("2.0.0")
+    assert "wrapper.py の JVSetServiceKey 呼び出し箇所" not in constants
+    for record_type in range(1, 7):
+        assert f"DATA_SPEC_O{record_type} =" not in constants
+        assert f"RECORD_TYPE_O{record_type} =" in constants

--- a/tests/test_public_setup_contract.py
+++ b/tests/test_public_setup_contract.py
@@ -1,8 +1,9 @@
 """Public setup examples must match the executable provider contract."""
 
+import hashlib
+import re
 import sys
 import tomllib
-import re
 from pathlib import Path
 from unittest.mock import patch
 
@@ -65,6 +66,27 @@ def test_automatic_windows_paths_do_not_select_unverified_64_bit_python() -> Non
     assert "py -3 -c" not in quickstart
 
 
+def test_tracked_public_markdown_omits_the_retired_infrastructure_token() -> None:
+    blocked_hash = "730bea4ff16f200fb931b06cae08a5da8e279813775d7ed81e680b4a77946fe1"
+    markdown_paths = [
+        REPOSITORY_ROOT / "README.md",
+        REPOSITORY_ROOT / "CHANGELOG.md",
+        REPOSITORY_ROOT / "RELEASE_NOTES.md",
+        *(REPOSITORY_ROOT / "docs").rglob("*.md"),
+        *(REPOSITORY_ROOT / "specs").rglob("*.md"),
+    ]
+    for path in markdown_paths:
+        tokens = re.findall(
+            r"[A-Za-z][A-Za-z0-9_.+]+",
+            path.read_text(encoding="utf-8"),
+        )
+        assert all(
+            hashlib.sha256(token.lower().encode("ascii")).hexdigest()
+            != blocked_hash
+            for token in tokens
+        ), path
+
+
 def test_sqlite_bootstrap_does_not_import_an_optional_postgresql_driver() -> None:
     from src.database import create_database_from_config
     from src.database.sqlite_handler import SQLiteDatabase
@@ -84,6 +106,9 @@ def test_sqlite_bootstrap_does_not_import_an_optional_postgresql_driver() -> Non
 
 def test_removed_public_setup_contract_is_recorded_for_2_0() -> None:
     changelog = (REPOSITORY_ROOT / "CHANGELOG.md").read_text(encoding="utf-8")
+    release_notes = (REPOSITORY_ROOT / "RELEASE_NOTES.md").read_text(
+        encoding="utf-8"
+    )
     constants = (REPOSITORY_ROOT / "src/jvlink/constants.py").read_text(
         encoding="utf-8"
     )
@@ -93,6 +118,11 @@ def test_removed_public_setup_contract_is_recorded_for_2_0() -> None:
 
     assert "2.0.0" in changelog
     assert "JVLINK_BRIDGE_RUNNER" in changelog
+    assert "JVLinkWrapper.jv_set_service_key" in release_notes
+    assert "JVLinkBridge.jv_set_service_key" in release_notes
+    assert "RECORD_TYPE_O1" in release_notes
+    assert "RECORD_TYPE_O6" in release_notes
+    assert "uses_external_runner" in release_notes
     assert project["project"]["version"].startswith("2.0.0")
     assert "wrapper.py の JVSetServiceKey 呼び出し箇所" not in constants
     for record_type in range(1, 7):

--- a/tests/test_public_setup_contract.py
+++ b/tests/test_public_setup_contract.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from unittest.mock import patch
 
 import yaml
+from packaging.version import Version
 
 from src.jvlink.constants import validate_jvopen_combination
 from src.utils.config import Config, get_default_config
@@ -147,6 +148,24 @@ def test_version_and_lock_metadata_are_consistent() -> None:
     assert __version__ == project["project"]["version"]
     assert cli_main.__version__ == __version__
     assert locked_project["version"] == __version__
+
+    build_requires = project["build-system"]["requires"]
+    setuptools_requirement = next(
+        requirement
+        for requirement in build_requires
+        if requirement.startswith("setuptools>=")
+    )
+    assert Version(setuptools_requirement.removeprefix("setuptools>=")) >= Version(
+        "77.0.3"
+    )
+
+    manifest = (REPOSITORY_ROOT / "MANIFEST.in").read_text(encoding="utf-8")
+    assert "prune specs" in manifest.splitlines()
+
+    workflow = (
+        REPOSITORY_ROOT / ".github/workflows/test.yml"
+    ).read_text(encoding="utf-8")
+    assert "pip install uv==" in workflow
 
 
 def test_architecture_documents_the_generic_non_windows_runner_contract() -> None:

--- a/tests/test_public_setup_contract.py
+++ b/tests/test_public_setup_contract.py
@@ -2,6 +2,7 @@
 
 import sys
 import tomllib
+import re
 from pathlib import Path
 from unittest.mock import patch
 
@@ -41,10 +42,27 @@ def test_public_setup_uses_supported_registration_and_dataspecs() -> None:
 
 
 def test_installer_manual_commands_bind_the_installed_configuration() -> None:
-    for path in (REPOSITORY_ROOT / "install.ps1", REPOSITORY_ROOT / "install.bat"):
-        text = path.read_text(encoding="utf-8").lower()
-        assert "run: jltsql init" not in text, path
-        assert "jltsql --config" in text, path
+    powershell = (REPOSITORY_ROOT / "install.ps1").read_text(encoding="utf-8").lower()
+    batch = (REPOSITORY_ROOT / "install.bat").read_text(encoding="utf-8").lower()
+
+    assert "run: jltsql init" not in powershell
+    assert "run: jltsql init" not in batch
+    assert 'set-location `"$install_dir`"' in powershell
+    assert 'jltsql --config `".\\config\\config.yaml`"' in powershell
+    assert 'cd /d "%install_dir%"' in batch
+    assert 'jltsql --config "config\\config.yaml"' in batch
+
+
+def test_automatic_windows_paths_do_not_select_unverified_64_bit_python() -> None:
+    batch = (REPOSITORY_ROOT / "install.bat").read_text(encoding="utf-8")
+    powershell = (REPOSITORY_ROOT / "install.ps1").read_text(encoding="utf-8")
+    quickstart = (REPOSITORY_ROOT / "quickstart.bat").read_text(encoding="utf-8")
+
+    assert "py -3.12 --version" not in batch
+    assert "py -3 --version" not in batch
+    assert re.search(r'Command = "py"; Arguments = @\("-3\.12"\)', powershell) is None
+    assert "py -3.12 --version" not in quickstart
+    assert "py -3 -c" not in quickstart
 
 
 def test_sqlite_bootstrap_does_not_import_an_optional_postgresql_driver() -> None:
@@ -80,3 +98,48 @@ def test_removed_public_setup_contract_is_recorded_for_2_0() -> None:
     for record_type in range(1, 7):
         assert f"DATA_SPEC_O{record_type} =" not in constants
         assert f"RECORD_TYPE_O{record_type} =" in constants
+
+
+def test_version_and_lock_metadata_are_consistent() -> None:
+    from src import __version__
+    from src.cli import main as cli_main
+
+    project = tomllib.loads(
+        (REPOSITORY_ROOT / "pyproject.toml").read_text(encoding="utf-8")
+    )
+    lock = tomllib.loads(
+        (REPOSITORY_ROOT / "uv.lock").read_text(encoding="utf-8")
+    )
+    locked_project = next(
+        package for package in lock["package"] if package["name"] == "jltsql"
+    )
+
+    assert __version__ == project["project"]["version"]
+    assert cli_main.__version__ == __version__
+    assert locked_project["version"] == __version__
+
+
+def test_architecture_documents_the_generic_non_windows_runner_contract() -> None:
+    architecture = (REPOSITORY_ROOT / "docs/architecture.md").read_text(
+        encoding="utf-8"
+    )
+
+    assert "JVLINK_BRIDGE_RUNNER" in architecture
+
+
+def test_2_0_notes_define_the_data_and_rollback_migration_boundary() -> None:
+    notes = (REPOSITORY_ROOT / "RELEASE_NOTES.md").read_text(encoding="utf-8").lower()
+    changelog = (REPOSITORY_ROOT / "CHANGELOG.md").read_text(encoding="utf-8").lower()
+
+    for term in (
+        "parser",
+        "schema",
+        "transaction",
+        "backup",
+        "rebuild",
+        "reimport",
+        "docs/data_support.md",
+    ):
+        assert term in notes
+    assert "reimport" in changelog
+    assert "rollback" in changelog

--- a/tests/test_quickstart_cli.py
+++ b/tests/test_quickstart_cli.py
@@ -316,6 +316,15 @@ class TestQuickstartBatchRoles:
             assert 'set "PYTHON_CMD=%PYTHON%"' not in text, launcher.name
             assert "sys.version_info ^<" not in text, launcher.name
             assert "sys.version_info < (3, 12)" in text, launcher.name
+            venv32_probes = [
+                line
+                for line in text.splitlines()
+                if "venv32" in line.lower() and " -c " in line
+            ]
+            assert venv32_probes, launcher.name
+            assert all(
+                "struct.calcsize('P') != 4" in line for line in venv32_probes
+            ), launcher.name
 
     def test_launcher_command_assignment_defers_paths_until_execution(self):
         """Parentheses in Program Files paths must not close an IF block early."""
@@ -367,17 +376,17 @@ class TestQuickstartBatchRoles:
         assert "PYTHON must be a full path to python.exe" in batch
         assert "PYTHON must be a full path to python.exe" in powershell
 
-    def test_timeseries_fetch_prefers_installed_cli_before_global_python(self):
-        """A working PATH installation must win over an unrelated global Python."""
+    def test_timeseries_fetch_uses_only_explicit_or_32bit_interpreters(self):
+        """An arbitrary PATH entry must not bypass the bitness contract."""
         batch = Path(__file__).resolve().parents[1] / "fetch_timeseries_postgres.bat"
         text = batch.read_text(encoding="utf-8")
 
-        assert "where jltsql" in text
+        assert "where jltsql" not in text
+        assert 'set "JLTSQL="' not in text.splitlines()
         assert text.index("if defined PYTHON") < text.index("if defined VIRTUAL_ENV")
         assert text.index("if defined VIRTUAL_ENV") < text.index("venv32\\Scripts")
         assert text.index("venv32\\Scripts") < text.index(".venv\\Scripts")
-        assert text.index(".venv\\Scripts") < text.index("where jltsql")
-        assert text.index("where jltsql") < text.index("py -3.12-32 --version")
+        assert text.index(".venv\\Scripts") < text.index("py -3.12-32 --version")
 
     def test_installers_default_to_release_validated_32bit_python(self):
         root = Path(__file__).resolve().parents[1]

--- a/tests/test_quickstart_cli.py
+++ b/tests/test_quickstart_cli.py
@@ -383,7 +383,10 @@ class TestQuickstartBatchRoles:
 
         assert "where jltsql" not in text
         assert 'set "JLTSQL="' not in text.splitlines()
-        assert text.index("if defined PYTHON") < text.index("if defined VIRTUAL_ENV")
+        assert "if not defined JLTSQL if defined PYTHON" in text
+        assert text.index("if not defined JLTSQL if defined PYTHON") < text.index(
+            "if not defined JLTSQL if defined VIRTUAL_ENV"
+        )
         assert text.index("if defined VIRTUAL_ENV") < text.index("venv32\\Scripts")
         assert text.index("venv32\\Scripts") < text.index(".venv\\Scripts")
         assert text.index(".venv\\Scripts") < text.index("py -3.12-32 --version")

--- a/tests/test_quickstart_cli.py
+++ b/tests/test_quickstart_cli.py
@@ -289,11 +289,8 @@ class TestQuickstartBatchRoles:
 
         for launcher in launchers:
             text = launcher.read_text(encoding="utf-8")
-            assert "py -3.12 --version" in text, launcher.name
             assert "py -3.12-32 --version" in text, launcher.name
-            assert text.index("py -3.12-32 --version") < text.index(
-                "py -3.12 --version"
-            ), launcher.name
+            assert "py -3.12 --version" not in text, launcher.name
             assert "64-bit Python may not support JV-Link" not in text
             assert "Python 3.10+" not in text
 
@@ -388,11 +385,14 @@ class TestQuickstartBatchRoles:
         powershell = (root / "install.ps1").read_text(encoding="utf-8")
 
         assert "Checking Python 3.12" in batch
-        assert batch.index("py -3.12-32 --version") < batch.index("py -3.12 --version")
+        assert "py -3.12-32 --version" in batch
+        assert "py -3.12 --version" not in batch
         assert "Checking 32-bit Python" not in batch
         assert "32-bit Python 3.12 not found" not in batch
 
         assert "Checking Python $PYTHON_VERSION" in powershell
+        assert 'Arguments = @("-$PYTHON_VERSION-32")' in powershell
+        assert 'Arguments = @("-$PYTHON_VERSION")' not in powershell
         assert "Checking 32-bit Python" not in powershell
         assert "32-bit Python $PYTHON_VERSION not found" not in powershell
 

--- a/tests/test_realtime.py
+++ b/tests/test_realtime.py
@@ -948,7 +948,7 @@ class TestRealtimeUpdater(unittest.TestCase):
         self.assertEqual((imported, failed), (0, 1))
         updater.replace_date_snapshot.assert_called_once_with("20260715")
 
-    def test_wine_bridge_unsubscribed_spec_does_not_fail_cycle(self):
+    def test_external_bridge_unsubscribed_spec_does_not_fail_cycle(self):
         from src.jvlink.bridge import JVLinkBridgeError
 
         monitor = RealtimeMonitor(database=self.mock_db)
@@ -964,7 +964,7 @@ class TestRealtimeUpdater(unittest.TestCase):
         self.assertEqual((imported, failed), (0, 0))
         jvlink.jv_close.assert_called_once()
 
-    def test_wine_bridge_busy_spec_retries_without_failing_cycle(self):
+    def test_external_bridge_busy_spec_retries_without_failing_cycle(self):
         from src.jvlink.bridge import JVLinkBridgeError
 
         monitor = RealtimeMonitor(database=self.mock_db)

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -42,6 +42,11 @@ class TestVersionComparison:
         assert _version_newer("2.2.1", "2.2.0") is True
         assert _version_newer("2.2.0", "2.2.1") is False
 
+    def test_final_release_is_newer_than_its_development_prerelease(self):
+        from src.utils.updater import _version_newer
+
+        assert _version_newer("2.0.0", "2.0.0.dev0") is True
+
 
 class TestGetCurrentVersion:
     """Test getting current version."""
@@ -152,13 +157,23 @@ class TestPerformUpdate:
     """Test update execution."""
 
     @patch("subprocess.run")
-    def test_successful_update(self, mock_run):
+    def test_successful_update(self, mock_run, tmp_path):
         from src.utils.updater import perform_update
 
         mock_run.return_value = MagicMock(returncode=0, stdout="Already up to date.\n", stderr="")
-        result = perform_update(verbose=False)
+        (tmp_path / ".git").mkdir()
+        with patch("src.utils.updater.PROJECT_ROOT", tmp_path):
+            result = perform_update(verbose=False)
         assert result is True
         assert mock_run.call_count == 2  # git pull + pip install
+
+    @patch("subprocess.run")
+    def test_installed_distribution_update_fails_before_subprocess(self, mock_run, tmp_path):
+        from src.utils.updater import perform_update
+
+        with patch("src.utils.updater.PROJECT_ROOT", tmp_path):
+            assert perform_update(verbose=False) is False
+        mock_run.assert_not_called()
 
     @patch("subprocess.run")
     def test_git_pull_failure(self, mock_run):

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -47,21 +47,41 @@ class TestGetCurrentVersion:
     """Test getting current version."""
 
     @patch("subprocess.run")
-    def test_from_git_tag(self, mock_run):
+    def test_from_git_tag_when_source_metadata_is_absent(self, mock_run, tmp_path):
         from src.utils.updater import get_current_version
 
         mock_run.return_value = MagicMock(returncode=0, stdout="v2.2.0\n")
-        version = get_current_version()
-        assert version == "v2.2.0"
+        with (
+            patch("src.utils.updater.PROJECT_ROOT", tmp_path),
+            patch("importlib.metadata.version", side_effect=LookupError),
+        ):
+            version = get_current_version()
+            assert version == "v2.2.0"
 
     @patch("subprocess.run")
     def test_fallback_to_pyproject(self, mock_run):
         from src.utils.updater import get_current_version
 
-        mock_run.return_value = MagicMock(returncode=1, stdout="")
+        mock_run.return_value = MagicMock(returncode=0, stdout="v1.6.10\n")
         version = get_current_version()
-        # Should fall back to pyproject.toml
-        assert version != "unknown"
+        # Source metadata is the candidate version; a stale release tag must
+        # not make a development checkout report the previous release.
+        assert version == "2.0.0.dev0"
+
+    @patch("subprocess.run")
+    def test_fallback_to_installed_distribution_metadata(
+        self,
+        mock_run,
+        tmp_path,
+    ):
+        from src.utils.updater import get_current_version
+
+        mock_run.return_value = MagicMock(returncode=1, stdout="")
+        with (
+            patch("src.utils.updater.PROJECT_ROOT", tmp_path),
+            patch("importlib.metadata.version", return_value="9.8.7"),
+        ):
+            assert get_current_version() == "9.8.7"
 
 
 class TestShouldCheckUpdates:
@@ -72,6 +92,11 @@ class TestShouldCheckUpdates:
 
         with patch("src.utils.updater.UPDATE_CHECK_FILE", tmp_path / "nonexistent.json"):
             assert should_check_updates() is True
+
+    def test_default_state_file_is_outside_the_installed_package_tree(self):
+        from src.utils.updater import PROJECT_ROOT, UPDATE_CHECK_FILE
+
+        assert PROJECT_ROOT not in UPDATE_CHECK_FILE.parents
 
     def test_recent_check_should_skip(self, tmp_path):
         from src.utils.updater import should_check_updates

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -2,6 +2,7 @@
 
 import json
 import time
+from importlib import metadata
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -58,7 +59,10 @@ class TestGetCurrentVersion:
         mock_run.return_value = MagicMock(returncode=0, stdout="v2.2.0\n")
         with (
             patch("src.utils.updater.PROJECT_ROOT", tmp_path),
-            patch("importlib.metadata.version", side_effect=LookupError),
+            patch(
+                "importlib.metadata.version",
+                side_effect=metadata.PackageNotFoundError,
+            ),
         ):
             version = get_current_version()
             assert version == "v2.2.0"
@@ -82,6 +86,34 @@ class TestGetCurrentVersion:
         from src.utils.updater import get_current_version
 
         mock_run.return_value = MagicMock(returncode=1, stdout="")
+        with (
+            patch("src.utils.updater.PROJECT_ROOT", tmp_path),
+            patch("importlib.metadata.version", return_value="9.8.7"),
+        ):
+            assert get_current_version() == "9.8.7"
+
+    def test_unexpected_source_metadata_failure_is_not_silently_ignored(
+        self,
+        tmp_path,
+    ):
+        from src.utils.updater import get_current_version
+
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text('[project]\nversion = "1.0.0"\n', encoding="utf-8")
+        with (
+            patch("src.utils.updater.PROJECT_ROOT", tmp_path),
+            patch.object(Path, "read_text", side_effect=RuntimeError("unexpected")),
+            pytest.raises(RuntimeError, match="unexpected"),
+        ):
+            get_current_version()
+
+    def test_invalid_source_metadata_falls_back_to_installed_metadata(
+        self,
+        tmp_path,
+    ):
+        from src.utils.updater import get_current_version
+
+        (tmp_path / "pyproject.toml").write_text("not valid toml = [", encoding="utf-8")
         with (
             patch("src.utils.updater.PROJECT_ROOT", tmp_path),
             patch("importlib.metadata.version", return_value="9.8.7"),

--- a/tests/test_windows_launchers.py
+++ b/tests/test_windows_launchers.py
@@ -95,7 +95,7 @@ def test_quickstart_rejects_invalid_active_virtual_environment(tmp_path):
     result = _run_batch(batch, "--yes", "--help", env=env, cwd=checkout)
 
     assert result.returncode != 0
-    assert "VIRTUAL_ENV must point to Python 3.12 or later" in result.stdout
+    assert "VIRTUAL_ENV must point to 32-bit Python 3.12 or later" in result.stdout
     assert "UNEXPECTED_FALLBACK" not in result.stdout
 
 

--- a/tests/test_windows_launchers.py
+++ b/tests/test_windows_launchers.py
@@ -99,8 +99,8 @@ def test_quickstart_rejects_invalid_active_virtual_environment(tmp_path):
     assert "UNEXPECTED_FALLBACK" not in result.stdout
 
 
-def test_timeseries_fetch_uses_path_installed_cli_before_global_python(tmp_path):
-    """A working PATH CLI must win over unrelated global launcher fallbacks."""
+def test_timeseries_fetch_requires_an_explicit_cli_override(tmp_path):
+    """PATH-only commands are ignored; an explicit validated command is used."""
     checkout = tmp_path / "checkout"
     (checkout / "config").mkdir(parents=True)
     batch = checkout / "fetch_timeseries_postgres.bat"
@@ -118,10 +118,16 @@ def test_timeseries_fetch_uses_path_installed_cli_before_global_python(tmp_path)
     env.pop("PYTHON", None)
     env.pop("VIRTUAL_ENV", None)
     env["PATH"] = str(bin_dir) + os.pathsep + env["PATH"]
-    result = _run_batch(batch, "20260801", "20260801", env=env, cwd=checkout)
+    path_only = _run_batch(batch, "20260801", "20260801", env=env, cwd=checkout)
 
-    assert result.returncode == 0, result.stdout + result.stderr
-    assert "PATH_JLTSQL_SELECTED" in result.stdout
+    assert path_only.returncode != 0
+    assert "PATH_JLTSQL_SELECTED" not in path_only.stdout
+
+    env["JLTSQL"] = f'"{bin_dir / "jltsql.cmd"}"'
+    explicit = _run_batch(batch, "20260801", "20260801", env=env, cwd=checkout)
+
+    assert explicit.returncode == 0, explicit.stdout + explicit.stderr
+    assert "PATH_JLTSQL_SELECTED" in explicit.stdout
 
 
 def test_daily_sync_preserves_password_without_command_line_exposure(tmp_path):

--- a/tests/test_windows_launchers.py
+++ b/tests/test_windows_launchers.py
@@ -124,6 +124,7 @@ def test_timeseries_fetch_requires_an_explicit_cli_override(tmp_path):
     assert "PATH_JLTSQL_SELECTED" not in path_only.stdout
 
     env["JLTSQL"] = f'"{bin_dir / "jltsql.cmd"}"'
+    env["PYTHON"] = str(tmp_path / "must-not-override-jltsql.exe")
     explicit = _run_batch(batch, "20260801", "20260801", env=env, cwd=checkout)
 
     assert explicit.returncode == 0, explicit.stdout + explicit.stderr

--- a/tests/unit/test_jvlink_bridge.py
+++ b/tests/unit/test_jvlink_bridge.py
@@ -78,6 +78,7 @@ class TestJVLinkBridgeInit:
     def test_non_windows_bridge_uses_only_the_explicit_external_runner(
         self, tmp_path, monkeypatch
     ):
+        monkeypatch.setattr("src.jvlink.bridge.sys.platform", "linux")
         exe = tmp_path / "JVLinkBridge.exe"
         exe.touch()
         monkeypatch.setenv("JVLINK_BRIDGE_RUNNER", "external-runner")
@@ -92,6 +93,7 @@ class TestJVLinkBridgeInit:
     def test_non_windows_bridge_fails_closed_without_an_external_runner(
         self, tmp_path, monkeypatch
     ):
+        monkeypatch.setattr("src.jvlink.bridge.sys.platform", "linux")
         exe = tmp_path / "JVLinkBridge.exe"
         exe.touch()
         monkeypatch.delenv("JVLINK_BRIDGE_RUNNER", raising=False)

--- a/tests/unit/test_jvlink_bridge.py
+++ b/tests/unit/test_jvlink_bridge.py
@@ -100,6 +100,18 @@ class TestJVLinkBridgeInit:
         with pytest.raises(JVLinkBridgeError, match="JVLINK_BRIDGE_RUNNER"):
             bridge._build_command()
 
+    def test_windows_bridge_uses_direct_execution(self, tmp_path, monkeypatch):
+        exe = tmp_path / "JVLinkBridge.exe"
+        exe.touch()
+        monkeypatch.setattr("src.jvlink.bridge.sys.platform", "win32")
+        monkeypatch.setenv("JVLINK_BRIDGE_RUNNER", "external-runner")
+
+        bridge = JVLinkBridge(bridge_path=exe)
+
+        assert bridge.uses_external_runner is False
+        assert bridge._build_command() == [str(exe)]
+        assert bridge._dialog_watcher_enabled() is False
+
     def test_known_update_dialog_is_rejected_instead_of_accepted(
         self, tmp_path, monkeypatch
     ):

--- a/tests/unit/test_jvlink_bridge.py
+++ b/tests/unit/test_jvlink_bridge.py
@@ -75,26 +75,30 @@ class TestJVLinkBridgeInit:
         with pytest.raises(JVLinkBridgeError, match="JVLINK_BRIDGE_EXE"):
             find_bridge_executable()
 
-    def test_non_windows_bridge_builds_a_wine_command(self, tmp_path):
+    def test_non_windows_bridge_uses_only_the_explicit_external_runner(
+        self, tmp_path, monkeypatch
+    ):
         exe = tmp_path / "JVLinkBridge.exe"
         exe.touch()
+        monkeypatch.setenv("JVLINK_BRIDGE_RUNNER", "external-runner")
         bridge = JVLinkBridge(bridge_path=exe)
-        bridge._use_wine = True
 
-        with patch("src.jvlink.bridge.shutil.which", return_value="/usr/bin/wine"):
-            assert bridge._build_command() == ["wine", str(exe)]
+        with patch(
+            "src.jvlink.bridge.shutil.which",
+            return_value="/usr/bin/external-runner",
+        ):
+            assert bridge._build_command() == ["external-runner", str(exe)]
 
-    def test_non_windows_bridge_fails_closed_when_wine_is_missing(self, tmp_path):
+    def test_non_windows_bridge_fails_closed_without_an_external_runner(
+        self, tmp_path, monkeypatch
+    ):
         exe = tmp_path / "JVLinkBridge.exe"
         exe.touch()
+        monkeypatch.delenv("JVLINK_BRIDGE_RUNNER", raising=False)
         bridge = JVLinkBridge(bridge_path=exe)
-        bridge._use_wine = True
 
-        with patch("src.jvlink.bridge.shutil.which", return_value=None):
-            with pytest.raises(JVLinkBridgeError, match="Wine") as exc_info:
-                bridge._build_command()
-
-        assert "非Windows" in str(exc_info.value)
+        with pytest.raises(JVLinkBridgeError, match="JVLINK_BRIDGE_RUNNER"):
+            bridge._build_command()
 
     def test_known_update_dialog_is_rejected_instead_of_accepted(
         self, tmp_path, monkeypatch
@@ -102,7 +106,8 @@ class TestJVLinkBridgeInit:
         exe = tmp_path / "JVLinkBridge.exe"
         exe.touch()
         bridge = JVLinkBridge(bridge_path=exe)
-        bridge._use_wine = True
+        bridge._use_external_runner = True
+        bridge._runner = "external-runner"
         bridge._process = MagicMock(pid=777)
         bridge._process.poll.return_value = None
         monkeypatch.setenv("DISPLAY", ":1")
@@ -147,7 +152,8 @@ class TestJVLinkBridgeInit:
         exe = tmp_path / "JVLinkBridge.exe"
         exe.touch()
         bridge = JVLinkBridge(bridge_path=exe)
-        bridge._use_wine = True
+        bridge._use_external_runner = True
+        bridge._runner = "external-runner"
         monkeypatch.setenv("DISPLAY", ":1")
         monkeypatch.setenv("JVLINK_AUTO_CLOSE_DIALOGS", "0")
 
@@ -165,9 +171,9 @@ class TestJVLinkBridgeInit:
         ):
             assert bridge._dialog_watch_interval() == 0.5
 
-    def test_bridge_response_consumes_buffered_json_after_wine_preamble(self, bridge):
+    def test_bridge_response_consumes_buffered_json_after_runner_preamble(self, bridge):
         bridge._process.stdout.readline.side_effect = [
-            "wine runtime preamble\n",
+            "external runner preamble\n",
             '\ufeff{"status":"ready","version":"test"}\n',
         ]
         with patch(
@@ -356,11 +362,6 @@ class TestJVLinkBridgeAPI:
         code, rc = bridge.jv_rt_open("0B12")
         assert code == 0
         assert rc == 0
-
-    def test_jv_set_service_key_stub(self, bridge):
-        """Service key setting is a stub in bridge mode."""
-        assert bridge.jv_set_service_key("test-key") == 0
-
 
 class TestJVLinkBridgeLifecycle:
     def test_cleanup(self, bridge):

--- a/uv.lock
+++ b/uv.lock
@@ -325,10 +325,11 @@ wheels = [
 
 [[package]]
 name = "jltsql"
-version = "1.6.10"
+version = "2.0.0.dev0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },
+    { name = "packaging" },
     { name = "python-dateutil" },
     { name = "pywin32", marker = "sys_platform == 'win32'" },
     { name = "pyyaml" },
@@ -364,6 +365,7 @@ requires-dist = [
     { name = "click", specifier = ">=8.1" },
     { name = "cryptography", marker = "extra == 's3'", specifier = ">=41.0" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.5" },
+    { name = "packaging", specifier = ">=23.0" },
     { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=3.0" },
     { name = "psycopg", extras = ["binary"], marker = "extra == 'postgres'" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.4" },


### PR DESCRIPTION
## Summary

- remove credential-shaped and deployment-private provenance from distributable source, and replace it with a generic explicit runner contract
- make `jltsql init`, config inspection, version reporting, and SQLite bootstrap work from a base-dependency wheel in a fresh writable directory
- remove stale service-key, retired standalone data-spec, and unvalidated automatic architecture guidance
- make wheel/sdist inspection fail closed for sensitive names/content, split/encoded/concatenated literals, unsafe paths, archive links/special members, corrupt streams, and partial-wheel import borrowing without echoing matched content
- exclude repository tests and `specs/` from runtime distributions while retaining `specs/` in Git
- validate nested configuration/backend selection and bind installer manual commands to the install root
- align project/module/lock metadata on the breaking development line `2.0.0.dev0`; this PR does not publish a release

## Root cause and impact

The earlier release-content gate checked only a narrow path/text subset, and the wheel smoke could import an already installed source checkout. CLI bootstrap/config tests also relied on source-tree files or optional PostgreSQL dependencies absent from a normal SQLite-only wheel. Installers could select an unvalidated interpreter architecture automatically, and release metadata did not describe the cumulative schema/reimport boundary. These false-green paths could allow a sensitive or unusable artifact to look ready.

This is one bounded pre-release repair. It does not change the remaining parser/status/key/storage contracts, select the final 2.0.0 release, or claim 64-bit SDK validation. A potentially live credential was found in history; this PR removes it from current artifacts, while owner-side revocation/rotation remains required if it was real.

## Red-first evidence

Before the grouped repairs, negative tests reproduced archive acceptance of synthetic sensitive/private payloads and split/encoded/concatenated variants, unsafe names/paths, corrupt streams, partial wheels, installed bootstrap/config/version failures, nested config/backend false-success, stale setup guidance, and automatic unvalidated interpreter fallback.

The first grouped negative selection returned `20 failed, 31 passed` (`5` subtest failures). After independent exact-SHA review, the bounded closure selection returned `8 failed, 8 passed, 5 subtests passed` before implementation: archive concatenation, three config semantics, two launcher paths, tracked-Markdown privacy, and API migration notes. Only synthetic values were used. Sensitive matches are never rendered in test or gate output.

## Exact candidate validation

Candidate: `9ad814067c39c53395bb5e288971017a2e815da7`

- full locked Python 3.12 suite: `2738 passed, 131 skipped, 22 subtests passed`
- affected repair selection: `326 passed, 5 skipped, 8 subtests passed`
- `TEST GATE PASS`; compileall passed; fatal flake8 `E9,F63,F7,F82` has 0 findings
- strict MkDocs and `uv lock --check` passed
- exact `git archive` PEP 517 wheel and sdist built successfully as `2.0.0.dev0`
- all-member content gate passed both artifacts; sdist contains 0 `tests/` and 0 `specs/` members
- isolated extracted-wheel smoke passed init/config/version/SQLite create/readback with optional PostgreSQL drivers blocked
- fresh Python 3.12 venv installed only the exact wheel plus base dependencies; init/config/SQLite creation produced 80 tables with integrity `ok`
- exact SHA, current PR head, clean worktree, and `git diff --check` confirmed

## Compatibility and remaining release gates

Windows keeps direct bridge execution. Non-Windows validation environments must explicitly configure their externally managed generic runner. Automatic discovery verifies the validated 32-bit Python path, including virtual environments; another architecture or CLI is accepted only through an explicit operator override for separate SDK validation. This is not a 64-bit support claim.

The release notes now map removed public setup methods/constants to supported replacements and require backup, v2 schema rebuild/reimport, key/cancellation/count/readback verification, and backup-based rollback. This PR remains draft until two independent exact-SHA Codex closure reviews, Actions, and unresolved-thread-zero checks complete. Official DataKubun/key/storage gaps remain separate release blockers; merging this PR alone does not authorize a tag or release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Breaking Changes**
  - Preparing the 2.0.0 release with updated data specifications and removal of legacy service-key and odds APIs.
  - Requires validated 32-bit Python 3.12 or later on Windows.

- **New Features**
  - Added explicit external bridge-runner support for non-Windows environments.
  - Added stronger configuration validation and safer user-state/log locations.
  - Added documented database migration, rebuild, and rollback procedures.

- **Bug Fixes**
  - Improved initialization, update handling, and SQLite-only operation without PostgreSQL drivers.
  - Enhanced package checks to detect unsafe archives and sensitive content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->