### PR TITLE
fix: enforce the official HC hill-training contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,8 +40,9 @@
 ### Fixed
 
 - `HC`を公式現行60バイト配置と4項目キーへ結び付け、native `NL_HC`と標準名
-  `HANRO`で0.1秒単位の全time field、provider順の更新、status 0 exact delete、
-  caller validation、SQLite/PostgreSQLのstrict schema preflightを一致させた。
+  `HANRO`で7つの走破・lap time fieldを0.1秒単位で保持し、provider順の更新、
+  status 0 exact delete、caller validation、SQLite/PostgreSQLのstrict schema
+  preflightを一致させた。
   旧nullable/keyless/wrong-key tableや未承認の追加列・constraintは自動移行せず
   backup・rebuild・`SLOP` reimportを要求し、HCは蓄積系のみであることを明記した
 - `HS`を現行HOSNの公式200バイト配置と3項目キーへ結び付け、native `NL_HS`と

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,11 @@
 
 ### Fixed
 
+- `HC`を公式現行60バイト配置と4項目キーへ結び付け、native `NL_HC`と標準名
+  `HANRO`で0.1秒単位の全time field、provider順の更新、status 0 exact delete、
+  caller validation、SQLite/PostgreSQLのstrict schema preflightを一致させた。
+  旧nullable/keyless/wrong-key tableは自動移行せずbackup・rebuild・`SLOP`
+  reimportを要求し、HCは蓄積系のみであることを明記した
 - `HS`を現行HOSNの公式200バイト配置と3項目キーへ結び付け、native `NL_HS`と
   標準名`SALE`でprovider順の更新・exact delete・operation統計を一致させた。
   旧196バイトHOSEは引き続き拒否し、v2以前の既存tableは空でも値長から推測せず

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,8 +42,8 @@
 - `HC`を公式現行60バイト配置と4項目キーへ結び付け、native `NL_HC`と標準名
   `HANRO`で0.1秒単位の全time field、provider順の更新、status 0 exact delete、
   caller validation、SQLite/PostgreSQLのstrict schema preflightを一致させた。
-  旧nullable/keyless/wrong-key tableは自動移行せずbackup・rebuild・`SLOP`
-  reimportを要求し、HCは蓄積系のみであることを明記した
+  旧nullable/keyless/wrong-key tableや未承認の追加列・constraintは自動移行せず
+  backup・rebuild・`SLOP` reimportを要求し、HCは蓄積系のみであることを明記した
 - `HS`を現行HOSNの公式200バイト配置と3項目キーへ結び付け、native `NL_HS`と
   標準名`SALE`でprovider順の更新・exact delete・operation統計を一致させた。
   旧196バイトHOSEは引き続き拒否し、v2以前の既存tableは空でも値長から推測せず

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -35,6 +35,12 @@ Public API replacements:
 - native and standard schemas now verify primary keys, types, capacities,
   child-table constraints, and cancellation/delete behavior before mutation;
   several record families gained complete child storage or corrected keys
+- HC hill-training storage now binds the current official 60-byte layout and
+  four-part identity in both `NL_HC` and standard `HANRO`, preserves every
+  tenths-of-a-second timing field as seconds, applies provider-order update and
+  exact status-0 erase, and rejects legacy nullable/keyless/unsafe tables before
+  mutation. Operators must back up, rebuild, and reimport `SLOP`; HC remains an
+  accumulated-only format and does not imply realtime support
 - SE horse-per-race storage now uses the complete eight-part official identity
   ending in `KettoNum` across native, realtime, and `UMA_RACE`; legacy
   seven-key/keyless tables require backup, rebuild, and `RACE` reimport rather

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -38,9 +38,9 @@ Public API replacements:
 - HC hill-training storage now binds the current official 60-byte layout and
   four-part identity in both `NL_HC` and standard `HANRO`, preserves every
   tenths-of-a-second timing field as seconds, applies provider-order update and
-  exact status-0 erase, and rejects legacy nullable/keyless/unsafe tables before
-  mutation. Operators must back up, rebuild, and reimport `SLOP`; HC remains an
-  accumulated-only format and does not imply realtime support
+  exact status-0 erase, and rejects legacy nullable/keyless/unsafe or extended
+  tables before mutation. Operators must back up, rebuild, and reimport `SLOP`;
+  HC remains an accumulated-only format and does not imply realtime support
 - SE horse-per-race storage now uses the complete eight-part official identity
   ending in `KettoNum` across native, realtime, and `UMA_RACE`; legacy
   seven-key/keyless tables require backup, rebuild, and `RACE` reimport rather

--- a/docs/data_support.md
+++ b/docs/data_support.md
@@ -240,7 +240,8 @@ key、必須header/key/body、公式field capacityを使用し、7つの走破�
 `DataKubun=0`は4項目keyだけを使うexact eraseです。非key本文をdecodeしないのは
 削除指示を失わせないためのproject policyであり、provider仕様が任意binary本文を
 規定するという意味ではありません。既存のnullable、keyless、wrong-key、wrong-type、
-追加UNIQUE/FK/CHECKを持つ`NL_HC`/`HANRO`は自動修復せず、mutation前に停止します。
+追加列または追加UNIQUE/FK/CHECKを持つ`NL_HC`/`HANRO`は自動修復せず、
+mutation前に停止します。
 backup後にcurrent schemaでrebuildし、`SLOP`を再importしてください。HCは蓄積系のみで
 `RT_HC`は作成しません。美浦の測定距離は2004-11-30に600mから800mへ変わりましたが、
 物理record長と4項目identityは変わりません。

--- a/docs/data_support.md
+++ b/docs/data_support.md
@@ -53,7 +53,7 @@ jrvltsql は JRA / 中央競馬専用です。NAR / 地方競馬はこのリポ�
 | `DIFN` | `DIFF` | 蓄積系マスタ差分 | `UM`, `KS`, `CH`, `BR`, `BN`, `RC` | `NL_UM`, `NL_KS`, `NL_KS_SEISEKI`, `NL_CH`, `NL_CH_SEISEKI`, `NL_BR`, `NL_BN`, `NL_RC` | はい | いいえ | はい | 旧名 `DIFF` は受け付けません（下記参照）。 |
 | `BLDN` | `BLOD` | 血統情報 | `HN`, `SK`, `BT` | `NL_HN`, `NL_SK`, `NL_BT` | はい | いいえ | はい | 旧名 `BLOD` は受け付けません（下記参照）。 |
 | `MING` | - | データマイニング予想 | `DM`, `TM` | `NL_DM`, `NL_TM` | はい | いいえ | はい | full quickstart に含めています。 |
-| `SLOP` | - | 坂路調教関連 | `HC` | `NL_HC`（native）、`HANRO`（標準名モード） | はい | いいえ | はい | 現行60バイトを全項目保存します。公式4項目キーの同一recordを更新し、`0`はexact deleteです。standard / full quickstart に含めています。 |
+| `SLOP` | - | 坂路調教関連 | `HC` | `NL_HC`（native）、`HANRO`（標準名モード） | はい | いいえ | はい | 現行`DataKubun=1`は60バイトの全項目を保存します。`DataKubun=0`は本文を保存せず、公式4項目キーでexact deleteします。standard / full quickstart に含めています。 |
 | `WOOD` | - | ウッドチップ調教関連 | `WC` | `NL_WC`（native）、`WOOD`（標準名モード） | はい | いいえ | はい | 現行105バイトを全項目保存します。公式キーはトレセン区分・調教年月日・調教時刻・血統登録番号の4項目で、`0` は同じキーの削除です。standard / full quickstart に含めています。 |
 | `YSCH` | - | 開催スケジュール | `YS` | `NL_YS` | はい | いいえ | はい | 開催カレンダー保守に使います。 |
 | `HOSN` | `HOSE` | 競走馬市場取引価格 | `HS` | `NL_HS` | はい | いいえ | はい | 旧名 `HOSE` は受け付けません（下記参照）。 |

--- a/docs/data_support.md
+++ b/docs/data_support.md
@@ -53,7 +53,7 @@ jrvltsql は JRA / 中央競馬専用です。NAR / 地方競馬はこのリポ�
 | `DIFN` | `DIFF` | 蓄積系マスタ差分 | `UM`, `KS`, `CH`, `BR`, `BN`, `RC` | `NL_UM`, `NL_KS`, `NL_KS_SEISEKI`, `NL_CH`, `NL_CH_SEISEKI`, `NL_BR`, `NL_BN`, `NL_RC` | はい | いいえ | はい | 旧名 `DIFF` は受け付けません（下記参照）。 |
 | `BLDN` | `BLOD` | 血統情報 | `HN`, `SK`, `BT` | `NL_HN`, `NL_SK`, `NL_BT` | はい | いいえ | はい | 旧名 `BLOD` は受け付けません（下記参照）。 |
 | `MING` | - | データマイニング予想 | `DM`, `TM` | `NL_DM`, `NL_TM` | はい | いいえ | はい | full quickstart に含めています。 |
-| `SLOP` | - | 坂路調教関連 | `HC` | `NL_HC` | はい | いいえ | はい | standard / full quickstart に含めています。 |
+| `SLOP` | - | 坂路調教関連 | `HC` | `NL_HC`（native）、`HANRO`（標準名モード） | はい | いいえ | はい | 現行60バイトを全項目保存します。公式4項目キーの同一recordを更新し、`0`はexact deleteです。standard / full quickstart に含めています。 |
 | `WOOD` | - | ウッドチップ調教関連 | `WC` | `NL_WC`（native）、`WOOD`（標準名モード） | はい | いいえ | はい | 現行105バイトを全項目保存します。公式キーはトレセン区分・調教年月日・調教時刻・血統登録番号の4項目で、`0` は同じキーの削除です。standard / full quickstart に含めています。 |
 | `YSCH` | - | 開催スケジュール | `YS` | `NL_YS` | はい | いいえ | はい | 開催カレンダー保守に使います。 |
 | `HOSN` | `HOSE` | 競走馬市場取引価格 | `HS` | `NL_HS` | はい | いいえ | はい | 旧名 `HOSE` は受け付けません（下記参照）。 |
@@ -229,6 +229,21 @@ jrvltsql は現在、以下 38 種類の JRA レコード種別に対してパ�
 対応済みの速報系レコードは `RT_*` にも保存できます。公式時系列オッズは
 `TS_O1` / `TS_O2`、開催週速報オッズは `TS_SOKUHO_O1`〜`TS_SOKUHO_O6`
 に保存します。
+
+`HC`（坂路調教）は現行JV-Data 4.9.0.1 / SDK 5.0.0の60バイト配置だけを
+受け付けます。identityは`TresenKubun`, `ChokyoDate`, `ChokyoTime`,
+`KettoNum`の4項目です。native `NL_HC`と標準名`HANRO`は同じordered primary
+key、必須header/key/body、公式field capacityを使用し、7つの走破・lap timeを
+0.1秒単位のprovider整数から秒へ正規化します。公式の測定不能値`0000`/`000`は
+0.0秒として欠損と混同せず保持します。
+
+`DataKubun=0`は4項目keyだけを使うexact eraseです。非key本文をdecodeしないのは
+削除指示を失わせないためのproject policyであり、provider仕様が任意binary本文を
+規定するという意味ではありません。既存のnullable、keyless、wrong-key、wrong-type、
+追加UNIQUE/FK/CHECKを持つ`NL_HC`/`HANRO`は自動修復せず、mutation前に停止します。
+backup後にcurrent schemaでrebuildし、`SLOP`を再importしてください。HCは蓄積系のみで
+`RT_HC`は作成しません。美浦の測定距離は2004-11-30に600mから800mへ変わりましたが、
+物理record長と4項目identityは変わりません。
 
 `HS`（競走馬市場取引価格）は現行JV-Data 4.9.0.1 / SDK 5.0.0の
 200バイト配置だけを受け付け、旧196バイト配置は常に拒否します。公式の保存identityは

--- a/specs/operations/20260818_hc_official_contract_worklog.md
+++ b/specs/operations/20260818_hc_official_contract_worklog.md
@@ -255,3 +255,22 @@
   parser/schema/metadata selection is `568 passed, 9 skipped`; fatal flake8,
   test gate, lock check and diff check remain green. The disposable container
   was removed.
+
+## PR review (2026-08-18)
+
+- PR #213 was opened from exact head
+  `58f4ae126a4cd47d9fbab8120a15a2be14a2c69b` after both bounded closure
+  reviews returned GREEN with P0/P1/P2 zero. GitHub Copilot review was requested
+  once, but reported that the requester's quota was exhausted; no Copilot code
+  review was available. The independent Codex reviews remain the critical
+  review evidence.
+- CodeRabbit completed against that head with two actionable documentation-
+  precision comments and no implementation blocker. Both were accepted in one
+  documentation-only batch: `ChokyoTime` is no longer implied to use 0.1-second
+  units, and the SLOP summary now distinguishes stored `DataKubun=1` rows from
+  key-only `DataKubun=0` exact-delete commands. No new external review was
+  requested for this wording-only correction.
+- The documentation-only correction passed
+  `tests/test_public_setup_contract.py tests/test_quickstart_cli.py` (`60 passed`)
+  and `mkdocs build --strict`. No production source or test contract changed,
+  so the previously recorded exact-head implementation suites were not replayed.

--- a/specs/operations/20260818_hc_official_contract_worklog.md
+++ b/specs/operations/20260818_hc_official_contract_worklog.md
@@ -235,3 +235,23 @@
   verifier's new option defaults to the old permissive behavior and only HC
   opts into exact columns; the first candidate already passed the one-time full
   workflow-equivalent suite.
