### PR TITLE
Bind MCP metadata to all executable schemas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,9 +39,11 @@
 
 ### Fixed
 
-- MCP向け`TABLE_METADATA`を全74表の実DDLへ結び付け、列名・型・NULL可否・
-  主キー・索引対象が実在する物理列と一致するよう修正。SQLiteは再適用時に旧版の
-  表示専用疑似列を除去し、PostgreSQLは全物理列へ`COMMENT ON COLUMN`を適用できる
+- MCP向け`TABLE_METADATA`をnative 80表とJRA-VAN標準54表の全134実DDLへ
+  結び付け、列名・型・論理NULL可否・主キー・索引対象が実在する物理列と一致する
+  よう修正。適用前に各backendの実catalogを照合し、SQLiteは旧版の表示専用疑似列を
+  除去、PostgreSQLは物理列へcommentを適用、Dualは各backend固有の構文で処理する。
+  MCP exportは破壊的な物理metadata契約を明示するversion 2.0.0へ更新
 - JV-Link COM class 未登録時の診断を、公式SDKが提供する同じbit数のJV-Linkと、
   jrvltsqlでリリース検証済みの32-bit経路を区別する案内へ修正
 - `NL_SK` の公開メタデータに欠けていた曽祖父母8頭の繁殖登録番号を追加し、

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,9 @@
 
 ### Fixed
 
+- MCP向け`TABLE_METADATA`を全74表の実DDLへ結び付け、列名・型・NULL可否・
+  主キー・索引対象が実在する物理列と一致するよう修正。SQLiteは再適用時に旧版の
+  表示専用疑似列を除去し、PostgreSQLは全物理列へ`COMMENT ON COLUMN`を適用できる
 - JV-Link COM class 未登録時の診断を、公式SDKが提供する同じbit数のJV-Linkと、
   jrvltsqlでリリース検証済みの32-bit経路を区別する案内へ修正
 - `NL_SK` の公開メタデータに欠けていた曽祖父母8頭の繁殖登録番号を追加し、

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -43,6 +43,9 @@ Public API replacements:
 - distribution and bootstrap gates now inspect built artifacts, isolate wheel
   imports, and verify a base-dependency SQLite installation without writing
   runtime state into the package tree
+- MCP schema metadata now names every executable column and primary-key field
+  across all 74 published tables; SQLite drops stale display-only metadata on
+  reapplication and PostgreSQL comments target actual physical identifiers
 
 The record-by-record support and storage details are maintained in
 [`docs/data_support.md`](docs/data_support.md).

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -43,9 +43,15 @@ Public API replacements:
 - distribution and bootstrap gates now inspect built artifacts, isolate wheel
   imports, and verify a base-dependency SQLite installation without writing
   runtime state into the package tree
-- MCP schema metadata now names every executable column and primary-key field
-  across all 74 published tables; SQLite drops stale display-only metadata on
-  reapplication and PostgreSQL comments target actual physical identifiers
+- MCP schema metadata now covers all 134 executable storage tables: 80 native
+  tables and 54 JRA-VAN-standard tables. Application first verifies each live
+  backend's exact column set, normalized type family, logical nullability, and
+  ordered primary key; SQLite then replaces stale display-only rows,
+  PostgreSQL comments physical identifiers, and Dual applies backend-specific
+  operations independently. The MCP metadata export is version 2.0.0:
+  `nullable` describes the portable logical schema (not SQLite's raw PRAGMA
+  enforcement bit), while `indexes` lists distinct physical columns used by
+  configured secondary indexes rather than complete index definitions
 
 The record-by-record support and storage details are maintained in
 [`docs/data_support.md`](docs/data_support.md).

--- a/specs/operations/20260817_executable_metadata_contract_worklog.md
+++ b/specs/operations/20260817_executable_metadata_contract_worklog.md
@@ -87,3 +87,98 @@
   contract on the immutable full SHA; and obtain two independent bounded Codex
   critical reviews. STOP on any executable-column mismatch, stale SQLite row,
   PostgreSQL comment failure, full-suite failure, or reviewer P0/P1.
+
+## 2026-08-17 — independent review aggregation and red-first closure
+
+- Exact clean candidate `d64d6c0dbe6f87ef188e2e36dac31aeafd1c6c89`
+  was reviewed independently by two Codex critical reviewers because Claude
+  Code remained unavailable. Both returned `NEEDS_CHANGES`; no P0 was found.
+- The findings were aggregated before further production edits:
+  1. metadata covered only 74 entries, not the complete disjoint union of 80
+     native and 54 standard executable schemas;
+  2. application checked table existence only, so a wrong column set/type/key
+     could receive misleading metadata before failure or be accepted;
+  3. Dual mode selected the primary backend syntax and could report success
+     while PostgreSQL rejected mirrored SQLite statements;
+  4. index extraction checked columns but not the index target table;
+  5. the MCP-visible physical metadata contract still exported version 1.0.0
+     and did not define logical-nullability/index-column semantics;
+  6. the exhaustive test reused production extractors and therefore was not a
+     sufficiently independent database oracle.
+- Test-only regressions were added while production remained the exact
+  `d64d6c0...` commit. The local selection failed `4 failed`: missing metadata
+  entries, MCP version 1.0.0, schema-drift application returning true, and the
+  index-target validator accepting `NL_RA` metadata bound to an `NL_SE` index.
+  The initial index run exposed a missing `pytest` import in the new test; after
+  fixing the test itself, it failed for the intended reason (`DID NOT RAISE`).
+- A fresh disposable PostgreSQL 16 instance then failed both intended live
+  regressions: an otherwise complete `NL_RA` with `Year TEXT` and a one-column
+  primary key returned true and overwrote its sentinel table comment; Dual
+  mode returned true and wrote 122 SQLite metadata rows while PostgreSQL had
+  zero column comments. The container was removed after the red evidence.
+- One aggregate production repair is now authorized: cover all 134 schemas,
+  independently preflight exact catalog columns/type families/logical
+  nullability/ordered key before mutation, route Dual targets through their
+  backend-specific implementation, validate index ownership, and export MCP
+  metadata contract 2.0 with precise semantics. No provider layout, table DDL,
+  acquisition behavior, or runtime release-readiness claim is changed; the
+  public metadata contract and its release documentation are intentionally
+  changed by this iteration.
+- Next safe command: implement the aggregate repair without broad formatting,
+  then run the exact six red cases plus paired canonical positives before
+  expanding to the affected and full suites.
+
+## 2026-08-17 — aggregate repair implementation and pre-freeze verification
+
+- Production now synthesizes metadata owners for the complete 134-table union
+  while preserving existing table-level descriptions where available. The
+  public column contract remains the executable physical identifier/type/key
+  shape; generic descriptions on newly covered tables are intentionally not
+  claimed to be an official semantic glossary.
+- The metadata application path now reads the live SQLite or PostgreSQL
+  catalog and requires an exact column set, normalized MCP type family,
+  portable logical nullability, and ordered primary key before any metadata
+  mutation. SQLite primary-key columns are logically non-null even where raw
+  `PRAGMA table_info.notnull` is zero. Dual mode preflights every connected
+  target and then calls each backend's own metadata writer instead of mirroring
+  SQLite syntax to PostgreSQL.
+- Index extraction now rejects a statement whose `ON` target differs from the
+  metadata owner even when the referenced column name exists in both tables.
+  MCP export version is 2.0.0 and explicitly defines `nullable` and `indexes`
+  semantics; the latter is a distinct column union, not complete index DDL.
+- Paired local verification after implementation:
+  - metadata SQLite selection, including all 134 live PRAGMA schemas:
+    `26 passed, 8 deselected`;
+  - affected metadata/official contracts: `661 passed, 78 skipped`;
+  - fresh disposable PostgreSQL 16 metadata contract: `34 passed`, covering
+    all 134 catalogs/comments, wrong type/nullability/key rejection, and
+    backend-specific Dual application; the container was removed;
+  - ordinary full suite: `2934 passed, 175 skipped, 22 subtests passed`;
+  - `uv lock --check`, fail-closed test-gate validation, fatal Flake8,
+    compileall, focused Ruff, strict MkDocs, and `git diff --check`: pass;
+  - fresh wheel/sdist build, distribution content gate, and isolated wheel
+    init smoke: pass. Pre-freeze artifact hashes were
+    wheel `c0394713e45039a4839b63e2d40acd80ae1846881c8c479bd82724386df87b76`
+    and sdist `c97d6a66545c0525884ce5a942ec8dd099e101d617270eef37364dcab7015d3b`.
+- This remains a metadata/MCP iteration only. It makes no SDK acquisition,
+  64-bit compatibility, provider-data, full release-readiness, or release
+  claim. The package version remains the already established unreleased
+  `2.0.0.dev0`; only the nested MCP metadata contract version becomes 2.0.0.
+- Remaining: rerun the extended Dual no-mutation case on fresh PostgreSQL,
+  inspect the final diff/worktree, commit one repair candidate, repeat focused
+  DB/package gates on that exact SHA, then request one bounded closure pass
+  from the same two independent Codex reviewers.
+
+### Catalog type fail-closed refinement
+
+- Before candidate freeze, the new PostgreSQL negative was split into one
+  existing test with three independent subcases (unknown type, wrong logical
+  nullability, wrong ordered key). This exposed a real fail-open in the new
+  type normalizer: PostgreSQL `INTERVAL` was treated as integer because of an
+  `INT` prefix check. On the unfixed implementation the live test failed
+  `1 failed, 1 passed, 2 subtests passed` at `unknown-type` because metadata
+  application returned true.
+- The normalizer now accepts only explicit catalog type tokens/families. The
+  same fresh PostgreSQL test passes `1 passed, 3 subtests passed`. The extended
+  Dual test also passes on fresh PostgreSQL and proves that a drifted secondary
+  is rejected before the canonical SQLite metadata description changes.

