### PR TITLE
fix: enforce official AV contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,8 +41,8 @@
 
 - `AV`を公式78バイト・7項目キーへ結び付け、native/速報/JRA-VAN標準名の
   主キーを`NOT NULL`で統一。旧status 0はexact delete、現行status 1/2と
-  2021年前後の事由blank/000〜003を両立し、不正key・本文・unsafe schemaを
-  SQLite/PostgreSQLのmutation前に拒否
+  2021年前後の事由blank/000〜003を両立し、旧`AVOIDENCE`単独構成、不正key・
+  本文・unsafe schemaをSQLite/PostgreSQLのmutation前に拒否
 - `SE`の現行555バイト全sliceをSDK 5.0.0 manifestへ結び付け、native/速報/
   JRA-VAN標準名の主キーを公式8項目（末尾`KettoNum`）へ統一。旧7項目・keyless・
   不正型・追加一意制約・deferrable主キーはmutation前に拒否し、個別取消、4予約領域、

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,10 @@
 
 ### Fixed
 
+- `AV`を公式78バイト・7項目キーへ結び付け、native/速報/JRA-VAN標準名の
+  主キーを`NOT NULL`で統一。旧status 0はexact delete、現行status 1/2と
+  2021年前後の事由blank/000〜003を両立し、不正key・本文・unsafe schemaを
+  SQLite/PostgreSQLのmutation前に拒否
 - `SE`の現行555バイト全sliceをSDK 5.0.0 manifestへ結び付け、native/速報/
   JRA-VAN標準名の主キーを公式8項目（末尾`KettoNum`）へ統一。旧7項目・keyless・
   不正型・追加一意制約・deferrable主キーはmutation前に拒否し、個別取消、4予約領域、

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -40,6 +40,11 @@ Public API replacements:
   than an automatic key rewrite. The current 555-byte layout, all four reserved
   fields, integer-kilogram body weight/change, exact targeted erase, and status-A
   prize-zero semantics are preserved on SQLite and PostgreSQL
+- AV scratch/exclusion storage now uses the official seven-part identity in
+  native, realtime, and `TORIKESI_JYOGAI` tables. Historical status 0 is an
+  exact erase only before 2003-07-11; current status 1/2 and both pre/post-2021
+  reason-field initial representations remain supported. Existing keyless,
+  nullable-key, or otherwise unsafe AV tables require rebuild and reimport
 - imports and realtime updates preserve provider order and use fail-closed
   transaction recovery so returned statistics agree with durable rows across
   SQLite and PostgreSQL

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -44,7 +44,8 @@ Public API replacements:
   native, realtime, and `TORIKESI_JYOGAI` tables. Historical status 0 is an
   exact erase only before 2003-07-11; current status 1/2 and both pre/post-2021
   reason-field initial representations remain supported. Existing keyless,
-  nullable-key, or otherwise unsafe AV tables require rebuild and reimport
+  nullable-key, legacy `AVOIDENCE`-only, or otherwise unsafe AV tables require
+  rebuild and reimport
 - imports and realtime updates preserve provider order and use fail-closed
   transaction recovery so returned statistics agree with durable rows across
   SQLite and PostgreSQL

--- a/docs/data_support.md
+++ b/docs/data_support.md
@@ -293,7 +293,9 @@ losslessでないキー型、キーのNULL許容、追加の`UNIQUE`/exclusion�
 key、主キーなし・誤順序、losslessでない型や容量、追加の`UNIQUE`/exclusion、
 PostgreSQLの遅延主キーを持つ既存表はmutation前に停止します。自動的なPK変更は
 行わないため、DBをバックアップし、対象表だけを現行DDLで再作成して保持範囲内を
-再取込してください。旧標準名`AVOIDENCE`だけが存在する構成も、自動移行や別表への
+再取込してください。NULLまたは不完全なidentityを持つ旧行は正しい7項目キーへ
+安全にbackfillできないため、バックアップには残しても現行表へ再利用せず、公式provider
+から再取得してください。旧標準名`AVOIDENCE`だけが存在する構成も、自動移行や別表への
 誤保存を行わず、すべてのDB targetを変更前に停止します。標準名は
 `TORIKESI_JYOGAI`へ再作成してください。
 

--- a/docs/data_support.md
+++ b/docs/data_support.md
@@ -278,6 +278,28 @@ losslessでないキー型、キーのNULL許容、追加の`UNIQUE`/exclusion�
 `0B14`の新しい応答が前回の日付snapshotを置換する既存の一括更新契約は維持し、
 1応答内では上記7項目キーで各発表を保持します。
 
+`AV`（出走取消・競走除外）はJV-Data 4.8.0.2 / 4.9.0.1とSDK 5.0.0で
+同一の78バイト配置です。公式キーは`Year`, `MonthDay`, `JyoCD`, `Kaiji`,
+`Nichiji`, `RaceNum`, `Umaban`の7項目であり、`HappyoTime`は発表情報として
+保存しますがキーではありません。同一馬の後続発表は同じ行を更新します。
+現行のデータ区分は`1=出走取消`と`2=競走除外`です。2003-07-11より前の
+`MakeDate`でだけ旧区分`0`を受け付け、7項目が完全に一致する行を物理削除します。
+旧削除レコードでは発表時刻・馬名・事由の本文を解釈しません。
+
+事由区分はblankと`000`〜`003`を受け付けます。2021-01-25の仕様変更は
+初期値表記を`000`からspaceへ変えた同長変更であり、履歴データのprovenanceが
+不明な場合にどちらかを過剰拒否しません。nativeの`NL_AV`/`RT_AV`と標準名
+モードの`TORIKESI_JYOGAI`は同じ順序の`NOT NULL`主キーを使います。旧nullable
+key、主キーなし・誤順序、losslessでない型や容量、追加の`UNIQUE`/exclusion、
+PostgreSQLの遅延主キーを持つ既存表はmutation前に停止します。自動的なPK変更は
+行わないため、DBをバックアップし、対象表だけを現行DDLで再作成して保持範囲内を
+再取込してください。
+
+`0B14`は開催日単位の完全な現行snapshotです。現行の取消が撤回された場合は
+status `0`が届くのではなく、次のsnapshotからAV行が消えるため、同一transactionで
+その日の`RT_AV`を置換します。個別イベントは`0B16`/`JVWatchEvent`で受けられる
+という公式サポートの[説明](https://developer.jra-van.jp/t/topic/195)があります。
+
 `JC`（騎手変更）はJV-Data 4.8.0.2 / 4.9.0.1とSDK 5.0.0で同一の
 161バイト配置です。公式キーは`Year`, `MonthDay`, `JyoCD`, `Kaiji`,
 `Nichiji`, `RaceNum`, `HappyoTime`, `Umaban`の8項目です。同一馬について

--- a/docs/data_support.md
+++ b/docs/data_support.md
@@ -293,7 +293,9 @@ losslessでないキー型、キーのNULL許容、追加の`UNIQUE`/exclusion�
 key、主キーなし・誤順序、losslessでない型や容量、追加の`UNIQUE`/exclusion、
 PostgreSQLの遅延主キーを持つ既存表はmutation前に停止します。自動的なPK変更は
 行わないため、DBをバックアップし、対象表だけを現行DDLで再作成して保持範囲内を
-再取込してください。
+再取込してください。旧標準名`AVOIDENCE`だけが存在する構成も、自動移行や別表への
+誤保存を行わず、すべてのDB targetを変更前に停止します。標準名は
+`TORIKESI_JYOGAI`へ再作成してください。
 
 `0B14`は開催日単位の完全な現行snapshotです。現行の取消が撤回された場合は
 status `0`が届くのではなく、次のsnapshotからAV行が消えるため、同一transactionで

--- a/specs/operations/20260818_av_official_contract_worklog.md
+++ b/specs/operations/20260818_av_official_contract_worklog.md
@@ -118,6 +118,38 @@
   `scripts/smoke_distribution_init.py` passed the extracted wheel. The tracked
   `specs/`, this worklog, and official-layout fixtures remain excluded from the
   distributable artifacts.
+- PR #210 was opened as a draft at candidate
+  `219fbd52b2eb612200cd70f74de1aee06d6ee6c6`. GitHub `test`, `lint`, and
+  `windows-batch-syntax` checks succeeded; `performance-test` was intentionally
+  skipped. The one requested Copilot review returned only its quota-exhausted
+  notice and is not counted as correctness evidence.
+- Three independent Codex reviews were aggregated before changing the
+  candidate. They identified: (1) exact-erase tests seeded only the target row
+  and could not reject a whole-table delete; (2) PostgreSQL bulk upsert
+  deduplication made successful AV provider-operation statistics report `2`
+  for three accepted rows; and (3) a legacy standard `AVOIDENCE` table on
+  either DualDatabase target was missed, allowing unrelated additive migration
+  before failure.
+- Added regressions were run before the repair. The legacy-only Dual matrix
+  failed in all six DataImporter/OptimizedDataImporter/single-record and
+  primary/secondary combinations. On fresh PostgreSQL 16, the default-batch
+  provider-order matrix failed in eight batch-import combinations with
+  `records_imported == 2` instead of `3`; single-record controls remained
+  green. These failures bind the actual checks rather than only a happy path.
+- The aggregated repair now checks every concrete migration target for a
+  legacy-only `AVOIDENCE` table before mutation, counts successful AV batch
+  provider operations independently of PostgreSQL's final-row deduplication,
+  and verifies a survivor row plus revision body across exact erase. The same
+  SQLite AV suite passed `55` tests with `18` PostgreSQL skips, and the fresh
+  PostgreSQL 16 suite passed all `73` tests.
+- After restoring the repository's existing manual formatting (a local Black
+  invocation tried to rewrite unrelated lines), the repaired tree replayed the
+  same AV suites with `55 passed, 18 skipped` on SQLite and `73 passed` on
+  actual PostgreSQL 16. The affected existing suite then passed `329` tests,
+  skipped `25` opt-in tests, and passed `10` subtests. `TEST GATE PASS`, fatal
+  flake8, `uv lock --check`, `mkdocs build --strict`, and `git diff --check`
+  also passed. The disposable PostgreSQL container was removed and its
+  exact-name listing was empty.
 
 ## STOP conditions
 

--- a/specs/operations/20260818_av_official_contract_worklog.md
+++ b/specs/operations/20260818_av_official_contract_worklog.md
@@ -185,6 +185,28 @@
   the local date was 2026-08-18. The parser micro-refactor and duplicate test
   builder suggestions are non-blocking scope expansions with no reproduced AV
   correctness defect and are not part of this iteration.
+- The final bounded oracle review found no production defect but identified a
+  P2 negative-oracle gap: the new missing-column and `attnotnull` tests proved
+  only successful cases. One existing test was minimally expanded rather than
+  creating one test per reviewer hypothesis. It now covers `NL_AV` / `RT_AV`
+  with a simultaneously missing non-key column plus wrong key, nullable key,
+  wrong key type, insufficient text capacity, or extra uniqueness, and verifies
+  that neither AV nor an unrelated additive table is altered. A paired actual-
+  PostgreSQL test directly exercises native/standard nullable-key rejection in
+  a later search-path schema.
+- Fail-open mutation evidence was recorded before accepting the test-only
+  repair: a temporary preflight bypass made all ten SQLite cases fail after AV
+  or unrelated schema mutation, and a temporary `attnotnull=True` mutant made
+  both PostgreSQL cases fail with `DID NOT RAISE`. Both production mutations
+  were immediately removed; the exact production diff returned to zero. With
+  the real implementation restored, the same SQLite matrix passed `10/10` and
+  the PostgreSQL negative passed `2/2`.
+- The final test-only oracle candidate passed the complete AV contract with
+  `67 passed, 22 skipped` on SQLite and `89/89` on fresh PostgreSQL 16. The
+  affected existing suite passed `341 tests`, skipped `29` opt-in tests, and
+  passed `10` subtests. `TEST GATE PASS`, fatal flake8, and `git diff --check`
+  remained green. No production, public documentation, packaging, or version
+  file changed after `ff75fb1b88f7e9d4226ebfa38622837e7502d70b`.
 
 ## STOP conditions
 

--- a/specs/operations/20260818_av_official_contract_worklog.md
+++ b/specs/operations/20260818_av_official_contract_worklog.md
@@ -187,8 +187,8 @@
   correctness defect and are not part of this iteration.
 - The final bounded oracle review found no production defect but identified a
   P2 negative-oracle gap: the new missing-column and `attnotnull` tests proved
-  only successful cases. One existing test was minimally expanded rather than
-  creating one test per reviewer hypothesis. It now covers `NL_AV` / `RT_AV`
+  only successful cases. One parameterized test was added rather than creating
+  one test per reviewer hypothesis. It covers `NL_AV` / `RT_AV`
   with a simultaneously missing non-key column plus wrong key, nullable key,
   wrong key type, insufficient text capacity, or extra uniqueness, and verifies
   that neither AV nor an unrelated additive table is altered. A paired actual-