+
+## First carry-forward finding and repair
+
+- The first replacement candidate
+  `70207a8fcce93fbadee04d58cc38fb3546334304` closed the ordinary extra-column
+  and three test-oracle findings, but two independent reviewers found one
+  same-root SQLite bypass before any PR was opened. `PRAGMA table_info` omits
+  generated/hidden columns, so a generated `ExternalRequired ... NOT NULL`
+  column remained invisible and failed only at DML.
+- The generated-column negative was added before changing production and
+  failed for both `NL_HC` and `HANRO` with the required
+  `Failed: DID NOT RAISE SchemaMigrationError` result. The bounded repair uses
+  `PRAGMA table_xinfo` for the strict column census and adds an actual
+  PostgreSQL-primary/SQLite-secondary Dual case. Default permissive consumers
+  still ignore actual-minus-expected columns, so their behavior is unchanged.
+- Post-repair SQLite HC/reconstructed result: `121 passed, 2 skipped`. Fresh
+  PostgreSQL 16 plus cross-engine Dual result: `45 passed`. The affected
+  parser/schema/metadata selection is `568 passed, 9 skipped`; fatal flake8,
+  test gate, lock check and diff check remain green. The disposable container
+  was removed.

--- a/specs/operations/20260818_hc_official_contract_worklog.md
+++ b/specs/operations/20260818_hc_official_contract_worklog.md
@@ -100,3 +100,91 @@
 - Per the user-approved fallback, Codex will implement only after red-first
   evidence, and at least two independent Codex reviewers will audit one frozen
   candidate SHA before PR/release action.
+
+## Red-first contract evidence
+
+- Added the compact reviewed fixture
+  `tests/fixtures/official_layout/hc_contract_4901.json` and one grouped
+  `tests/test_hc_official_contract.py` contract. It binds both pinned workbook
+  hashes, every physical byte span, SDK 5.0 manifest structure, current status
+  set, exact four-column identity, parser/caller validation, native/standard
+  storage, provider order, exact delete, schema fail-closed behavior and the
+  optional actual-PostgreSQL route.
+- On unchanged production base
+  `ed39ac78aa371e7ce4e18a87d8a25c50a07fe78a`, the paired provider-valid
+  layout/parser oracle passed while the gate failed as intended:
+  `31 failed, 1 passed, 1 skipped`. The failures independently cover invalid
+  dates/time/key/timing acceptance, status-0 whole-body decoding, keyless
+  standard storage, nullable/unsafe schemas, tombstone rather than exact
+  deletion, caller coercion before validation, and all batch/single entry
+  points. This is the required evidence that the new contract can say no;
+  production implementation had not been changed when it was recorded.
+
+## Next safe action
+
+1. Apply one aggregated HC repair to parser, both executable schemas, metadata,
+   both batch importers, single-record import, exact-delete routing and strict
+   schema preflight.
+2. Run the compact SQLite contract, adjacent parser/importer/schema suites and
+   a fresh disposable PostgreSQL contract on the resulting candidate.
+3. Freeze one full SHA, then collect independent official-oracle,
+   data-integrity and release/package reviews before any PR or merge action.
+
+## Aggregated implementation and local evidence
+
+- Implemented the repair as one batch rather than iterating per finding:
+  - `HCParser` now binds all official spans, validates real dates/HHMM,
+    training-center/key domains and every fixed numeric timing field. Status 0
+    decodes only its exact key and keeps the non-key body opaque by documented
+    project policy.
+  - `NL_HC` and standard `HANRO` now have complete required columns, exact
+    four-part primary keys and lossless numeric capacities. Metadata is derived
+    from the executable native schema.
+  - both batch importers and `DataImporter.import_single_record` share the HC
+    validator, strict schema verifier and exact-delete route. Standard `HANRO`
+    is non-additive; nullable/keyless/wrong-key/wrong-type and unapproved
+    UNIQUE/CHECK/FK constraints stop before mutation on every migration target.
+  - provider-operation statistics preserve same-key update/delete order on
+    SQLite and PostgreSQL; HC remains accumulated-only with no `RT_HC` claim.
+  - public support/release documents now state the official identity, units,
+    migration/reimport boundary and unverified realtime/non-applicable scope.
+- A later extension of the same strict-schema gate was independently replayed
+  on unchanged base `ed39ac78aa371e7ce4e18a87d8a25c50a07fe78a` before it
+  was accepted: both native/standard extra-CHECK cases failed because the base
+  reached DML instead of raising `SchemaMigrationError`, and the Dual unsafe-
+  primary case failed because the base accepted and wrote it. The candidate
+  rejects all three before mutation. This supplements the initial grouped
+  `31 failed` red evidence and proves the new constraint/target census can fail.
+- Current candidate validation so far:
+  - compact SQLite HC contract: `35 passed, 1 PostgreSQL opt-in skipped`;
+  - adjacent parser/status/importer/schema set: `404 passed, 1 skipped`;
+  - metadata/schema/index set: `96 passed, 8 skipped`;
+  - fresh PostgreSQL 16 compact contract with native/standard, both importers,
+    auto-commit true/false, provider-order readback and schema negatives:
+    `36 passed`;
+  - test-gate validator: `TEST GATE PASS`; fatal flake8 selection: `0`;
+    compileall and `uv lock --check`: pass.
+- The required one-time broad regression run initially exposed three generic
+  parser positives that still supplied a blank HC body. Those tests were based
+  on the old permissive parser rather than the official format, so their HC
+  sample was corrected to include the four-part identity and all seven fixed
+  timing spans. The targeted three cases then passed, and the complete local
+  workflow-equivalent suite finished `3314 passed, 333 skipped, 14 deselected,
+  20 subtests passed`.
+- Final post-format focused aggregate finished `602 passed, 8 skipped`; fatal
+  flake8 remained `0`, `TEST GATE PASS`, `uv lock --check` passed, and
+  `git diff --check` was clean.
+- A fresh PEP 517 wheel and sdist built as unreleased `2.0.0.dev0`; the actual
+  distribution content gate passed both artifacts and the installed-wheel init
+  smoke passed. The artifacts and local build metadata were removed afterward.
+- The disposable PostgreSQL container was removed after the run. No provider,
+  production, GitHub, NAR, MCP or release state was changed.
+
+## Next safe action
+
+1. Run the one justified broad local suite because central importer/schema
+   dispatch changed, then strict documentation and distribution build gates.
+2. Commit/push one clean candidate SHA and freeze it.
+3. Run the three independent read-only Codex reviews in parallel against that
+   exact SHA, aggregate all concrete findings once, and only then decide the
+   repair/PR boundary.