--- a/specs/operations/20260817_executable_metadata_contract_worklog.md
+++ b/specs/operations/20260817_executable_metadata_contract_worklog.md
@@ -182,3 +182,21 @@
   same fresh PostgreSQL test passes `1 passed, 3 subtests passed`. The extended
   Dual test also passes on fresh PostgreSQL and proves that a drifted secondary
   is rejected before the canonical SQLite metadata description changes.
+
+### Exact candidate verification and PostgreSQL test isolation
+
+- Candidate `99aea9e0743688c0c106943046ca2e909bb04b6b` was frozen clean. Its
+  ordinary full suite passed `2934 passed, 175 skipped, 22 subtests passed`.
+- The first exact-SHA PostgreSQL file run exposed a test-isolation error, not a
+  production failure: the extended Dual test intentionally committed a drifted
+  `NL_RA`, while `tearDown` dropped it without committing; psycopg disconnect
+  rolled the cleanup back and later tests observed the drifted table. The run
+  therefore failed 2 of 34 tests with `NL_RA.year actual=text`.
+- The shared PostgreSQL test teardown now commits its explicit table drops.
+  A new fresh PostgreSQL 16 container then passed the complete metadata file:
+  `34 passed, 3 subtests passed`. This is a test-only isolation correction;
+  production sources remain byte-identical to candidate `99aea9e...`.
+- Next safe command: commit the test/worklog-only isolation correction, run
+  the focused SQLite/PostgreSQL/static/package gates on the resulting clean
+  full SHA (without repeating the unaffected full suite), then begin the two
+  bounded independent closure reviews.

--- a/specs/operations/20260817_executable_metadata_contract_worklog.md
+++ b/specs/operations/20260817_executable_metadata_contract_worklog.md
@@ -1,0 +1,89 @@
+# Executable metadata contract worklog
+
+## 2026-08-17 — start
+
+- Objective: make every `TABLE_METADATA` entry describe the executable SQL
+  schema exactly, so SQLite MCP metadata and PostgreSQL `COMMENT ON COLUMN`
+  target real columns and primary keys. This is one metadata/MCP correctness
+  iteration; it does not change provider record layouts or claim release
+  readiness.
+- Repository: `miyamamoto/jrvltsql`.
+- Dedicated worktree:
+  `/home/keiba/scratch/20260817_jrvltsql_ra_se_metadata`.
+- Branch: `agent/ra-se-metadata-20260817`.
+- Base and initial HEAD:
+  `0ca68a7c1ab3eb6fe7a40bb60bc2800a5ea16993` (PR #205 merge,
+  `origin/master`).
+- Production/release line: unreleased `2.0.0.dev0`; no tag or release is
+  authorized by this iteration.
+- Trigger: the prior live PostgreSQL sweep exposed failing RA/SE metadata
+  comments. An exhaustive read-only comparison found that 61 of 74 metadata
+  tables have a column/type or primary-key mismatch against
+  `schema_types.get_table_column_types()` /
+  `get_table_primary_key_columns()`. Most mismatches use Japanese display
+  labels that are not executable column identifiers; SQLite stores those
+  stale labels while PostgreSQL rejects them.
+- Minimum implementation scope:
+  1. add one red-first exhaustive metadata-vs-DDL contract;
+  2. bind every metadata entry to the complete executable column/type/key
+     contract while preserving table-level Japanese description and purpose;
+  3. ensure SQLite reapplication removes stale column metadata for that table;
+  4. verify representative SQLite retrieval and fresh PostgreSQL comments,
+     then run affected/full/package gates on an exact clean SHA.
+- Review model: Claude Code quota is unavailable in this environment, so the
+  maintainer-authorized independent Codex critical-review fallback will be
+  used. The final immutable candidate requires two independent bounded Codex
+  reviews because this changes an MCP-visible contract and a fail-closed
+  metadata gate.
+- STOP conditions: an executable schema has no deterministic metadata owner;
+  the repair would change provider data or table DDL; a preflight can mutate
+  real data; any new P0/P1; failed exact-SHA SQLite/PostgreSQL/full/package
+  gate; unresolved PR thread; or worktree/SHA drift.
+- Next safe command: extend the existing metadata consistency test with one
+  exhaustive exact column/type/key assertion and run it against this base to
+  record the expected red before production edits.
+
+## 2026-08-17 — red-first evidence and aggregate repair
+
+- The exhaustive contract was added before production changes. On unchanged
+  base `0ca68a7c1ab3eb6fe7a40bb60bc2800a5ea16993` it failed with
+  `1 failed`; the assertion reported 61 mismatched metadata tables out of 74.
+  This proves the check rejects display-only columns rather than merely
+  accepting the current fixture.
+- A second existing reapplication test was extended to seed one legacy
+  display-only SQLite metadata row. The test-only patch was applied to an
+  immutable archive of the same base and failed at `assert stale_rows == []`
+  (`1 failed`). The temporary archive was moved to trash afterward.
+- The aggregate repair now derives complete column names, normalized types,
+  logical nullability, primary keys, and configured index columns from the
+  executable schema. Existing descriptions/examples are retained only when
+  they already address a physical column; newly bound columns use the physical
+  identifier as a safe description. Table-level Japanese descriptions and
+  purposes remain unchanged.
+- SQLite metadata reapplication deletes the prior column-metadata set for that
+  one table before inserting the complete executable set, preventing stale
+  pseudo-columns from surviving `INSERT OR REPLACE`.
+- Post-change SQLite metadata tests pass `24 passed, 5 skipped`; the test now
+  creates all executable tables, applies all 74 metadata entries, and compares
+  every stored column set. A fresh disposable PostgreSQL 16 run passes
+  `29 passed`, including creation of all schemas and executable
+  `COMMENT ON TABLE/COLUMN` application for every metadata table. The
+  container `jrvltsql-metadata-pg16-0ca68a7` was stopped and auto-removed.
+- The affected schema/official-contract selection passes `400 passed, 65
+  skipped`. One TM test still asserted the retired Japanese display key; it
+  was updated to the existing physical `NATIVE_KEY` contract. No provider data,
+  table DDL, parser, importer, or release claim changed.
+- The pre-candidate ordinary full suite passes `2917 passed, 167 skipped, 14
+  deselected, 22 subtests passed`. Lock validation, the fail-closed test gate,
+  fatal Flake8, compileall, focused Ruff, strict MkDocs, and `git diff --check`
+  pass. A broad Black invocation attempted to reformat thousands of unrelated
+  legacy metadata lines; that mechanical output was explicitly discarded and
+  the reviewed minimal patch was reapplied. The rebuilt focused metadata/TM
+  selection passes `67 passed, 8 skipped` with a compact `212 insertions / 43
+  deletions` production/test/docs delta rather than the unrelated formatter
+  churn.
+- Remaining before candidate freeze: run full tests, fatal/static/docs/package
+  gates; commit the complete worklog; repeat the fresh PostgreSQL metadata
+  contract on the immutable full SHA; and obtain two independent bounded Codex
+  critical reviews. STOP on any executable-column mismatch, stale SQLite row,
+  PostgreSQL comment failure, full-suite failure, or reviewer P0/P1.

--- a/specs/operations/20260817_executable_metadata_contract_worklog.md
+++ b/specs/operations/20260817_executable_metadata_contract_worklog.md
@@ -200,3 +200,35 @@
   the focused SQLite/PostgreSQL/static/package gates on the resulting clean
   full SHA (without repeating the unaffected full suite), then begin the two
   bounded independent closure reviews.