--- a/specs/operations/20260818_av_official_contract_worklog.md
+++ b/specs/operations/20260818_av_official_contract_worklog.md
@@ -1,0 +1,131 @@
+# AV Official Contract Worklog
+
+- Started: 2026-08-18 (Asia/Tokyo)
+- Objective: audit and repair the AV record parser, native/standard/realtime
+  storage identity, validation, migration, erasure, units, metadata, tests, and
+  public documentation against pinned official JV-Data sources.
+- Minimum scope: AV only. Unrelated record types and generic refactors are
+  excluded unless an AV correctness or data-integrity repair cannot be made
+  safely without them.
+- Repository: `miyamamoto/jrvltsql`
+- Worktree: `/home/keiba/scratch/20260818_jrvltsql_av_official`
+- Branch: `agent/av-official-contract-20260818`
+- Base / production master at start:
+  `a152045c4bf9c6f9c53f483d2f2cfa0baa05dcb7`
+- Dependency: JC official-contract PR #209 merged first at the base SHA above.
+- Package version at start: `2.0.0.dev0` (`pyproject.toml` and
+  `src/__init__.py`).
+
+## Review and implementation model
+
+- This iteration changes validators, database identity, ordering, and
+  fail-before-mutation boundaries, so it is classified as complex under
+  `AGENTS.md`.
+- Claude Code is requested with `--model fable`. The generated session UUID is
+  intentionally not retained because a substring tripped the repository's
+  public privacy gate. If authentication or quota prevents
+  it from reading or acting, that failure is not evidence and implementation
+  continues with Codex as explicitly authorized by the user.
+- Findings will be collected and deduplicated before one repair batch. The
+  immutable candidate will receive one bounded independent Codex critical
+  review plus one official-source oracle review.
+
+## Required sequence
+
+1. Re-derive AV length, all physical spans, ordered official key, status domain,
+   status history, provider-spec availability, field units, and cancellation
+   behavior from pinned 4.8/4.9 workbooks, SDK manifest/source, and relevant
+   official/community discussions.
+2. Compare parser, native `NL_AV`/`RT_AV`, standard owner, importer paths,
+   realtime paths, metadata, migration verification, documentation, and tests.
+3. Add the minimum contract regression and run it on the unchanged base to
+   record an actual red result before changing validator/gate behavior.
+4. Implement only the aggregated AV repair. Validate SQLite, fresh PostgreSQL,
+   Dual orientation, provider order, caller-owned transactions, exact erasure,
+   unsafe-schema no-mutation, current/prior boundaries, and durable readback.
+5. Freeze a clean full SHA, run the required local/workflow/package gates once,
+   request the configured GitHub reviews once, resolve actionable threads to
+   zero, and merge only when every blocking gate is green.
+
+## Current state
+
+- New worktree was created from a freshly fetched `origin/master`; start status
+  was clean.
+- No AV code or test has been changed yet.
+- A read-only Codex oracle pre-audit is running in parallel. Its findings are
+  provisional until independently reproduced in this worktree.
+- Claude Code `2.1.233` was invoked once with `--model fable`, but its OAuth
+  session was expired and
+  could not be refreshed. It did not read, test, or edit the repository, and no
+  Claude output is counted as audit or implementation evidence. Per the user's
+  fallback authorization, Codex continues the iteration.
+- The pinned 4.8.0.2 and 4.9.0.1 workbooks independently agree on the 78-byte,
+  fourteen-field AV layout and the seven-part key
+  `(Year, MonthDay, JyoCD, Kaiji, Nichiji, RaceNum, Umaban)`; `HappyoTime` is
+  not a key field. SDK 5.0.0 binds the same root length and nineteen expanded
+  leaves.
+- Current statuses are `1` and `2`. Historical status `0` is accepted only for
+  `MakeDate < 2003-07-11` and means exact physical deletion. The 2021-01-25
+  reason-field change altered the initial representation from zero to spaces,
+  not the physical layout, so blank and `000` through `003` remain accepted
+  when provenance is unknown.
+- Independent unchanged-base SQLite probes reproduced the actionable gaps:
+  keyless standard storage retained two revisions of one official identity;
+  historical status zero became a stored tombstone in both importer modes;
+  and caller `RaceNum='1X'` was silently coerced to integer 1 and overwrote a
+  valid row. No provider or user data was used by these synthetic probes.
+- Red-first evidence on unchanged base
+  `a152045c4bf9c6f9c53f483d2f2cfa0baa05dcb7`:
+  `.venv/bin/python -m pytest tests/test_av_official_contract.py -q
+  --basetemp=/tmp/jrvltsql-av-red --no-cov` produced `20 failed, 11 passed`
+  before stopping at `--maxfail=20`. Representative failures were
+  `DID NOT RAISE ValueError` for all seven malformed raw-field cases, native
+  durable count `1` instead of exact erase `0`, and standard durable count `3`
+  instead of `0`. The first oracle failure was an independently corrected test
+  transcription of SDK `MDHM`'s four scalar leaf names; it was not counted as
+  production evidence.
+- The aggregated implementation now adds strict AV raw/caller validation,
+  seven-column `NOT NULL` identity DDL for native/realtime/standard storage,
+  exact historical erase routing, all-target schema preflight, and realtime
+  dictionary validation. The first post-repair AV run passed `34` tests; the
+  expanded unsafe-schema matrix and public documentation are now being checked
+  before the candidate is frozen.
+- SQLite focused verification after the repair passed `363 tests`, skipped `9`
+  opt-in tests, and passed `10` subtests across AV, current-record framing,
+  realtime, schema/index/metadata, importer, and DataKubun entry contracts.
+- A fresh disposable PostgreSQL 16 instance was used with no provider or user
+  data. The final AV contract passed `65/65`: native/standard, DataImporter/
+  OptimizedDataImporter/single-record, owned/caller transactions, status
+  `1 -> 2 -> historical 0`, wrong type, short text, extra UNIQUE, deferrable
+  primary key, and both SQLite/PostgreSQL Dual orientations. A broader actual-
+  PostgreSQL run including the adjacent SE/WE/JC official contracts passed
+  `318/318`. The exact container was removed and an exact-name listing was
+  empty afterward.
+- Workflow-equivalent local verification on the final pre-review tree passed:
+  `scripts/validate_test_gate.py` reported `TEST GATE PASS`, followed by
+  `3126 passed, 244 skipped, 14 deselected, 21 subtests passed` with `78%`
+  line coverage. No production or test semantics changed after that run; a
+  broad Black rewrite was deliberately undone, and Python AST equality was
+  checked for every restored file before the focused suite was replayed.
+- The final post-format focused AV/parser set passed `465/465` with `18`
+  PostgreSQL-only skips. Fatal flake8 (`E9,F63,F7,F82`) reported zero errors,
+  `uv lock --check` passed, and `mkdocs build --strict` completed successfully.
+  Ruff import-order comparison has one pre-existing finding in
+  `schema_jravan.py`; the same finding is present in the unchanged base and
+  this iteration adds no Ruff import-order debt.
+- Fresh PEP 517 wheel and sdist build succeeded as `2.0.0.dev0`.
+  `scripts/check_distribution_contents.py` passed both artifacts and
+  `scripts/smoke_distribution_init.py` passed the extracted wheel. The tracked
+  `specs/`, this worklog, and official-layout fixtures remain excluded from the
+  distributable artifacts.
+
+## STOP conditions
+
+- Stop before mutation if official key/status/unit semantics remain ambiguous.
+- Stop on worktree drift outside this worklog before implementation starts.
+- Stop before merge on failed required test, unsafe schema mutation, durable
+  count/stat mismatch in the AV path, unresolved review thread, dirty worktree,
+  or absent exact-SHA evidence.
+- Do not claim 64-bit support without an installed official x64 SDK runtime test.
+- Do not include private implementation provenance or prohibited internal
+  environment identifiers in tracked files, PR text, logs, or artifacts.

--- a/specs/operations/20260818_av_official_contract_worklog.md
+++ b/specs/operations/20260818_av_official_contract_worklog.md
@@ -8,7 +8,7 @@
   excluded unless an AV correctness or data-integrity repair cannot be made
   safely without them.
 - Repository: `miyamamoto/jrvltsql`
-- Worktree: `/home/keiba/scratch/20260818_jrvltsql_av_official`
+- Worktree: dedicated scratch worktree for this iteration; remove after merge.
 - Branch: `agent/av-official-contract-20260818`
 - Base / production master at start:
   `a152045c4bf9c6f9c53f483d2f2cfa0baa05dcb7`
@@ -150,6 +150,41 @@
   flake8, `uv lock --check`, `mkdocs build --strict`, and `git diff --check`
   also passed. The disposable PostgreSQL container was removed and its
   exact-name listing was empty.
+- GitHub Codex and CodeRabbit review comments were aggregated before one final
+  repair batch. Two actionable defects were independently reproduced: the AV
+  nullability query used `current_schema()` instead of resolving the visible
+  relation, and strict preflight rejected an otherwise safe missing non-key
+  column on existing `NL_AV` / `RT_AV`. The first made native and standard AV
+  imports fail when the correct table was visible later in PostgreSQL
+  `search_path`; the second blocked the additive migration that the public
+  schema contract permits.
+- Red-first evidence on unchanged candidate
+  `bf78af91da3146d2265c827b4e3e084457c58b67`: the SQLite missing-`Bamei`
+  preflight regression failed `2/2` with `missing columns=['Bamei']`; a fresh
+  PostgreSQL 16 search-path regression failed native and standard storage
+  `2/2` because all seven key columns were falsely reported nullable.
+- The final review repair resolves the PostgreSQL relation with
+  `to_regclass(?)` and reads `pg_attribute.attnotnull`. AV preflight now allows
+  only missing columns for existing native/realtime tables while retaining
+  exact key, type, nullability, primary-key, and additional-uniqueness checks;
+  normal post-migration verification remains strict. The worktree record was
+  generalized to avoid publishing a local absolute path while retaining the
+  repository-required handoff context. The public migration text now states
+  that NULL or incomplete legacy identities may be preserved only in backup,
+  not reused or inferred in the rebuilt table.
+- The paired regressions passed `2/2` on SQLite and `2/2` on fresh PostgreSQL
+  16 after the repair. The complete AV contract then passed `57` tests with
+  `20` PostgreSQL-only skips on SQLite and `77/77` on PostgreSQL. The affected
+  existing suite passed `331` tests, skipped `27` opt-in tests, and passed `10`
+  subtests. `TEST GATE PASS`, fatal flake8, `uv lock --check`, strict MkDocs,
+  and `git diff --check` also passed.
+- Review dispositions to record on PR #210: the missing-column and PostgreSQL
+  search-path findings were accepted and repaired; the absolute local path was
+  sanitized while retaining a worktree handoff entry; the 2026-08-18 worklog
+  date is retained because the repository-required timezone is Asia/Tokyo and
+  the local date was 2026-08-18. The parser micro-refactor and duplicate test
+  builder suggestions are non-blocking scope expansions with no reproduced AV
+  correctness defect and are not part of this iteration.
 
 ## STOP conditions
 