--- a/specs/operations/20260818_hc_official_contract_worklog.md
+++ b/specs/operations/20260818_hc_official_contract_worklog.md
@@ -1,0 +1,102 @@
+# HC official contract worklog
+
+## Iteration start (2026-08-18)
+
+- Objective: audit and implement the complete current JRA-VAN `HC` hill-training
+  contract against the pinned official 4.8.0.2/4.9.0.1 workbooks and SDK 5.0
+  source/manifest, then prove parser, native/standard storage, exact identity,
+  importer/realtime behavior, migration safety, documentation and distribution
+  behavior on SQLite and fresh PostgreSQL.
+- Minimum scope: `HC` only. Do not mix the remaining `TC` or `CC` record
+  iterations, NAR implementation, MCP changes, release tagging, or any 64-bit
+  support claim into this PR.
+- Repository: `miyamamoto/jrvltsql`.
+- Dedicated worktree:
+  `/home/keiba/scratch/20260818_jrvltsql_hc_official`.
+- Branch: `agent/hc-official-contract-20260818`.
+- Base/HEAD/origin master at start:
+  `ed39ac78aa371e7ce4e18a87d8a25c50a07fe78a` (HS PR #212 squash merge).
+- Published production release remains `v1.6.10`; source version is the
+  unreleased `2.0.0.dev0`. This iteration does not publish either artifact.
+- Dependency order: complete and merge this HC iteration first; start TC/CC
+  only from the resulting latest master; run the final cumulative official-doc,
+  real-provider-storage and release-document audit after all record iterations;
+  only then release jrvltsql and proceed to jrvltsql-nar and jvlink-mcp-server.
+
+## Initial risk and verification plan
+
+- Existing reconstruction is only a 60-byte layout smoke. The initial audit
+  must independently pin every physical span, current/historical status and
+  key rule, unit/sentinel semantics, native `NL_HC`, standard `HANRO`, importer
+  and realtime ownership, schema constraint/type/nullability behavior, and
+  metadata/documentation claims.
+- Before changing a parser/validator/schema gate, add one compact official
+  negative contract and run it on this unchanged base to prove red; retain the
+  paired provider-valid green. Do not add one test function per reviewer
+  hypothesis.
+- Test real durable rows rather than parser-only success: provider-order
+  updates/deletes, two distinct official keys, same-key revision, both batch
+  importers, single-record, auto-commit true/false, SQLite, fresh PostgreSQL and
+  Dual orientation where relevant.
+- Use Claude Code `--model fable` for the complex aggregated implementation if
+  the CLI service is available; otherwise record the failure and use Codex with
+  two independent critical reviews on one frozen candidate SHA. Reuse one
+  Claude session for this worktree/iteration.
+- STOP on official-source ambiguity that changes storage meaning, any
+  provider-valid over-rejection, partial/silent field loss, wrong-key collapse,
+  mutation-before-schema rejection, stats/durability divergence, transaction
+  ownership leak, candidate drift during review, failed executed CI step,
+  unresolved thread, or unsupported SDK/64-bit/release claim.
+
+## Next safe action
+
+1. Freeze start SHA and clean state, then extract the HC oracle from the pinned
+   official sources without editing production.
+2. Compare that oracle to parser/schema/mapping/importer/realtime/tests/docs and
+   reproduce concrete gaps on SQLite.
+3. Add one compact red-first HC contract, then implement one aggregated repair.
+
+## Initial official-source audit (2026-08-18)
+
+- The start identity remained exact: HEAD and `origin/master` were both
+  `ed39ac78aa371e7ce4e18a87d8a25c50a07fe78a`; the only worktree change was
+  this intentional worklog.
+- Pinned primary artifacts were re-read from
+  `/home/keiba/scratch/20260815_jvdata_official_materials`:
+  - `JV-Data4802.xlsx` SHA-256
+    `6a567f10b601115eca350571f36d27d9d28bd2d3835ea72b5bc057711155d4a7`;
+  - `JV-Data4901.xlsx` SHA-256
+    `23bafd375f704acbdd696b5032ac1619f17d47e882587d6e7954b610527a8234`;
+  - `JV-Data4901.pdf` SHA-256
+    `b6c21aae4ccbba6a71c5e8065609c4fbb1ccee826c16e7d99ca6ecf7a4101522`.
+- Both current workbooks define the same gap-free 60-byte HC record in
+  `フォーマット` rows 1142-1167. The SDK 5.0 manifest independently binds
+  `HC` to `JV_HC_HANRO`, width 60, with the same 15 logical fields and CRLF at
+  bytes 59-60.
+- The official ordered identity is
+  `(TresenKubun, ChokyoDate, ChokyoTime, KettoNum)`. `DataKubun` is exactly
+  `1` (initial value) or `0` (exact record deletion). The body owns seven
+  fixed-width numeric timing fields; `0000`/`000` are documented measurement-
+  failure values and their units are tenths of a second.
+- `特記事項` rows 195-198 state that SLOP provides data from 2003 onward and
+  that Miho used 600m measurement through 2004-11-29 and 800m from
+  2004-11-30. This changes interpretation/availability, not physical size.
+  The change history only records wording/unit additions (rows 170, 174 and
+  344); no alternate HC physical layout is documented in the two pinned
+  current workbooks or SDK manifest.
+- `データ提供タイミング・提供単位` row 26 defines irregular daily delivery,
+  one complete day/training-center unit, and one-year retention. HC is
+  accumulated through SLOP, not an RT table in the current application.
+
+## Claude availability and fallback
+
+- The selected complex-task model was Claude Code `--model fable` (CLI
+  2.1.233), because this iteration combines a validator, exact-delete order,
+  cross-backend schema gates and migration safety. The audit-only launch used
+  session id `8fd313d0-4bc7-4b46-9cb4-d03e4f4ea659` but failed before a usable
+  session was created: the local OAuth session was expired and could not be
+  refreshed. No repository mutation came from Claude and there is no usable
+  session to resume.
+- Per the user-approved fallback, Codex will implement only after red-first
+  evidence, and at least two independent Codex reviewers will audit one frozen
+  candidate SHA before PR/release action.

--- a/specs/operations/20260818_hc_official_contract_worklog.md
+++ b/specs/operations/20260818_hc_official_contract_worklog.md
@@ -180,11 +180,58 @@
 - The disposable PostgreSQL container was removed after the run. No provider,
   production, GitHub, NAR, MCP or release state was changed.
 
+## Frozen-candidate reviews and aggregated repair (2026-08-18)
+
+- The first frozen candidate was
+  `ffb75074d61d7ef9424ba210088442795f394504`, based on unchanged
+  `ed39ac78aa371e7ce4e18a87d8a25c50a07fe78a`. Three independent read-only
+  Codex reviews completed against that exact clean SHA: official-source oracle,
+  SQLite/PostgreSQL 16/18/Dual data-integrity, and test/package/release surface.
+- All three reviewers agreed on one production P1. An otherwise current
+  `NL_HC` or `HANRO` with an unapproved `ExternalRequired TEXT NOT NULL` column
+  passed schema preflight and failed only at DML. Actual Dual SQLite/PostgreSQL
+  could then preserve the row on only one backend. The first repair test was
+  run before production changes and failed as required: the native and standard
+  schema cases each reported `Failed: DID NOT RAISE SchemaMigrationError`; the
+  Dual case likewise returned normal failed-import statistics instead of the
+  preflight exception.
+- The release/test review also proved three false-green classes with temporary
+  mutants while leaving the candidate untouched:
+  - removing `KettoNum` from the erase predicate still left the original HC
+    suite green because the sole survivor differed in two key columns;
+  - allowing blank live timing spans still left the adjacent suites green;
+  - adding HC to realtime routing still left the HC suite green despite the
+    accumulated-only contract.
+- The aggregated repair therefore uses one HC-only exact physical-column
+  contract, extends the existing schema-negative matrix with required-column
+  and FK cases, gives exact erase one survivor per individual key component,
+  adds the blank timing and realtime/cache negatives, and binds the reviewed
+  history/delivery/sentinel fixture content directly in the existing oracle
+  test. This is one repair batch, not a per-finding review loop.
+
 ## Next safe action
 
-1. Run the one justified broad local suite because central importer/schema
-   dispatch changed, then strict documentation and distribution build gates.
-2. Commit/push one clean candidate SHA and freeze it.
-3. Run the three independent read-only Codex reviews in parallel against that
-   exact SHA, aggregate all concrete findings once, and only then decide the
-   repair/PR boundary.
+1. Run the repaired compact contract on SQLite and fresh PostgreSQL, including
+   cross-engine Dual unsafe-primary/unsafe-secondary cases.
+2. Run only affected adjacent importer/schema/parser tests plus static,
+   documentation and distribution gates justified by this repair.
+3. Freeze and push one replacement full SHA, request bounded carry-forward
+   reviews of the repair, then create the PR only if all gates are green.
+
+## Aggregated repair verification
+
+- Repaired SQLite HC/reconstructed contract: `119 passed, 2 skipped`.
+- Fresh disposable PostgreSQL 16 HC contract: `43 passed`. This includes
+  native/standard operation order, the four one-column-different erase
+  survivors, required-column and FK negatives, and SQLite/PostgreSQL Dual with
+  the unsafe table on each side. The container was removed afterward.
+- Affected HC/parser/current-layout/reconstructed/schema/metadata selection:
+  `566 passed, 9 skipped`.
+- Black check, fatal flake8 selection, compileall, `uv lock --check` and the
+  fail-closed test-gate validator all passed; `git diff --check` remains part of
+  the final clean gate.
+- Remaining steps are an exact committed-tree distribution build/smoke and the
+  bounded carry-forward reviews. No broad suite is repeated because the common
+  verifier's new option defaults to the old permissive behavior and only HC
+  opts into exact columns; the first candidate already passed the one-time full
+  workflow-equivalent suite.

--- a/src/database/schema.py
+++ b/src/database/schema.py
@@ -448,20 +448,20 @@ SCHEMAS = {
     """,
     "NL_HC": """
         CREATE TABLE IF NOT EXISTS NL_HC (
-            RecordSpec TEXT,
-            DataKubun TEXT,
-            MakeDate TEXT,
-            TresenKubun TEXT,
-            ChokyoDate TEXT,
-            ChokyoTime TEXT,
-            KettoNum TEXT,
-            HaronTime4 REAL,
-            LapTime4 REAL,
-            HaronTime3 REAL,
-            LapTime3 REAL,
-            HaronTime2 REAL,
-            LapTime2 REAL,
-            LapTime1 REAL,
+            RecordSpec TEXT NOT NULL,
+            DataKubun TEXT NOT NULL,
+            MakeDate TEXT NOT NULL,
+            TresenKubun TEXT NOT NULL,
+            ChokyoDate TEXT NOT NULL,
+            ChokyoTime TEXT NOT NULL,
+            KettoNum TEXT NOT NULL,
+            HaronTime4 REAL NOT NULL,
+            LapTime4 REAL NOT NULL,
+            HaronTime3 REAL NOT NULL,
+            LapTime3 REAL NOT NULL,
+            HaronTime2 REAL NOT NULL,
+            LapTime2 REAL NOT NULL,
+            LapTime1 REAL NOT NULL,
             RecordDelimiter TEXT,
             PRIMARY KEY (TresenKubun, ChokyoDate, ChokyoTime, KettoNum)
         )
@@ -2759,6 +2759,7 @@ STRICT_WE_STORAGE_TABLES = frozenset({"NL_WE", "RT_WE"})
 STRICT_AV_STORAGE_TABLES = frozenset({"NL_AV", "RT_AV"})
 STRICT_HR_STORAGE_TABLES = frozenset({"NL_HR", "RT_HR"})
 STRICT_HS_STORAGE_TABLES = frozenset({"NL_HS"})
+STRICT_HC_STORAGE_TABLES = frozenset({"NL_HC"})
 STRICT_JC_STORAGE_TABLES = frozenset({"NL_JC", "RT_JC"})
 
 
@@ -2768,6 +2769,7 @@ def _preflight_existing_strict_storage(db: BaseDatabase) -> None:
     from src.database.migration import _migration_targets
     from src.importer.importer import (
         verify_av_storage_schema,
+        verify_hc_storage_schema,
         verify_hr_storage_schema,
         verify_hs_storage_schema,
         verify_jc_storage_schema,
@@ -2808,6 +2810,9 @@ def _preflight_existing_strict_storage(db: BaseDatabase) -> None:
                     table_name,
                     allow_missing_columns=True,
                 )
+        for table_name in STRICT_HC_STORAGE_TABLES:
+            if target.table_exists_strict(table_name):
+                verify_hc_storage_schema(target, table_name)
         for table_name in STRICT_JC_STORAGE_TABLES:
             if target.table_exists_strict(table_name):
                 verify_jc_storage_schema(target, table_name)
@@ -2898,6 +2903,10 @@ class SchemaManager:
                 from src.importer.importer import verify_hs_storage_schema
 
                 verify_hs_storage_schema(self.db, table_name)
+            if table_name in STRICT_HC_STORAGE_TABLES:
+                from src.importer.importer import verify_hc_storage_schema
+
+                verify_hc_storage_schema(self.db, table_name)
             if table_name in STRICT_JC_STORAGE_TABLES:
                 from src.importer.importer import verify_jc_storage_schema
 
@@ -2960,6 +2969,10 @@ class SchemaManager:
                     from src.importer.importer import verify_hs_storage_schema
 
                     verify_hs_storage_schema(self.db, table_name)
+                if table_name in STRICT_HC_STORAGE_TABLES:
+                    from src.importer.importer import verify_hc_storage_schema
+
+                    verify_hc_storage_schema(self.db, table_name)
                 if table_name in STRICT_JC_STORAGE_TABLES:
                     from src.importer.importer import verify_jc_storage_schema
 
@@ -3325,6 +3338,10 @@ def create_all_tables(db: BaseDatabase) -> None:
                 from src.importer.importer import verify_hs_storage_schema
 
                 verify_hs_storage_schema(db, table_name)
+            if table_name in STRICT_HC_STORAGE_TABLES:
+                from src.importer.importer import verify_hc_storage_schema
+
+                verify_hc_storage_schema(db, table_name)
             if table_name in STRICT_JC_STORAGE_TABLES:
                 from src.importer.importer import verify_jc_storage_schema
 

--- a/src/database/schema_jravan.py
+++ b/src/database/schema_jravan.py
@@ -196,20 +196,21 @@ JRAVAN_SCHEMAS: Dict[str, str] = {
     """,
     "HANRO": """
         CREATE TABLE IF NOT EXISTS HANRO (
-            RecordSpec                     CHAR(2)             ,  -- レコード種別ID
-            DataKubun                      CHAR(1)             ,  -- データ区分
-            MakeDate                       DATE                ,  -- YYYYMMDD形式の日付
-            TresenKubun                    VARCHAR(255)        ,  -- テキスト
-            ChokyoDate                     VARCHAR(255)        ,  -- テキスト
-            ChokyoTime                     VARCHAR(255)        ,  -- テキスト
-            KettoNum                       VARCHAR(255)        ,  -- テキスト
-            HaronTime4                     VARCHAR(255)        ,  -- テキスト
-            LapTime4                       VARCHAR(255)        ,  -- テキスト
-            HaronTime3                     VARCHAR(255)        ,  -- テキスト
-            LapTime3                       DECIMAL(4,1)        ,  -- ラップタイム3
-            HaronTime2                     VARCHAR(255)        ,  -- テキスト
-            LapTime2                       DECIMAL(4,1)        ,  -- ラップタイム2
-            LapTime1                       DECIMAL(4,1)          -- ラップタイム1(秒)
+            RecordSpec                     CHAR(2) NOT NULL    ,  -- レコード種別ID
+            DataKubun                      CHAR(1) NOT NULL    ,  -- 0:削除 1:初期値
+            MakeDate                       DATE NOT NULL       ,  -- データ作成年月日
+            TresenKubun                    CHAR(1) NOT NULL    ,  -- 0:美浦 1:栗東
+            ChokyoDate                     VARCHAR(8) NOT NULL ,  -- 調教年月日
+            ChokyoTime                     VARCHAR(4) NOT NULL ,  -- 調教時刻
+            KettoNum                       VARCHAR(10) NOT NULL,  -- 血統登録番号
+            HaronTime4                     DECIMAL(4,1) NOT NULL, -- 4F走破タイム
+            LapTime4                       DECIMAL(3,1) NOT NULL, -- 800M-600M
+            HaronTime3                     DECIMAL(4,1) NOT NULL, -- 3F走破タイム
+            LapTime3                       DECIMAL(3,1) NOT NULL, -- 600M-400M
+            HaronTime2                     DECIMAL(4,1) NOT NULL, -- 2F走破タイム
+            LapTime2                       DECIMAL(3,1) NOT NULL, -- 400M-200M
+            LapTime1                       DECIMAL(3,1) NOT NULL, -- 200M-0M
+            PRIMARY KEY (TresenKubun, ChokyoDate, ChokyoTime, KettoNum)
         )
     """,
     "WOOD": """

--- a/src/database/schema_metadata.py
+++ b/src/database/schema_metadata.py
@@ -1024,30 +1024,16 @@ TABLE_METADATA: Dict[str, TableMetadata] = {
         indexes=["JyoCD", "Kyori"],
     ),
 
-    "NL_HC": {
-        "table_name": "NL_HC",
-        "record_type": "HC",
-        "description": "調教タイム情報",
-        "purpose": "坂路調教時の走破タイムとラップタイムを格納",
-        "columns": [
-            {"name": "レコード種別ID", "type": "TEXT", "description": "レコード種別識別子（'HC'）", "example": "HC", "nullable": False},
-            {"name": "データ区分", "type": "TEXT", "description": "データ区分", "example": "1", "nullable": False},
-            {"name": "データ作成年月日", "type": "TEXT", "description": "データ作成日", "example": "20240525", "nullable": False},
-            {"name": "トレセン区分", "type": "TEXT", "description": "トレーニングセンター（0=美浦、1=栗東）", "example": "1", "nullable": False},
-            {"name": "調教年月日", "type": "TEXT", "description": "調教実施日", "example": "20240525", "nullable": False},
-            {"name": "調教時刻", "type": "TEXT", "description": "調教実施時刻", "example": "0630", "nullable": False},
-            {"name": "血統登録番号", "type": "TEXT", "description": "馬の血統登録番号", "example": "2020123456", "nullable": False},
-            {"name": "4F走破タイム", "type": "REAL", "description": "4ハロン走破タイム（秒）", "example": "52.3", "nullable": True},
-            {"name": "800M-600Mラップ", "type": "REAL", "description": "800M～600Mのラップタイム（秒）", "example": "13.8", "nullable": True},
-            {"name": "3F走破タイム", "type": "REAL", "description": "3ハロン走破タイム（秒）", "example": "38.5", "nullable": True},
-            {"name": "600M-400Mラップ", "type": "REAL", "description": "600M～400Mのラップタイム（秒）", "example": "13.0", "nullable": True},
-            {"name": "2F走破タイム", "type": "REAL", "description": "2ハロン走破タイム（秒）", "example": "25.5", "nullable": True},
-            {"name": "400M-200Mラップ", "type": "REAL", "description": "400M～200Mのラップタイム（秒）", "example": "12.8", "nullable": True},
-            {"name": "200M-0Mラップ", "type": "REAL", "description": "200M～0Mのラップタイム（秒）", "example": "12.7", "nullable": True}
-        ],
-        "primary_key": ["トレセン区分", "調教年月日", "調教時刻", "血統登録番号"],
-        "indexes": ["血統登録番号", "調教年月日"]
-    },
+    "NL_HC": _schema_backed_metadata(
+        "NL_HC",
+        record_type="HC",
+        description="坂路調教タイム情報",
+        purpose=(
+            "公式60バイトHCをトレセン・調教日・調教時刻・血統登録番号の"
+            "4項目キーで保持し、走破タイムとラップを秒へ正規化"
+        ),
+        indexes=["KettoNum", "ChokyoDate"],
+    ),
 
     "NL_HS": {
         "table_name": "NL_HS",

--- a/src/importer/importer.py
+++ b/src/importer/importer.py
@@ -555,8 +555,29 @@ _HS_LOSSLESS_TEXT_WIDTHS = {
     }
     for table_name in _HS_STORAGE_TABLES
 }
+_HC_STORAGE_TABLES = frozenset({"NL_HC", "HANRO"})
+_HC_KEY_COLUMNS = ("TresenKubun", "ChokyoDate", "ChokyoTime", "KettoNum")
+_HC_LOSSLESS_TEXT_WIDTHS = {
+    "NL_HC": {
+        "RecordSpec": 2,
+        "DataKubun": 1,
+        "MakeDate": 8,
+        "TresenKubun": 1,
+        "ChokyoDate": 8,
+        "ChokyoTime": 4,
+        "KettoNum": 10,
+    },
+    "HANRO": {
+        "RecordSpec": 2,
+        "DataKubun": 1,
+        "TresenKubun": 1,
+        "ChokyoDate": 8,
+        "ChokyoTime": 4,
+        "KettoNum": 10,
+    },
+}
 _PROVIDER_OPERATION_COUNT_STORAGE_TABLES = (
-    _AV_STORAGE_TABLES | _HR_STORAGE_TABLES | _HS_STORAGE_TABLES
+    _AV_STORAGE_TABLES | _HR_STORAGE_TABLES | _HS_STORAGE_TABLES | _HC_STORAGE_TABLES
 )
 _JC_STORAGE_TABLES = frozenset({"NL_JC", "RT_JC", "KISYU_CHANGE"})
 _JC_KEY_COLUMNS = (
@@ -615,6 +636,7 @@ _STRICT_NONADDITIVE_STANDARD_TABLES = frozenset(
         "JOGAIBA",
         "HARAI",
         "SALE",
+        "HANRO",
         "KISYU_CHANGE",
         "TORIKESI_JYOGAI",
         "TENKO_BABA",
@@ -1641,6 +1663,108 @@ def validate_hs_record(record: dict, table_name: str | None = None) -> bool:
     except ValueError as error:
         raise SchemaMigrationError(str(error)) from error
     record["CurrentLayoutVersion"] = HSParser.CURRENT_LAYOUT_VERSION
+    return True
+
+
+def _verify_hc_no_unapproved_constraints(
+    database: BaseDatabase,
+    table_name: str,
+) -> None:
+    """Reject constraints beyond HC's one official immediate primary key."""
+
+    from src.database.migration import _migration_targets
+
+    targets = _migration_targets(database)
+    if targets != (database,):
+        for target in targets:
+            _verify_hc_no_unapproved_constraints(target, table_name)
+        return
+
+    db_type = database.get_db_type()
+    if db_type == "sqlite":
+        if database.fetch_all(f'PRAGMA foreign_key_list("{table_name}")'):
+            raise SchemaMigrationError(
+                f"HC storage {table_name} has unsupported FOREIGN KEY constraints"
+            )
+        row = database.fetch_one(
+            "SELECT sql FROM sqlite_master WHERE type = 'table' AND name = ?",
+            (table_name,),
+        )
+        definition = str((row or {}).get("sql") or "")
+        if re.search(r"\bCHECK\s*\(", definition, flags=re.IGNORECASE):
+            raise SchemaMigrationError(
+                f"HC storage {table_name} has unsupported CHECK constraints"
+            )
+        return
+    if db_type == "postgresql":
+        unexpected = database.fetch_all(
+            "SELECT conname AS constraint_name, contype AS constraint_type "
+            "FROM pg_constraint WHERE conrelid = to_regclass(?) "
+            "AND contype NOT IN ('p', 'n') ORDER BY conname",
+            (table_name.lower(),),
+        )
+        if unexpected:
+            raise SchemaMigrationError(
+                f"HC storage {table_name} has unsupported additional constraints: "
+                f"{unexpected}"
+            )
+        return
+    raise SchemaMigrationError(
+        f"HC constraints cannot be verified for database type {db_type!r}"
+    )
+
+
+def verify_hc_storage_schema(database: BaseDatabase, table_name: str) -> bool:
+    """Fail closed unless HC storage preserves every field and official key."""
+
+    if table_name not in _HC_STORAGE_TABLES:
+        return False
+    transaction_snapshot = _snapshot_validation_transactions(database)
+    from src.database.migration import verify_table_schema
+    from src.database.schema import SCHEMAS
+    from src.database.schema_jravan import JRAVAN_SCHEMAS
+
+    try:
+        schema_sql = SCHEMAS.get(table_name) or JRAVAN_SCHEMAS.get(table_name)
+        if schema_sql is None:
+            raise SchemaMigrationError(f"HC storage schema is undefined: {table_name}")
+        verify_table_schema(database, table_name, schema_sql)
+        _verify_strict_storage_column_contract(
+            database,
+            table_name,
+            schema_sql,
+            allow_missing_columns=False,
+            storage_label="HC",
+            lossless_text_widths=_HC_LOSSLESS_TEXT_WIDTHS[table_name],
+        )
+        _verify_hc_no_unapproved_constraints(database, table_name)
+        _verify_replacement_key_constraints(database, table_name, "HC storage")
+        return True
+    except Exception:
+        _rollback_call_created_validation_transactions(
+            transaction_snapshot,
+            context="failed HC schema validation",
+        )
+        raise
+
+
+def validate_hc_record(record: dict, table_name: str | None = None) -> bool:
+    """Validate a caller-built HC row before coercion or mutation."""
+
+    if table_name is not None and table_name not in _HC_STORAGE_TABLES:
+        return False
+    if _record_type_from_record(record) != "HC":
+        if table_name is None:
+            return False
+        raise SchemaMigrationError(f"{table_name} received a non-HC record")
+
+    from src.parser.hc_parser import HCParser
+
+    try:
+        data_kubun = resolve_record_data_kubun(record)
+        HCParser.validate_current_fields(record, data_kubun=data_kubun)
+    except ValueError as error:
+        raise SchemaMigrationError(str(error)) from error
     return True
 
 
@@ -2760,6 +2884,8 @@ def _preflight_standard_schema_migrations(
             verify_hr_storage_schema(database, standard_name)
         if standard_name == "SALE":
             verify_hs_storage_schema(database, standard_name)
+        if standard_name == "HANRO":
+            verify_hc_storage_schema(database, standard_name)
         if standard_name == "KISYU_CHANGE":
             verify_jc_storage_schema(database, standard_name)
         if standard_name in {"UMA", "COURSE"}:
@@ -3285,6 +3411,7 @@ _OFFICIAL_ERASE_KEY_COLUMNS = {
     "JC": _JC_KEY_COLUMNS,
     "HR": _MINING_RACE_KEY_COLUMNS,
     "HS": _HS_KEY_COLUMNS,
+    "HC": _HC_KEY_COLUMNS,
     # One physical H1/H6/O1-O6 record expands into multiple child rows.
     "H1": _MINING_RACE_KEY_COLUMNS,
     "H6": _MINING_RACE_KEY_COLUMNS,
@@ -3309,6 +3436,7 @@ _OFFICIAL_ERASE_STORAGE_TABLES = {
     "JC": set(_JC_STORAGE_TABLES),
     "HR": {"NL_HR", "RT_HR", "HARAI"},
     "HS": set(_HS_STORAGE_TABLES),
+    "HC": set(_HC_STORAGE_TABLES),
     "H1": {"NL_H1", "RT_H1", "HYO_TANPUKU"},
     "H6": {"NL_H6", "RT_H6", "HYO_SANRENTAN"},
     "O1": {"NL_O1", "RT_O1", "ODDS_TANPUKUWAKU_HEAD"},
@@ -3410,6 +3538,8 @@ def validate_import_record_header(record: dict) -> tuple[str, str]:
             validate_hr_record(record)
         if record_type == "HS":
             validate_hs_record(record)
+        if record_type == "HC":
+            validate_hc_record(record)
         if record_type == "JC":
             validate_jc_record(record)
         return record_type, data_kubun
@@ -5954,6 +6084,7 @@ class DataImporter:
         self._verified_av_tables: set[str] = set()
         self._verified_hr_tables: set[str] = set()
         self._verified_hs_tables: set[str] = set()
+        self._verified_hc_tables: set[str] = set()
         self._verified_jc_tables: set[str] = set()
         self._verified_cs_tables: set[str] = set()
         self._verified_jg_tables: set[str] = set()
@@ -6219,6 +6350,7 @@ class DataImporter:
                     validate_av_record(first_record, first_table_name)
                     validate_hr_record(first_record, first_table_name)
                     validate_hs_record(first_record, first_table_name)
+                    validate_hc_record(first_record, first_table_name)
                     validate_jc_record(first_record, first_table_name)
                 records = chain((first_record,), records)
         except Exception:
@@ -6304,6 +6436,10 @@ class DataImporter:
                     if verify_hs_storage_schema(self.database, table_name):
                         self._verified_hs_tables.add(table_name)
                 validate_hs_record(record, table_name)
+                if table_name not in self._verified_hc_tables:
+                    if verify_hc_storage_schema(self.database, table_name):
+                        self._verified_hc_tables.add(table_name)
+                validate_hc_record(record, table_name)
                 if table_name not in self._verified_jc_tables:
                     if verify_jc_storage_schema(self.database, table_name):
                         self._verified_jc_tables.add(table_name)
@@ -6953,6 +7089,7 @@ class DataImporter:
                 validate_av_record(record, table_name)
                 validate_hr_record(record, table_name)
                 validate_hs_record(record, table_name)
+                validate_hc_record(record, table_name)
                 validate_jc_record(record, table_name)
         except SchemaMigrationError:
             if not auto_commit:
@@ -7034,6 +7171,10 @@ class DataImporter:
                 if verify_hs_storage_schema(self.database, table_name):
                     self._verified_hs_tables.add(table_name)
             validate_hs_record(record, table_name)
+            if table_name not in self._verified_hc_tables:
+                if verify_hc_storage_schema(self.database, table_name):
+                    self._verified_hc_tables.add(table_name)
+            validate_hc_record(record, table_name)
             if table_name not in self._verified_jc_tables:
                 if verify_jc_storage_schema(self.database, table_name):
                     self._verified_jc_tables.add(table_name)

--- a/src/importer/importer.py
+++ b/src/importer/importer.py
@@ -848,6 +848,7 @@ def _verify_strict_storage_column_contract(
     storage_label: str = "SE",
     lossless_text_widths: dict[str, int] | None = None,
     allow_stricter_not_null: frozenset[str] = frozenset(),
+    allow_extra_columns: bool = True,
 ) -> None:
     """Verify every present strict-storage column's type and nullability."""
 
@@ -868,6 +869,7 @@ def _verify_strict_storage_column_contract(
                 storage_label=storage_label,
                 lossless_text_widths=lossless_text_widths,
                 allow_stricter_not_null=allow_stricter_not_null,
+                allow_extra_columns=allow_extra_columns,
             )
         return
 
@@ -899,6 +901,11 @@ def _verify_strict_storage_column_contract(
         for row in rows
     }
     mismatches: list[str] = []
+    if not allow_extra_columns:
+        expected_columns = {column.lower() for column in definitions}
+        extra_columns = sorted(set(actual) - expected_columns)
+        if extra_columns:
+            mismatches.append(f"unapproved extra columns={extra_columns}")
     for column_name, definition in definitions.items():
         column = column_name.lower()
         if column not in actual:
@@ -1736,6 +1743,7 @@ def verify_hc_storage_schema(database: BaseDatabase, table_name: str) -> bool:
             allow_missing_columns=False,
             storage_label="HC",
             lossless_text_widths=_HC_LOSSLESS_TEXT_WIDTHS[table_name],
+            allow_extra_columns=False,
         )
         _verify_hc_no_unapproved_constraints(database, table_name)
         _verify_replacement_key_constraints(database, table_name, "HC storage")

--- a/src/importer/importer.py
+++ b/src/importer/importer.py
@@ -887,7 +887,11 @@ def _verify_strict_storage_column_contract(
             (table_name.lower(),),
         )
     elif database.get_db_type() == "sqlite":
-        rows = database.fetch_all(f'PRAGMA table_info("{table_name}")')
+        # table_info omits generated/hidden columns, which can still make an
+        # otherwise valid insert fail. Exact-column consumers must see the
+        # complete physical census; permissive consumers retain their prior
+        # behavior because they ignore actual-minus-expected columns.
+        rows = database.fetch_all(f'PRAGMA table_xinfo("{table_name}")')
     else:
         raise SchemaMigrationError(
             f"{storage_label} column contract cannot be verified for database type "

--- a/src/importer/importer_optimized.py
+++ b/src/importer/importer_optimized.py
@@ -13,11 +13,11 @@ from typing import Dict, Iterator, List, Optional, Union
 from src.database.base import BaseDatabase, DatabaseError
 from src.database.migration import SchemaMigrationError
 from src.importer.importer import (
-    _PROVIDER_OPERATION_COUNT_STORAGE_TABLES,
     _ORDERED_MASTER_STORAGE_TABLES,
     _PREPARED_CH_SEISEKI_ROWS_KEY,
     _PREPARED_CK_ROWS_KEY,
     _PREPARED_KS_SEISEKI_ROWS_KEY,
+    _PROVIDER_OPERATION_COUNT_STORAGE_TABLES,
     _RC_STORAGE_TABLES,
     _STANDARD_ODDS_CONFIG_BY_OWNER,
     _STANDARD_VOTE_CONFIG_BY_OWNER,
@@ -66,6 +66,7 @@ from src.importer.importer import (
     resolve_standard_table_name,
     rollback_failed_import,
     validate_av_record,
+    validate_hc_record,
     validate_hr_record,
     validate_hs_record,
     validate_import_record_header,
@@ -80,9 +81,10 @@ from src.importer.importer import (
     verify_ch_coupled_table,
     verify_ck_coupled_tables,
     verify_cs_storage_schema,
-    verify_hy_storage_schema,
+    verify_hc_storage_schema,
     verify_hr_storage_schema,
     verify_hs_storage_schema,
+    verify_hy_storage_schema,
     verify_jc_storage_schema,
     verify_jg_storage_schema,
     verify_ks_coupled_table,
@@ -136,6 +138,7 @@ class OptimizedDataImporter:
         self._verified_av_tables: set[str] = set()
         self._verified_hr_tables: set[str] = set()
         self._verified_hs_tables: set[str] = set()
+        self._verified_hc_tables: set[str] = set()
         self._verified_jc_tables: set[str] = set()
         self._verified_cs_tables: set[str] = set()
         self._verified_jg_tables: set[str] = set()
@@ -353,6 +356,7 @@ class OptimizedDataImporter:
                     validate_av_record(first_record, first_table_name)
                     validate_hr_record(first_record, first_table_name)
                     validate_hs_record(first_record, first_table_name)
+                    validate_hc_record(first_record, first_table_name)
                     validate_jc_record(first_record, first_table_name)
                 records = chain((first_record,), records)
         except Exception:
@@ -446,6 +450,10 @@ class OptimizedDataImporter:
                     if verify_hs_storage_schema(self.database, table_name):
                         self._verified_hs_tables.add(table_name)
                 validate_hs_record(record, table_name)
+                if table_name not in self._verified_hc_tables:
+                    if verify_hc_storage_schema(self.database, table_name):
+                        self._verified_hc_tables.add(table_name)
+                validate_hc_record(record, table_name)
                 if table_name not in self._verified_jc_tables:
                     if verify_jc_storage_schema(self.database, table_name):
                         self._verified_jc_tables.add(table_name)

--- a/src/parser/hc_parser.py
+++ b/src/parser/hc_parser.py
@@ -1,38 +1,159 @@
-"""Parser for HC record - hill training (HANRO) data."""
+"""Parser for the official current 60-byte HC hill-training record."""
 
-from typing import List
+from __future__ import annotations
 
-from src.parser.base import BaseParser, FieldDef
+from collections.abc import Mapping
+from datetime import date
+
+from src.parser import status_domain
+from src.parser.base import FieldDef
+from src.utils.logger import get_logger
 
 
-class HCParser(BaseParser):
-    """Parser for HC hill training records.
-
-    HC is returned by the SLOP data spec and corresponds to JRA-VAN's
-    HANRO table. The record contains hill training timestamps and furlong
-    split times, not trainer master/statistics fields.
-    """
+class HCParser:
+    """Parse one current JV-Data HC record without lossy coercion."""
 
     RECORD_TYPE = "HC"
+    record_type = RECORD_TYPE
     RECORD_LENGTH = 60
-    record_type = "HC"
+    KEY_COLUMNS = ("TresenKubun", "ChokyoDate", "ChokyoTime", "KettoNum")
+    FIELD_LAYOUT = (
+        ("RecordSpec", 0, 2),
+        ("DataKubun", 2, 1),
+        ("MakeDate", 3, 8),
+        ("TresenKubun", 11, 1),
+        ("ChokyoDate", 12, 8),
+        ("ChokyoTime", 20, 4),
+        ("KettoNum", 24, 10),
+        ("HaronTime4", 34, 4),
+        ("LapTime4", 38, 3),
+        ("HaronTime3", 41, 4),
+        ("LapTime3", 45, 3),
+        ("HaronTime2", 48, 4),
+        ("LapTime2", 52, 3),
+        ("LapTime1", 55, 3),
+        ("RecordDelimiter", 58, 2),
+    )
+    TIME_WIDTHS = {
+        "HaronTime4": 4,
+        "LapTime4": 3,
+        "HaronTime3": 4,
+        "LapTime3": 3,
+        "HaronTime2": 4,
+        "LapTime2": 3,
+        "LapTime1": 3,
+    }
 
-    def _define_fields(self) -> List[FieldDef]:
-        """Define field positions with JRA-VAN standard names."""
-        return [
-            FieldDef("RecordSpec", 0, 2, description="レコード種別ID"),
-            FieldDef("DataKubun", 2, 1, description="データ区分"),
-            FieldDef("MakeDate", 3, 8, description="データ作成年月日"),
-            FieldDef("TresenKubun", 11, 1, description="トレセン区分"),
-            FieldDef("ChokyoDate", 12, 8, description="調教年月日"),
-            FieldDef("ChokyoTime", 20, 4, description="調教時刻"),
-            FieldDef("KettoNum", 24, 10, description="血統登録番号"),
-            FieldDef("HaronTime4", 34, 4, description="4ハロンタイム合計(800M～0M)"),
-            FieldDef("LapTime4", 38, 3, description="ラップタイム(800M～600M)"),
-            FieldDef("HaronTime3", 41, 4, description="3ハロンタイム合計(600M～0M)"),
-            FieldDef("LapTime3", 45, 3, description="ラップタイム(600M～400M)"),
-            FieldDef("HaronTime2", 48, 4, description="2ハロンタイム合計(400M～0M)"),
-            FieldDef("LapTime2", 52, 3, description="ラップタイム(400M～200M)"),
-            FieldDef("LapTime1", 55, 3, description="ラップタイム(200M～0M)"),
-            FieldDef("RecordDelimiter", 58, 2, description="レコード区切"),
-        ]
+    def __init__(self) -> None:
+        self.logger = get_logger(__name__)
+        self._fields = [FieldDef(name, start, width) for name, start, width in self.FIELD_LAYOUT]
+        self._field_map = {field.name: field for field in self._fields}
+
+    @staticmethod
+    def _decode_field(data: bytes) -> str:
+        return data.decode("cp932", errors="strict").strip()
+
+    @staticmethod
+    def _require_ascii_digits(field_name: str, value: object, width: int) -> str:
+        if isinstance(value, str) and len(value) == width and value.isascii() and value.isdigit():
+            return value
+        raise ValueError(f"HC {field_name} must be exactly {width} ASCII digits")
+
+    @classmethod
+    def _require_date(cls, field_name: str, value: object) -> str:
+        digits = cls._require_ascii_digits(field_name, value, 8)
+        try:
+            date(int(digits[:4]), int(digits[4:6]), int(digits[6:]))
+        except ValueError as error:
+            raise ValueError(f"HC {field_name} must be a real YYYYMMDD date") from error
+        return digits
+
+    @classmethod
+    def _require_hhmm(cls, field_name: str, value: object) -> str:
+        digits = cls._require_ascii_digits(field_name, value, 4)
+        if int(digits[:2]) > 23 or int(digits[2:]) > 59:
+            raise ValueError(f"HC {field_name} must be a real HHMM time")
+        return digits
+
+    @classmethod
+    def validate_key_fields(cls, record: Mapping[str, object]) -> None:
+        cls._require_date("MakeDate", record.get("MakeDate"))
+        tresen = cls._require_ascii_digits("TresenKubun", record.get("TresenKubun"), 1)
+        if tresen not in {"0", "1"}:
+            raise ValueError("HC TresenKubun must be 0 (Miho) or 1 (Ritto)")
+        cls._require_date("ChokyoDate", record.get("ChokyoDate"))
+        cls._require_hhmm("ChokyoTime", record.get("ChokyoTime"))
+        cls._require_ascii_digits("KettoNum", record.get("KettoNum"), 10)
+
+    @classmethod
+    def validate_current_fields(
+        cls,
+        record: Mapping[str, object],
+        *,
+        data_kubun: str | None = None,
+    ) -> None:
+        """Validate one current row before coercion or database mutation."""
+
+        cls.validate_key_fields(record)
+        status = data_kubun if data_kubun is not None else record.get("DataKubun")
+        if status == "0":
+            # Project exact-delete policy: HC identity is sufficient for a
+            # deletion command; every non-key body byte remains uninterpreted.
+            return
+        for field_name, width in cls.TIME_WIDTHS.items():
+            cls._require_ascii_digits(field_name, record.get(field_name), width)
+
+    @classmethod
+    def _validate_envelope(cls, data: bytes) -> tuple[str, str]:
+        if len(data) != cls.RECORD_LENGTH:
+            raise ValueError(
+                f"HC record length mismatch: expected={(cls.RECORD_LENGTH,)}, "
+                f"actual={len(data)}"
+            )
+        if data[:2] != b"HC":
+            raise ValueError(f"Record type mismatch: expected HC, got {data[:2]!r}")
+        if data[-2:] != b"\r\n":
+            raise ValueError("HC record delimiter must be CRLF")
+        data_kubun = data[2:3].decode("ascii", errors="strict")
+        make_date = data[3:11].decode("ascii", errors="strict")
+        cls._require_date("MakeDate", make_date)
+        status_domain.validate_data_kubun("HC", data_kubun, make_date=make_date)
+        return data_kubun, make_date
+
+    def parse(self, data: bytes) -> dict[str, object] | None:
+        """Return a strict current HC row, or ``None`` for malformed input."""
+
+        try:
+            data_kubun, make_date = self._validate_envelope(data)
+            if data_kubun == "0":
+                result: dict[str, object] = {
+                    "RecordSpec": "HC",
+                    "DataKubun": data_kubun,
+                    "MakeDate": make_date,
+                    "TresenKubun": self._decode_field(data[11:12]),
+                    "ChokyoDate": self._decode_field(data[12:20]),
+                    "ChokyoTime": self._decode_field(data[20:24]),
+                    "KettoNum": self._decode_field(data[24:34]),
+                    **dict.fromkeys(self.TIME_WIDTHS, ""),
+                    "RecordDelimiter": None,
+                }
+            else:
+                result = {
+                    field.name: (
+                        None
+                        if field.name == "RecordDelimiter"
+                        else self._decode_field(data[field.start : field.start + field.length])
+                    )
+                    for field in self._fields
+                }
+            self.validate_current_fields(result, data_kubun=data_kubun)
+            return result
+        except Exception as error:
+            self.logger.error(f"HCレコードパース中にエラー: {error}")
+            return None
+
+    def get_field_names(self) -> list[str]:
+        return [field.name for field in self._fields]
+
+    def get_field_def(self, field_name: str) -> FieldDef | None:
+        return self._field_map.get(field_name)

--- a/tests/fixtures/official_layout/README.md
+++ b/tests/fixtures/official_layout/README.md
@@ -32,6 +32,10 @@ JV-Data. They do not contain provider records or a copy of the SDK source.
   196-byte HOSE store. It also pins the official historical-value policy: age
   is already unified to the post-2001 method, while sale names retain their
   historical notation.
+- `hc_contract_4901.json` records the current 60-byte HC hill-training layout,
+  four-part identity, status domain, tenths-of-a-second timing fields, and the
+  same-layout Miho measurement-distance history independently transcribed from
+  both pinned current workbooks.
 
 The manifest is intentionally independent of jrvltsql parser and schema code.
 When the official source changes, regenerate it from a separately obtained SDK

--- a/tests/fixtures/official_layout/hc_contract_4901.json
+++ b/tests/fixtures/official_layout/hc_contract_4901.json
@@ -1,0 +1,66 @@
+{
+  "schema_version": 1,
+  "record_type": "HC",
+  "data_spec": "SLOP",
+  "record_length": 60,
+  "format_sources": [
+    {
+      "artifact": "JV-Data4802.xlsx",
+      "sha256": "6a567f10b601115eca350571f36d27d9d28bd2d3835ea72b5bc057711155d4a7",
+      "sheet": "フォーマット",
+      "rows": "1142-1167"
+    },
+    {
+      "artifact": "JV-Data4901.xlsx",
+      "sha256": "23bafd375f704acbdd696b5032ac1619f17d47e882587d6e7954b610527a8234",
+      "sheet": "フォーマット",
+      "rows": "1142-1167"
+    }
+  ],
+  "fields": [
+    ["RecordSpec", 1, 2],
+    ["DataKubun", 3, 1],
+    ["MakeDate", 4, 8],
+    ["TresenKubun", 12, 1],
+    ["ChokyoDate", 13, 8],
+    ["ChokyoTime", 21, 4],
+    ["KettoNum", 25, 10],
+    ["HaronTime4", 35, 4],
+    ["LapTime4", 39, 3],
+    ["HaronTime3", 42, 4],
+    ["LapTime3", 46, 3],
+    ["HaronTime2", 49, 4],
+    ["LapTime2", 53, 3],
+    ["LapTime1", 56, 3],
+    ["RecordDelimiter", 59, 2]
+  ],
+  "primary_key": ["TresenKubun", "ChokyoDate", "ChokyoTime", "KettoNum"],
+  "current_data_kubun": ["0", "1"],
+  "measurement_fields": {
+    "HaronTime4": {"width": 4, "scale_seconds": 0.1, "failure_value": "0000"},
+    "LapTime4": {"width": 3, "scale_seconds": 0.1, "failure_value": "000"},
+    "HaronTime3": {"width": 4, "scale_seconds": 0.1, "failure_value": "0000"},
+    "LapTime3": {"width": 3, "scale_seconds": 0.1, "failure_value": "000"},
+    "HaronTime2": {"width": 4, "scale_seconds": 0.1, "failure_value": "0000"},
+    "LapTime2": {"width": 3, "scale_seconds": 0.1, "failure_value": "000"},
+    "LapTime1": {"width": 3, "scale_seconds": 0.1, "failure_value": "000"}
+  },
+  "history": {
+    "physical_layout_changed": false,
+    "data_available_from": "2003",
+    "miho_measurement": {
+      "through_2004_11_29": "600m",
+      "from_2004_11_30": "800m"
+    },
+    "sources": [
+      "JV-Data4901.xlsx:特記事項:195-198",
+      "JV-Data4901.xlsx:変更履歴:170,174,344"
+    ]
+  },
+  "delivery": {
+    "frequency": "daily_irregular",
+    "unit": "complete_training_center_day",
+    "retention": "1 year",
+    "source": "JV-Data4901.xlsx:データ提供タイミング・提供単位:26"
+  }
+}

--- a/tests/test_current_record_validation.py
+++ b/tests/test_current_record_validation.py
@@ -46,6 +46,7 @@ DOMAIN_PAYLOAD_REQUIRED = {
     "CK",
     "CS",
     "DM",
+    "HC",
     "HR",
     "HS",
     "JG",

--- a/tests/test_hc_official_contract.py
+++ b/tests/test_hc_official_contract.py
@@ -1,0 +1,486 @@
+"""HC hill-training contract from the pinned current official sources."""
+
+from __future__ import annotations
+
+import json
+import os
+from itertools import pairwise
+from pathlib import Path
+from uuid import uuid4
+
+import pytest
+
+from src.database.dual_handler import DualDatabase
+from src.database.migration import SchemaMigrationError
+from src.database.schema import SCHEMAS
+from src.database.schema_jravan import JRAVAN_SCHEMAS
+from src.database.schema_metadata import TABLE_METADATA
+from src.database.schema_types import (
+    get_table_column_nullability,
+    get_table_column_types,
+    get_table_primary_key_columns,
+)
+from src.database.sqlite_handler import SQLiteDatabase
+from src.importer.importer import DataImporter
+from src.importer.importer_optimized import OptimizedDataImporter
+from src.parser.hc_parser import HCParser
+
+FIELDS = (
+    ("RecordSpec", 1, 2, b"HC"),
+    ("DataKubun", 3, 1, b"1"),
+    ("MakeDate", 4, 8, b"20260818"),
+    ("TresenKubun", 12, 1, b"0"),
+    ("ChokyoDate", 13, 8, b"20260817"),
+    ("ChokyoTime", 21, 4, b"0630"),
+    ("KettoNum", 25, 10, b"2020100001"),
+    ("HaronTime4", 35, 4, b"0480"),
+    ("LapTime4", 39, 3, b"120"),
+    ("HaronTime3", 42, 4, b"0360"),
+    ("LapTime3", 46, 3, b"120"),
+    ("HaronTime2", 49, 4, b"0240"),
+    ("LapTime2", 53, 3, b"120"),
+    ("LapTime1", 56, 3, b"120"),
+    ("RecordDelimiter", 59, 2, b"\r\n"),
+)
+EXPECTED = {name: value.decode("cp932").strip() for name, _, _, value in FIELDS}
+# The physical CRLF is verified before extraction; the legacy BaseParser
+# represents its stripped storage field as None.
+EXPECTED["RecordDelimiter"] = None
+OFFICIAL_KEY = ["TresenKubun", "ChokyoDate", "ChokyoTime", "KettoNum"]
+TIME_FIELDS = tuple(
+    (name, width) for name, _, width, _ in FIELDS if name.startswith(("HaronTime", "LapTime"))
+)
+NATIVE_FIELDS = set(EXPECTED)
+STANDARD_FIELDS = NATIVE_FIELDS - {"RecordDelimiter"}
+CONTRACT_PATH = Path("tests/fixtures/official_layout/hc_contract_4901.json")
+MANIFEST_PATH = Path("tests/fixtures/official_layout/jvdata_sdk500_manifest.json")
+
+
+def _pad(value: str, width: int) -> bytes:
+    encoded = value.encode("cp932")
+    assert len(encoded) <= width
+    return encoded.ljust(width, b" ")
+
+
+def build_record(
+    *,
+    data_kubun: str = "1",
+    make_date: str = "20260818",
+    tresen_kubun: str = "0",
+    chokyo_date: str = "20260817",
+    chokyo_time: str = "0630",
+    ketto_num: str = "2020100001",
+    field_overrides: dict[str, str] | None = None,
+) -> bytes:
+    values = {
+        "DataKubun": data_kubun,
+        "MakeDate": make_date,
+        "TresenKubun": tresen_kubun,
+        "ChokyoDate": chokyo_date,
+        "ChokyoTime": chokyo_time,
+        "KettoNum": ketto_num,
+    }
+    if field_overrides:
+        values.update(field_overrides)
+    record = bytearray()
+    for name, position, width, default in FIELDS:
+        value = _pad(values[name], width) if name in values else default
+        assert len(record) == position - 1
+        assert len(value) == width
+        record += value
+    assert len(record) == HCParser.RECORD_LENGTH == 60
+    return bytes(record)
+
+
+def parsed_record(**kwargs) -> dict:
+    parsed = HCParser().parse(build_record(**kwargs))
+    assert parsed is not None
+    return parsed
+
+
+@pytest.fixture
+def postgresql_db():
+    if os.getenv("JLTSQL_RUN_POSTGRESQL_INTEGRATION") != "1":
+        pytest.skip("Set JLTSQL_RUN_POSTGRESQL_INTEGRATION=1 to run PostgreSQL tests")
+
+    from src.database.postgresql_handler import PostgreSQLDatabase
+
+    database = PostgreSQLDatabase(
+        {
+            "host": os.getenv("POSTGRES_HOST") or os.getenv("PGHOST", "localhost"),
+            "port": int(os.getenv("POSTGRES_PORT") or os.getenv("PGPORT", "5432")),
+            "database": os.getenv("POSTGRES_DB") or os.getenv("PGDATABASE", "jltsql_test"),
+            "user": os.getenv("POSTGRES_USER") or os.getenv("PGUSER", "jltsql"),
+            "password": os.getenv("POSTGRES_PASSWORD") or os.getenv("PGPASSWORD", ""),
+            "connect_timeout": 5,
+        }
+    )
+    schema_name = f"jlt_hc_{uuid4().hex[:12]}"
+    database.connect()
+    try:
+        database.execute(f"CREATE SCHEMA {schema_name}")
+        database.execute(f"SET search_path TO {schema_name}")
+        database.commit()
+        yield database
+    finally:
+        try:
+            database.execute(f"DROP SCHEMA IF EXISTS {schema_name} CASCADE")
+            database.commit()
+        finally:
+            database.disconnect()
+
+
+def test_hc_reviewed_oracle_binds_both_workbooks_sdk_and_every_parser_span() -> None:
+    contract = json.loads(CONTRACT_PATH.read_text(encoding="utf-8"))
+    assert contract["record_length"] == 60
+    assert contract["format_sources"] == [
+        {
+            "artifact": "JV-Data4802.xlsx",
+            "sha256": "6a567f10b601115eca350571f36d27d9d28bd2d3835ea72b5bc057711155d4a7",
+            "sheet": "フォーマット",
+            "rows": "1142-1167",
+        },
+        {
+            "artifact": "JV-Data4901.xlsx",
+            "sha256": "23bafd375f704acbdd696b5032ac1619f17d47e882587d6e7954b610527a8234",
+            "sheet": "フォーマット",
+            "rows": "1142-1167",
+        },
+    ]
+    fixture_spans = [(name, position, width) for name, position, width, _ in FIELDS]
+    assert contract["fields"] == [list(item) for item in fixture_spans]
+    assert contract["primary_key"] == OFFICIAL_KEY
+    assert contract["current_data_kubun"] == ["0", "1"]
+    assert all(
+        position + width == next_position
+        for (_, position, width), (_, next_position, _) in pairwise(fixture_spans)
+    )
+
+    parser = HCParser()
+    assert [
+        (field.name, field.start + 1, field.length) for field in parser._fields
+    ] == fixture_spans
+    assert parser.parse(build_record()) == EXPECTED
+
+    manifest = json.loads(MANIFEST_PATH.read_text(encoding="utf-8"))
+    assert manifest["root_records"]["HC"] == {"struct": "JV_HC_HANRO", "length": 60}
+    structures = manifest["structures"]
+    sdk_spans = []
+    for field in structures["JV_HC_HANRO"]["fields"]:
+        if field["name"] == "head":
+            for header in structures[field["struct"]]["fields"]:
+                sdk_spans.append(
+                    (header["name"], field["start"] + header["start"] - 1, header["width"])
+                )
+        else:
+            sdk_spans.append(
+                (
+                    "RecordDelimiter" if field["name"] == "crlf" else field["name"],
+                    field["start"],
+                    field["width"],
+                )
+            )
+    assert sdk_spans == fixture_spans
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "field_name"),
+    [
+        ({"make_date": "20260230"}, "MakeDate"),
+        ({"tresen_kubun": "2"}, "TresenKubun"),
+        ({"chokyo_date": "20260230"}, "ChokyoDate"),
+        ({"chokyo_time": "1160"}, "ChokyoTime"),
+        ({"ketto_num": "20201A0001"}, "KettoNum"),
+        ({"field_overrides": {"HaronTime4": "ABCD"}}, "HaronTime4"),
+        ({"field_overrides": {"LapTime1": "1A0"}}, "LapTime1"),
+    ],
+)
+def test_hc_parser_rejects_malformed_key_and_live_payload(kwargs, field_name: str) -> None:
+    assert HCParser().parse(build_record(**kwargs)) is None, field_name
+
+
+def test_hc_parser_keeps_documented_zero_measurements_and_delete_body_opaque() -> None:
+    zero = parsed_record(field_overrides={name: "0" * width for name, width in TIME_FIELDS})
+    assert all(zero[name] == "0" * width for name, width in TIME_FIELDS)
+
+    opaque = bytearray(build_record(data_kubun="0"))
+    opaque[34:36] = b"\x81 "  # deliberately invalid CP932 inside the unused body
+    deleted = HCParser().parse(bytes(opaque))
+    assert deleted is not None
+    assert deleted["DataKubun"] == "0"
+    assert [deleted[name] for name in OFFICIAL_KEY] == [
+        "0",
+        "20260817",
+        "0630",
+        "2020100001",
+    ]
+    assert all(deleted[name] == "" for name, _ in TIME_FIELDS)
+
+
+def test_hc_native_and_standard_schemas_are_executable_official_contracts() -> None:
+    assert set(get_table_column_types("NL_HC")) == NATIVE_FIELDS
+    assert set(get_table_column_types("HANRO")) == STANDARD_FIELDS
+    assert get_table_primary_key_columns("NL_HC") == OFFICIAL_KEY
+    assert get_table_primary_key_columns("HANRO") == OFFICIAL_KEY
+    for table_name in ("NL_HC", "HANRO"):
+        nullability = get_table_column_nullability(table_name)
+        required = set(get_table_column_types(table_name)) - {"RecordDelimiter"}
+        assert all(not nullability[column] for column in required)
+    metadata = TABLE_METADATA["NL_HC"]
+    assert [(column["name"], column["type"]) for column in metadata["columns"]] == list(
+        get_table_column_types("NL_HC").items()
+    )
+    assert metadata["primary_key"] == OFFICIAL_KEY
+
+
+@pytest.mark.parametrize(
+    ("importer_class", "table_name", "standard", "auto_commit"),
+    [
+        pytest.param(
+            importer_class,
+            table_name,
+            standard,
+            auto_commit,
+            id=f"{importer_class.__name__}-{table_name}-{auto_commit}",
+        )
+        for importer_class in (DataImporter, OptimizedDataImporter)
+        for table_name, standard in (("NL_HC", False), ("HANRO", True))
+        for auto_commit in (True, False)
+    ],
+)
+def test_hc_provider_order_update_exact_delete_and_durable_units(
+    tmp_path,
+    importer_class,
+    table_name: str,
+    standard: bool,
+    auto_commit: bool,
+) -> None:
+    database = SQLiteDatabase({"path": str(tmp_path / f"ordered-{table_name}.db")})
+    schema = JRAVAN_SCHEMAS[table_name] if standard else SCHEMAS[table_name]
+    with database:
+        database.execute(schema)
+        database.commit()
+        importer = importer_class(database, use_jravan_schema=standard)
+        records = [
+            parsed_record(),
+            parsed_record(tresen_kubun="1", ketto_num="2020100002"),
+            parsed_record(field_overrides={"HaronTime4": "0510"}),
+            parsed_record(
+                data_kubun="0",
+                field_overrides={"HaronTime4": "BAD!", "LapTime1": "A1B"},
+            ),
+        ]
+        stats = importer.import_records(iter(records), auto_commit=auto_commit)
+        assert {
+            key: stats[key] for key in ("records_imported", "records_failed", "batches_processed")
+        } == {"records_imported": 4, "records_failed": 0, "batches_processed": 2}
+        rows = database.fetch_all(
+            f"SELECT TresenKubun, KettoNum, HaronTime4, LapTime1 FROM {table_name}"
+        )
+        assert rows == [
+            {
+                "TresenKubun": "1",
+                "KettoNum": "2020100002",
+                "HaronTime4": 48.0,
+                "LapTime1": 12.0,
+            }
+        ]
+        if not auto_commit:
+            database.commit()
+
+
+@pytest.mark.parametrize("table_name,standard", [("NL_HC", False), ("HANRO", True)])
+def test_hc_caller_validation_precedes_coercion_and_mutation(
+    tmp_path, table_name: str, standard: bool
+) -> None:
+    database = SQLiteDatabase({"path": str(tmp_path / f"invalid-{table_name}.db")})
+    schema = JRAVAN_SCHEMAS[table_name] if standard else SCHEMAS[table_name]
+    invalid_records = []
+    for field_name, invalid in (
+        ("MakeDate", "20260230"),
+        ("TresenKubun", "2"),
+        ("ChokyoDate", "20260230"),
+        ("ChokyoTime", "1160"),
+        ("KettoNum", "20201A0001"),
+        ("HaronTime4", "ABCD"),
+        ("LapTime1", "1A0"),
+    ):
+        record = parsed_record()
+        record[field_name] = invalid
+        invalid_records.append(record)
+
+    with database:
+        database.execute(schema)
+        database.commit()
+        importer = DataImporter(database, use_jravan_schema=standard)
+        for invalid in invalid_records:
+            with pytest.raises(SchemaMigrationError):
+                importer.import_records(iter([invalid]))
+        assert database.fetch_one(f"SELECT COUNT(*) AS count FROM {table_name}") == {"count": 0}
+
+
+def test_hc_dual_verifies_both_targets_before_mutation(tmp_path) -> None:
+    safe_schema = SCHEMAS["NL_HC"]
+    unsafe_schema = _defective_schema("NL_HC", "extra-unique")
+    for unsafe_target in ("primary", "secondary"):
+        primary = SQLiteDatabase({"path": str(tmp_path / f"{unsafe_target}-primary.db")})
+        secondary = SQLiteDatabase({"path": str(tmp_path / f"{unsafe_target}-secondary.db")})
+        with primary, secondary:
+            primary.execute(unsafe_schema if unsafe_target == "primary" else safe_schema)
+            secondary.execute(unsafe_schema if unsafe_target == "secondary" else safe_schema)
+            primary.commit()
+            secondary.commit()
+            with pytest.raises(SchemaMigrationError):
+                DataImporter(DualDatabase(primary, secondary)).import_records(
+                    iter([parsed_record()])
+                )
+            assert primary.fetch_one("SELECT COUNT(*) AS count FROM NL_HC") == {"count": 0}
+            assert secondary.fetch_one("SELECT COUNT(*) AS count FROM NL_HC") == {"count": 0}
+
+
+def _defective_schema(table_name: str, defect: str) -> str:
+    schema = SCHEMAS[table_name] if table_name == "NL_HC" else JRAVAN_SCHEMAS[table_name]
+    key = "PRIMARY KEY (TresenKubun, ChokyoDate, ChokyoTime, KettoNum)"
+    if defect == "wrong-key":
+        return schema.replace(key, "PRIMARY KEY (TresenKubun, ChokyoDate, KettoNum)")
+    if defect == "extra-unique":
+        body, close = schema.rsplit(")", 1)
+        return f"{body}, UNIQUE (ChokyoDate)\n        ){close}"
+    if defect == "extra-check":
+        body, close = schema.rsplit(")", 1)
+        return f"{body}, CHECK (HaronTime4 <= 10)\n        ){close}"
+    if defect == "wrong-type":
+        if table_name == "NL_HC":
+            return schema.replace("ChokyoDate TEXT", "ChokyoDate INTEGER")
+        return schema.replace(
+            "ChokyoDate                     VARCHAR(8) NOT NULL",
+            "ChokyoDate                     INTEGER NOT NULL   ",
+        )
+    if defect == "nullable-key":
+        return schema.replace("KettoNum TEXT NOT NULL", "KettoNum TEXT").replace(
+            "KettoNum                       VARCHAR(10) NOT NULL",
+            "KettoNum                       VARCHAR(10)         ",
+        )
+    raise AssertionError(defect)
+
+
+@pytest.mark.parametrize("table_name,standard", [("NL_HC", False), ("HANRO", True)])
+@pytest.mark.parametrize(
+    "defect",
+    ["wrong-key", "extra-unique", "extra-check", "wrong-type", "nullable-key"],
+)
+def test_hc_schema_defects_fail_before_any_row_mutation(
+    tmp_path, table_name: str, standard: bool, defect: str
+) -> None:
+    database = SQLiteDatabase({"path": str(tmp_path / f"{table_name}-{defect}.db")})
+    with database:
+        database.execute(_defective_schema(table_name, defect))
+        database.commit()
+        before_schema = database.fetch_one(
+            "SELECT sql FROM sqlite_master WHERE type='table' AND name=?", (table_name,)
+        )
+        with pytest.raises(SchemaMigrationError):
+            DataImporter(database, use_jravan_schema=standard).import_records(
+                iter([parsed_record()])
+            )
+        assert (
+            database.fetch_one(
+                "SELECT sql FROM sqlite_master WHERE type='table' AND name=?", (table_name,)
+            )
+            == before_schema
+        )
+        assert database.fetch_one(f"SELECT COUNT(*) AS count FROM {table_name}") == {"count": 0}
+
+
+@pytest.mark.parametrize("table_name,standard", [("NL_HC", False), ("HANRO", True)])
+@pytest.mark.parametrize("auto_commit", [True, False])
+def test_hc_single_record_uses_the_same_validator_and_exact_delete(
+    tmp_path, table_name: str, standard: bool, auto_commit: bool
+) -> None:
+    database = SQLiteDatabase({"path": str(tmp_path / f"single-{table_name}.db")})
+    schema = JRAVAN_SCHEMAS[table_name] if standard else SCHEMAS[table_name]
+    with database:
+        database.execute(schema)
+        database.commit()
+        importer = DataImporter(database, use_jravan_schema=standard)
+        assert importer.import_single_record(parsed_record(), auto_commit=auto_commit)
+        invalid = parsed_record()
+        invalid["ChokyoTime"] = "1160"
+        with pytest.raises(SchemaMigrationError):
+            importer.import_single_record(invalid, auto_commit=auto_commit)
+        delete = parsed_record(data_kubun="0")
+        delete["HaronTime4"] = "not interpreted"
+        assert importer.import_single_record(delete, auto_commit=auto_commit)
+        assert database.fetch_one(f"SELECT COUNT(*) AS count FROM {table_name}") == {"count": 0}
+
+
+def test_hc_postgresql_provider_order_and_wrong_key_gate(postgresql_db) -> None:
+    for table_name, standard in (("NL_HC", False), ("HANRO", True)):
+        schema = JRAVAN_SCHEMAS[table_name] if standard else SCHEMAS[table_name]
+        postgresql_db.execute(schema)
+        postgresql_db.commit()
+        for importer_class in (DataImporter, OptimizedDataImporter):
+            for auto_commit in (True, False):
+                stats = importer_class(postgresql_db, use_jravan_schema=standard).import_records(
+                    iter(
+                        [
+                            parsed_record(),
+                            parsed_record(tresen_kubun="1", ketto_num="2020100002"),
+                            parsed_record(field_overrides={"HaronTime4": "0510"}),
+                            parsed_record(data_kubun="0"),
+                        ]
+                    ),
+                    auto_commit=auto_commit,
+                )
+                assert stats["records_imported"] == 4
+                assert postgresql_db.fetch_all(
+                    'SELECT TresenKubun AS "TresenKubun", '
+                    'KettoNum AS "KettoNum", HaronTime4 AS "HaronTime4", '
+                    'LapTime1 AS "LapTime1" '
+                    f"FROM {table_name}"
+                ) == [
+                    {
+                        "TresenKubun": "1",
+                        "KettoNum": "2020100002",
+                        "HaronTime4": 48.0,
+                        "LapTime1": 12.0,
+                    }
+                ]
+                postgresql_db.execute(f"DELETE FROM {table_name}")
+                postgresql_db.commit()
+        postgresql_db.execute(f"DROP TABLE {table_name}")
+        postgresql_db.commit()
+
+        # PostgreSQL marks primary-key attributes NOT NULL in its catalog even
+        # when the DDL omits the redundant spelling; SQLite requires the
+        # explicit nullable-key negative exercised above.
+        for defect in ("wrong-key", "extra-unique", "extra-check", "wrong-type"):
+            postgresql_db.execute(_defective_schema(table_name, defect))
+            postgresql_db.commit()
+            before_schema = postgresql_db.fetch_all(
+                "SELECT a.attname AS name, format_type(a.atttypid, a.atttypmod) AS type, "
+                "a.attnotnull AS not_null FROM pg_attribute a "
+                "WHERE a.attrelid = to_regclass(?) AND a.attnum > 0 "
+                "AND NOT a.attisdropped ORDER BY a.attnum",
+                (table_name.lower(),),
+            )
+            with pytest.raises(SchemaMigrationError):
+                DataImporter(postgresql_db, use_jravan_schema=standard).import_records(
+                    iter([parsed_record()])
+                )
+            assert (
+                postgresql_db.fetch_all(
+                    "SELECT a.attname AS name, format_type(a.atttypid, a.atttypmod) AS type, "
+                    "a.attnotnull AS not_null FROM pg_attribute a "
+                    "WHERE a.attrelid = to_regclass(?) AND a.attnum > 0 "
+                    "AND NOT a.attisdropped ORDER BY a.attnum",
+                    (table_name.lower(),),
+                )
+                == before_schema
+            )
+            assert postgresql_db.fetch_one(f"SELECT COUNT(*) AS count FROM {table_name}") == {
+                "count": 0
+            }
+            postgresql_db.rollback()
+            postgresql_db.execute(f"DROP TABLE {table_name}")
+            postgresql_db.commit()

--- a/tests/test_hc_official_contract.py
+++ b/tests/test_hc_official_contract.py
@@ -24,6 +24,7 @@ from src.database.sqlite_handler import SQLiteDatabase
 from src.importer.importer import DataImporter
 from src.importer.importer_optimized import OptimizedDataImporter
 from src.parser.hc_parser import HCParser
+from src.realtime.updater import RealtimeUpdater
 
 FIELDS = (
     ("RecordSpec", 1, 2, b"HC"),
@@ -98,6 +99,59 @@ def parsed_record(**kwargs) -> dict:
     return parsed
 
 
+def provider_order_records() -> list[dict]:
+    """Keep one survivor for every one-column difference from the delete key."""
+
+    return [
+        parsed_record(),
+        parsed_record(tresen_kubun="1"),
+        parsed_record(chokyo_date="20260816"),
+        parsed_record(chokyo_time="0631"),
+        parsed_record(ketto_num="2020100002"),
+        parsed_record(field_overrides={"HaronTime4": "0510"}),
+        parsed_record(
+            data_kubun="0",
+            field_overrides={"HaronTime4": "BAD!", "LapTime1": "A1B"},
+        ),
+    ]
+
+
+EXPECTED_SURVIVORS = [
+    {
+        "TresenKubun": "0",
+        "ChokyoDate": "20260816",
+        "ChokyoTime": "0630",
+        "KettoNum": "2020100001",
+        "HaronTime4": 48.0,
+        "LapTime1": 12.0,
+    },
+    {
+        "TresenKubun": "0",
+        "ChokyoDate": "20260817",
+        "ChokyoTime": "0630",
+        "KettoNum": "2020100002",
+        "HaronTime4": 48.0,
+        "LapTime1": 12.0,
+    },
+    {
+        "TresenKubun": "0",
+        "ChokyoDate": "20260817",
+        "ChokyoTime": "0631",
+        "KettoNum": "2020100001",
+        "HaronTime4": 48.0,
+        "LapTime1": 12.0,
+    },
+    {
+        "TresenKubun": "1",
+        "ChokyoDate": "20260817",
+        "ChokyoTime": "0630",
+        "KettoNum": "2020100001",
+        "HaronTime4": 48.0,
+        "LapTime1": 12.0,
+    },
+]
+
+
 @pytest.fixture
 def postgresql_db():
     if os.getenv("JLTSQL_RUN_POSTGRESQL_INTEGRATION") != "1":
@@ -151,6 +205,32 @@ def test_hc_reviewed_oracle_binds_both_workbooks_sdk_and_every_parser_span() -> 
     assert contract["fields"] == [list(item) for item in fixture_spans]
     assert contract["primary_key"] == OFFICIAL_KEY
     assert contract["current_data_kubun"] == ["0", "1"]
+    assert contract["measurement_fields"] == {
+        name: {
+            "width": width,
+            "scale_seconds": 0.1,
+            "failure_value": "0" * width,
+        }
+        for name, width in TIME_FIELDS
+    }
+    assert contract["history"] == {
+        "physical_layout_changed": False,
+        "data_available_from": "2003",
+        "miho_measurement": {
+            "through_2004_11_29": "600m",
+            "from_2004_11_30": "800m",
+        },
+        "sources": [
+            "JV-Data4901.xlsx:特記事項:195-198",
+            "JV-Data4901.xlsx:変更履歴:170,174,344",
+        ],
+    }
+    assert contract["delivery"] == {
+        "frequency": "daily_irregular",
+        "unit": "complete_training_center_day",
+        "retention": "1 year",
+        "source": "JV-Data4901.xlsx:データ提供タイミング・提供単位:26",
+    }
     assert all(
         position + width == next_position
         for (_, position, width), (_, next_position, _) in pairwise(fixture_spans)
@@ -192,6 +272,7 @@ def test_hc_reviewed_oracle_binds_both_workbooks_sdk_and_every_parser_span() -> 
         ({"chokyo_time": "1160"}, "ChokyoTime"),
         ({"ketto_num": "20201A0001"}, "KettoNum"),
         ({"field_overrides": {"HaronTime4": "ABCD"}}, "HaronTime4"),
+        ({"field_overrides": {"HaronTime4": ""}}, "HaronTime4-blank"),
         ({"field_overrides": {"LapTime1": "1A0"}}, "LapTime1"),
     ],
 )
@@ -261,30 +342,16 @@ def test_hc_provider_order_update_exact_delete_and_durable_units(
         database.execute(schema)
         database.commit()
         importer = importer_class(database, use_jravan_schema=standard)
-        records = [
-            parsed_record(),
-            parsed_record(tresen_kubun="1", ketto_num="2020100002"),
-            parsed_record(field_overrides={"HaronTime4": "0510"}),
-            parsed_record(
-                data_kubun="0",
-                field_overrides={"HaronTime4": "BAD!", "LapTime1": "A1B"},
-            ),
-        ]
-        stats = importer.import_records(iter(records), auto_commit=auto_commit)
+        stats = importer.import_records(iter(provider_order_records()), auto_commit=auto_commit)
         assert {
             key: stats[key] for key in ("records_imported", "records_failed", "batches_processed")
-        } == {"records_imported": 4, "records_failed": 0, "batches_processed": 2}
+        } == {"records_imported": 7, "records_failed": 0, "batches_processed": 2}
         rows = database.fetch_all(
-            f"SELECT TresenKubun, KettoNum, HaronTime4, LapTime1 FROM {table_name}"
+            "SELECT TresenKubun, ChokyoDate, ChokyoTime, KettoNum, "
+            f"HaronTime4, LapTime1 FROM {table_name} "
+            "ORDER BY TresenKubun, ChokyoDate, ChokyoTime, KettoNum"
         )
-        assert rows == [
-            {
-                "TresenKubun": "1",
-                "KettoNum": "2020100002",
-                "HaronTime4": 48.0,
-                "LapTime1": 12.0,
-            }
-        ]
+        assert rows == EXPECTED_SURVIVORS
         if not auto_commit:
             database.commit()
 
@@ -321,7 +388,7 @@ def test_hc_caller_validation_precedes_coercion_and_mutation(
 
 def test_hc_dual_verifies_both_targets_before_mutation(tmp_path) -> None:
     safe_schema = SCHEMAS["NL_HC"]
-    unsafe_schema = _defective_schema("NL_HC", "extra-unique")
+    unsafe_schema = _defective_schema("NL_HC", "extra-required-column")
     for unsafe_target in ("primary", "secondary"):
         primary = SQLiteDatabase({"path": str(tmp_path / f"{unsafe_target}-primary.db")})
         secondary = SQLiteDatabase({"path": str(tmp_path / f"{unsafe_target}-secondary.db")})
@@ -349,6 +416,16 @@ def _defective_schema(table_name: str, defect: str) -> str:
     if defect == "extra-check":
         body, close = schema.rsplit(")", 1)
         return f"{body}, CHECK (HaronTime4 <= 10)\n        ){close}"
+    if defect == "extra-foreign-key":
+        body, close = schema.rsplit(")", 1)
+        return (
+            f"{body}, FOREIGN KEY (TresenKubun, ChokyoDate, ChokyoTime, KettoNum) "
+            f"REFERENCES {table_name} "
+            "(TresenKubun, ChokyoDate, ChokyoTime, KettoNum) ON DELETE CASCADE\n"
+            f"        ){close}"
+        )
+    if defect == "extra-required-column":
+        return schema.replace(key, f"ExternalRequired TEXT NOT NULL, {key}")
     if defect == "wrong-type":
         if table_name == "NL_HC":
             return schema.replace("ChokyoDate TEXT", "ChokyoDate INTEGER")
@@ -367,7 +444,15 @@ def _defective_schema(table_name: str, defect: str) -> str:
 @pytest.mark.parametrize("table_name,standard", [("NL_HC", False), ("HANRO", True)])
 @pytest.mark.parametrize(
     "defect",
-    ["wrong-key", "extra-unique", "extra-check", "wrong-type", "nullable-key"],
+    [
+        "wrong-key",
+        "extra-unique",
+        "extra-check",
+        "extra-foreign-key",
+        "extra-required-column",
+        "wrong-type",
+        "nullable-key",
+    ],
 )
 def test_hc_schema_defects_fail_before_any_row_mutation(
     tmp_path, table_name: str, standard: bool, defect: str
@@ -414,6 +499,23 @@ def test_hc_single_record_uses_the_same_validator_and_exact_delete(
         assert database.fetch_one(f"SELECT COUNT(*) AS count FROM {table_name}") == {"count": 0}
 
 
+def test_hc_accumulated_only_raw_does_not_write_realtime_cache_or_table(tmp_path) -> None:
+    class CacheProbe:
+        def __init__(self) -> None:
+            self.calls = 0
+
+        def write_rt_record(self, *_args) -> None:
+            self.calls += 1
+
+    cache = CacheProbe()
+    database = SQLiteDatabase({"path": str(tmp_path / "realtime-hc.db")})
+    with database:
+        updater = RealtimeUpdater(database, cache_manager=cache)
+        assert updater.process_record(build_record()) is None
+        assert cache.calls == 0
+        assert not database.table_exists("RT_HC")
+
+
 def test_hc_postgresql_provider_order_and_wrong_key_gate(postgresql_db) -> None:
     for table_name, standard in (("NL_HC", False), ("HANRO", True)):
         schema = JRAVAN_SCHEMAS[table_name] if standard else SCHEMAS[table_name]
@@ -422,30 +524,21 @@ def test_hc_postgresql_provider_order_and_wrong_key_gate(postgresql_db) -> None:
         for importer_class in (DataImporter, OptimizedDataImporter):
             for auto_commit in (True, False):
                 stats = importer_class(postgresql_db, use_jravan_schema=standard).import_records(
-                    iter(
-                        [
-                            parsed_record(),
-                            parsed_record(tresen_kubun="1", ketto_num="2020100002"),
-                            parsed_record(field_overrides={"HaronTime4": "0510"}),
-                            parsed_record(data_kubun="0"),
-                        ]
-                    ),
+                    iter(provider_order_records()),
                     auto_commit=auto_commit,
                 )
-                assert stats["records_imported"] == 4
-                assert postgresql_db.fetch_all(
-                    'SELECT TresenKubun AS "TresenKubun", '
-                    'KettoNum AS "KettoNum", HaronTime4 AS "HaronTime4", '
-                    'LapTime1 AS "LapTime1" '
-                    f"FROM {table_name}"
-                ) == [
-                    {
-                        "TresenKubun": "1",
-                        "KettoNum": "2020100002",
-                        "HaronTime4": 48.0,
-                        "LapTime1": 12.0,
-                    }
-                ]
+                assert stats["records_imported"] == 7
+                assert (
+                    postgresql_db.fetch_all(
+                        'SELECT TresenKubun AS "TresenKubun", '
+                        'ChokyoDate AS "ChokyoDate", ChokyoTime AS "ChokyoTime", '
+                        'KettoNum AS "KettoNum", HaronTime4 AS "HaronTime4", '
+                        'LapTime1 AS "LapTime1" '
+                        f"FROM {table_name} "
+                        "ORDER BY TresenKubun, ChokyoDate, ChokyoTime, KettoNum"
+                    )
+                    == EXPECTED_SURVIVORS
+                )
                 postgresql_db.execute(f"DELETE FROM {table_name}")
                 postgresql_db.commit()
         postgresql_db.execute(f"DROP TABLE {table_name}")
@@ -454,7 +547,14 @@ def test_hc_postgresql_provider_order_and_wrong_key_gate(postgresql_db) -> None:
         # PostgreSQL marks primary-key attributes NOT NULL in its catalog even
         # when the DDL omits the redundant spelling; SQLite requires the
         # explicit nullable-key negative exercised above.
-        for defect in ("wrong-key", "extra-unique", "extra-check", "wrong-type"):
+        for defect in (
+            "wrong-key",
+            "extra-unique",
+            "extra-check",
+            "extra-foreign-key",
+            "extra-required-column",
+            "wrong-type",
+        ):
             postgresql_db.execute(_defective_schema(table_name, defect))
             postgresql_db.commit()
             before_schema = postgresql_db.fetch_all(
@@ -484,3 +584,36 @@ def test_hc_postgresql_provider_order_and_wrong_key_gate(postgresql_db) -> None:
             postgresql_db.rollback()
             postgresql_db.execute(f"DROP TABLE {table_name}")
             postgresql_db.commit()
+
+
+def test_hc_postgresql_dual_rejects_extra_required_column_on_either_target(
+    postgresql_db, tmp_path
+) -> None:
+    for table_name, standard in (("NL_HC", False), ("HANRO", True)):
+        safe_schema = JRAVAN_SCHEMAS[table_name] if standard else SCHEMAS[table_name]
+        unsafe_schema = _defective_schema(table_name, "extra-required-column")
+        for unsafe_target in ("primary", "secondary"):
+            sqlite = SQLiteDatabase({"path": str(tmp_path / f"{table_name}-{unsafe_target}.db")})
+            with sqlite:
+                sqlite.execute(unsafe_schema if unsafe_target == "primary" else safe_schema)
+                postgresql_db.execute(
+                    unsafe_schema if unsafe_target == "secondary" else safe_schema
+                )
+                sqlite.commit()
+                postgresql_db.commit()
+
+                with pytest.raises(SchemaMigrationError):
+                    DataImporter(
+                        DualDatabase(sqlite, postgresql_db),
+                        use_jravan_schema=standard,
+                    ).import_records(iter([parsed_record()]))
+
+                assert sqlite.fetch_one(f"SELECT COUNT(*) AS count FROM {table_name}") == {
+                    "count": 0
+                }
+                assert postgresql_db.fetch_one(f"SELECT COUNT(*) AS count FROM {table_name}") == {
+                    "count": 0
+                }
+                postgresql_db.rollback()
+                postgresql_db.execute(f"DROP TABLE {table_name}")
+                postgresql_db.commit()

--- a/tests/test_hc_official_contract.py
+++ b/tests/test_hc_official_contract.py
@@ -426,6 +426,12 @@ def _defective_schema(table_name: str, defect: str) -> str:
         )
     if defect == "extra-required-column":
         return schema.replace(key, f"ExternalRequired TEXT NOT NULL, {key}")
+    if defect == "extra-generated-required-column":
+        return schema.replace(
+            key,
+            "ExternalRequired TEXT GENERATED ALWAYS AS (NULL) "
+            f"VIRTUAL NOT NULL, {key}",
+        )
     if defect == "wrong-type":
         if table_name == "NL_HC":
             return schema.replace("ChokyoDate TEXT", "ChokyoDate INTEGER")
@@ -450,6 +456,7 @@ def _defective_schema(table_name: str, defect: str) -> str:
         "extra-check",
         "extra-foreign-key",
         "extra-required-column",
+        "extra-generated-required-column",
         "wrong-type",
         "nullable-key",
     ],
@@ -617,3 +624,27 @@ def test_hc_postgresql_dual_rejects_extra_required_column_on_either_target(
                 postgresql_db.rollback()
                 postgresql_db.execute(f"DROP TABLE {table_name}")
                 postgresql_db.commit()
+
+        sqlite = SQLiteDatabase({"path": str(tmp_path / f"{table_name}-generated.db")})
+        with sqlite:
+            sqlite.execute(_defective_schema(table_name, "extra-generated-required-column"))
+            postgresql_db.execute(safe_schema)
+            sqlite.commit()
+            postgresql_db.commit()
+            dual = DualDatabase(postgresql_db, sqlite)
+            importer = DataImporter(dual, use_jravan_schema=standard)
+
+            with pytest.raises(SchemaMigrationError):
+                importer.import_records(iter([parsed_record()]))
+
+            assert importer.get_statistics()["records_imported"] == 0
+            assert dual.secondary_in_sync is True
+            assert sqlite.fetch_one(f"SELECT COUNT(*) AS count FROM {table_name}") == {
+                "count": 0
+            }
+            assert postgresql_db.fetch_one(f"SELECT COUNT(*) AS count FROM {table_name}") == {
+                "count": 0
+            }
+            postgresql_db.rollback()
+            postgresql_db.execute(f"DROP TABLE {table_name}")
+            postgresql_db.commit()

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -128,6 +128,22 @@ class TestIndividualParsers:
                 mutable[187:188] = b"2"
                 mutable[188:198] = b"0000000100"
                 data = bytes(mutable)
+            if record_type == "HC":
+                # HC requires its complete four-part identity and all seven
+                # fixed numeric time spans; a blank envelope is not valid.
+                mutable = bytearray(data)
+                mutable[11:12] = b"0"
+                mutable[12:20] = b"20240601"
+                mutable[20:24] = b"0630"
+                mutable[24:34] = b"2020000001"
+                mutable[34:38] = b"0480"
+                mutable[38:41] = b"120"
+                mutable[41:45] = b"0360"
+                mutable[45:48] = b"120"
+                mutable[48:52] = b"0240"
+                mutable[52:55] = b"120"
+                mutable[55:58] = b"120"
+                data = bytes(mutable)
             if record_type == "AV":
                 mutable = bytearray(data)
                 mutable[11:15] = b"2024"

--- a/tests/test_reconstructed_db_fixtures.py
+++ b/tests/test_reconstructed_db_fixtures.py
@@ -294,6 +294,10 @@ class TestHCParserReconstructedValues:
         assert "ChokyosiCode" not in result
         assert "HonSyokinHeichi" not in result
 
+    def test_rejects_reconstructed_rows_with_blank_fixed_numeric_times(self):
+        assert self.parser.parse(self.records[0]) is None
+        assert self.parser.parse(self.records[1]) is None
+
     def test_parses_official_hanro_positions(self):
         result = self.parser.parse(self.records[-1])
 

--- a/tests/test_reconstructed_db_fixtures.py
+++ b/tests/test_reconstructed_db_fixtures.py
@@ -41,7 +41,6 @@ PARSER_MAP = {
     "BR": (BRParser, BRParser.RECORD_LENGTH),
     "CH": (CHParser, CHParser.RECORD_LENGTH),
     "DM": (DMParser, DMParser.RECORD_LENGTH),
-    "HC": (HCParser, 60),
     "HN": (HNParser, 251),
     "HS": (HSParser, 200),
     "HY": (HYParser, 123),
@@ -55,6 +54,10 @@ PARSER_MAP = {
     "TM": (TMParser, TMParser.RECORD_LENGTH),
     "YS": (YSParser, YSParser.RECORD_LENGTH),
 }
+# HC records are also excluded from the generic all-row positive matrix. Two
+# reconstructed rows contain space-filled fixed numeric spans that are not
+# valid current provider HC. The dedicated class below retains the one complete
+# value reconstruction, while the official HC contract is authoritative.
 # The old O1-O6 fixture files were reconstructed from already-expanded SQL
 # rows, not preserved provider records. They cannot prove a physical parser
 # contract; complete current layouts are covered in test_time_series.py.


### PR DESCRIPTION
## Summary

- bind `HC` to the reviewed current 60-byte JV-Data 4.8.0.2/4.9.0.1 and SDK 5.0 `JV_HC_HANRO` layout
- preserve the official four-part identity in native `NL_HC` and standard `HANRO`, including provider-order update and exact status-0 erase
- validate caller-built keys/timings before coercion, preserve documented zero measurements as `0.0`, and keep delete bodies opaque by explicit project policy
- fail closed on nullable, keyless, wrong-key/type/capacity, extra-column, generated-column, UNIQUE, CHECK, FK, or deferrable/incompatible HC storage before mutation
- document the rebuild/reimport boundary and HC's accumulated-only ownership without making a 64-bit support claim

## Root cause and impact

The previous HC implementation was only a permissive layout reconstruction. It did not enforce the official key/body domains, standard `HANRO` was keyless, status 0 could become a tombstone, and schema verification could allow writes into incompatible storage. In Dual mode an unapproved required column could allow one backend to persist while the other failed.

Existing incompatible `NL_HC` or `HANRO` tables are not guessed or amended. Operators must back up, rebuild with the current schema, and reimport `SLOP`.

## Official-source and red-first evidence

- pinned workbook SHA-256 values, every byte span, SDK structure, key, status set, timing sentinel/unit, 2003/2004 history, delivery unit, and retention are bound in the tracked compact oracle
- unchanged base `ed39ac78aa371e7ce4e18a87d8a25c50a07fe78a`: `31 failed, 1 passed, 1 skipped` before production repair
- first review candidate `ffb75074d61d7ef9424ba210088442795f394504`: ordinary required-column negatives failed with `DID NOT RAISE SchemaMigrationError`
- carry-forward parent `70207a8fcce93fbadee04d58cc38fb3546334304`: generated required-column negatives failed with the same expected red result
- delete-key, blank-timing, and realtime-routing mutants were also proved red by the independent test review

## Validation for exact head

Head: `58f4ae126a4cd47d9fbab8120a15a2be14a2c69b`

- SQLite HC + reconstructed contract: `121 passed, 2 skipped`
- fresh PostgreSQL 16 plus cross-engine Dual contract: `45 passed`
- affected parser/current-layout/schema/metadata selection: `568 passed, 9 skipped`
- prior one-time workflow-equivalent full suite on the same implementation line: `3314 passed, 333 skipped, 14 deselected, 20 subtests passed`
- fatal flake8: `0`; `TEST GATE PASS`; compileall, `uv lock --check`, and `git diff --check`: pass
- exact `git archive` PEP 517 wheel/sdist build, distribution content gate, and installed-wheel SQLite smoke: pass
- final bounded official-oracle and SQLite/PostgreSQL/Dual critical reviews: GREEN, P0/P1/P2 = 0

Claude Code Fable was selected for this complex validator iteration, but its local OAuth refresh failed before a usable session was created. Per the approved fallback, implementation followed red-first evidence and three independent Codex reviews on frozen full SHAs.

## Scope

This PR is HC-only. It does not release the package, change NAR or MCP repositories, claim realtime HC support, or claim validated 64-bit SDK support. TC/CC and the final cumulative release audit remain follow-up iterations.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for official HC hill-training records using the standardized 60-byte layout and four-part identity.
  * Preserves timing data with required precision across native and standard table formats.
  * Supports ordered updates and exact deletion of status-0 records.
  * HC data remains accumulated-only and is not written to realtime storage.

* **Bug Fixes**
  * Rejects malformed records and incompatible or unsafe table schemas before changes are applied.
  * Improved handling of zero measurements and legacy-table migration requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->