+
+### Final local gates and independent closure reviews
+
+- Exact candidate `a7f69d82916884915eecc6a5ca745951b5a9bf00` was clean and
+  remained byte-identical to `99aea9e...` under `src/`. The test-only delta
+  commits PostgreSQL teardown after explicit catalog-table cleanup.
+- Exact-SHA gates passed:
+  - SQLite metadata file: `26 passed, 8 deselected`;
+  - fresh PostgreSQL 16 metadata file: `34 passed, 3 subtests passed`;
+  - fail-closed test gate, focused Ruff, fatal Flake8, compileall, strict
+    MkDocs, `uv lock --check`, and `git diff --check`;
+  - fresh wheel/sdist build, distribution-content gate, and isolated wheel
+    init smoke. Artifact SHA-256 values were wheel
+    `4ee272596ab2311defa9ae4dedeca160239905d3459114c7717286bc531d0369`
+    and sdist
+    `79a65574ec4f15bef8cf17bdd85598660e4c01bc72abf2054c9183163becc0b8`.
+  The disposable PostgreSQL container was removed.
+- Two independent Codex critical reviewers then examined the same exact SHA
+  read-only. Both returned `GREEN` with P0/P1/P2 all zero. Their independent
+  checks covered all 134 executable tables, live catalog/type/nullability/key
+  matching, stale-row cleanup, PostgreSQL comments, both Dual orientations,
+  mutation-before-rejection sentinels, index ownership, and MCP version and
+  semantics. Each confirmed the end SHA remained exact and the worktree clean,
+  and removed its disposable PostgreSQL container.
+- These results close this metadata/MCP iteration only. They do not constitute
+  a provider-layout, SDK acquisition, x64, full release-readiness, or release
+  verdict. Final candidate identity and merge evidence belong in the PR/GitHub
+  metadata rather than a self-referential follow-up commit.
+- Next safe command: commit this worklog-only review record, perform a bounded
+  carry-forward identity check, then push, open the PR, run the one review
+  cycle, resolve all threads, and merge only if the exact-head gates remain
+  green.

--- a/src/database/schema.py
+++ b/src/database/schema.py
@@ -95,6 +95,7 @@ Benefits with PRIMARY KEY constraints:
 - Optimized query performance on primary key columns
 """
 
+import re
 from typing import Any, Dict, List
 
 from src.database.base import BaseDatabase
@@ -2732,6 +2733,24 @@ SCHEMAS.update(
 STRICT_RECREATE_TABLES = frozenset({"NL_CK_CHAKU", "NL_CK_RUIKEI"})
 
 
+def _normalize_metadata_catalog_type(declared_type: str) -> str | None:
+    """Normalize backend catalog types to the public MCP type families."""
+
+    normalized = re.sub(r"\s+", " ", str(declared_type or "").strip().upper())
+    token = normalized.split("(", 1)[0].split(" ", 1)[0]
+    if token in {"CHAR", "CHARACTER", "CLOB", "NCHAR", "NVARCHAR", "TEXT", "VARCHAR"}:
+        return "TEXT"
+    if token in {"DATE", "DATETIME", "TIME", "TIMESTAMP"}:
+        return "TEXT"
+    if token in {"BIGINT", "INT8"}:
+        return "BIGINT"
+    if token in {"INT", "INT2", "INT4", "INTEGER", "SMALLINT"}:
+        return "INTEGER"
+    if token in {"DECIMAL", "DOUBLE", "FLOAT", "NUMERIC", "REAL"}:
+        return "REAL"
+    return None
+
+
 class SchemaManager:
     """Schema management for JLTSQL database.
 
@@ -2865,6 +2884,166 @@ class SchemaManager:
                 missing.append(table_name)
         return missing
 
+    @staticmethod
+    def _metadata_targets(db: BaseDatabase) -> tuple[BaseDatabase, ...]:
+        """Return each physical backend that must receive metadata."""
+
+        getter = getattr(db, "get_migration_targets", None)
+        if callable(getter):
+            targets = tuple(getter())
+            if targets:
+                return targets
+        return (db,)
+
+    @staticmethod
+    def _metadata_catalog_rows(
+        db: BaseDatabase, table_name: str
+    ) -> list[dict[str, Any]]:
+        """Read ordered column/type/nullability facts from the live catalog."""
+
+        if db.get_db_type() == "sqlite":
+            return db.fetch_all(f'PRAGMA table_info("{table_name}")')
+        if db.get_db_type() == "postgresql":
+            return db.fetch_all(
+                """SELECT a.attname AS name,
+                          format_type(a.atttypid, a.atttypmod) AS type,
+                          a.attnotnull AS not_null
+                   FROM pg_attribute a
+                   WHERE a.attrelid = to_regclass(?)
+                     AND a.attnum > 0
+                     AND NOT a.attisdropped
+                   ORDER BY a.attnum""",
+                (table_name.lower(),),
+            )
+        raise ValueError(f"Unsupported metadata backend: {db.get_db_type()}")
+
+    @classmethod
+    def _metadata_schema_matches(
+        cls, db: BaseDatabase, table_name: str, metadata: dict[str, Any]
+    ) -> bool:
+        """Fail closed unless live columns, types, nullability and key are exact."""
+
+        from src.database.migration import _get_existing_primary_key_columns
+
+        if not db.table_exists_strict(table_name):
+            logger.warning(f"Table {table_name} does not exist on {db.get_db_type()}")
+            return False
+
+        rows = cls._metadata_catalog_rows(db, table_name)
+        expected_columns = {
+            str(column["name"]).lower(): column
+            for column in metadata.get("columns", [])
+        }
+        actual_columns = {str(row["name"]).lower(): row for row in rows}
+        if len(actual_columns) != len(rows) or set(actual_columns) != set(expected_columns):
+            logger.warning(
+                f"Metadata schema mismatch for {table_name} on {db.get_db_type()}: "
+                f"columns actual={sorted(actual_columns)}, "
+                f"expected={sorted(expected_columns)}"
+            )
+            return False
+
+        actual_pk = _get_existing_primary_key_columns(db, table_name)
+        expected_pk = [str(column) for column in metadata.get("primary_key", [])]
+        if [column.lower() for column in actual_pk] != [
+            column.lower() for column in expected_pk
+        ]:
+            logger.warning(
+                f"Metadata schema mismatch for {table_name} on {db.get_db_type()}: "
+                f"primary key actual={actual_pk}, expected={expected_pk}"
+            )
+            return False
+
+        pk_columns = {column.lower() for column in actual_pk}
+        problems = []
+        for column_name, expected in expected_columns.items():
+            actual = actual_columns[column_name]
+            expected_type = _normalize_metadata_catalog_type(expected.get("type", ""))
+            actual_type = _normalize_metadata_catalog_type(actual.get("type", ""))
+            if expected_type is None or actual_type != expected_type:
+                problems.append(
+                    f"{column_name} type actual={actual.get('type')}, "
+                    f"expected={expected.get('type')}"
+                )
+
+            if db.get_db_type() == "sqlite":
+                actual_nullable = not bool(actual.get("notnull")) and (
+                    column_name not in pk_columns
+                )
+            else:
+                actual_nullable = not bool(actual.get("not_null"))
+            if actual_nullable != bool(expected.get("nullable")):
+                problems.append(
+                    f"{column_name} nullable actual={actual_nullable}, "
+                    f"expected={bool(expected.get('nullable'))}"
+                )
+
+        if problems:
+            logger.warning(
+                f"Metadata schema mismatch for {table_name} on {db.get_db_type()}: "
+                + "; ".join(problems)
+            )
+            return False
+        return True
+
+    @staticmethod
+    def _apply_prevalidated_metadata(
+        db: BaseDatabase, table_name: str, metadata: dict[str, Any]
+    ) -> None:
+        """Write metadata using syntax owned by one already-validated backend."""
+
+        db_type = db.get_db_type()
+        if db_type == "sqlite":
+            db.execute("""
+                CREATE TABLE IF NOT EXISTS _metadata (
+                    table_name TEXT NOT NULL,
+                    column_name TEXT NOT NULL DEFAULT '',
+                    description TEXT,
+                    metadata_type TEXT NOT NULL DEFAULT 'column',
+                    PRIMARY KEY (table_name, column_name)
+                )
+            """)
+            db.execute(
+                """INSERT OR REPLACE INTO _metadata
+                   (table_name, column_name, description, metadata_type)
+                   VALUES (?, '', ?, 'table')""",
+                (table_name, metadata.get("description", "")),
+            )
+            db.execute(
+                """DELETE FROM _metadata
+                   WHERE table_name = ? AND metadata_type = 'column'""",
+                (table_name,),
+            )
+            for column in metadata.get("columns", []):
+                column_name = column.get("name", "")
+                if column_name:
+                    db.execute(
+                        """INSERT OR REPLACE INTO _metadata
+                           (table_name, column_name, description, metadata_type)
+                           VALUES (?, ?, ?, 'column')""",
+                        (table_name, column_name, column.get("description", "")),
+                    )
+            return
+
+        if db_type == "postgresql":
+            table_identifier = db._quote_identifier(table_name)
+            table_description = metadata.get("description", "").replace("'", "''")
+            db.execute(
+                f"COMMENT ON TABLE {table_identifier} IS '{table_description}'"
+            )
+            for column in metadata.get("columns", []):
+                column_name = column.get("name", "")
+                if column_name:
+                    column_identifier = db._quote_identifier(column_name)
+                    column_description = column.get("description", "").replace("'", "''")
+                    db.execute(
+                        f"COMMENT ON COLUMN {table_identifier}.{column_identifier} "
+                        f"IS '{column_description}'"
+                    )
+            return
+
+        raise ValueError(f"Unsupported metadata backend: {db_type}")
+
     def apply_metadata_to_table(self, table_name: str) -> bool:
         """Apply metadata to a specific table.
 
@@ -2876,77 +3055,23 @@ class SchemaManager:
         """
         from src.database.schema_metadata import TABLE_METADATA
 