--- a/src/database/schema.py
+++ b/src/database/schema.py
@@ -196,14 +196,14 @@ SCHEMAS = {
             RecordSpec TEXT,
             DataKubun TEXT,
             MakeDate TEXT,
-            Year INTEGER,
-            MonthDay INTEGER,
-            JyoCD TEXT,
-            Kaiji INTEGER,
-            Nichiji INTEGER,
-            RaceNum INTEGER,
+            Year INTEGER NOT NULL,
+            MonthDay INTEGER NOT NULL,
+            JyoCD TEXT NOT NULL,
+            Kaiji INTEGER NOT NULL,
+            Nichiji INTEGER NOT NULL,
+            RaceNum INTEGER NOT NULL,
             HappyoTime TEXT,
-            Umaban INTEGER,
+            Umaban INTEGER NOT NULL,
             Bamei TEXT,
             JiyuKubun TEXT,
             RecordDelimiter TEXT,
@@ -1604,14 +1604,14 @@ SCHEMAS = {
             RecordSpec TEXT,
             DataKubun TEXT,
             MakeDate TEXT,
-            Year INTEGER,
-            MonthDay INTEGER,
-            JyoCD TEXT,
-            Kaiji INTEGER,
-            Nichiji INTEGER,
-            RaceNum INTEGER,
+            Year INTEGER NOT NULL,
+            MonthDay INTEGER NOT NULL,
+            JyoCD TEXT NOT NULL,
+            Kaiji INTEGER NOT NULL,
+            Nichiji INTEGER NOT NULL,
+            RaceNum INTEGER NOT NULL,
             HappyoTime TEXT,
-            Umaban INTEGER,
+            Umaban INTEGER NOT NULL,
             Bamei TEXT,
             JiyuKubun TEXT,
             RecordDelimiter TEXT,
@@ -2739,6 +2739,7 @@ SCHEMAS.update(
 STRICT_RECREATE_TABLES = frozenset({"NL_CK_CHAKU", "NL_CK_RUIKEI"})
 STRICT_SE_STORAGE_TABLES = frozenset({"NL_SE", "RT_SE"})
 STRICT_WE_STORAGE_TABLES = frozenset({"NL_WE", "RT_WE"})
+STRICT_AV_STORAGE_TABLES = frozenset({"NL_AV", "RT_AV"})
 STRICT_JC_STORAGE_TABLES = frozenset({"NL_JC", "RT_JC"})
 
 
@@ -2747,6 +2748,7 @@ def _preflight_existing_strict_storage(db: BaseDatabase) -> None:
 
     from src.database.migration import _migration_targets
     from src.importer.importer import (
+        verify_av_storage_schema,
         verify_jc_storage_schema,
         verify_se_storage_schema,
         verify_we_storage_schema,
@@ -2764,6 +2766,9 @@ def _preflight_existing_strict_storage(db: BaseDatabase) -> None:
         for table_name in STRICT_WE_STORAGE_TABLES:
             if target.table_exists_strict(table_name):
                 verify_we_storage_schema(target, table_name)
+        for table_name in STRICT_AV_STORAGE_TABLES:
+            if target.table_exists_strict(table_name):
+                verify_av_storage_schema(target, table_name)
         for table_name in STRICT_JC_STORAGE_TABLES:
             if target.table_exists_strict(table_name):
                 verify_jc_storage_schema(target, table_name)
@@ -2842,6 +2847,10 @@ class SchemaManager:
                 from src.importer.importer import verify_we_storage_schema
 
                 verify_we_storage_schema(self.db, table_name)
+            if table_name in STRICT_AV_STORAGE_TABLES:
+                from src.importer.importer import verify_av_storage_schema
+
+                verify_av_storage_schema(self.db, table_name)
             if table_name in STRICT_JC_STORAGE_TABLES:
                 from src.importer.importer import verify_jc_storage_schema
 
@@ -2892,6 +2901,10 @@ class SchemaManager:
                     from src.importer.importer import verify_we_storage_schema
 
                     verify_we_storage_schema(self.db, table_name)
+                if table_name in STRICT_AV_STORAGE_TABLES:
+                    from src.importer.importer import verify_av_storage_schema
+
+                    verify_av_storage_schema(self.db, table_name)
                 if table_name in STRICT_JC_STORAGE_TABLES:
                     from src.importer.importer import verify_jc_storage_schema
 
@@ -3245,6 +3258,10 @@ def create_all_tables(db: BaseDatabase) -> None:
                 from src.importer.importer import verify_we_storage_schema
 
                 verify_we_storage_schema(db, table_name)
+            if table_name in STRICT_AV_STORAGE_TABLES:
+                from src.importer.importer import verify_av_storage_schema
+
+                verify_av_storage_schema(db, table_name)
             if table_name in STRICT_JC_STORAGE_TABLES:
                 from src.importer.importer import verify_jc_storage_schema
 

--- a/src/database/schema.py
+++ b/src/database/schema.py
@@ -2744,7 +2744,7 @@ STRICT_JC_STORAGE_TABLES = frozenset({"NL_JC", "RT_JC"})
 
 
 def _preflight_existing_strict_storage(db: BaseDatabase) -> None:
-    """Reject unsafe SE/WE/JC identities before unrelated additive migration."""
+    """Reject unsafe SE/WE/AV/JC identities before unrelated additive migration."""
 
     from src.database.migration import _migration_targets
     from src.importer.importer import (
@@ -2768,7 +2768,11 @@ def _preflight_existing_strict_storage(db: BaseDatabase) -> None:
                 verify_we_storage_schema(target, table_name)
         for table_name in STRICT_AV_STORAGE_TABLES:
             if target.table_exists_strict(table_name):
-                verify_av_storage_schema(target, table_name)
+                verify_av_storage_schema(
+                    target,
+                    table_name,
+                    allow_missing_columns=True,
+                )
         for table_name in STRICT_JC_STORAGE_TABLES:
             if target.table_exists_strict(table_name):
                 verify_jc_storage_schema(target, table_name)

--- a/src/database/schema_jravan.py
+++ b/src/database/schema_jravan.py
@@ -1557,16 +1557,17 @@ JRAVAN_SCHEMAS: Dict[str, str] = {
             RecordSpec                     CHAR(2)             ,  -- レコード種別ID
             DataKubun                      CHAR(1)             ,  -- データ区分
             MakeDate                       DATE                ,  -- YYYYMMDD形式の日付
-            Year                           SMALLINT            ,  -- 年(4桁)
-            MonthDay                       SMALLINT            ,  -- 月日(MMDD)
-            JyoCD                          CHAR(2)             ,  -- 競馬場コード
-            Kaiji                          SMALLINT            ,  -- 開催回
-            Nichiji                        SMALLINT            ,  -- 開催日目
-            RaceNum                        SMALLINT            ,  -- レース番号
+            Year                           SMALLINT NOT NULL   ,  -- 年(4桁)
+            MonthDay                       SMALLINT NOT NULL   ,  -- 月日(MMDD)
+            JyoCD                          CHAR(2) NOT NULL    ,  -- 競馬場コード
+            Kaiji                          SMALLINT NOT NULL   ,  -- 開催回
+            Nichiji                        SMALLINT NOT NULL   ,  -- 開催日目
+            RaceNum                        SMALLINT NOT NULL   ,  -- レース番号
             HappyoTime                     VARCHAR(8)          ,  -- 発表月日時分(MMDDhhmm)
-            Umaban                         SMALLINT            ,  -- 馬番
+            Umaban                         SMALLINT NOT NULL   ,  -- 馬番
             Bamei                          VARCHAR(36)         ,  -- 文字列(36)
-            JiyuKubun                      VARCHAR(3)            -- 文字列(3)
+            JiyuKubun                      VARCHAR(3)          ,  -- 文字列(3)
+            PRIMARY KEY (Year, MonthDay, JyoCD, Kaiji, Nichiji, RaceNum, Umaban)
         )
     """,
     "UMA": """

--- a/src/importer/importer.py
+++ b/src/importer/importer.py
@@ -1076,13 +1076,14 @@ def _verify_av_key_not_null_constraints(database: BaseDatabase, table_name: str)
         not_null = {str(row.get("name") or "").lower(): bool(row.get("notnull")) for row in rows}
     elif db_type == "postgresql":
         rows = database.fetch_all(
-            "SELECT column_name, is_nullable FROM information_schema.columns "
-            "WHERE table_schema = current_schema() AND table_name = ?",
-            (table_name.lower(),),
+            "SELECT a.attname AS column_name, a.attnotnull AS not_null "
+            "FROM pg_attribute AS a "
+            "WHERE a.attrelid = to_regclass(?) "
+            "AND a.attnum > 0 AND NOT a.attisdropped",
+            (table_name,),
         )
         not_null = {
-            str(row.get("column_name") or "").lower(): str(row.get("is_nullable") or "").upper()
-            == "NO"
+            str(row.get("column_name") or "").lower(): bool(row.get("not_null"))
             for row in rows
         }
     else:
@@ -1096,7 +1097,12 @@ def _verify_av_key_not_null_constraints(database: BaseDatabase, table_name: str)
         )
 
 
-def verify_av_storage_schema(database: BaseDatabase, table_name: str) -> bool:
+def verify_av_storage_schema(
+    database: BaseDatabase,
+    table_name: str,
+    *,
+    allow_missing_columns: bool = False,
+) -> bool:
     """Fail closed unless AV storage preserves the official seven-part key."""
 
     if table_name not in _AV_STORAGE_TABLES:
@@ -1108,12 +1114,17 @@ def verify_av_storage_schema(database: BaseDatabase, table_name: str) -> bool:
     schema_sql = SCHEMAS.get(table_name) or JRAVAN_SCHEMAS.get(table_name)
     if schema_sql is None:
         raise SchemaMigrationError(f"AV storage schema is undefined: {table_name}")
-    verify_table_schema(database, table_name, schema_sql)
+    verify_table_schema(
+        database,
+        table_name,
+        schema_sql,
+        allow_missing_columns=allow_missing_columns,
+    )
     _verify_strict_storage_column_contract(
         database,
         table_name,
         schema_sql,
-        allow_missing_columns=False,
+        allow_missing_columns=allow_missing_columns,
         storage_label="AV",
         lossless_text_widths=_AV_LOSSLESS_TEXT_WIDTHS[table_name],
     )

--- a/src/importer/importer.py
+++ b/src/importer/importer.py
@@ -466,6 +466,27 @@ _WE_LIVE_BODY_COLUMNS = {
     "RT_WE": _WE_NATIVE_LIVE_BODY_COLUMNS,
     "TENKO_BABA": _WE_STANDARD_LIVE_BODY_COLUMNS,
 }
+_AV_STORAGE_TABLES = frozenset({"NL_AV", "RT_AV", "TORIKESI_JYOGAI"})
+_AV_KEY_COLUMNS = (
+    "Year",
+    "MonthDay",
+    "JyoCD",
+    "Kaiji",
+    "Nichiji",
+    "RaceNum",
+    "Umaban",
+)
+_AV_LOSSLESS_TEXT_WIDTHS = {
+    table_name: {
+        "RecordSpec": 2,
+        "DataKubun": 1,
+        "JyoCD": 2,
+        "HappyoTime": 8,
+        "Bamei": 36,
+        "JiyuKubun": 3,
+    }
+    for table_name in _AV_STORAGE_TABLES
+}
 _JC_STORAGE_TABLES = frozenset({"NL_JC", "RT_JC", "KISYU_CHANGE"})
 _JC_KEY_COLUMNS = (
     "Year",
@@ -522,6 +543,7 @@ _STRICT_NONADDITIVE_STANDARD_TABLES = frozenset(
         "KEITO",
         "JOGAIBA",
         "KISYU_CHANGE",
+        "TORIKESI_JYOGAI",
         "TENKO_BABA",
         "WOOD",
         _WF_STANDARD_HEAD_TABLE,
@@ -530,6 +552,7 @@ _STRICT_NONADDITIVE_STANDARD_TABLES = frozenset(
 _LEGACY_STANDARD_PREFLIGHT_NATIVE_TABLES = (
     "NL_BT",
     "NL_JG",
+    "NL_AV",
     "NL_JC",
     "NL_SK",
     "NL_BR",
@@ -981,6 +1004,127 @@ def verify_we_storage_schema(database: BaseDatabase, table_name: str) -> bool:
     _verify_we_key_storage_types(database, table_name)
     _verify_we_key_not_null_constraints(database, table_name)
     _verify_replacement_key_constraints(database, table_name, "WE storage")
+    return True
+
+
+def _verify_av_key_storage_types(database: BaseDatabase, table_name: str) -> None:
+    """Reject affinities that can coerce or split one AV identity."""
+
+    from src.database.migration import (
+        _get_existing_column_types,
+        _is_lossless_text_type,
+        _migration_targets,
+    )
+
+    targets = _migration_targets(database)
+    if targets != (database,):
+        for target in targets:
+            _verify_av_key_storage_types(target, table_name)
+        return
+
+    actual_types = _get_existing_column_types(database, table_name)
+    integral = {
+        "smallint",
+        "int2",
+        "integer",
+        "int",
+        "int4",
+        "bigint",
+        "int8",
+    }
+    problems: list[str] = []
+    for column in ("Year", "MonthDay", "Kaiji", "Nichiji", "RaceNum", "Umaban"):
+        actual = actual_types.get(column.lower(), "")
+        if re.sub(r"\s+", " ", actual.strip().lower()) not in integral:
+            problems.append(f"{column} existing={actual or '<unknown>'} expected=integral")
+    actual_jyo = actual_types.get("jyocd", "")
+    if not actual_jyo or not _is_lossless_text_type(actual_jyo):
+        problems.append(f"JyoCD existing={actual_jyo or '<unknown>'} expected=text")
+    if problems:
+        raise SchemaMigrationError(f"AV key type mismatch for {table_name}: {', '.join(problems)}")
+
+
+def _verify_av_key_not_null_constraints(database: BaseDatabase, table_name: str) -> None:
+    """Require every component of the AV identity to reject NULL."""
+
+    from src.database.migration import _migration_targets
+
+    targets = _migration_targets(database)
+    if targets != (database,):
+        for target in targets:
+            _verify_av_key_not_null_constraints(target, table_name)
+        return
+
+    db_type = database.get_db_type()
+    if db_type == "sqlite":
+        rows = database.fetch_all(f'PRAGMA table_info("{table_name}")')
+        not_null = {str(row.get("name") or "").lower(): bool(row.get("notnull")) for row in rows}
+    elif db_type == "postgresql":
+        rows = database.fetch_all(
+            "SELECT column_name, is_nullable FROM information_schema.columns "
+            "WHERE table_schema = current_schema() AND table_name = ?",
+            (table_name.lower(),),
+        )
+        not_null = {
+            str(row.get("column_name") or "").lower(): str(row.get("is_nullable") or "").upper()
+            == "NO"
+            for row in rows
+        }
+    else:
+        raise SchemaMigrationError(
+            f"AV key nullability cannot be verified for database type {db_type!r}"
+        )
+    missing = [column for column in _AV_KEY_COLUMNS if not not_null.get(column.lower(), False)]
+    if missing:
+        raise SchemaMigrationError(
+            f"AV storage {table_name} key columns must be NOT NULL: {missing}"
+        )
+
+
+def verify_av_storage_schema(database: BaseDatabase, table_name: str) -> bool:
+    """Fail closed unless AV storage preserves the official seven-part key."""
+
+    if table_name not in _AV_STORAGE_TABLES:
+        return False
+    from src.database.migration import verify_table_schema
+    from src.database.schema import SCHEMAS
+    from src.database.schema_jravan import JRAVAN_SCHEMAS
+
+    schema_sql = SCHEMAS.get(table_name) or JRAVAN_SCHEMAS.get(table_name)
+    if schema_sql is None:
+        raise SchemaMigrationError(f"AV storage schema is undefined: {table_name}")
+    verify_table_schema(database, table_name, schema_sql)
+    _verify_strict_storage_column_contract(
+        database,
+        table_name,
+        schema_sql,
+        allow_missing_columns=False,
+        storage_label="AV",
+        lossless_text_widths=_AV_LOSSLESS_TEXT_WIDTHS[table_name],
+    )
+    _verify_av_key_storage_types(database, table_name)
+    _verify_av_key_not_null_constraints(database, table_name)
+    _verify_replacement_key_constraints(database, table_name, "AV storage")
+    return True
+
+
+def validate_av_record(record: dict, table_name: str | None = None) -> bool:
+    """Validate one caller-built AV row before schema or row mutation."""
+
+    if table_name is not None and table_name not in _AV_STORAGE_TABLES:
+        return False
+    if _record_type_from_record(record) != "AV":
+        if table_name is None:
+            return False
+        raise SchemaMigrationError(f"{table_name} received a non-AV record")
+
+    from src.parser.av_parser import AVParser
+
+    try:
+        data_kubun = resolve_record_data_kubun(record)
+        AVParser.validate_current_fields(record, data_kubun=data_kubun)
+    except ValueError as error:
+        raise SchemaMigrationError(str(error)) from error
     return True
 
 
@@ -2134,6 +2278,8 @@ def preflight_standard_schema_migrations(
             )
         if standard_name == "TENKO_BABA":
             verify_we_storage_schema(database, standard_name)
+        if standard_name == "TORIKESI_JYOGAI":
+            verify_av_storage_schema(database, standard_name)
         if standard_name == "KISYU_CHANGE":
             verify_jc_storage_schema(database, standard_name)
         if standard_name in {"UMA", "COURSE"}:
@@ -2641,6 +2787,7 @@ _OFFICIAL_ERASE_KEY_COLUMNS = {
     "RA": _MINING_RACE_KEY_COLUMNS,
     "SE": _SE_KEY_COLUMNS,
     "WE": _WE_KEY_COLUMNS,
+    "AV": _AV_KEY_COLUMNS,
     "JC": _JC_KEY_COLUMNS,
     "HR": _MINING_RACE_KEY_COLUMNS,
     # One physical H1/H6/O1-O6 record expands into multiple child rows.
@@ -2663,6 +2810,7 @@ _OFFICIAL_ERASE_STORAGE_TABLES = {
     "RA": {"NL_RA", "RT_RA", "RACE"},
     "SE": {"NL_SE", "RT_SE", "UMA_RACE"},
     "WE": set(_WE_STORAGE_TABLES),
+    "AV": set(_AV_STORAGE_TABLES),
     "JC": set(_JC_STORAGE_TABLES),
     "HR": {"NL_HR", "RT_HR", "HARAI"},
     "H1": {"NL_H1", "RT_H1", "HYO_TANPUKU"},
@@ -2761,6 +2909,8 @@ def validate_import_record_header(record: dict) -> tuple[str, str]:
             SEParser.validate_current_fields(record)
         if record_type == "WE":
             validate_we_record(record)
+        if record_type == "AV":
+            validate_av_record(record)
         if record_type == "JC":
             validate_jc_record(record)
         return record_type, data_kubun
@@ -5344,6 +5494,7 @@ class DataImporter:
         self._verified_bt_tables: set[str] = set()
         self._verified_se_tables: set[str] = set()
         self._verified_we_tables: set[str] = set()
+        self._verified_av_tables: set[str] = set()
         self._verified_jc_tables: set[str] = set()
         self._verified_cs_tables: set[str] = set()
         self._verified_jg_tables: set[str] = set()
@@ -5594,6 +5745,7 @@ class DataImporter:
                 if first_table_name is not None:
                     validate_se_record(first_record, first_table_name)
                     validate_we_record(first_record, first_table_name)
+                    validate_av_record(first_record, first_table_name)
                     validate_jc_record(first_record, first_table_name)
                 records = chain((first_record,), records)
         except Exception:
@@ -5670,6 +5822,10 @@ class DataImporter:
                     if verify_we_storage_schema(self.database, table_name):
                         self._verified_we_tables.add(table_name)
                 validate_we_record(record, table_name)
+                if table_name not in self._verified_av_tables:
+                    if verify_av_storage_schema(self.database, table_name):
+                        self._verified_av_tables.add(table_name)
+                validate_av_record(record, table_name)
                 if table_name not in self._verified_jc_tables:
                     if verify_jc_storage_schema(self.database, table_name):
                         self._verified_jc_tables.add(table_name)
@@ -6314,6 +6470,7 @@ class DataImporter:
             if table_name is not None:
                 validate_se_record(record, table_name)
                 validate_we_record(record, table_name)
+                validate_av_record(record, table_name)
                 validate_jc_record(record, table_name)
         except SchemaMigrationError:
             if not auto_commit:
@@ -6384,6 +6541,10 @@ class DataImporter:
                 if verify_we_storage_schema(self.database, table_name):
                     self._verified_we_tables.add(table_name)
             validate_we_record(record, table_name)
+            if table_name not in self._verified_av_tables:
+                if verify_av_storage_schema(self.database, table_name):
+                    self._verified_av_tables.add(table_name)
+            validate_av_record(record, table_name)
             if table_name not in self._verified_jc_tables:
                 if verify_jc_storage_schema(self.database, table_name):
                     self._verified_jc_tables.add(table_name)

--- a/src/importer/importer.py
+++ b/src/importer/importer.py
@@ -92,6 +92,21 @@ def resolve_standard_table_name(database: BaseDatabase, native_table_name: str) 
             "CK standard-schema storage is not implemented; use native NL_CK until the "
             "canonical CHOKYO_DETAIL parent/child contract is available"
         )
+    if native_table_name == "NL_AV":
+        from src.database.migration import _migration_targets
+
+        for target in _migration_targets(database):
+            if (
+                target.is_connected()
+                and target.table_exists("AVOIDENCE")
+                and not target.table_exists(standard_name)
+            ):
+                raise SchemaMigrationError(
+                    "Legacy standard table AVOIDENCE exists but canonical "
+                    "TORIKESI_JYOGAI does not. Automatic AV import is refused; "
+                    "rebuild the standard table as TORIKESI_JYOGAI and reimport "
+                    "current 78-byte source records."
+                )
     if (
         native_table_name == "NL_BT"
         and database.is_connected()
@@ -6312,7 +6327,16 @@ class DataImporter:
                 return
 
             # Insert batch using INSERT OR REPLACE
-            rows = self.database.insert_many(table_name, converted_batch, use_replace=True)
+            affected_rows = self.database.insert_many(
+                table_name, converted_batch, use_replace=True
+            )
+            # PostgreSQL collapses same-key AV operations before one upsert.
+            # Statistics count accepted provider operations, not final rows.
+            rows = (
+                len(converted_batch)
+                if table_name in _AV_STORAGE_TABLES
+                else affected_rows
+            )
 
             self._records_imported += rows
             self._batches_processed += 1

--- a/src/importer/importer_optimized.py
+++ b/src/importer/importer_optimized.py
@@ -62,6 +62,7 @@ from src.importer.importer import (
     resolve_standard_storage_table_name,
     resolve_standard_table_name,
     rollback_failed_import,
+    validate_av_record,
     validate_import_record_header,
     validate_jc_record,
     validate_jg_record,
@@ -69,6 +70,7 @@ from src.importer.importer import (
     validate_wc_record,
     validate_we_record,
     validate_wf_record,
+    verify_av_storage_schema,
     verify_bt_storage_schema,
     verify_ch_coupled_table,
     verify_ck_coupled_tables,
@@ -124,6 +126,7 @@ class OptimizedDataImporter:
         self._verified_bt_tables: set[str] = set()
         self._verified_se_tables: set[str] = set()
         self._verified_we_tables: set[str] = set()
+        self._verified_av_tables: set[str] = set()
         self._verified_jc_tables: set[str] = set()
         self._verified_cs_tables: set[str] = set()
         self._verified_jg_tables: set[str] = set()
@@ -326,6 +329,7 @@ class OptimizedDataImporter:
                 if first_table_name is not None:
                     validate_se_record(first_record, first_table_name)
                     validate_we_record(first_record, first_table_name)
+                    validate_av_record(first_record, first_table_name)
                     validate_jc_record(first_record, first_table_name)
                 records = chain((first_record,), records)
         except Exception:
@@ -407,6 +411,10 @@ class OptimizedDataImporter:
                     if verify_we_storage_schema(self.database, table_name):
                         self._verified_we_tables.add(table_name)
                 validate_we_record(record, table_name)
+                if table_name not in self._verified_av_tables:
+                    if verify_av_storage_schema(self.database, table_name):
+                        self._verified_av_tables.add(table_name)
+                validate_av_record(record, table_name)
                 if table_name not in self._verified_jc_tables:
                     if verify_jc_storage_schema(self.database, table_name):
                         self._verified_jc_tables.add(table_name)

--- a/src/importer/importer_optimized.py
+++ b/src/importer/importer_optimized.py
@@ -13,6 +13,7 @@ from typing import Dict, Iterator, List, Optional, Union
 from src.database.base import BaseDatabase, DatabaseError
 from src.database.migration import SchemaMigrationError
 from src.importer.importer import (
+    _AV_STORAGE_TABLES,
     _ORDERED_MASTER_STORAGE_TABLES,
     _PREPARED_CH_SEISEKI_ROWS_KEY,
     _PREPARED_CK_ROWS_KEY,
@@ -964,10 +965,14 @@ class OptimizedDataImporter:
             # Use optimized insert if available
             if hasattr(self.database, "insert_many_optimized"):
                 # Optimized path
-                rows = self.database.insert_many_optimized(table_name, batch)
+                affected_rows = self.database.insert_many_optimized(table_name, batch)
             else:
                 # Standard insert_many
-                rows = self.database.insert_many(table_name, batch)
+                affected_rows = self.database.insert_many(table_name, batch)
+
+            # PostgreSQL collapses same-key AV operations before one upsert.
+            # Statistics count accepted provider operations, not final rows.
+            rows = len(batch) if table_name in _AV_STORAGE_TABLES else affected_rows
 
             self._records_imported += rows
             self._batches_processed += 1

--- a/src/parser/av_parser.py
+++ b/src/parser/av_parser.py
@@ -1,8 +1,11 @@
-"""Parser for AV record - scratched/excluded horse realtime data."""
+"""Parser for the official AV scratched/excluded-horse record."""
 
-from typing import List
+from collections.abc import Mapping
+from datetime import date
+from typing import Any, List
 
 from src.parser.base import BaseParser, FieldDef, validate_fixed_record
+from src.parser.code_domains import OFFICIAL_JYO_CODES_2001
 
 
 class AVParser(BaseParser):
@@ -11,12 +14,116 @@ class AVParser(BaseParser):
     record_type = "AV"
     RECORD_TYPE = "AV"
     RECORD_LENGTH = 78
+    KEY_COLUMNS = (
+        "Year",
+        "MonthDay",
+        "JyoCD",
+        "Kaiji",
+        "Nichiji",
+        "RaceNum",
+        "Umaban",
+    )
+    OFFICIAL_JYO_CODES = OFFICIAL_JYO_CODES_2001
+    REASON_CODES = frozenset({"", "000", "001", "002", "003"})
+
+    @staticmethod
+    def _require_date(field_name: str, value: object) -> date:
+        if isinstance(value, date):
+            return value
+        if (
+            not isinstance(value, str)
+            or len(value) != 8
+            or not value.isascii()
+            or not value.isdigit()
+        ):
+            raise ValueError(f"AV {field_name} must be exactly 8 ASCII digits")
+        try:
+            return date(int(value[:4]), int(value[4:6]), int(value[6:]))
+        except ValueError as error:
+            raise ValueError(f"AV {field_name} must be a real YYYYMMDD date") from error
+
+    @staticmethod
+    def _require_fixed_integer(field_name: str, value: object, width: int) -> int:
+        if isinstance(value, bool):
+            raise ValueError(f"AV {field_name} must be an official {width}-digit integer")
+        if isinstance(value, int):
+            if 0 <= value < 10**width:
+                return value
+        elif isinstance(value, str) and len(value) == width and value.isascii() and value.isdigit():
+            return int(value)
+        raise ValueError(f"AV {field_name} must be an official {width}-digit integer")
+
+    @classmethod
+    def validate_key_fields(cls, record: Mapping[str, object]) -> None:
+        """Validate the complete official seven-part identity before coercion."""
+
+        cls._require_date("MakeDate", record.get("MakeDate"))
+        year = cls._require_fixed_integer("Year", record.get("Year"), 4)
+        month_day = cls._require_fixed_integer("MonthDay", record.get("MonthDay"), 4)
+        try:
+            date(year, month_day // 100, month_day % 100)
+        except ValueError as error:
+            raise ValueError("AV Year and MonthDay must form a real date") from error
+
+        if record.get("JyoCD") not in cls.OFFICIAL_JYO_CODES:
+            raise ValueError("AV JyoCD is not in official code table 2001")
+        for field_name in ("Kaiji", "Nichiji", "RaceNum"):
+            cls._require_fixed_integer(field_name, record.get(field_name), 2)
+
+        umaban = cls._require_fixed_integer("Umaban", record.get("Umaban"), 2)
+        if not 1 <= umaban <= 18:
+            raise ValueError("AV Umaban must be between 01 and 18")
+
+    @classmethod
+    def validate_current_fields(
+        cls,
+        record: Mapping[str, object],
+        *,
+        data_kubun: str | None = None,
+    ) -> None:
+        """Validate one live AV row; a date-proven historical erase is opaque."""
+
+        cls.validate_key_fields(record)
+        status = data_kubun if data_kubun is not None else record.get("DataKubun")
+        if status == "0":
+            return
+
+        year = cls._require_fixed_integer("Year", record.get("Year"), 4)
+        happyo_time = record.get("HappyoTime")
+        if (
+            not isinstance(happyo_time, str)
+            or len(happyo_time) != 8
+            or not happyo_time.isascii()
+            or not happyo_time.isdigit()
+        ):
+            raise ValueError("AV HappyoTime must be exactly 8 ASCII digits")
+        if happyo_time != "00000000":
+            try:
+                date(year, int(happyo_time[:2]), int(happyo_time[2:4]))
+            except ValueError as error:
+                raise ValueError("AV HappyoTime must contain a real MMDD date") from error
+            if int(happyo_time[4:6]) > 23 or int(happyo_time[6:]) > 59:
+                raise ValueError("AV HappyoTime must contain a real hhmm time")
+
+        bamei = record.get("Bamei")
+        if bamei not in (None, ""):
+            if not isinstance(bamei, str):
+                raise ValueError("AV Bamei must be provider text")
+            try:
+                encoded = bamei.encode("cp932", errors="strict")
+            except UnicodeEncodeError as error:
+                raise ValueError("AV Bamei is not CP932 encodable") from error
+            if len(encoded) > 36:
+                raise ValueError("AV Bamei exceeds its official 36-byte span")
+
+        if record.get("JiyuKubun") not in cls.REASON_CODES:
+            raise ValueError("AV JiyuKubun is not an official reason code")
 
     @staticmethod
     def decode_field(data: bytes) -> str:
         return data.decode("cp932", errors="strict").strip()
 
-    def parse(self, record: bytes) -> dict:
+    def parse(self, record: bytes) -> dict[str, Any]:
         """Parse AV by byte offsets because Bamei is a multibyte cp932 field."""
         if not record:
             raise ValueError("Empty record")
@@ -26,10 +133,12 @@ class AVParser(BaseParser):
                 f"Record type mismatch: expected {self.record_type}, "
                 f"got {self.decode_field(record[0:2])}"
             )
-        return {
-            field.name: self.decode_field(record[field.start:field.start + field.length])
+        parsed = {
+            field.name: self.decode_field(record[field.start : field.start + field.length])
             for field in self._fields
         }
+        self.validate_current_fields(parsed)
+        return parsed
 
     def _define_fields(self) -> List[FieldDef]:
         """Define field positions from JRA-VAN JV-Data490."""

--- a/src/realtime/updater.py
+++ b/src/realtime/updater.py
@@ -16,10 +16,12 @@ from src.importer.importer import (
     clean_record_metadata,
     resolve_record_data_kubun,
     rollback_failed_import,
+    validate_av_record,
     validate_jc_record,
     validate_se_record,
     validate_we_record,
     validate_wf_record,
+    verify_av_storage_schema,
     verify_jc_storage_schema,
     verify_se_storage_schema,
     verify_we_storage_schema,
@@ -197,6 +199,7 @@ class RealtimeUpdater:
         self._verified_mining_native_tables: set[str] = set()
         self._verified_se_tables: set[str] = set()
         self._verified_we_tables: set[str] = set()
+        self._verified_av_tables: set[str] = set()
         self._verified_jc_tables: set[str] = set()
         self._verified_wf_tables: set[str] = set()
 
@@ -204,7 +207,7 @@ class RealtimeUpdater:
 
     # Realtime tables whose caller-built rows are revalidated against the
     # official contract before any coercion or mutation.
-    STRICT_RECORD_TABLES = frozenset({"RT_SE", "RT_WE", "RT_JC", "RT_WF"})
+    STRICT_RECORD_TABLES = frozenset({"RT_SE", "RT_WE", "RT_AV", "RT_JC", "RT_WF"})
 
     def _canonicalize_strict_record_aliases(
         self, record: Dict
@@ -256,6 +259,11 @@ class RealtimeUpdater:
                     if verify_we_storage_schema(self.database, table_name):
                         self._verified_we_tables.add(table_name)
                 validate_we_record(record, table_name)
+            elif table_name == "RT_AV":
+                if table_name not in self._verified_av_tables:
+                    if verify_av_storage_schema(self.database, table_name):
+                        self._verified_av_tables.add(table_name)
+                validate_av_record(record, table_name)
             elif table_name == "RT_JC":
                 if table_name not in self._verified_jc_tables:
                     if verify_jc_storage_schema(self.database, table_name):

--- a/tests/fixtures/official_layout/README.md
+++ b/tests/fixtures/official_layout/README.md
@@ -20,6 +20,9 @@ JV-Data. They do not contain provider records or a copy of the SDK source.
 - `jc_contract_4901.json` records the JC jockey-change layout, eight-part key,
   status history, apprentice-code domain, provider specs, and weight unit
   independently transcribed from both pinned current workbooks.
+- `av_contract_4901.json` records the AV scratch/exclusion layout, seven-part
+  key, status history, reason-code representation change, and provider specs
+  independently transcribed from both pinned current workbooks.
 
 The manifest is intentionally independent of jrvltsql parser and schema code.
 When the official source changes, regenerate it from a separately obtained SDK

--- a/tests/fixtures/official_layout/av_contract_4901.json
+++ b/tests/fixtures/official_layout/av_contract_4901.json
@@ -1,0 +1,67 @@
+{
+  "schema_version": 1,
+  "record_type": "AV",
+  "record_length": 78,
+  "format_sources": [
+    {
+      "artifact": "JV-Data4802.xlsx",
+      "sha256": "6a567f10b601115eca350571f36d27d9d28bd2d3835ea72b5bc057711155d4a7",
+      "sheet": "フォーマット",
+      "rows": "1461-1476"
+    },
+    {
+      "artifact": "JV-Data4901.xlsx",
+      "sha256": "23bafd375f704acbdd696b5032ac1619f17d47e882587d6e7954b610527a8234",
+      "sheet": "フォーマット",
+      "rows": "1461-1476"
+    }
+  ],
+  "fields": [
+    ["RecordSpec", 1, 2],
+    ["DataKubun", 3, 1],
+    ["MakeDate", 4, 8],
+    ["Year", 12, 4],
+    ["MonthDay", 16, 4],
+    ["JyoCD", 20, 2],
+    ["Kaiji", 22, 2],
+    ["Nichiji", 24, 2],
+    ["RaceNum", 26, 2],
+    ["HappyoTime", 28, 8],
+    ["Umaban", 36, 2],
+    ["Bamei", 38, 36],
+    ["JiyuKubun", 74, 3],
+    ["RecordDelimiter", 77, 2]
+  ],
+  "primary_key": [
+    "Year",
+    "MonthDay",
+    "JyoCD",
+    "Kaiji",
+    "Nichiji",
+    "RaceNum",
+    "Umaban"
+  ],
+  "current_data_kubun": ["1", "2"],
+  "historical_data_kubun": {
+    "value": "0",
+    "valid_before_make_date": "2003-07-11",
+    "source": {
+      "artifact": "JV-Data4901.xlsx",
+      "sheet": "変更履歴",
+      "row": 305
+    }
+  },
+  "reason_codes": ["", "000", "001", "002", "003"],
+  "reason_initial_representation_change": {
+    "effective_date": "2021-01-25",
+    "before": "000",
+    "after": "",
+    "source": {
+      "artifact": "JV-Data4901.xlsx",
+      "sheet": "変更履歴",
+      "row": 66
+    }
+  },
+  "current_provider_specs": ["0B14", "0B16"],
+  "snapshot_provider_spec": "0B14"
+}

--- a/tests/test_av_official_contract.py
+++ b/tests/test_av_official_contract.py
@@ -267,14 +267,40 @@ def test_av_storage_revises_one_identity_and_exactly_erases_old_status_zero(
             happyo_time="99999999",
             jiyu_kubun="999",
         )
+        survivor = parsed_av(
+            make_date="20030710",
+            umaban="02",
+            bamei="サバイバー",
+            happyo_time="07090635",
+            jiyu_kubun="002",
+        )
         import_records(
             database,
             entrypoint,
-            [first, revision, delete],
+            [first, revision, survivor],
             standard=standard,
             auto_commit=auto_commit,
         )
-        assert database.fetch_one(f"SELECT COUNT(*) AS n FROM {table_name}") == {"n": 0}
+        assert database.fetch_one(
+            f"SELECT DataKubun, HappyoTime, JiyuKubun FROM {table_name} WHERE Umaban = 1"
+        ) == {"DataKubun": "2", "HappyoTime": "07090710", "JiyuKubun": "003"}
+        import_records(
+            database,
+            entrypoint,
+            [delete],
+            standard=standard,
+            auto_commit=auto_commit,
+        )
+        assert database.fetch_all(
+            f"SELECT Umaban, Bamei, HappyoTime, JiyuKubun FROM {table_name} ORDER BY Umaban"
+        ) == [
+            {
+                "Umaban": 2,
+                "Bamei": "サバイバー",
+                "HappyoTime": "07090635",
+                "JiyuKubun": "002",
+            }
+        ]
 
 
 @pytest.mark.parametrize("standard", (False, True), ids=("native", "standard"))
@@ -344,6 +370,60 @@ def test_av_malformed_caller_is_rejected_before_mutation(tmp_path) -> None:
         assert database.fetch_one("SELECT COUNT(*) AS n FROM NL_AV") == {"n": 0}
 
 
+@pytest.mark.parametrize("entrypoint", ("data-batch", "optimized-batch", "single-record"))
+@pytest.mark.parametrize("legacy_target", ("primary", "secondary"))
+def test_av_legacy_standard_alias_stops_dual_migration_before_any_alter(
+    tmp_path, legacy_target: str, entrypoint: str
+) -> None:
+    race_without_youbi = JRAVAN_SCHEMAS["RACE"].replace(
+        "            YoubiCD                        VARCHAR(1)          ,  -- 文字列(1)\n",
+        "",
+    )
+    assert race_without_youbi != JRAVAN_SCHEMAS["RACE"]
+    legacy_av = JRAVAN_SCHEMAS["TORIKESI_JYOGAI"].replace("TORIKESI_JYOGAI", "AVOIDENCE", 1)
+    primary = SQLiteDatabase({"path": str(tmp_path / "primary.db")})
+    secondary = SQLiteDatabase({"path": str(tmp_path / "secondary.db")})
+    with primary, secondary:
+        for database in (primary, secondary):
+            database.execute(race_without_youbi)
+            database.commit()
+        legacy_database = primary if legacy_target == "primary" else secondary
+        legacy_database.execute(legacy_av)
+        legacy_database.commit()
+        before_primary = primary.fetch_all('PRAGMA table_info("RACE")')
+        before_secondary = secondary.fetch_all('PRAGMA table_info("RACE")')
+
+        with pytest.raises(SchemaMigrationError, match=r"AVOIDENCE.*TORIKESI_JYOGAI"):
+            dual = DualDatabase(primary, secondary)
+            if entrypoint == "data-batch":
+                DataImporter(dual, use_jravan_schema=True).import_records(iter([]))
+            elif entrypoint == "optimized-batch":
+                OptimizedDataImporter(dual, use_jravan_schema=True).import_records(iter([]))
+            else:
+                DataImporter(dual, use_jravan_schema=True).import_single_record(parsed_av())
+
+        assert primary.fetch_all('PRAGMA table_info("RACE")') == before_primary
+        assert secondary.fetch_all('PRAGMA table_info("RACE")') == before_secondary
+
+
+def test_av_canonical_standard_table_takes_precedence_over_legacy_alias(tmp_path) -> None:
+    database = SQLiteDatabase({"path": str(tmp_path / "coexisting-alias.db")})
+    legacy_av = JRAVAN_SCHEMAS["TORIKESI_JYOGAI"].replace("TORIKESI_JYOGAI", "AVOIDENCE", 1)
+    with database:
+        database.execute(legacy_av)
+        database.execute(JRAVAN_SCHEMAS["TORIKESI_JYOGAI"])
+        database.commit()
+        import_records(
+            database,
+            "data-batch",
+            [parsed_av()],
+            standard=True,
+            auto_commit=True,
+        )
+        assert database.fetch_one("SELECT COUNT(*) AS n FROM TORIKESI_JYOGAI") == {"n": 1}
+        assert database.fetch_one("SELECT COUNT(*) AS n FROM AVOIDENCE") == {"n": 0}
+
+
 @pytest.mark.parametrize("changes", ({"Bamei": "😀"}, {"Bamei": "あ" * 19}))
 def test_av_caller_text_must_fit_the_official_cp932_span(changes: dict) -> None:
     record = parsed_av()
@@ -376,6 +456,41 @@ def test_realtime_av_rejects_malformed_rows_and_replaces_complete_date_snapshot(
     assert replaced["success"] is True
     assert replaced["inserted"] == 1
     assert rows == [{"Umaban": 2}]
+
+
+def test_realtime_av_historical_erase_preserves_another_official_identity(tmp_path) -> None:
+    database = SQLiteDatabase({"path": str(tmp_path / "realtime-erase.db")})
+    with database:
+        database.execute(SCHEMAS["RT_AV"])
+        database.commit()
+        updater = RealtimeUpdater(database)
+        inserted = updater.process_parsed_records_batch(
+            [
+                parsed_av(make_date="20030710", umaban="01"),
+                parsed_av(
+                    make_date="20030710",
+                    umaban="02",
+                    bamei="サバイバー",
+                    jiyu_kubun="002",
+                ),
+            ]
+        )
+        erased = updater.process_parsed_records_batch(
+            [
+                parsed_av(
+                    data_kubun="0",
+                    make_date="20030710",
+                    umaban="01",
+                    happyo_time="99999999",
+                    jiyu_kubun="999",
+                )
+            ]
+        )
+        rows = database.fetch_all("SELECT Umaban, Bamei, JiyuKubun FROM RT_AV ORDER BY Umaban")
+
+    assert inserted["success"] is True
+    assert erased["success"] is True
+    assert rows == [{"Umaban": 2, "Bamei": "サバイバー", "JiyuKubun": "002"}]
 
 
 @pytest.mark.parametrize("unsafe_target", ("primary", "secondary"))
@@ -448,12 +563,43 @@ def test_av_postgresql_identity_revision_and_historical_exact_erase(
     import_records(
         postgresql_db,
         entrypoint,
-        [first, revision, delete],
+        [
+            first,
+            revision,
+            parsed_av(
+                make_date="20030710",
+                umaban="02",
+                bamei="サバイバー",
+                happyo_time="07090635",
+                jiyu_kubun="002",
+            ),
+        ],
         standard=standard,
         auto_commit=auto_commit,
-        batch_size=1,
     )
-    assert postgresql_db.fetch_one(f'SELECT COUNT(*) AS "n" FROM {table_name}') == {"n": 0}
+    assert postgresql_db.fetch_one(
+        f'SELECT DataKubun AS "DataKubun", HappyoTime AS "HappyoTime", '
+        f'JiyuKubun AS "JiyuKubun" FROM {table_name} WHERE Umaban = 1'
+    ) == {"DataKubun": "2", "HappyoTime": "07090710", "JiyuKubun": "003"}
+    import_records(
+        postgresql_db,
+        entrypoint,
+        [delete],
+        standard=standard,
+        auto_commit=auto_commit,
+    )
+    assert postgresql_db.fetch_all(
+        f'SELECT Umaban AS "Umaban", Bamei AS "Bamei", '
+        f'HappyoTime AS "HappyoTime", JiyuKubun AS "JiyuKubun" '
+        f"FROM {table_name} ORDER BY Umaban"
+    ) == [
+        {
+            "Umaban": 2,
+            "Bamei": "サバイバー",
+            "HappyoTime": "07090635",
+            "JiyuKubun": "002",
+        }
+    ]
 
 
 @pytest.mark.parametrize("defect", ("wrong-type", "short-text", "extra-unique", "deferrable-pk"))

--- a/tests/test_av_official_contract.py
+++ b/tests/test_av_official_contract.py
@@ -18,7 +18,11 @@ from src.database.schema_types import (
     get_table_primary_key_columns,
 )
 from src.database.sqlite_handler import SQLiteDatabase
-from src.importer.importer import DataImporter, validate_import_record_header
+from src.importer.importer import (
+    DataImporter,
+    _verify_av_key_not_null_constraints,
+    validate_import_record_header,
+)
 from src.importer.importer_optimized import OptimizedDataImporter
 from src.parser.av_parser import AVParser
 from src.parser.status_domain import (
@@ -203,6 +207,43 @@ def test_av_preflight_allows_a_missing_non_key_column_to_be_added(
         }
 
     assert "Bamei" in columns
+
+
+@pytest.mark.parametrize("table_name", ("NL_AV", "RT_AV"))
+@pytest.mark.parametrize(
+    "defect", ("wrong-key", "nullable-key", "wrong-type", "short-text", "extra-unique")
+)
+def test_av_preflight_rejects_unsafe_identity_before_any_additive_migration(
+    tmp_path, table_name: str, defect: str
+) -> None:
+    unsafe = SCHEMAS[table_name].replace("            Bamei TEXT,\n", "", 1)
+    if defect == "wrong-key":
+        unsafe = unsafe.replace("RaceNum, Umaban)", "RaceNum, HappyoTime, Umaban)", 1)
+    elif defect == "nullable-key":
+        unsafe = unsafe.replace("Umaban INTEGER NOT NULL", "Umaban INTEGER", 1)
+    elif defect == "wrong-type":
+        unsafe = unsafe.replace("Year INTEGER NOT NULL", "Year TEXT NOT NULL", 1)
+    elif defect == "short-text":
+        unsafe = unsafe.replace("HappyoTime TEXT", "HappyoTime VARCHAR(7)", 1)
+    else:
+        unsafe = unsafe.replace(
+            "PRIMARY KEY (", "UNIQUE (HappyoTime),\n            PRIMARY KEY (", 1
+        )
+    incomplete_ra = SCHEMAS["NL_RA"].replace("            Crlf TEXT,\n", "", 1)
+    assert unsafe != SCHEMAS[table_name]
+    assert incomplete_ra != SCHEMAS["NL_RA"]
+    database = SQLiteDatabase({"path": str(tmp_path / f"{table_name}-{defect}.db")})
+    with database:
+        database.execute(unsafe)
+        database.execute(incomplete_ra)
+        database.commit()
+        before_av = database.fetch_all(f'PRAGMA table_info("{table_name}")')
+        before_ra = database.fetch_all('PRAGMA table_info("NL_RA")')
+        with pytest.raises(SchemaMigrationError):
+            create_all_tables(database)
+
+        assert database.fetch_all(f'PRAGMA table_info("{table_name}")') == before_av
+        assert database.fetch_all('PRAGMA table_info("NL_RA")') == before_ra
 
 
 @pytest.mark.parametrize(
@@ -582,6 +623,41 @@ def test_av_postgresql_resolves_a_visible_table_after_an_empty_search_path_schem
         assert postgresql_db.fetch_one(
             f'SELECT COUNT(*) AS "n" FROM {table_name}'
         ) == {"n": 1}
+    finally:
+        postgresql_db.rollback()
+        postgresql_db.execute(f"SET search_path TO {owner}")
+        postgresql_db.execute(f"DROP SCHEMA IF EXISTS {empty_schema} CASCADE")
+        postgresql_db.commit()
+
+
+@pytest.mark.parametrize("standard", (False, True), ids=("native", "standard"))
+def test_av_postgresql_rejects_a_nullable_key_in_a_later_search_path_schema(
+    postgresql_db, standard: bool
+) -> None:
+    table_name = "TORIKESI_JYOGAI" if standard else "NL_AV"
+    schema_sql = JRAVAN_SCHEMAS[table_name] if standard else SCHEMAS[table_name]
+    schema_sql = schema_sql.replace(
+        (
+            "Umaban                         SMALLINT NOT NULL"
+            if standard
+            else "Umaban INTEGER NOT NULL"
+        ),
+        "Umaban                         SMALLINT         " if standard else "Umaban INTEGER",
+        1,
+    )
+    schema_sql = schema_sql.replace("PRIMARY KEY (", "UNIQUE (", 1)
+    owner = postgresql_db.fetch_one('SELECT current_schema() AS "owner"')["owner"]
+    empty_schema = f"av_empty_{uuid4().hex[:12]}"
+    postgresql_db.execute(schema_sql)
+    postgresql_db.execute(f"CREATE SCHEMA {empty_schema}")
+    postgresql_db.execute(f"SET search_path TO {empty_schema}, {owner}")
+    postgresql_db.commit()
+    try:
+        with pytest.raises(SchemaMigrationError, match="Umaban"):
+            _verify_av_key_not_null_constraints(postgresql_db, table_name)
+        assert postgresql_db.fetch_one(
+            f'SELECT COUNT(*) AS "n" FROM {table_name}'
+        ) == {"n": 0}
     finally:
         postgresql_db.rollback()
         postgresql_db.execute(f"SET search_path TO {owner}")

--- a/tests/test_av_official_contract.py
+++ b/tests/test_av_official_contract.py
@@ -11,7 +11,7 @@ import pytest
 
 from src.database.dual_handler import DualDatabase
 from src.database.migration import SchemaMigrationError
-from src.database.schema import SCHEMAS
+from src.database.schema import SCHEMAS, create_all_tables
 from src.database.schema_jravan import JRAVAN_SCHEMAS
 from src.database.schema_types import (
     get_table_column_nullability,
@@ -185,6 +185,24 @@ def test_av_layout_status_and_storage_keys_match_official_sources() -> None:
         assert tuple(get_table_primary_key_columns(table_name)) == AV_KEY
         nullability = get_table_column_nullability(table_name)
         assert all(nullability[column] is False for column in AV_KEY)
+
+
+@pytest.mark.parametrize("table_name", ("NL_AV", "RT_AV"))
+def test_av_preflight_allows_a_missing_non_key_column_to_be_added(
+    tmp_path, table_name: str
+) -> None:
+    partial_schema = SCHEMAS[table_name].replace("            Bamei TEXT,\n", "", 1)
+    assert partial_schema != SCHEMAS[table_name]
+    database = SQLiteDatabase({"path": str(tmp_path / f"{table_name}.db")})
+    with database:
+        database.execute(partial_schema)
+        database.commit()
+        create_all_tables(database)
+        columns = {
+            row["name"] for row in database.fetch_all(f'PRAGMA table_info("{table_name}")')
+        }
+
+    assert "Bamei" in columns
 
 
 @pytest.mark.parametrize(
@@ -451,6 +469,7 @@ def test_realtime_av_rejects_malformed_rows_and_replaces_complete_date_snapshot(
         rows = database.fetch_all("SELECT Umaban FROM RT_AV ORDER BY Umaban")
 
     assert first["success"] is True
+    assert first["inserted"] == 2
     assert rejected["success"] is False
     assert rejected["inserted"] == 0
     assert replaced["success"] is True
@@ -530,11 +549,44 @@ def postgresql_db():
         yield database
     finally:
         try:
-            database.rollback()
+            try:
+                database.rollback()
+            except Exception:
+                pass
             database.execute(f"DROP SCHEMA IF EXISTS {schema_name} CASCADE")
             database.commit()
         finally:
             database.disconnect()
+
+
+@pytest.mark.parametrize("standard", (False, True), ids=("native", "standard"))
+def test_av_postgresql_resolves_a_visible_table_after_an_empty_search_path_schema(
+    postgresql_db, standard: bool
+) -> None:
+    table_name = "TORIKESI_JYOGAI" if standard else "NL_AV"
+    schema_sql = JRAVAN_SCHEMAS[table_name] if standard else SCHEMAS[table_name]
+    owner = postgresql_db.fetch_one('SELECT current_schema() AS "owner"')["owner"]
+    empty_schema = f"av_empty_{uuid4().hex[:12]}"
+    postgresql_db.execute(schema_sql)
+    postgresql_db.execute(f"CREATE SCHEMA {empty_schema}")
+    postgresql_db.execute(f"SET search_path TO {empty_schema}, {owner}")
+    postgresql_db.commit()
+    try:
+        import_records(
+            postgresql_db,
+            "data-batch",
+            [parsed_av()],
+            standard=standard,
+            auto_commit=True,
+        )
+        assert postgresql_db.fetch_one(
+            f'SELECT COUNT(*) AS "n" FROM {table_name}'
+        ) == {"n": 1}
+    finally:
+        postgresql_db.rollback()
+        postgresql_db.execute(f"SET search_path TO {owner}")
+        postgresql_db.execute(f"DROP SCHEMA IF EXISTS {empty_schema} CASCADE")
+        postgresql_db.commit()
 
 
 @pytest.mark.parametrize("standard", (False, True), ids=("native", "standard"))

--- a/tests/test_av_official_contract.py
+++ b/tests/test_av_official_contract.py
@@ -1,0 +1,503 @@
+"""Official AV scratched/excluded-horse contracts."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from uuid import uuid4
+
+import pytest
+
+from src.database.dual_handler import DualDatabase
+from src.database.migration import SchemaMigrationError
+from src.database.schema import SCHEMAS
+from src.database.schema_jravan import JRAVAN_SCHEMAS
+from src.database.schema_types import (
+    get_table_column_nullability,
+    get_table_primary_key_columns,
+)
+from src.database.sqlite_handler import SQLiteDatabase
+from src.importer.importer import DataImporter, validate_import_record_header
+from src.importer.importer_optimized import OptimizedDataImporter
+from src.parser.av_parser import AVParser
+from src.parser.status_domain import (
+    CURRENT_ACCUMULATED_DATA_KUBUN,
+    HISTORICAL_DATA_KUBUN,
+)
+from src.realtime.updater import RealtimeUpdater
+
+FIXTURES = Path(__file__).parent / "fixtures" / "official_layout"
+OFFICIAL_MANIFEST = json.loads(
+    (FIXTURES / "jvdata_sdk500_manifest.json").read_text(encoding="utf-8")
+)
+AV_CONTRACT = json.loads((FIXTURES / "av_contract_4901.json").read_text(encoding="utf-8"))
+AV_KEY = (
+    "Year",
+    "MonthDay",
+    "JyoCD",
+    "Kaiji",
+    "Nichiji",
+    "RaceNum",
+    "Umaban",
+)
+
+AV_SDK_FIELD_NAMES = {
+    ("head", "RecordSpec"): "RecordSpec",
+    ("head", "DataKubun"): "DataKubun",
+    ("head", "MakeDate"): "MakeDate",
+    ("id", "Year"): "Year",
+    ("id", "MonthDay"): "MonthDay",
+    ("id", "JyoCD"): "JyoCD",
+    ("id", "Kaiji"): "Kaiji",
+    ("id", "Nichiji"): "Nichiji",
+    ("id", "RaceNum"): "RaceNum",
+    ("HappyoTime", "Month"): "HappyoTimeMonth",
+    ("HappyoTime", "Day"): "HappyoTimeDay",
+    ("HappyoTime", "Hour"): "HappyoTimeHour",
+    ("HappyoTime", "Minute"): "HappyoTimeMinute",
+    ("Umaban",): "Umaban",
+    ("Bamei",): "Bamei",
+    ("JiyuKubun",): "JiyuKubun",
+    ("crlf",): "RecordDelimiter",
+}
+
+
+def _put(record: bytearray, start: int, width: int, value: str) -> None:
+    encoded = value.encode("cp932", errors="strict")
+    assert len(encoded) <= width
+    record[start : start + width] = encoded.ljust(width, b" ")
+
+
+def build_av_record(
+    *,
+    data_kubun: str = "1",
+    make_date: str = "20260818",
+    year: str = "2026",
+    month_day: str = "0818",
+    jyo_cd: str = "05",
+    kaiji: str = "03",
+    nichiji: str = "08",
+    race_num: str = "11",
+    happyo_time: str = "08180930",
+    umaban: str = "01",
+    bamei: str = "テストホース",
+    jiyu_kubun: str = "001",
+) -> bytes:
+    record = bytearray(b" " * AVParser.RECORD_LENGTH)
+    for start, width, value in (
+        (0, 2, "AV"),
+        (2, 1, data_kubun),
+        (3, 8, make_date),
+        (11, 4, year),
+        (15, 4, month_day),
+        (19, 2, jyo_cd),
+        (21, 2, kaiji),
+        (23, 2, nichiji),
+        (25, 2, race_num),
+        (27, 8, happyo_time),
+        (35, 2, umaban),
+        (37, 36, bamei),
+        (73, 3, jiyu_kubun),
+    ):
+        _put(record, start, width, value)
+    record[-2:] = b"\r\n"
+    return bytes(record)
+
+
+def parsed_av(**overrides) -> dict:
+    parsed = AVParser().parse(build_av_record(**overrides))
+    assert parsed is not None
+    return parsed
+
+
+def sdk_av_parser_contract() -> list[tuple[str, int, int]]:
+    structures = OFFICIAL_MANIFEST["structures"]
+    contract: list[tuple[str, int, int]] = []
+
+    def visit(structure_name: str, start: int, path: tuple[str, ...]) -> None:
+        for field in structures[structure_name]["fields"]:
+            field_start = start + field["start"] - 1
+            field_path = (*path, field["name"])
+            parser_name = AV_SDK_FIELD_NAMES.get(field_path)
+            if parser_name is not None:
+                contract.append((parser_name, field_start, field["width"]))
+            elif field["kind"] == "nested":
+                visit(field["struct"], field_start, field_path)
+            else:
+                raise AssertionError(f"unmapped AV SDK scalar: {field_path}")
+
+    visit("JV_AV_INFO", 1, ())
+    return contract
+
+
+def import_records(
+    database, entrypoint, records, *, standard, auto_commit, batch_size=1000
+) -> None:
+    if entrypoint == "data-batch":
+        result = DataImporter(
+            database, batch_size=batch_size, use_jravan_schema=standard
+        ).import_records(iter(records), auto_commit=auto_commit)
+        assert result["records_imported"] == len(records)
+        assert result["records_failed"] == 0
+    elif entrypoint == "optimized-batch":
+        result = OptimizedDataImporter(
+            database, batch_size=batch_size, use_jravan_schema=standard
+        ).import_records(iter(records), auto_commit=auto_commit)
+        assert result["records_imported"] == len(records)
+        assert result["records_failed"] == 0
+    else:
+        importer = DataImporter(database, use_jravan_schema=standard)
+        assert all(
+            importer.import_single_record(record, auto_commit=auto_commit) for record in records
+        )
+    if not auto_commit:
+        database.commit()
+
+
+def test_av_layout_status_and_storage_keys_match_official_sources() -> None:
+    assert AV_CONTRACT["record_length"] == 78
+    assert tuple(AV_CONTRACT["primary_key"]) == AV_KEY
+    parser_contract = [(field.name, field.start + 1, field.length) for field in AVParser()._fields]
+    assert parser_contract == [tuple(field) for field in AV_CONTRACT["fields"]]
+
+    sdk_contract = sdk_av_parser_contract()
+    assert sdk_contract[:9] == parser_contract[:9]
+    assert sdk_contract[9:13] == [
+        ("HappyoTimeMonth", 28, 2),
+        ("HappyoTimeDay", 30, 2),
+        ("HappyoTimeHour", 32, 2),
+        ("HappyoTimeMinute", 34, 2),
+    ]
+    assert sdk_contract[13:] == parser_contract[10:]
+    assert OFFICIAL_MANIFEST["root_records"]["AV"] == {
+        "struct": "JV_AV_INFO",
+        "length": 78,
+    }
+    assert frozenset(AV_CONTRACT["current_data_kubun"]) == CURRENT_ACCUMULATED_DATA_KUBUN["AV"]
+    historical = HISTORICAL_DATA_KUBUN["AV"]
+    assert AV_CONTRACT["historical_data_kubun"]["value"] == historical.value
+    assert AV_CONTRACT["historical_data_kubun"]["valid_before_make_date"] == (
+        historical.valid_before_make_date.isoformat()
+    )
+
+    for table_name in ("NL_AV", "RT_AV", "TORIKESI_JYOGAI"):
+        assert tuple(get_table_primary_key_columns(table_name)) == AV_KEY
+        nullability = get_table_column_nullability(table_name)
+        assert all(nullability[column] is False for column in AV_KEY)
+
+
+@pytest.mark.parametrize(
+    "overrides",
+    (
+        {"make_date": "20260230"},
+        {"month_day": "0230"},
+        {"jyo_cd": "ZZ"},
+        {"race_num": "1X"},
+        {"happyo_time": "99999999"},
+        {"umaban": "19"},
+        {"jiyu_kubun": "999"},
+    ),
+)
+def test_av_parser_and_caller_reject_invalid_fields_before_mutation(overrides: dict) -> None:
+    with pytest.raises(ValueError):
+        AVParser().parse(build_av_record(**overrides))
+
+    valid = parsed_av()
+    field_name = {
+        "make_date": "MakeDate",
+        "month_day": "MonthDay",
+        "jyo_cd": "JyoCD",
+        "race_num": "RaceNum",
+        "happyo_time": "HappyoTime",
+        "umaban": "Umaban",
+        "jiyu_kubun": "JiyuKubun",
+    }[next(iter(overrides))]
+    valid[field_name] = next(iter(overrides.values()))
+    with pytest.raises(SchemaMigrationError):
+        validate_import_record_header(valid)
+
+
+@pytest.mark.parametrize("data_kubun", ("1", "2"))
+@pytest.mark.parametrize("reason", AV_CONTRACT["reason_codes"])
+def test_av_accepts_both_reason_representations_and_current_statuses(
+    data_kubun: str, reason: str
+) -> None:
+    record = parsed_av(
+        data_kubun=data_kubun,
+        happyo_time="00000000",
+        jiyu_kubun=reason,
+    )
+    assert validate_import_record_header(record) == ("AV", data_kubun)
+
+
+def test_av_historical_erase_has_an_opaque_body_and_an_exact_cutoff() -> None:
+    assert parsed_av(
+        data_kubun="0",
+        make_date="20030710",
+        happyo_time="99999999",
+        jiyu_kubun="999",
+    )
+    with pytest.raises(ValueError):
+        AVParser().parse(build_av_record(data_kubun="0", make_date="20030711"))
+
+
+@pytest.mark.parametrize("standard", (False, True), ids=("native", "standard"))
+@pytest.mark.parametrize("entrypoint", ("data-batch", "optimized-batch", "single"))
+@pytest.mark.parametrize("auto_commit", (True, False), ids=("owned", "caller"))
+def test_av_storage_revises_one_identity_and_exactly_erases_old_status_zero(
+    tmp_path, standard: bool, entrypoint: str, auto_commit: bool
+) -> None:
+    table_name = "TORIKESI_JYOGAI" if standard else "NL_AV"
+    schema = JRAVAN_SCHEMAS[table_name] if standard else SCHEMAS[table_name]
+    database = SQLiteDatabase({"path": str(tmp_path / f"{standard}-{entrypoint}-{auto_commit}.db")})
+    with database:
+        database.execute(schema)
+        database.commit()
+        first = parsed_av(make_date="20030710", happyo_time="07090630")
+        revision = parsed_av(
+            data_kubun="2",
+            make_date="20030710",
+            happyo_time="07090710",
+            jiyu_kubun="003",
+        )
+        delete = parsed_av(
+            data_kubun="0",
+            make_date="20030710",
+            happyo_time="99999999",
+            jiyu_kubun="999",
+        )
+        import_records(
+            database,
+            entrypoint,
+            [first, revision, delete],
+            standard=standard,
+            auto_commit=auto_commit,
+        )
+        assert database.fetch_one(f"SELECT COUNT(*) AS n FROM {table_name}") == {"n": 0}
+
+
+@pytest.mark.parametrize("standard", (False, True), ids=("native", "standard"))
+@pytest.mark.parametrize(
+    "defect", ("wrong-key", "nullable-key", "wrong-type", "short-text", "extra-unique")
+)
+def test_av_unsafe_schema_is_rejected_before_mutation(
+    tmp_path, standard: bool, defect: str
+) -> None:
+    table_name = "TORIKESI_JYOGAI" if standard else "NL_AV"
+    unsafe = JRAVAN_SCHEMAS[table_name] if standard else SCHEMAS[table_name]
+    if defect == "wrong-key":
+        unsafe = unsafe.replace("RaceNum, Umaban)", "RaceNum, HappyoTime, Umaban)", 1)
+    elif defect == "nullable-key":
+        unsafe = unsafe.replace(
+            (
+                "Umaban                         SMALLINT NOT NULL"
+                if standard
+                else "Umaban INTEGER NOT NULL"
+            ),
+            "Umaban                         SMALLINT         " if standard else "Umaban INTEGER",
+            1,
+        )
+    elif defect == "wrong-type":
+        unsafe = unsafe.replace(
+            (
+                "Year                           SMALLINT NOT NULL"
+                if standard
+                else "Year INTEGER NOT NULL"
+            ),
+            (
+                "Year                           VARCHAR(4) NOT NULL"
+                if standard
+                else "Year TEXT NOT NULL"
+            ),
+            1,
+        )
+    elif defect == "short-text":
+        unsafe = unsafe.replace(
+            "HappyoTime                     VARCHAR(8)" if standard else "HappyoTime TEXT",
+            "HappyoTime                     VARCHAR(7)" if standard else "HappyoTime VARCHAR(7)",
+            1,
+        )
+    else:
+        unsafe = unsafe.replace(
+            "PRIMARY KEY (", "UNIQUE (HappyoTime),\n            PRIMARY KEY (", 1
+        )
+
+    database = SQLiteDatabase({"path": str(tmp_path / f"{standard}-{defect}.db")})
+    with database:
+        database.execute(unsafe)
+        database.commit()
+        with pytest.raises(SchemaMigrationError):
+            DataImporter(database, use_jravan_schema=standard).import_records(iter([parsed_av()]))
+        assert database.fetch_one(f"SELECT COUNT(*) AS n FROM {table_name}") == {"n": 0}
+
+
+def test_av_malformed_caller_is_rejected_before_mutation(tmp_path) -> None:
+    database = SQLiteDatabase({"path": str(tmp_path / "caller.db")})
+    with database:
+        database.execute(SCHEMAS["NL_AV"])
+        database.commit()
+        malformed = parsed_av()
+        malformed["RaceNum"] = "1X"
+        with pytest.raises(SchemaMigrationError):
+            DataImporter(database).import_records(iter([malformed]))
+        assert database.fetch_one("SELECT COUNT(*) AS n FROM NL_AV") == {"n": 0}
+
+
+@pytest.mark.parametrize("changes", ({"Bamei": "😀"}, {"Bamei": "あ" * 19}))
+def test_av_caller_text_must_fit_the_official_cp932_span(changes: dict) -> None:
+    record = parsed_av()
+    record.update(changes)
+    with pytest.raises(SchemaMigrationError):
+        validate_import_record_header(record)
+
+
+def test_realtime_av_rejects_malformed_rows_and_replaces_complete_date_snapshot(tmp_path) -> None:
+    database = SQLiteDatabase({"path": str(tmp_path / "realtime.db")})
+    with database:
+        for table_name in RealtimeUpdater.DATE_SNAPSHOT_TABLES:
+            database.execute(SCHEMAS[table_name])
+        database.commit()
+        updater = RealtimeUpdater(database)
+        first = updater.process_parsed_records_batch(
+            [parsed_av(umaban="01"), parsed_av(umaban="02")]
+        )
+        malformed = parsed_av(umaban="03")
+        malformed["RaceNum"] = "1X"
+        rejected = updater.process_parsed_records_batch([malformed])
+        updater.replace_date_snapshot("20260818")
+        replaced = updater.process_parsed_records_batch([parsed_av(umaban="02")])
+        database.commit()
+        rows = database.fetch_all("SELECT Umaban FROM RT_AV ORDER BY Umaban")
+
+    assert first["success"] is True
+    assert rejected["success"] is False
+    assert rejected["inserted"] == 0
+    assert replaced["success"] is True
+    assert replaced["inserted"] == 1
+    assert rows == [{"Umaban": 2}]
+
+
+@pytest.mark.parametrize("unsafe_target", ("primary", "secondary"))
+def test_av_dual_rejects_one_unsafe_target_before_either_database_changes(
+    tmp_path, unsafe_target: str
+) -> None:
+    safe = SCHEMAS["NL_AV"]
+    unsafe = safe.replace("PRIMARY KEY (", "UNIQUE (HappyoTime),\n            PRIMARY KEY (", 1)
+    primary = SQLiteDatabase({"path": str(tmp_path / "primary.db")})
+    secondary = SQLiteDatabase({"path": str(tmp_path / "secondary.db")})
+    with primary, secondary:
+        primary.execute(unsafe if unsafe_target == "primary" else safe)
+        secondary.execute(unsafe if unsafe_target == "secondary" else safe)
+        primary.commit()
+        secondary.commit()
+        with pytest.raises(SchemaMigrationError):
+            DataImporter(DualDatabase(primary, secondary)).import_records(iter([parsed_av()]))
+        assert primary.fetch_one("SELECT COUNT(*) AS n FROM NL_AV") == {"n": 0}
+        assert secondary.fetch_one("SELECT COUNT(*) AS n FROM NL_AV") == {"n": 0}
+
+
+@pytest.fixture
+def postgresql_db():
+    if os.getenv("JLTSQL_RUN_POSTGRESQL_INTEGRATION") != "1":
+        pytest.skip("Set JLTSQL_RUN_POSTGRESQL_INTEGRATION=1 to run PostgreSQL tests")
+
+    from scripts.setup_pg_test_db import postgresql_test_config
+    from src.database.postgresql_handler import PostgreSQLDatabase
+
+    database = PostgreSQLDatabase(postgresql_test_config())
+    schema_name = f"jlt_av_{uuid4().hex[:12]}"
+    database.connect()
+    try:
+        database.execute(f"CREATE SCHEMA {schema_name}")
+        database.execute(f"SET search_path TO {schema_name}")
+        database.commit()
+        yield database
+    finally:
+        try:
+            database.rollback()
+            database.execute(f"DROP SCHEMA IF EXISTS {schema_name} CASCADE")
+            database.commit()
+        finally:
+            database.disconnect()
+
+
+@pytest.mark.parametrize("standard", (False, True), ids=("native", "standard"))
+@pytest.mark.parametrize("entrypoint", ("data-batch", "optimized-batch", "single"))
+@pytest.mark.parametrize("auto_commit", (True, False), ids=("owned", "caller"))
+def test_av_postgresql_identity_revision_and_historical_exact_erase(
+    postgresql_db, standard: bool, entrypoint: str, auto_commit: bool
+) -> None:
+    table_name = "TORIKESI_JYOGAI" if standard else "NL_AV"
+    schema = JRAVAN_SCHEMAS[table_name] if standard else SCHEMAS[table_name]
+    postgresql_db.execute(schema)
+    postgresql_db.commit()
+    first = parsed_av(make_date="20030710", happyo_time="07090630")
+    revision = parsed_av(
+        data_kubun="2",
+        make_date="20030710",
+        happyo_time="07090710",
+        jiyu_kubun="003",
+    )
+    delete = parsed_av(
+        data_kubun="0",
+        make_date="20030710",
+        happyo_time="99999999",
+        jiyu_kubun="999",
+    )
+    import_records(
+        postgresql_db,
+        entrypoint,
+        [first, revision, delete],
+        standard=standard,
+        auto_commit=auto_commit,
+        batch_size=1,
+    )
+    assert postgresql_db.fetch_one(f'SELECT COUNT(*) AS "n" FROM {table_name}') == {"n": 0}
+
+
+@pytest.mark.parametrize("defect", ("wrong-type", "short-text", "extra-unique", "deferrable-pk"))
+def test_av_postgresql_rejects_unsafe_identity_schema(postgresql_db, defect: str) -> None:
+    schema = SCHEMAS["NL_AV"]
+    if defect == "wrong-type":
+        schema = schema.replace("Year INTEGER NOT NULL", "Year TEXT NOT NULL", 1)
+    elif defect == "short-text":
+        schema = schema.replace("HappyoTime TEXT", "HappyoTime VARCHAR(7)", 1)
+    elif defect == "extra-unique":
+        schema = schema.replace(
+            "PRIMARY KEY (", "UNIQUE (HappyoTime),\n            PRIMARY KEY (", 1
+        )
+    else:
+        schema = schema.replace(
+            "RaceNum, Umaban)",
+            "RaceNum, Umaban) DEFERRABLE INITIALLY DEFERRED",
+            1,
+        )
+    postgresql_db.execute(schema)
+    postgresql_db.commit()
+    with pytest.raises(SchemaMigrationError):
+        DataImporter(postgresql_db).import_records(iter([parsed_av()]))
+
+
+@pytest.mark.parametrize("postgresql_is_primary", (False, True))
+def test_av_postgresql_dual_rejects_an_unsafe_peer_before_either_changes(
+    postgresql_db, tmp_path, postgresql_is_primary: bool
+) -> None:
+    safe = SCHEMAS["NL_AV"]
+    unsafe = safe.replace("PRIMARY KEY (", "UNIQUE (HappyoTime),\n            PRIMARY KEY (", 1)
+    sqlite = SQLiteDatabase({"path": str(tmp_path / "peer.db")})
+    with sqlite:
+        if postgresql_is_primary:
+            postgresql_db.execute(safe)
+            sqlite.execute(unsafe)
+            primary, secondary = postgresql_db, sqlite
+        else:
+            sqlite.execute(safe)
+            postgresql_db.execute(unsafe)
+            primary, secondary = sqlite, postgresql_db
+        postgresql_db.commit()
+        sqlite.commit()
+        with pytest.raises(SchemaMigrationError):
+            DataImporter(DualDatabase(primary, secondary)).import_records(iter([parsed_av()]))
+        assert sqlite.fetch_one("SELECT COUNT(*) AS n FROM NL_AV") == {"n": 0}
+        assert postgresql_db.fetch_one('SELECT COUNT(*) AS "n" FROM NL_AV') == {"n": 0}

--- a/tests/test_current_record_validation.py
+++ b/tests/test_current_record_validation.py
@@ -38,10 +38,11 @@ PREVIOUS_OFFICIAL_LENGTHS = tuple(
 # These parsers also require populated domain-specific arrays or master fields.
 # Their valid payloads are covered by dedicated official-contract tests; this
 # module limits their positive case to the shared physical-record envelope.
-# CS, JG, SE, WC, WE, and WF additionally require their official fixed-width keys,
+# AV, CS, JG, SE, WC, WE, and WF additionally require their official fixed-width keys,
 # bodies, race composites, and current status/code domains, so a generic
 # space-filled envelope is not valid.
 DOMAIN_PAYLOAD_REQUIRED = {
+    "AV",
     "CK",
     "CS",
     "DM",

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -104,6 +104,19 @@ class TestIndividualParsers:
                     umaban="01",
                     kettonum="2024012345",
                 )
+            if record_type == "AV":
+                mutable = bytearray(data)
+                mutable[11:15] = b"2024"
+                mutable[15:19] = b"0601"
+                mutable[19:21] = b"05"
+                mutable[21:23] = b"03"
+                mutable[23:25] = b"08"
+                mutable[25:27] = b"11"
+                mutable[27:35] = b"06010930"
+                mutable[35:37] = b"01"
+                mutable[37:73] = "テスト馬".encode("cp932").ljust(36, b" ")
+                mutable[73:76] = b"001"
+                data = bytes(mutable)
             if record_type == "DM":
                 mutable = bytearray(data)
                 mutable[11:15] = b"2024"


### PR DESCRIPTION
## What changed

- bind AV to the official 78-byte JV-Data layout and seven-part key
- reject malformed raw and caller-built AV records before schema or row mutation
- support current statuses 1/2 and the pre-2003-07-11 status-0 exact erase boundary
- accept both documented reason-field representations around the 2021 transition
- make native, realtime, and standard AV storage fail closed on unsafe keys, types, nullability, capacities, extra uniqueness, and unusable PostgreSQL primary keys
- reject a legacy `AVOIDENCE`-only standard schema on every DualDatabase target before unrelated migration; canonical `TORIKESI_JYOGAI` wins when both coexist
- count accepted AV provider operations consistently when PostgreSQL folds same-key operations into one upsert
- resolve AV PostgreSQL catalogs through the visible relation and retain safe additive migration for missing native/realtime non-key columns

## Root cause and impact

The parser previously checked physical length but not the complete AV semantic contract. Native and realtime key columns were nullable, standard storage had no primary key, and historical status 0 was persisted rather than applied as an exact erase. Malformed caller values could also be coerced into another official identity. Review then found three adjacent gaps in legacy Dual preflight, PostgreSQL operation statistics, and exact-erase test strength, followed by two migration/catalog gaps: a valid PostgreSQL table later in `search_path` was falsely rejected, and safe missing non-key columns were rejected before additive migration. The production repair closes all five without weakening identity constraints.

## Red-first evidence

- unchanged base `a152045c4bf9c6f9c53f483d2f2cfa0baa05dcb7`: original AV contract produced `20 failed, 11 passed` before the configured max-failure stop
- parent candidate `219fbd52b2eb612200cd70f74de1aee06d6ee6c6`: legacy-only Dual preflight failed in all 6 entrypoint/target combinations; PostgreSQL provider-order statistics failed in all 8 batch importer/schema/transaction combinations with `2 != 3`
- parent candidate `bf78af91da3146d2265c827b4e3e084457c58b67`: missing-`Bamei` native/realtime migration failed 2/2; PostgreSQL later-search-path native/standard imports failed 2/2 because all seven keys were falsely reported nullable
- final oracle strengthening: a temporary fail-open preflight mutant made the SQLite no-mutation matrix fail 10/10; a temporary `attnotnull=True` mutant made the PostgreSQL negative fail 2/2 with `DID NOT RAISE`; both mutants were removed before commit
- the strengthened erase test rejects the prior whole-table-delete mutant in all 12 historical batch cases and the realtime case

## Verification

Candidate: `7f714787c20b5ca7d12576d2040b4dca303f4175`

- production repair commit: `ff75fb1b88f7e9d4226ebfa38622837e7502d70b`; the final follow-up changes only tests and the tracked worklog
- final AV SQLite contract: `67 passed, 22 skipped`
- final fresh PostgreSQL 16 AV contract: `89 passed`
- affected existing suite: `341 passed, 29 skipped, 10 subtests passed`
- paired review regressions: SQLite safe-add 2/2, SQLite unsafe no-mutation 10/10, PostgreSQL visible-table positive 2/2, and PostgreSQL nullable-key negative 2/2
- prior exact-candidate independent PostgreSQL operation matrix: all 8 batch combinations reported `records_imported=3`, `records_failed=0`, with correct revision and survivor readback
- `TEST GATE PASS`; fatal flake8, `uv lock --check`, `mkdocs build --strict`, and `git diff --check` passed
- fresh wheel/sdist build, distribution-content gate, and extracted-wheel init smoke passed on the package-equivalent production candidate; the final delta does not change packaging metadata or package membership
- disposable PostgreSQL containers and temporary artifacts removed; worktree clean

`specs/` and official oracle fixtures remain tracked for auditability and remain excluded from wheel/sdist artifacts. This change makes no 64-bit SDK support claim. Rows with NULL or incomplete legacy AV identity are preserved only in backup; operators must recreate the affected table and reimport from the provider rather than infer or reuse those rows.