-        # Check if table exists in database
-        if not self.db.table_exists(table_name):
-            logger.warning(f"Table {table_name} does not exist")
-            return False
-
         # Check if metadata is defined for this table
         if table_name not in TABLE_METADATA:
             logger.warning(f"No metadata defined for table {table_name}")
             return False
 
         metadata = TABLE_METADATA[table_name]
-        db_type = self.db.get_db_type()
 
         try:
-            if db_type == "sqlite":
-                # SQLite: Use _metadata table
-                # Create _metadata table if it doesn't exist
-                self.db.execute("""
-                    CREATE TABLE IF NOT EXISTS _metadata (
-                        table_name TEXT NOT NULL,
-                        column_name TEXT NOT NULL DEFAULT '',
-                        description TEXT,
-                        metadata_type TEXT NOT NULL DEFAULT 'column',
-                        PRIMARY KEY (table_name, column_name)
-                    )
-                """)
+            targets = self._metadata_targets(self.db)
+            if not all(
+                self._metadata_schema_matches(target, table_name, metadata)
+                for target in targets
+            ):
+                return False
 
-                # Insert table description (column_name is empty string for table descriptions)
-                self.db.execute(
-                    """INSERT OR REPLACE INTO _metadata (table_name, column_name, description, metadata_type)
-                       VALUES (?, '', ?, 'table')""",
-                    (table_name, metadata.get("description", ""))
-                )
-
-                # Replace the complete executable column set. Older releases
-                # stored display-only labels here, so INSERT OR REPLACE alone
-                # would leave stale, non-queryable metadata behind.
-                self.db.execute(
-                    """DELETE FROM _metadata
-                       WHERE table_name = ? AND metadata_type = 'column'""",
-                    (table_name,),
-                )
-
-                # Insert column descriptions
-                for col in metadata.get("columns", []):
-                    col_name = col.get("name", "")
-                    col_desc = col.get("description", "")
-                    if col_name:
-                        self.db.execute(
-                            """INSERT OR REPLACE INTO _metadata (table_name, column_name, description, metadata_type)
-                               VALUES (?, ?, ?, 'column')""",
-                            (table_name, col_name, col_desc)
-                        )
-
-            elif db_type == "postgresql":
-                # PostgreSQL: Use COMMENT ON
-                table_identifier = self.db._quote_identifier(table_name)
-                # Table comment
-                table_desc = metadata.get("description", "").replace("'", "''")
-                self.db.execute(f"COMMENT ON TABLE {table_identifier} IS '{table_desc}'")
-
-                # Column comments
-                for col in metadata.get("columns", []):
-                    col_name = col.get("name", "")
-                    col_desc = col.get("description", "").replace("'", "''")
-                    if col_name:
-                        column_identifier = self.db._quote_identifier(col_name)
-                        self.db.execute(
-                            f"COMMENT ON COLUMN {table_identifier}.{column_identifier} "
-                            f"IS '{col_desc}'"
-                        )
+            for target in targets:
+                self._apply_prevalidated_metadata(target, table_name, metadata)
 
             logger.info(f"Applied metadata to table {table_name}")
             return True

--- a/src/database/schema.py
+++ b/src/database/schema.py
@@ -2910,6 +2910,15 @@ class SchemaManager:
                     (table_name, metadata.get("description", ""))
                 )
 
+                # Replace the complete executable column set. Older releases
+                # stored display-only labels here, so INSERT OR REPLACE alone
+                # would leave stale, non-queryable metadata behind.
+                self.db.execute(
+                    """DELETE FROM _metadata
+                       WHERE table_name = ? AND metadata_type = 'column'""",
+                    (table_name,),
+                )
+
                 # Insert column descriptions
                 for col in metadata.get("columns", []):
                     col_name = col.get("name", "")

--- a/src/database/schema_metadata.py
+++ b/src/database/schema_metadata.py
@@ -1,7 +1,11 @@
 """Schema metadata for MCP (Model Context Protocol) integration.
 
 This module provides detailed descriptions of tables and columns
-for LLM-based applications to understand the database schema.
+for LLM-based applications to understand the database schema. ``nullable``
+describes the portable logical contract, including primary-key non-nullability
+even where SQLite's raw catalog flag differs. ``indexes`` is the distinct
+physical-column union used by configured secondary indexes, not an export of
+complete index definitions.
 """
 
 import re
@@ -10,10 +14,12 @@ from typing import Dict, List, TypedDict
 
 from src.database.indexes import INDEXES
 from src.database.schema_types import (
+    get_all_executable_tables,
     get_table_column_nullability,
     get_table_column_types,
     get_table_primary_key_columns,
 )
+from src.database.table_mappings import JRAVAN_TO_JLTSQL, TABLE_TO_RECORD_TYPE
 
 
 class ColumnMetadata(TypedDict):
@@ -1804,7 +1810,43 @@ for _source_table, _target_table in (
     TABLE_METADATA[_target_table] = _metadata
 
 
-_INDEX_COLUMNS_PATTERN = re.compile(r'\bON\s+[^\s(]+\s*\(([^)]*)\)', re.IGNORECASE)
+def _ensure_all_executable_metadata() -> None:
+    """Create a metadata owner for every executable storage table."""
+
+    for table_name in get_all_executable_tables():
+        if table_name in TABLE_METADATA:
+            continue
+
+        native_owner = JRAVAN_TO_JLTSQL.get(table_name)
+        owner_metadata = TABLE_METADATA.get(native_owner or "")
+        record_type = (
+            owner_metadata["record_type"]
+            if owner_metadata is not None
+            else TABLE_TO_RECORD_TYPE.get(table_name, table_name.removeprefix("NL_"))
+        )
+        if owner_metadata is not None:
+            description = f"{owner_metadata['description']}（JRA-VAN標準）"
+            purpose = (
+                f"{owner_metadata['purpose']}。"
+                "JRA-VAN標準レイアウトの実行可能テーブル"
+            )
+        else:
+            description = f"実行可能テーブル {table_name}"
+            purpose = "jrvltsqlが作成・参照する実行可能な物理テーブル"
+
+        TABLE_METADATA[table_name] = _schema_backed_metadata(
+            table_name,
+            record_type=record_type,
+            description=description,
+            purpose=purpose,
+            indexes=[],
+        )
+
+
+_INDEX_COLUMNS_PATTERN = re.compile(
+    r'\bON\s+(?P<table>[^\s(]+)\s*\((?P<columns>[^)]*)\)',
+    re.IGNORECASE,
+)
 
 
 def _get_executable_index_columns(table_name: str) -> List[str]:
@@ -1816,7 +1858,12 @@ def _get_executable_index_columns(table_name: str) -> List[str]:
         match = _INDEX_COLUMNS_PATTERN.search(statement)
         if match is None:
             raise ValueError(f"Unrecognized index definition for {table_name}")
-        for raw_column in match.group(1).split(','):
+        index_table = match.group("table").strip().strip('`"[]')
+        if index_table.lower() != table_name.lower():
+            raise ValueError(
+                f"Index for {table_name} targets a different table: {index_table}"
+            )
+        for raw_column in match.group("columns").split(','):
             column_name = raw_column.strip().strip('`"[]')
             if column_name not in physical_columns:
                 raise ValueError(
@@ -1862,6 +1909,7 @@ def _bind_all_metadata_to_executable_schemas() -> None:
         metadata["indexes"] = _get_executable_index_columns(table_name)
 
 
+_ensure_all_executable_metadata()
 _bind_all_metadata_to_executable_schemas()
 
 
@@ -1905,7 +1953,11 @@ def export_schema_for_mcp() -> Dict:
         Dictionary containing all table and column metadata
     """
     return {
-        "version": "1.0.0",
+        "version": "2.0.0",
         "description": "JRA-VAN JV-Data database schema",
-        "tables": TABLE_METADATA
+        "semantics": {
+            "nullable": "logical portable schema contract",
+            "indexes": "distinct physical columns used by configured secondary indexes",
+        },
+        "tables": TABLE_METADATA,
     }

--- a/src/database/schema_metadata.py
+++ b/src/database/schema_metadata.py
@@ -4,10 +4,13 @@ This module provides detailed descriptions of tables and columns
 for LLM-based applications to understand the database schema.
 """
 
+import re
 from copy import deepcopy
 from typing import Dict, List, TypedDict
 
+from src.database.indexes import INDEXES
 from src.database.schema_types import (
+    get_table_column_nullability,
     get_table_column_types,
     get_table_primary_key_columns,
 )
@@ -44,6 +47,7 @@ def _schema_backed_metadata(
     """Build metadata from the executable schema so public names cannot drift."""
 
     primary_key = get_table_primary_key_columns(table_name)
+    nullability = get_table_column_nullability(table_name)
     return {
         "table_name": table_name,
         "record_type": record_type,
@@ -55,7 +59,7 @@ def _schema_backed_metadata(
                 "type": column_type,
                 "description": column_name,
                 "example": "",
-                "nullable": column_name not in primary_key,
+                "nullable": nullability[column_name],
             }
             for column_name, column_type in get_table_column_types(table_name).items()
         ],
@@ -1798,6 +1802,67 @@ for _source_table, _target_table in (
     )
     _metadata["primary_key"] = [*_metadata["primary_key"], "SourceSpec", "CollectedAt"]
     TABLE_METADATA[_target_table] = _metadata
+
+
+_INDEX_COLUMNS_PATTERN = re.compile(r'\bON\s+[^\s(]+\s*\(([^)]*)\)', re.IGNORECASE)
+
+
+def _get_executable_index_columns(table_name: str) -> List[str]:
+    """Return distinct physical columns referenced by configured SQL indexes."""
+
+    physical_columns = get_table_column_types(table_name)
+    result: List[str] = []
+    for statement in INDEXES.get(table_name, []):
+        match = _INDEX_COLUMNS_PATTERN.search(statement)
+        if match is None:
+            raise ValueError(f"Unrecognized index definition for {table_name}")
+        for raw_column in match.group(1).split(','):
+            column_name = raw_column.strip().strip('`"[]')
+            if column_name not in physical_columns:
+                raise ValueError(
+                    f"Index for {table_name} references unknown column {column_name}"
+                )
+            if column_name not in result:
+                result.append(column_name)
+    return result
+
+
+def _bind_all_metadata_to_executable_schemas() -> None:
+    """Replace display-only column labels with the complete executable schema."""
+
+    for table_name, metadata in TABLE_METADATA.items():
+        column_types = get_table_column_types(table_name)
+        nullability = get_table_column_nullability(table_name)
+        if not column_types or set(column_types) != set(nullability):
+            raise ValueError(f"Executable metadata schema is unavailable for {table_name}")
+
+        existing_columns = {
+            column["name"]: column for column in metadata.get("columns", [])
+        }
+        bound_columns: List[ColumnMetadata] = []
+        for column_name, column_type in column_types.items():
+            existing = existing_columns.get(column_name)
+            if existing is None:
+                bound_columns.append({
+                    "name": column_name,
+                    "type": column_type,
+                    "description": column_name,
+                    "example": "",
+                    "nullable": nullability[column_name],
+                })
+                continue
+
+            bound_column = deepcopy(existing)
+            bound_column["type"] = column_type
+            bound_column["nullable"] = nullability[column_name]
+            bound_columns.append(bound_column)
+
+        metadata["columns"] = bound_columns
+        metadata["primary_key"] = get_table_primary_key_columns(table_name)
+        metadata["indexes"] = _get_executable_index_columns(table_name)
+
+
+_bind_all_metadata_to_executable_schemas()
 
 
 def get_table_description(table_name: str) -> str:

--- a/src/database/schema_types.py
+++ b/src/database/schema_types.py
@@ -241,6 +241,18 @@ def get_all_tables() -> list[str]:
     return list(SCHEMAS.keys())
 
 
+def get_all_executable_tables() -> list[str]:
+    """Return every native and JRA-VAN-standard executable table name.
+
+    ``SCHEMAS`` and ``JRAVAN_SCHEMAS`` are intentionally separate storage
+    layouts.  Metadata and other catalog-facing integrations must cover their
+    complete, disjoint union rather than assuming that native tables are the
+    only executable surface.
+    """
+
+    return [*SCHEMAS.keys(), *JRAVAN_SCHEMAS.keys()]
+
+
 if __name__ == "__main__":
     # Test code demonstrating functionality
     print("=" * 60)

--- a/src/database/schema_types.py
+++ b/src/database/schema_types.py
@@ -12,6 +12,7 @@ from src.database.schema_jravan import JRAVAN_SCHEMAS
 # キャッシュ（テーブル名 → カラム型マッピング）
 _table_column_types_cache: dict[str, dict[str, str]] = {}
 _table_primary_keys_cache: dict[str, list[str]] = {}
+_table_column_nullability_cache: dict[str, dict[str, bool]] = {}
 
 # コンパイル済み正規表現パターン
 _column_pattern = re.compile(r'^\s*(\w+)\s+([A-Z]+)(?:\s*\([^)]*\))?', re.IGNORECASE)
@@ -148,6 +149,34 @@ def get_table_primary_key_columns(table_name: str) -> list[str]:
     ]
     _table_primary_keys_cache[table_name] = columns
     return columns
+
+
+def get_table_column_nullability(table_name: str) -> dict[str, bool]:
+    """Return whether each executable schema column accepts NULL values."""
+
+    if table_name in _table_column_nullability_cache:
+        return _table_column_nullability_cache[table_name]
+
+    create_statement = _schema_for_table(table_name)
+    if not create_statement:
+        return {}
+
+    primary_key = set(get_table_primary_key_columns(table_name))
+    nullability: dict[str, bool] = {}
+    for line in create_statement.split('\n'):
+        if 'PRIMARY KEY' in line.upper():
+            continue
+        match = _column_pattern.match(line)
+        if not match or _normalized_column_type(match.group(2)) is None:
+            continue
+        column_name = match.group(1)
+        nullability[column_name] = (
+            column_name not in primary_key
+            and re.search(r'\bNOT\s+NULL\b', line, re.IGNORECASE) is None
+        )
+
+    _table_column_nullability_cache[table_name] = nullability
+    return nullability
 
 
 def is_numeric_column(table_name: str, column_name: str) -> bool:

--- a/tests/test_metadata_application.py
+++ b/tests/test_metadata_application.py
@@ -16,16 +16,19 @@ Note: DuckDB is outside this project's supported database matrix.
 """
 
 import os
+import re
 import tempfile
 import unittest
 from pathlib import Path
 
 from scripts.setup_pg_test_db import postgresql_test_config
+from src.database.indexes import INDEXES
 from src.database.sqlite_handler import SQLiteDatabase
 from src.database.postgresql_handler import PostgreSQLDatabase
-from src.database.schema import SchemaManager
+from src.database.schema import SCHEMAS, SchemaManager
 from src.database.schema_metadata import TABLE_METADATA
 from src.database.schema_types import (
+    get_table_column_nullability,
     get_table_column_types,
     get_table_primary_key_columns,
 )
@@ -42,6 +45,50 @@ def test_metadata_primary_key_columns_are_described():
         defined_columns = {column["name"] for column in metadata["columns"]}
         missing = set(metadata.get("primary_key", [])) - defined_columns
         assert not missing, f"{table_name} primary_key references missing columns: {sorted(missing)}"
+
+
+def test_all_metadata_matches_the_executable_schema_exactly():
+    """MCP metadata must target every real SQL column and primary-key field."""
+
+    mismatches = {}
+    for table_name, metadata in TABLE_METADATA.items():
+        metadata_types = {
+            column["name"]: column["type"] for column in metadata["columns"]
+        }
+        expected_types = get_table_column_types(table_name)
+        metadata_nullability = {
+            column["name"]: column["nullable"] for column in metadata["columns"]
+        }
+        expected_nullability = get_table_column_nullability(table_name)
+        metadata_key = metadata.get("primary_key", [])
+        expected_key = get_table_primary_key_columns(table_name)
+        expected_index_columns = []
+        for statement in INDEXES.get(table_name, []):
+            match = re.search(r'\bON\s+[^\s(]+\s*\(([^)]*)\)', statement, re.I)
+            assert match is not None, statement
+            for raw_column in match.group(1).split(','):
+                column_name = raw_column.strip().strip('`"[]')
+                if column_name not in expected_index_columns:
+                    expected_index_columns.append(column_name)
+
+        if (
+            metadata_types != expected_types
+            or metadata_nullability != expected_nullability
+            or metadata_key != expected_key
+            or metadata.get("indexes", []) != expected_index_columns
+        ):
+            mismatches[table_name] = {
+                "metadata_columns": sorted(metadata_types),
+                "expected_columns": sorted(expected_types),
+                "metadata_nullability": metadata_nullability,
+                "expected_nullability": expected_nullability,
+                "metadata_key": metadata_key,
+                "expected_key": expected_key,
+                "metadata_indexes": metadata.get("indexes", []),
+                "expected_indexes": expected_index_columns,
+            }
+
+    assert mismatches == {}
 
 
 def test_ch_metadata_matches_normalized_native_schema():
@@ -80,13 +127,10 @@ def test_av_metadata_matches_scratch_exclusion_schema():
         metadata = TABLE_METADATA[table_name]
         column_names = {column["name"] for column in metadata["columns"]}
         assert "出走取消・競走除外" in metadata["description"]
-        assert metadata["primary_key"] == [
-            "開催年", "開催月日", "競馬場コード", "開催回",
-            "開催日目", "レース番号", "馬番",
-        ]
-        assert {"開催年", "開催月日", "競馬場コード", "レース番号", "馬番", "事由区分"} <= column_names
-        assert "セール主催者名" not in column_names
-        assert "取引価格" not in column_names
+        assert metadata["primary_key"] == get_table_primary_key_columns(table_name)
+        assert {"Year", "MonthDay", "JyoCD", "RaceNum", "Umaban", "JiyuKubun"} <= column_names
+        assert "SaleHostName" not in column_names
+        assert "Price" not in column_names
 
 
 def test_hs_metadata_matches_market_price_schema():
@@ -95,8 +139,8 @@ def test_hs_metadata_matches_market_price_schema():
     metadata = TABLE_METADATA["NL_HS"]
     column_names = {column["name"] for column in metadata["columns"]}
     assert "競走馬市場取引価格" in metadata["description"]
-    assert metadata["primary_key"] == ["血統登録番号", "主催者・市場コード", "市場開始日"]
-    assert {"血統登録番号", "主催者・市場コード", "市場開始日", "取引価格"} <= column_names
+    assert metadata["primary_key"] == get_table_primary_key_columns("NL_HS")
+    assert {"KettoNum", "SaleCode", "FromDate", "Price"} <= column_names
 
 
 def test_sk_metadata_describes_all_three_generation_lineage_slots():
@@ -191,7 +235,7 @@ class TestSQLiteMetadata(unittest.TestCase):
 
         # Check for specific column
         col_names = [row['column_name'] for row in rows]
-        self.assertIn('レコード種別ID', col_names)
+        self.assertIn('RecordSpec', col_names)
 
     def test_sqlite_metadata_retrieval(self):
         """Test retrieving metadata from SQLite."""
@@ -210,8 +254,15 @@ class TestSQLiteMetadata(unittest.TestCase):
         """Test that metadata can be updated (INSERT OR REPLACE)."""
         self.schema_mgr.create_table('NL_RA')
 
-        # Apply metadata twice
+        # Apply metadata once, then simulate a display-only label retained from
+        # a pre-contract release before applying the current metadata again.
         success1 = self.schema_mgr.apply_metadata_to_table('NL_RA')
+        self.database.execute(
+            """INSERT INTO _metadata
+               (table_name, column_name, description, metadata_type)
+               VALUES (?, ?, ?, 'column')""",
+            ('NL_RA', '旧表示専用列', 'stale',),
+        )
         success2 = self.schema_mgr.apply_metadata_to_table('NL_RA')
 
         self.assertTrue(success1)
@@ -223,6 +274,11 @@ class TestSQLiteMetadata(unittest.TestCase):
                WHERE table_name = 'NL_RA' AND column_name = ''"""
         )
         self.assertEqual(rows[0]['cnt'], 1)
+        stale_rows = self.database.fetch_all(
+            """SELECT column_name FROM _metadata
+               WHERE table_name = 'NL_RA' AND column_name = '旧表示専用列'"""
+        )
+        self.assertEqual(stale_rows, [])
 
 
 @unittest.skipUnless(
@@ -297,10 +353,25 @@ class TestPostgreSQLMetadata(unittest.TestCase):
         rows = self.database.fetch_all("""
             SELECT table_name
             FROM information_schema.tables
-            WHERE table_name = 'NL_RA'
+            WHERE table_name = 'nl_ra'
         """)
 
         self.assertEqual(len(rows), 1)
+
+    def test_postgresql_all_metadata_targets_are_executable(self):
+        """Every metadata entry must apply to a freshly created physical table."""
+
+        try:
+            create_results = self.schema_mgr.create_all_tables()
+            self.assertTrue(all(create_results.values()))
+            for table_name in TABLE_METADATA:
+                self.assertTrue(
+                    self.schema_mgr.apply_metadata_to_table(table_name),
+                    f"Should apply executable metadata to {table_name}",
+                )
+        finally:
+            for table_name in reversed(SCHEMAS):
+                self.database.execute(f"DROP TABLE IF EXISTS {table_name} CASCADE")
 
 
 class TestMetadataApplicationWorkflow(unittest.TestCase):
@@ -376,23 +447,21 @@ class TestMetadataApplicationWorkflow(unittest.TestCase):
 
     def test_metadata_for_all_record_types(self):
         """Test that all record types in TABLE_METADATA can be applied."""
-        # Sample a few different record types
-        sample_tables = [
-            'NL_RA',  # Race
-            'NL_SE',  # Horse per race
-            'NL_HR',  # Payoff
-            'NL_UM',  # Horse master
-            'NL_KS',  # Jockey master
-            'NL_O1',  # Odds
-            'RT_RA',  # Realtime race
-        ]
+        create_results = self.schema_mgr.create_all_tables()
+        self.assertTrue(all(create_results.values()))
 
-        for table_name in sample_tables:
-            if table_name in TABLE_METADATA:
-                self.schema_mgr.create_table(table_name)
-                success = self.schema_mgr.apply_metadata_to_table(table_name)
-                self.assertTrue(success,
-                    f"Should apply metadata to {table_name}")
+        for table_name, expected in TABLE_METADATA.items():
+            success = self.schema_mgr.apply_metadata_to_table(table_name)
+            self.assertTrue(success, f"Should apply metadata to {table_name}")
+            stored = self.database.fetch_all(
+                """SELECT column_name FROM _metadata
+                   WHERE table_name = ? AND metadata_type = 'column'""",
+                (table_name,),
+            )
+            self.assertEqual(
+                {row["column_name"] for row in stored},
+                {column["name"] for column in expected["columns"]},
+            )
 
 
 class TestMetadataRetrieval(unittest.TestCase):
@@ -452,7 +521,7 @@ class TestMetadataRetrieval(unittest.TestCase):
 
         # Check specific columns exist
         col_names = list(metadata['columns'].keys())
-        self.assertIn('レコード種別ID', col_names)
+        self.assertIn('RecordSpec', col_names)
 
 
 class TestMCPIntegration(unittest.TestCase):

--- a/tests/test_metadata_application.py
+++ b/tests/test_metadata_application.py
@@ -383,6 +383,7 @@ class TestPostgreSQLMetadata(unittest.TestCase):
         self.database.execute("DROP TABLE IF EXISTS NL_RA CASCADE")
         self.database.execute("DROP TABLE IF EXISTS NL_SE CASCADE")
         self.database.execute("DROP TABLE IF EXISTS NL_HR CASCADE")
+        self.database.commit()
         self.database.disconnect()
 
     def test_postgresql_comment_on_table(self):

--- a/tests/test_metadata_application.py
+++ b/tests/test_metadata_application.py
@@ -21,21 +21,47 @@ import tempfile
 import unittest
 from pathlib import Path
 
+import pytest
+
 from scripts.setup_pg_test_db import postgresql_test_config
+from src.database.dual_handler import DualDatabase
 from src.database.indexes import INDEXES
-from src.database.sqlite_handler import SQLiteDatabase
 from src.database.postgresql_handler import PostgreSQLDatabase
 from src.database.schema import SCHEMAS, SchemaManager
-from src.database.schema_metadata import TABLE_METADATA
+from src.database.schema_jravan import JRAVAN_SCHEMAS
+from src.database.schema_metadata import (
+    TABLE_METADATA,
+    _get_executable_index_columns,
+    export_schema_for_mcp,
+)
 from src.database.schema_types import (
     get_table_column_nullability,
     get_table_column_types,
     get_table_primary_key_columns,
 )
+from src.database.sqlite_handler import SQLiteDatabase
 
 RUN_POSTGRESQL_INTEGRATION = (
     os.environ.get("JLTSQL_RUN_POSTGRESQL_INTEGRATION") == "1"
 )
+
+
+def _catalog_type_family(declared_type):
+    """Independent test oracle for backend catalog type families."""
+
+    normalized = re.sub(r"\s+", " ", str(declared_type or "").strip().upper())
+    token = normalized.split("(", 1)[0].split(" ", 1)[0]
+    if token in {"CHAR", "CHARACTER", "CLOB", "NCHAR", "NVARCHAR", "TEXT", "VARCHAR"}:
+        return "TEXT"
+    if token in {"DATE", "DATETIME", "TIME", "TIMESTAMP"}:
+        return "TEXT"
+    if token in {"BIGINT", "INT8"}:
+        return "BIGINT"
+    if token in {"INT", "INT2", "INT4", "INTEGER", "SMALLINT"}:
+        return "INTEGER"
+    if token in {"DECIMAL", "DOUBLE", "FLOAT", "NUMERIC", "REAL"}:
+        return "REAL"
+    return None
 
 
 def test_metadata_primary_key_columns_are_described():
@@ -49,6 +75,9 @@ def test_metadata_primary_key_columns_are_described():
 
 def test_all_metadata_matches_the_executable_schema_exactly():
     """MCP metadata must target every real SQL column and primary-key field."""
+
+    executable_tables = set(SCHEMAS) | set(JRAVAN_SCHEMAS)
+    assert set(TABLE_METADATA) == executable_tables
 
     mismatches = {}
     for table_name, metadata in TABLE_METADATA.items():
@@ -64,9 +93,14 @@ def test_all_metadata_matches_the_executable_schema_exactly():
         expected_key = get_table_primary_key_columns(table_name)
         expected_index_columns = []
         for statement in INDEXES.get(table_name, []):
-            match = re.search(r'\bON\s+[^\s(]+\s*\(([^)]*)\)', statement, re.I)
+            match = re.search(
+                r'\bON\s+(?P<table>[^\s(]+)\s*\((?P<columns>[^)]*)\)',
+                statement,
+                re.I,
+            )
             assert match is not None, statement
-            for raw_column in match.group(1).split(','):
+            assert match.group("table").strip('`"[]').lower() == table_name.lower()
+            for raw_column in match.group("columns").split(','):
                 column_name = raw_column.strip().strip('`"[]')
                 if column_name not in expected_index_columns:
                     expected_index_columns.append(column_name)
@@ -91,6 +125,29 @@ def test_all_metadata_matches_the_executable_schema_exactly():
     assert mismatches == {}
 
 
+def test_metadata_index_binding_rejects_a_definition_for_another_table(monkeypatch):
+    """An index with a shared column name must still target its owning table."""
+
+    monkeypatch.setitem(
+        INDEXES,
+        "NL_RA",
+        ["CREATE INDEX idx_wrong_target ON NL_SE(Year)"],
+    )
+
+    with pytest.raises(ValueError, match="NL_RA.*NL_SE"):
+        _get_executable_index_columns("NL_RA")
+
+
+def test_mcp_export_declares_the_breaking_physical_metadata_contract():
+    exported = export_schema_for_mcp()
+
+    assert exported["version"] == "2.0.0"
+    assert exported["semantics"] == {
+        "nullable": "logical portable schema contract",
+        "indexes": "distinct physical columns used by configured secondary indexes",
+    }
+
+
 def test_ch_metadata_matches_normalized_native_schema():
     """CH MCP metadata must expose both normalized tables exactly as stored."""
 
@@ -111,7 +168,10 @@ def test_ch_postgresql_metadata_targets_the_actual_lowercase_identifiers():
     database.table_exists = lambda _table_name: True
     database.execute = lambda sql, parameters=None: statements.append(sql) or 0
 
-    assert SchemaManager(database).apply_metadata_to_table("NL_CH") is True
+    manager = SchemaManager(database)
+    manager._metadata_schema_matches = lambda *_args: True
+
+    assert manager.apply_metadata_to_table("NL_CH") is True
     assert "COMMENT ON TABLE nl_ch " in statements[0]
     assert any(
         statement.startswith("COMMENT ON COLUMN nl_ch.chokyosicode ")
@@ -280,6 +340,29 @@ class TestSQLiteMetadata(unittest.TestCase):
         )
         self.assertEqual(stale_rows, [])
 
+    def test_sqlite_metadata_rejects_schema_drift_before_mutation(self):
+        self.database.execute("CREATE TABLE NL_RA (RecordSpec TEXT)")
+        self.database.execute(
+            """CREATE TABLE _metadata (
+                   table_name TEXT NOT NULL,
+                   column_name TEXT NOT NULL DEFAULT '',
+                   description TEXT,
+                   metadata_type TEXT NOT NULL DEFAULT 'column',
+                   PRIMARY KEY (table_name, column_name)
+               )"""
+        )
+        self.database.execute(
+            """INSERT INTO _metadata
+               (table_name, column_name, description, metadata_type)
+               VALUES ('NL_RA', 'sentinel', 'keep', 'column')"""
+        )
+
+        self.assertFalse(self.schema_mgr.apply_metadata_to_table("NL_RA"))
+        rows = self.database.fetch_all(
+            "SELECT column_name, description FROM _metadata WHERE table_name = 'NL_RA'"
+        )
+        self.assertEqual(rows, [{"column_name": "sentinel", "description": "keep"}])
+
 
 @unittest.skipUnless(
     RUN_POSTGRESQL_INTEGRATION,
@@ -364,14 +447,150 @@ class TestPostgreSQLMetadata(unittest.TestCase):
         try:
             create_results = self.schema_mgr.create_all_tables()
             self.assertTrue(all(create_results.values()))
-            for table_name in TABLE_METADATA:
+            for schema_sql in JRAVAN_SCHEMAS.values():
+                self.database.execute(schema_sql)
+
+            for table_name in sorted(set(SCHEMAS) | set(JRAVAN_SCHEMAS)):
                 self.assertTrue(
                     self.schema_mgr.apply_metadata_to_table(table_name),
                     f"Should apply executable metadata to {table_name}",
                 )
+                catalog = self.database.fetch_all(
+                    """SELECT a.attname AS name,
+                              format_type(a.atttypid, a.atttypmod) AS type,
+                              a.attnotnull AS not_null
+                       FROM pg_attribute a
+                       WHERE a.attrelid = to_regclass(?)
+                         AND a.attnum > 0
+                         AND NOT a.attisdropped
+                       ORDER BY a.attnum""",
+                    (table_name.lower(),),
+                )
+                metadata_columns = {
+                    column["name"].lower(): column
+                    for column in TABLE_METADATA[table_name]["columns"]
+                }
+                self.assertEqual(
+                    set(metadata_columns),
+                    {row["name"].lower() for row in catalog},
+                )
+                for row in catalog:
+                    column = metadata_columns[row["name"].lower()]
+                    self.assertEqual(
+                        _catalog_type_family(row["type"]),
+                        column["type"],
+                        f"{table_name}.{row['name']} type",
+                    )
+                    self.assertEqual(
+                        not bool(row["not_null"]),
+                        column["nullable"],
+                        f"{table_name}.{row['name']} nullable",
+                    )
+
+                key_rows = self.database.fetch_all(
+                    """SELECT a.attname AS name
+                       FROM pg_index i
+                       JOIN pg_attribute a
+                         ON a.attrelid = i.indrelid
+                        AND a.attnum = ANY(i.indkey)
+                       WHERE i.indrelid = to_regclass(?)
+                         AND i.indisprimary
+                       ORDER BY array_position(i.indkey, a.attnum)""",
+                    (table_name.lower(),),
+                )
+                self.assertEqual(
+                    [row["name"].lower() for row in key_rows],
+                    [
+                        column.lower()
+                        for column in TABLE_METADATA[table_name]["primary_key"]
+                    ],
+                )
+                comment_count = self.database.fetch_one(
+                    """SELECT COUNT(*) AS n
+                       FROM pg_description d
+                       JOIN pg_class c ON c.oid = d.objoid
+                       WHERE c.relname = ? AND d.objsubid > 0""",
+                    (table_name.lower(),),
+                )["n"]
+                self.assertEqual(comment_count, len(catalog))
         finally:
-            for table_name in reversed(SCHEMAS):
+            all_tables = [*SCHEMAS.keys(), *JRAVAN_SCHEMAS.keys()]
+            for table_name in reversed(all_tables):
                 self.database.execute(f"DROP TABLE IF EXISTS {table_name} CASCADE")
+
+    def test_postgresql_metadata_rejects_wrong_type_and_key_before_comments(self):
+        defects = {
+            "unknown-type": SCHEMAS["NL_RA"].replace(
+                "Year INTEGER,", "Year INTERVAL,", 1
+            ),
+            "wrong-nullability": SCHEMAS["NL_RA"].replace(
+                "RecordSpec TEXT,", "RecordSpec TEXT NOT NULL,", 1
+            ),
+            "wrong-key": SCHEMAS["NL_RA"].replace(
+                "PRIMARY KEY (Year, MonthDay, JyoCD, Kaiji, Nichiji, RaceNum)",
+                "PRIMARY KEY (Year)",
+            ),
+        }
+        for defect, drifted_schema in defects.items():
+            with self.subTest(defect=defect):
+                self.database.execute("DROP TABLE IF EXISTS NL_RA CASCADE")
+                self.database.execute(drifted_schema)
+                self.database.execute("COMMENT ON TABLE NL_RA IS 'sentinel'")
+
+                self.assertFalse(self.schema_mgr.apply_metadata_to_table("NL_RA"))
+                comment = self.database.fetch_one(
+                    "SELECT obj_description('NL_RA'::regclass) AS description"
+                )["description"]
+                self.assertEqual(comment, "sentinel")
+
+    def test_dual_metadata_uses_each_backend_specific_storage(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            sqlite = SQLiteDatabase({"path": str(Path(temp_dir) / "metadata-dual.db")})
+            sqlite.connect()
+            try:
+                SchemaManager(sqlite).create_table("NL_RA")
+                self.schema_mgr.create_table("NL_RA")
+                dual = DualDatabase(sqlite, self.database)
+
+                self.assertTrue(SchemaManager(dual).apply_metadata_to_table("NL_RA"))
+                dual.commit()
+                sqlite_count = sqlite.fetch_one(
+                    """SELECT COUNT(*) AS n FROM _metadata
+                       WHERE table_name = 'NL_RA' AND metadata_type = 'column'"""
+                )["n"]
+                pg_count = self.database.fetch_one(
+                    """SELECT COUNT(*) AS n
+                       FROM pg_description d
+                       JOIN pg_class c ON c.oid = d.objoid
+                       WHERE c.relname = 'nl_ra' AND d.objsubid > 0"""
+                )["n"]
+                self.assertEqual(
+                    sqlite_count, len(TABLE_METADATA["NL_RA"]["columns"])
+                )
+                self.assertEqual(pg_count, sqlite_count)
+                self.assertTrue(dual.secondary_in_sync)
+
+                sqlite.execute(
+                    """UPDATE _metadata SET description = 'sentinel'
+                       WHERE table_name = 'NL_RA' AND column_name = ''"""
+                )
+                sqlite.commit()
+                self.database.execute("DROP TABLE NL_RA")
+                self.database.execute(
+                    SCHEMAS["NL_RA"].replace(
+                        "Year INTEGER,", "Year TEXT,", 1
+                    )
+                )
+                self.database.commit()
+
+                self.assertFalse(SchemaManager(dual).apply_metadata_to_table("NL_RA"))
+                description = sqlite.fetch_one(
+                    """SELECT description FROM _metadata
+                       WHERE table_name = 'NL_RA' AND column_name = ''"""
+                )["description"]
+                self.assertEqual(description, "sentinel")
+            finally:
+                sqlite.disconnect()
 
 
 class TestMetadataApplicationWorkflow(unittest.TestCase):
@@ -449,10 +668,14 @@ class TestMetadataApplicationWorkflow(unittest.TestCase):
         """Test that all record types in TABLE_METADATA can be applied."""
         create_results = self.schema_mgr.create_all_tables()
         self.assertTrue(all(create_results.values()))
+        for schema_sql in JRAVAN_SCHEMAS.values():
+            self.database.execute(schema_sql)
 
-        for table_name, expected in TABLE_METADATA.items():
+        for table_name in sorted(set(SCHEMAS) | set(JRAVAN_SCHEMAS)):
+            expected = TABLE_METADATA[table_name]
             success = self.schema_mgr.apply_metadata_to_table(table_name)
             self.assertTrue(success, f"Should apply metadata to {table_name}")
+            catalog = self.database.fetch_all(f'PRAGMA table_info("{table_name}")')
             stored = self.database.fetch_all(
                 """SELECT column_name FROM _metadata
                    WHERE table_name = ? AND metadata_type = 'column'""",
@@ -460,7 +683,28 @@ class TestMetadataApplicationWorkflow(unittest.TestCase):
             )
             self.assertEqual(
                 {row["column_name"] for row in stored},
-                {column["name"] for column in expected["columns"]},
+                {row["name"] for row in catalog},
+            )
+            metadata_columns = {
+                column["name"]: column for column in expected["columns"]
+            }
+            self.assertEqual(set(metadata_columns), {row["name"] for row in catalog})
+            for row in catalog:
+                column = metadata_columns[row["name"]]
+                self.assertEqual(
+                    _catalog_type_family(row["type"]),
+                    column["type"],
+                    f"{table_name}.{row['name']} type",
+                )
+                actual_nullable = not bool(row["notnull"]) and not bool(row["pk"])
+                self.assertEqual(
+                    actual_nullable,
+                    column["nullable"],
+                    f"{table_name}.{row['name']} nullable",
+                )
+            self.assertEqual(
+                [row["name"] for row in sorted(catalog, key=lambda row: row["pk"]) if row["pk"]],
+                expected["primary_key"],
             )
 
 

--- a/tests/test_tm_official_contract.py
+++ b/tests/test_tm_official_contract.py
@@ -192,20 +192,11 @@ def test_tm_native_and_standard_schema_contracts_are_keyed_and_lossless() -> Non
 
 
 def test_tm_metadata_describes_the_complete_native_race_key() -> None:
-    expected_key = [
-        "開催年月日",
-        "競馬場コード",
-        "開催回",
-        "開催日目",
-        "レース番号",
-        "馬番",
-    ]
-
     for table_name in ("NL_TM", "RT_TM"):
         metadata = TABLE_METADATA[table_name]
-        assert metadata["primary_key"] == expected_key
+        assert metadata["primary_key"] == NATIVE_KEY
         column_names = {column["name"] for column in metadata["columns"]}
-        assert set(expected_key) <= column_names
+        assert set(NATIVE_KEY) <= column_names
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## 概要

MCP向けのschema metadataを、表示用の手書き定義ではなく、jrvltsqlが実際に作成する全テーブルの物理DDLへ結び付けます。

- native 80表 + JRA-VAN standard 54表 = 134表を完全収録
- 列名、正規化type family、論理NULL可否、ordered primary keyをlive catalogで適用前に照合
- SQLiteは古い表示専用metadata行を置換、PostgreSQLは物理列へCOMMENTを適用
- Dualは各backendを先に検証し、それぞれの構文でmetadataを適用
- index metadataは列だけでなく`ON`対象tableも検証
- MCP exportをversion 2.0.0とし、`nullable` / `indexes` semanticsを明示

## 原因

従来の`TABLE_METADATA`は74表のみで、実行可能schema 134表を網羅していませんでした。またmetadata適用前の検証がtable存在確認に留まり、wrong column/type/nullability/keyへ誤解を招くmetadataを付与できました。Dualではprimary側の構文に依存し、secondary PostgreSQLへ反映されない経路もありました。

## Red-first evidence

production修正前に、最小回帰を追加して次を実測しました。

- local: 4 failures（schema coverage、MCP version、SQLite drift rejection、index target）
- fresh PostgreSQL 16: wrong schemaがtrueを返してsentinel commentを上書き
- Dual: SQLiteへ122 metadata rows、PostgreSQLへ0 commentsのままtrue
- type normalizer初版: `INTERVAL`を`INT`系として受理し、live negativeがfailure

修正後は全ケースがfail closedになり、canonical positiveも維持されています。

## 検証

対象full SHA: `364ff02ac912f31f3a5422412f71049a86a91d84`

- ordinary full suite（同一production tree）: `2934 passed, 175 skipped, 22 subtests passed`
- exact SQLite metadata: `26 passed, 8 deselected`
- exact fresh PostgreSQL 16 metadata: `34 passed, 3 subtests passed`
- affected contracts: `661 passed, 78 skipped`
- test-gate、focused Ruff、fatal Flake8、compileall、strict MkDocs、`uv lock --check`、`git diff --check`: pass
- fresh wheel/sdist build、distribution content gate、isolated wheel init smoke: pass
- 独立Codex critical review 2系統: exact SHAで双方GREEN、P0/P1/P2 = 0/0/0
- unresolved local findings: 0
- worktree: clean

## 影響範囲

MCP metadataの物理契約は破壊的にversion 2.0.0となります。package本体は未リリースの`2.0.0.dev0`のままです。このPRはprovider layout、SDK取得、64-bit対応、または全体release readinessをGREENとするものではなく、merge後も仕様ギャップ監査を継続します。
