### PR TITLE
Enforce the official TC record contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,13 @@
 
 ### Fixed
 
+- `TC`を公式45バイト配置と6項目race keyへ結び付け、発表`MMDDhhmm`と変更前後
+  `HHmm`をlosslessに検証・保存する。native `NL_TC`、速報`RT_TC`、標準名
+  `HASSOU_JIKOKU_CHANGE`でprovider順の改訂を1行へ反映し、current status 1以外、
+  不正日付/競馬場/時刻、nullable・keyless・wrong-type・追加constraintをmutation前に
+  拒否する。TCにはstatus 0 deleteを作らず、`0B14`の正常完了後だけ日単位の完全
+  snapshot置換を行う。旧unsafe tableと旧標準名`COMMENT`はbackup・rebuild・
+  reimportを要求する
 - `HC`を公式現行60バイト配置と4項目キーへ結び付け、native `NL_HC`と標準名
   `HANRO`で7つの走破・lap time fieldを0.1秒単位で保持し、provider順の更新、
   status 0 exact delete、caller validation、SQLite/PostgreSQLのstrict schema

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -32,6 +32,13 @@ Public API replacements:
   malformed CP932 in interpreted fields and unsupported historical/synthetic
   lengths, and preserve explicitly supported old/new semantic boundaries
   instead of guessing them
+- TC start-time changes now use the official 45-byte layout and exact six-part
+  race identity in `NL_TC`, `RT_TC`, and `HASSOU_JIKOKU_CHANGE`. Announcement
+  and before/after times remain lossless fixed-width text; current status 1 is
+  the only accepted TC status. Unsafe legacy/keyless/nullable/extended tables
+  require backup, rebuild, and reimport. TC does not invent a status-0 delete:
+  stale realtime changes are removed only by a successfully completed 0B14
+  full-date snapshot replacement
 - native and standard schemas now verify primary keys, types, capacities,
   child-table constraints, and cancellation/delete behavior before mutation;
   several record families gained complete child storage or corrected keys

--- a/docs/data_support.md
+++ b/docs/data_support.md
@@ -180,6 +180,28 @@ JRA-VAN標準名は `TENKO_BABA`, `TORIKESI_JYOGAI`, `KISYU_CHANGE`,
 標準名スキーマ（`VARCHAR(8)`）で再作成した後、JRA-VANの保持期間内のデータを
 再取得してください。既存値を時刻部分だけで移植しないでください。
 
+### TC（発走時刻変更）の現行契約
+
+`TC` は現行JV-Data 4.9.0.1 / SDK 5.0.0の45バイト配置だけを受け付けます。
+identityは `Year`, `MonthDay`, `JyoCD`, `Kaiji`, `Nichiji`, `RaceNum` の
+6項目です。native `NL_TC`、速報 `RT_TC`、JRA-VAN標準名
+`HASSOU_JIKOKU_CHANGE` は同じordered primary key、必須header/key/body、
+公式field capacityを使います。`HappyoTime` は `MMDDhhmm`、変更後・変更前の
+時刻は各 `HHmm` として先頭ゼロを保ったまま保存します。公式の初期値
+`00000000` / `0000` も欠損へ変換しません。
+
+現行の公式 `DataKubun` は `1` だけです。`0`をTC単体の削除指示として扱いません。
+`0B14` は指定日の完全な開催変更snapshotなので、正常終了を確認した同一transaction
+内で当該日の `RT_WE` / `RT_AV` / `RT_JC` / `RT_TC` / `RT_CC` を置換し、後続snapshot
+から消えた変更を除去します。`0B16` は指定イベントの更新であり、この日単位置換とは
+別です。
+
+既存のnullable、keyless、wrong-key、wrong-type、容量不足、追加列または追加
+UNIQUE/FK/CHECKを持つTC tableは自動修復せず、mutation前に停止します。DBを
+backupして該当TC tableをcurrent schemaでrebuildし、保持期間内の`0B14`/`0B16`
+または対応する蓄積sourceからreimportしてください。旧標準名`COMMENT`しかない構成を
+`HASSOU_JIKOKU_CHANGE`へ自動転用しません。
+
 ## JVRTOpen オッズ・票数
 
 | データ種別 | 内容 | 想定レコード種別 | 通常速報モードの保存先 | 時系列モードの保存先 | キー形式 | JRA-VAN 側の保持 | 運用コマンド |

--- a/docs/data_support.md
+++ b/docs/data_support.md
@@ -196,8 +196,9 @@ identityは `Year`, `MonthDay`, `JyoCD`, `Kaiji`, `Nichiji`, `RaceNum` の
 から消えた変更を除去します。`0B16` は指定イベントの更新であり、この日単位置換とは
 別です。
 
-既存のnullable、keyless、wrong-key、wrong-type、容量不足、追加列または追加
-UNIQUE/FK/CHECKを持つTC tableは自動修復せず、mutation前に停止します。DBを
+既存のnullable、keyless、wrong-key、wrong-type、容量不足、generated/identity列、
+追加列または追加UNIQUE/FK/CHECKを持つTC tableは自動修復せず、mutation前に
+停止します。DBを
 backupして該当TC tableをcurrent schemaでrebuildし、保持期間内の`0B14`/`0B16`
 または対応する蓄積sourceからreimportしてください。旧標準名`COMMENT`しかない構成を
 `HASSOU_JIKOKU_CHANGE`へ自動転用しません。

--- a/specs/operations/20260818_tc_official_contract_worklog.md
+++ b/specs/operations/20260818_tc_official_contract_worklog.md
@@ -45,6 +45,17 @@
   the failure will be recorded and Codex will implement with independent Codex
   reviews rather than silently changing the gate.
 
+### Claude execution result
+
+- Claude Code `2.1.233` was invoked with `--model fable` and session id
+  `eabbe5e2-34f9-4fe1-b4f9-a85d3976f230` after the start-worklog commit. It
+  exited before reading or editing the repository because the OAuth session was
+  expired and could not be refreshed. The CLI also printed non-fatal warnings
+  about obsolete `Write(...)` permission-rule spellings in the parent Claude
+  settings. No Claude implementation or review evidence exists for this
+  iteration. Codex will implement the bounded contract and require independent
+  official-oracle and critical Codex review as the recorded fallback.
+
 ## Known preliminary risks (not yet official findings)
 
 - Current `TCParser` has no TC-specific key/body validator.

--- a/specs/operations/20260818_tc_official_contract_worklog.md
+++ b/specs/operations/20260818_tc_official_contract_worklog.md
@@ -75,3 +75,97 @@
   destructive/provider operation would be required without new authority.
 - No credentials, provider identifiers, or connection strings belong in this
   worklog.
+
+## Official oracle and red-first evidence (2026-08-18)
+
+- Pinned sources were re-read from the locally archived artifacts. SHA-256:
+  `JV-Data4802.xlsx` =
+  `6a567f10b601115eca350571f36d27d9d28bd2d3835ea72b5bc057711155d4a7`,
+  `JV-Data4901.xlsx` =
+  `23bafd375f704acbdd696b5032ac1619f17d47e882587d6e7954b610527a8234`,
+  SDK 5.0.0 `JVData_Struct.cs` =
+  `605057bb211eb6a94056a54496f3dd30f864ac2ad140fcfc8840ac8a6ed9e4fe`.
+- Both workbook format sheets rows 1509-1528 and SDK `JV_TC_INFO` agree:
+  record length 45 bytes; current status is only `1`; the ordered official key
+  is `(Year, MonthDay, JyoCD, Kaiji, Nichiji, RaceNum)`; announcement time is
+  MDHM at bytes 28-35; changed and prior HHMM values occupy bytes 36-39 and
+  40-43; CRLF is bytes 44-45. TC was added 2004-05-25 in Ver.1.1.6. Current
+  provider contexts are 0B14/0B16, with 0B14 a complete date snapshot.
+- Two independent read-only Codex triages of exact master `282e03a...` both
+  ranked TC first. Each reproduced malformed HHMM/MDHM or JyoCD values being
+  stored and duplicate standard rows because `HASSOU_JIKOKU_CHANGE` was
+  keyless; both recommended keeping CC as the next separate iteration.
+- Added compact `tests/test_tc_official_contract.py` plus
+  `tc_contract_4901.json` without production edits. After correcting one test
+  harness import and one SQLite DDL placement error, the exact base run was:
+  `33 failed, 5 passed`. Representative red evidence: parser span lacked
+  `RecordDelimiter`; malformed dates/codes/times did not raise; standard
+  revision left two rows; schema/nullability/constraint defects were accepted;
+  batch/single/realtime caller validation did not fail closed. The valid
+  current-status and zero-initialized time controls remained green.
+- Exact red command:
+  `python -m pytest -q -o addopts='' --basetemp /tmp/jrvltsql-tc-red2 tests/test_tc_official_contract.py`.
+
+## Implementation and backend evidence (2026-08-18)
+
+- Implemented a strict TC parser that binds all 15 physical spans, validates
+  fixed-width source text before legacy numeric conversion, accepts only the
+  official status `1`, requires real dates/official JyoCD/HHMM values, and
+  preserves the official all-zero initial time representations.
+- Changed `NL_TC`, `RT_TC`, and `HASSOU_JIKOKU_CHANGE` to the same six-part
+  ordered primary key and complete NOT NULL storage contract. Added exact
+  type/capacity/nullability/column/constraint preflight to both importers,
+  single-record import, realtime dictionaries, standard preflight, and public
+  native schema creation. The standard legacy `COMMENT` table is rejected
+  rather than guessed as the TC owner.
+- Kept the provider distinction explicit: TC has no status-0 record deletion.
+  Completed `0B14` responses continue to replace all five date-snapshot tables
+  atomically; `0B16` remains event-scoped.
+- The compact SQLite contract reached `57 passed, 35 PostgreSQL skipped` after
+  expanding both importer classes, auto-commit modes, single/realtime, exact
+  schema negatives, and a public SchemaManager preflight pair. Existing
+  snapshot/HappyoTime/realtime alias fixtures that had built incomplete TC rows
+  were updated to valid complete current records; production strictness was not
+  relaxed.
+- A dedicated disposable PostgreSQL 16 instance was started only for this
+  iteration. Native/standard, DataImporter/OptimizedDataImporter/single,
+  auto-commit true/false, same-key provider revisions, realtime rejection,
+  unsafe constraint/type/key schemas, and SQLite/PostgreSQL Dual orientation
+  reached `92 passed`. PostgreSQL reported both accepted provider operations
+  while retaining exactly the revised row, matching SQLite semantics.
+- The non-E2E/non-integration full suite completed with `3394 passed, 369
+  skipped, 20 subtests passed`. Its first run exposed three shared parser tests
+  that still treated a blank TC body as a positive fixture; those tests were
+  corrected to carry the official six-key identity and valid announcement and
+  before/after times, after which the full suite passed without relaxing the
+  production validator.
+- The affected parser/importer/migration/realtime selection completed with
+  `271 passed, 37 skipped, 9 subtests passed`; the shared all-parser module
+  separately completed with `292 passed` after the TC fixture correction.
+- Fatal Python lint (`E9,F63,F7,F82`), the repository test-gate validator,
+  `uv lock --check`, `git diff --check`, and Black checks for the new TC parser
+  and official-contract module all passed. The older shared parser test module
+  is not globally Black-clean on the base, so it was deliberately not
+  mechanically reformatted beyond the TC fixture block.
+- The final disposable PostgreSQL container was removed after the green run;
+  no test database or container from this iteration remains active.
+- A fresh `git archive` source tree produced the real
+  `jltsql-2.0.0.dev0` wheel and sdist. The distribution-content gate passed
+  both artifacts, and the extracted-wheel smoke completed `init`, configuration
+  display/version, and SQLite table creation using only modules from the wheel.
+  Temporary build/install directories were removed after verification.
+- Public support/migration documentation, the release draft/changelog,
+  executable metadata, and the official-fixture catalog now describe the TC
+  contract and rebuild/reimport boundary. No release or production adoption is
+  claimed by this candidate.
+
+## Next safe command and STOP conditions
+
+- Freeze one clean full SHA after committing this evidence and run the actual
+  git-archive wheel/sdist content and installed-wheel smoke gates against that
+  immutable candidate. Send that
+  exact SHA once to both independent Codex reviewers, aggregate findings, and
+  apply at most one consolidated repair batch before PR gates.
+- STOP on any non-worklog external drift, backend divergence, unresolved
+  correctness/data-integrity finding, or recovery state that cannot be proven
+  safe without additional authority.

--- a/specs/operations/20260818_tc_official_contract_worklog.md
+++ b/specs/operations/20260818_tc_official_contract_worklog.md
@@ -159,13 +159,48 @@
   contract and rebuild/reimport boundary. No release or production adoption is
   claimed by this candidate.
 
+## Independent review and consolidated repair (2026-08-18)
+
+- Three independent read-only reviews targeted exact clean candidate
+  `c5953c8777fa9a592fad8a66dc17b12dba268bc6`: official workbook/SDK oracle,
+  SQLite/fresh PostgreSQL/Dual data-integrity attack, and test/package mutant
+  review. The official 45-byte/15-span/status-1/six-key/provider-context oracle
+  remained correct, but the reviewers found four grouped implementation gaps
+  and three test-oracle gaps.
+- The implementation gaps were: caller `datetime` values passing the DATE-only
+  MakeDate contract; secondary-only legacy `COMMENT` escaping Dual preflight;
+  generated/identity official columns and comment-obfuscated SQLite CHECKs
+  escaping strict schema validation; and the first invalid direct realtime TC
+  opening a lazy PostgreSQL catalog transaction before validation. The test
+  gaps were: nullable body columns not explicitly asserted, stale same-date TC
+  races not read back after 0B14 replacement, and 0B16 non-replacement not
+  bound to monitor behavior.
+- Tests were extended before the implementation repair. Exact c595 production
+  with those tests failed `12` SQLite cases and `19` cases with fresh
+  PostgreSQL enabled. Separately, the test reviewer proved the old 0B14 test
+  false-green with a mutation that disabled only the RT_TC date deletion; the
+  expanded two-race survivor assertion turns that mutant red.
+- One consolidated repair now rejects `datetime`, inspects every concrete Dual
+  migration target, rejects generated/identity/hidden official columns,
+  lexes SQLite DDL without comments or quoted tokens before CHECK detection,
+  and validates direct realtime TC input before any catalog read. Existing
+  tests were expanded rather than adding one function per review hypothesis.
+- Repair verification is green: SQLite TC/realtime `66 passed, 39 skipped`;
+  fresh PostgreSQL 16 TC contract `104 passed`; affected official/importer/
+  migration/realtime selection `1413 passed, 309 skipped, 9 subtests passed`;
+  and the non-E2E/non-integration full suite `3402 passed, 373 skipped, 20
+  subtests passed`. Fatal lint, test gate, lock check, Black on the new TC files,
+  and diff check also pass. The repair PostgreSQL container and red/green logs
+  were removed.
+
 ## Next safe command and STOP conditions
 
-- Freeze one clean full SHA after committing this evidence and run the actual
-  git-archive wheel/sdist content and installed-wheel smoke gates against that
-  immutable candidate. Send that
-  exact SHA once to both independent Codex reviewers, aggregate findings, and
-  apply at most one consolidated repair batch before PR gates.
+- Commit the consolidated repair and freeze a clean full SHA. Ask the same
+  reviewers only for bounded closure of their recorded findings, then rerun the
+  git-archive wheel/sdist content and installed-wheel smoke gates on that final
+  immutable candidate. If closure is green, push one PR, resolve every review
+  thread, verify the required checks on the exact PR head, and merge before the
+  separate CC iteration begins.
 - STOP on any non-worklog external drift, backend divergence, unresolved
   correctness/data-integrity finding, or recovery state that cannot be proven
   safe without additional authority.

--- a/specs/operations/20260818_tc_official_contract_worklog.md
+++ b/specs/operations/20260818_tc_official_contract_worklog.md
@@ -193,7 +193,7 @@
   and diff check also pass. The repair PostgreSQL container and red/green logs
   were removed.
 
-## Next safe command and STOP conditions
+## Final next safe command and STOP conditions
 
 - Commit the consolidated repair and freeze a clean full SHA. Ask the same
   reviewers only for bounded closure of their recorded findings, then rerun the

--- a/specs/operations/20260818_tc_official_contract_worklog.md
+++ b/specs/operations/20260818_tc_official_contract_worklog.md
@@ -1,0 +1,66 @@
+# TC official contract iteration worklog
+
+## Start state (2026-08-18)
+
+- Objective: bind the JRA `TC` start-time-change record to the pinned official
+  physical layout, status/key/body domains, native/standard/realtime storage,
+  exact schema preflight, provider ordering, and durable transaction semantics.
+- Minimal scope: `TC` only. The adjacent `CC` record remains a separate later
+  iteration even where implementation helpers may ultimately be shared.
+- Repository: `miyamamoto/jrvltsql`.
+- Worktree: `/home/keiba/scratch/20260818_jrvltsql_tc_official`.
+- Branch: `agent/tc-official-contract-20260818`.
+- Base and starting HEAD: `282e03a5cba06fdc42d4d651ee7624b27dadad01`
+  (`origin/master`, HC PR #213 squash merge).
+- Package version: `2.0.0.dev0`; latest published release remains `v1.6.10`.
+  This iteration is not itself a release or production-adoption claim.
+- Dependency order: HC is merged; TC is independent of the later CC iteration.
+- Working tree was clean at creation.
+
+## Planned contract and evidence
+
+1. Re-derive the TC byte spans, total length, ordered key, status domain,
+   history, and delivery context from the pinned JV-Data 4.8/4.9 workbooks and
+   SDK 5 source/manifest before changing production code.
+2. Extend or add one compact official-contract test module. New/changed
+   validators and schema gates must first be shown red on the exact base, with
+   paired valid green cases. Avoid a test function per reviewer hypothesis.
+3. Cover direct/factory parsing; caller aliases; native `NL_TC`; standard
+   `HASSOU_JIKOKU_CHANGE`; `RT_TC`; both batch importers; single-record import;
+   SQLite, fresh PostgreSQL, Dual orientation, caller-owned transactions,
+   exact-key coexistence/update behavior, and fail-before-mutation migration.
+4. Update executable metadata, public support/migration documentation, release
+   notes/changelog, and this worklog only to the degree required by the proven
+   TC contract.
+5. Freeze one full candidate SHA, aggregate independent official-oracle and
+   critical reviews, apply at most one consolidated repair batch, then run the
+   required focused/workflow/package gates before opening and merging one PR.
+
+## Coding-agent choice
+
+- Complex fail-closed validator/schema/migration work qualifies for Claude
+  Fable under `AGENTS.md`. Planned CLI model is `--model fable` with session id
+  `eabbe5e2-34f9-4fe1-b4f9-a85d3976f230`; the same session will be resumed for
+  review repairs. If Claude authentication/quota prevents useful execution,
+  the failure will be recorded and Codex will implement with independent Codex
+  reviews rather than silently changing the gate.
+
+## Known preliminary risks (not yet official findings)
+
+- Current `TCParser` has no TC-specific key/body validator.
+- Native/realtime tables use a six-column race key while standard
+  `HASSOU_JIKOKU_CHANGE` currently has no primary key; official key membership
+  must be re-derived before deciding whether either layout is correct.
+- Key columns and field types are not currently protected by a TC-specific
+  strict schema verifier.
+
+## Next safe command and STOP conditions
+
+- Next: extract the TC workbook/SDK oracle and compare it mechanically with
+  parser/schema/importer/realtime mappings, then write the smallest red-first
+  contract before production edits.
+- STOP if HEAD/worktree drifts outside this worklog, pinned official artifacts
+  disagree materially, a required real-backend proof cannot be isolated, or a
+  destructive/provider operation would be required without new authority.
+- No credentials, provider identifiers, or connection strings belong in this
+  worklog.

--- a/src/database/schema.py
+++ b/src/database/schema.py
@@ -1252,20 +1252,20 @@ SCHEMAS = {
 
     "NL_TC": """
         CREATE TABLE IF NOT EXISTS NL_TC (
-            RecordSpec TEXT,
-            DataKubun TEXT,
-            MakeDate TEXT,
-            Year INTEGER,
-            MonthDay INTEGER,
-            JyoCD TEXT,
-            Kaiji INTEGER,
-            Nichiji INTEGER,
-            RaceNum INTEGER,
-            HappyoTime TEXT,
-            AtoJi TEXT,
-            AtoFun TEXT,
-            MaeJi TEXT,
-            MaeFun TEXT,
+            RecordSpec TEXT NOT NULL,
+            DataKubun TEXT NOT NULL,
+            MakeDate TEXT NOT NULL,
+            Year INTEGER NOT NULL,
+            MonthDay INTEGER NOT NULL,
+            JyoCD TEXT NOT NULL,
+            Kaiji INTEGER NOT NULL,
+            Nichiji INTEGER NOT NULL,
+            RaceNum INTEGER NOT NULL,
+            HappyoTime TEXT NOT NULL,
+            AtoJi TEXT NOT NULL,
+            AtoFun TEXT NOT NULL,
+            MaeJi TEXT NOT NULL,
+            MaeFun TEXT NOT NULL,
             PRIMARY KEY (Year, MonthDay, JyoCD, Kaiji, Nichiji, RaceNum)
         )
     """,
@@ -2352,20 +2352,20 @@ SCHEMAS = {
     """,
     "RT_TC": """
         CREATE TABLE IF NOT EXISTS RT_TC (
-            RecordSpec TEXT,
-            DataKubun TEXT,
-            MakeDate TEXT,
-            Year INTEGER,
-            MonthDay INTEGER,
-            JyoCD TEXT,
-            Kaiji INTEGER,
-            Nichiji INTEGER,
-            RaceNum INTEGER,
-            HappyoTime TEXT,
-            AtoJi TEXT,
-            AtoFun TEXT,
-            MaeJi TEXT,
-            MaeFun TEXT,
+            RecordSpec TEXT NOT NULL,
+            DataKubun TEXT NOT NULL,
+            MakeDate TEXT NOT NULL,
+            Year INTEGER NOT NULL,
+            MonthDay INTEGER NOT NULL,
+            JyoCD TEXT NOT NULL,
+            Kaiji INTEGER NOT NULL,
+            Nichiji INTEGER NOT NULL,
+            RaceNum INTEGER NOT NULL,
+            HappyoTime TEXT NOT NULL,
+            AtoJi TEXT NOT NULL,
+            AtoFun TEXT NOT NULL,
+            MaeJi TEXT NOT NULL,
+            MaeFun TEXT NOT NULL,
             PRIMARY KEY (Year, MonthDay, JyoCD, Kaiji, Nichiji, RaceNum)
         )
     """,
@@ -2760,6 +2760,7 @@ STRICT_AV_STORAGE_TABLES = frozenset({"NL_AV", "RT_AV"})
 STRICT_HR_STORAGE_TABLES = frozenset({"NL_HR", "RT_HR"})
 STRICT_HS_STORAGE_TABLES = frozenset({"NL_HS"})
 STRICT_HC_STORAGE_TABLES = frozenset({"NL_HC"})
+STRICT_TC_STORAGE_TABLES = frozenset({"NL_TC", "RT_TC"})
 STRICT_JC_STORAGE_TABLES = frozenset({"NL_JC", "RT_JC"})
 
 
@@ -2774,6 +2775,7 @@ def _preflight_existing_strict_storage(db: BaseDatabase) -> None:
         verify_hs_storage_schema,
         verify_jc_storage_schema,
         verify_se_storage_schema,
+        verify_tc_storage_schema,
         verify_we_storage_schema,
     )
 
@@ -2813,6 +2815,9 @@ def _preflight_existing_strict_storage(db: BaseDatabase) -> None:
         for table_name in STRICT_HC_STORAGE_TABLES:
             if target.table_exists_strict(table_name):
                 verify_hc_storage_schema(target, table_name)
+        for table_name in STRICT_TC_STORAGE_TABLES:
+            if target.table_exists_strict(table_name):
+                verify_tc_storage_schema(target, table_name)
         for table_name in STRICT_JC_STORAGE_TABLES:
             if target.table_exists_strict(table_name):
                 verify_jc_storage_schema(target, table_name)
@@ -2907,6 +2912,10 @@ class SchemaManager:
                 from src.importer.importer import verify_hc_storage_schema
 
                 verify_hc_storage_schema(self.db, table_name)
+            if table_name in STRICT_TC_STORAGE_TABLES:
+                from src.importer.importer import verify_tc_storage_schema
+
+                verify_tc_storage_schema(self.db, table_name)
             if table_name in STRICT_JC_STORAGE_TABLES:
                 from src.importer.importer import verify_jc_storage_schema
 
@@ -2973,6 +2982,10 @@ class SchemaManager:
                     from src.importer.importer import verify_hc_storage_schema
 
                     verify_hc_storage_schema(self.db, table_name)
+                if table_name in STRICT_TC_STORAGE_TABLES:
+                    from src.importer.importer import verify_tc_storage_schema
+
+                    verify_tc_storage_schema(self.db, table_name)
                 if table_name in STRICT_JC_STORAGE_TABLES:
                     from src.importer.importer import verify_jc_storage_schema
 
@@ -3342,6 +3355,10 @@ def create_all_tables(db: BaseDatabase) -> None:
                 from src.importer.importer import verify_hc_storage_schema
 
                 verify_hc_storage_schema(db, table_name)
+            if table_name in STRICT_TC_STORAGE_TABLES:
+                from src.importer.importer import verify_tc_storage_schema
+
+                verify_tc_storage_schema(db, table_name)
             if table_name in STRICT_JC_STORAGE_TABLES:
                 from src.importer.importer import verify_jc_storage_schema
 

--- a/src/database/schema_jravan.py
+++ b/src/database/schema_jravan.py
@@ -479,20 +479,21 @@ JRAVAN_SCHEMAS: Dict[str, str] = {
     """,
     "HASSOU_JIKOKU_CHANGE": """
         CREATE TABLE IF NOT EXISTS HASSOU_JIKOKU_CHANGE (
-            RecordSpec                     CHAR(2)             ,  -- レコード種別ID
-            DataKubun                      CHAR(1)             ,  -- データ区分
-            MakeDate                       DATE                ,  -- YYYYMMDD形式の日付
-            Year                           SMALLINT            ,  -- 年(4桁)
-            MonthDay                       SMALLINT            ,  -- 月日(MMDD)
-            JyoCD                          CHAR(2)             ,  -- 競馬場コード
-            Kaiji                          SMALLINT            ,  -- 開催回
-            Nichiji                        SMALLINT            ,  -- 開催日目
-            RaceNum                        SMALLINT            ,  -- レース番号
-            HappyoTime                     VARCHAR(8)          ,  -- 発表月日時分(MMDDhhmm)
-            AtoJi                          VARCHAR(2)          ,  -- 文字列(2)
-            AtoFun                         VARCHAR(2)          ,  -- 文字列(2)
-            MaeJi                          VARCHAR(2)          ,  -- 文字列(2)
-            MaeFun                         VARCHAR(2)            -- 文字列(2)
+            RecordSpec                     CHAR(2) NOT NULL    ,  -- レコード種別ID
+            DataKubun                      CHAR(1) NOT NULL    ,  -- データ区分(現行は1のみ)
+            MakeDate                       DATE NOT NULL       ,  -- YYYYMMDD形式の日付
+            Year                           SMALLINT NOT NULL   ,  -- 年(4桁)
+            MonthDay                       SMALLINT NOT NULL   ,  -- 月日(MMDD)
+            JyoCD                          CHAR(2) NOT NULL    ,  -- 競馬場コード
+            Kaiji                          SMALLINT NOT NULL   ,  -- 開催回
+            Nichiji                        SMALLINT NOT NULL   ,  -- 開催日目
+            RaceNum                        SMALLINT NOT NULL   ,  -- レース番号
+            HappyoTime                     VARCHAR(8) NOT NULL ,  -- 発表月日時分(MMDDhhmm)
+            AtoJi                          VARCHAR(2) NOT NULL ,  -- 変更後 時
+            AtoFun                         VARCHAR(2) NOT NULL ,  -- 変更後 分
+            MaeJi                          VARCHAR(2) NOT NULL ,  -- 変更前 時
+            MaeFun                         VARCHAR(2) NOT NULL ,  -- 変更前 分
+            PRIMARY KEY (Year, MonthDay, JyoCD, Kaiji, Nichiji, RaceNum)
         )
     """,
     "HYOSU": """

--- a/src/database/schema_metadata.py
+++ b/src/database/schema_metadata.py
@@ -895,23 +895,16 @@ TABLE_METADATA: Dict[str, TableMetadata] = {
         indexes=["Year", "MonthDay", "JyoCD", "RaceNum"],
     ),
 
-    "NL_TC": {
-        "table_name": "NL_TC",
-        "record_type": "TC",
-        "description": "発走時刻変更情報",
-        "purpose": "レースの発走時刻変更情報を格納",
-        "columns": [
-            {"name": "レコード種別ID", "type": "TEXT", "description": "レコード種別識別子（'TC'）", "example": "TC", "nullable": False},
-            {"name": "開催年月日", "type": "TEXT", "description": "レース開催日", "example": "20240601", "nullable": False},
-            {"name": "競馬場コード", "type": "TEXT", "description": "競馬場コード", "example": "05", "nullable": False},
-            {"name": "レース番号", "type": "TEXT", "description": "レース番号", "example": "11", "nullable": False},
-            {"name": "変更後_発走時刻", "type": "TEXT", "description": "変更後の発走時刻（HHmm形式）", "example": "1530", "nullable": True},
-            {"name": "変更前_発走時刻", "type": "TEXT", "description": "変更前の発走時刻", "example": "1520", "nullable": True},
-            {"name": "発表月日時分", "type": "TEXT", "description": "変更発表日時", "example": "06011200", "nullable": True}
-        ],
-        "primary_key": ["開催年月日", "競馬場コード", "レース番号"],
-        "indexes": ["開催年月日"]
-    },
+    "NL_TC": _schema_backed_metadata(
+        "NL_TC",
+        record_type="TC",
+        description="発走時刻変更情報",
+        purpose=(
+            "開催6列の公式キーで発走時刻変更の改訂を1行に保持し、発表月日時分と"
+            "変更前後の時分を先頭ゼロ付きで格納"
+        ),
+        indexes=["Year", "MonthDay", "JyoCD", "RaceNum"],
+    ),
 
     "NL_WE": _schema_backed_metadata(
         "NL_WE",
@@ -1450,22 +1443,16 @@ TABLE_METADATA: Dict[str, TableMetadata] = {
         "indexes": ["開催年月日", "血統登録番号", "確定着順"]
     },
 
-    "RT_TC": {
-        "table_name": "RT_TC",
-        "record_type": "TC",
-        "description": "発走時刻変更情報（速報）",
-        "purpose": "リアルタイムでの発走時刻変更情報を格納（NL_TCと同構造）",
-        "columns": [
-            {"name": "レコード種別ID", "type": "TEXT", "description": "レコード種別識別子（'TC'）", "example": "TC", "nullable": False},
-            {"name": "開催年月日", "type": "TEXT", "description": "レース開催日", "example": "20240601", "nullable": False},
-            {"name": "競馬場コード", "type": "TEXT", "description": "競馬場コード", "example": "05", "nullable": False},
-            {"name": "レース番号", "type": "TEXT", "description": "レース番号", "example": "11", "nullable": False},
-            {"name": "変更後_発走時刻", "type": "TEXT", "description": "変更後の発走時刻", "example": "1530", "nullable": True},
-            {"name": "変更前_発走時刻", "type": "TEXT", "description": "変更前の発走時刻", "example": "1520", "nullable": True}
-        ],
-        "primary_key": ["開催年月日", "競馬場コード", "レース番号"],
-        "indexes": ["開催年月日"]
-    },
+    "RT_TC": _schema_backed_metadata(
+        "RT_TC",
+        record_type="TC",
+        description="発走時刻変更情報（速報）",
+        purpose=(
+            "0B14/0B16の発走時刻変更を開催6列の公式キーで保持し、0B14の"
+            "正常完了時は日単位snapshotとして置換"
+        ),
+        indexes=["Year", "MonthDay", "JyoCD", "RaceNum"],
+    ),
 
     "RT_TM": {
         "table_name": "RT_TM",

--- a/src/database/table_mappings.py
+++ b/src/database/table_mappings.py
@@ -145,7 +145,7 @@ RECORD_TYPE_TO_TABLE: Dict[str, str] = {
     "HS": "NL_HS",  # 競走馬市場取引価格 (Sale)
     "AV": "NL_AV",  # 出走取消・競走除外 (Scratched/Excluded Horse)
     "BT": "NL_BT",  # 血統情報 (Bloodline)
-    "TC": "NL_TC",  # コメント (Training Comment)
+    "TC": "NL_TC",  # 発走時刻変更 (Start Time Change)
     "CK": "NL_CK",  # 調教詳細 (Training Details)
     "TM": "NL_TM",  # 対戦型データマイニング予想
     "DM": "NL_DM",  # タイム型データマイニング予想

--- a/src/importer/importer.py
+++ b/src/importer/importer.py
@@ -138,18 +138,21 @@ def resolve_standard_table_name(database: BaseDatabase, native_table_name: str) 
             "does not. Automatic JC import is refused; rebuild the standard table "
             "as KISYU_CHANGE and reimport current 161-byte source records."
         )
-    if (
-        native_table_name == "NL_TC"
-        and database.is_connected()
-        and database.table_exists("COMMENT")
-        and not database.table_exists(standard_name)
-    ):
-        raise SchemaMigrationError(
-            "Legacy standard table COMMENT exists but canonical "
-            "HASSOU_JIKOKU_CHANGE does not. Automatic TC import is refused; "
-            "rebuild the standard table as HASSOU_JIKOKU_CHANGE and reimport "
-            "current 45-byte source records."
-        )
+    if native_table_name == "NL_TC":
+        from src.database.migration import _migration_targets
+
+        for target in _migration_targets(database):
+            if (
+                target.is_connected()
+                and target.table_exists("COMMENT")
+                and not target.table_exists(standard_name)
+            ):
+                raise SchemaMigrationError(
+                    "Legacy standard table COMMENT exists but canonical "
+                    "HASSOU_JIKOKU_CHANGE does not. Automatic TC import is refused; "
+                    "rebuild the standard table as HASSOU_JIKOKU_CHANGE and reimport "
+                    "current 45-byte source records."
+                )
     if (
         native_table_name == "NL_WF"
         and database.is_connected()
@@ -915,7 +918,8 @@ def _verify_strict_storage_column_contract(
     if database.get_db_type() == "postgresql":
         rows = database.fetch_all(
             "SELECT a.attname AS name, format_type(a.atttypid, a.atttypmod) AS type, "
-            "a.attnotnull AS not_null FROM pg_attribute a "
+            "a.attnotnull AS not_null, a.attgenerated AS generated, "
+            "a.attidentity AS identity FROM pg_attribute a "
             "WHERE a.attrelid = to_regclass(?) AND a.attnum > 0 AND NOT a.attisdropped",
             (table_name.lower(),),
         )
@@ -930,13 +934,7 @@ def _verify_strict_storage_column_contract(
             f"{storage_label} column contract cannot be verified for database type "
             f"{database.get_db_type()!r}"
         )
-    actual = {
-        str(row.get("name") or "").lower(): (
-            str(row.get("type") or ""),
-            bool(row.get("not_null", row.get("notnull", 0))),
-        )
-        for row in rows
-    }
+    actual = {str(row.get("name") or "").lower(): row for row in rows}
     mismatches: list[str] = []
     if not allow_extra_columns:
         expected_columns = {column.lower() for column in definitions}
@@ -949,7 +947,20 @@ def _verify_strict_storage_column_contract(
             if not allow_missing_columns:
                 mismatches.append(f"{column_name} missing")
             continue
-        actual_type, actual_not_null = actual[column]
+        actual_row = actual[column]
+        actual_type = str(actual_row.get("type") or "")
+        actual_not_null = bool(
+            actual_row.get("not_null", actual_row.get("notnull", 0))
+        )
+        generated = str(actual_row.get("generated") or "")
+        identity = str(actual_row.get("identity") or "")
+        hidden = int(actual_row.get("hidden") or 0)
+        if generated or identity or hidden:
+            mismatches.append(
+                f"{column_name} is generated/identity/hidden "
+                f"(generated={generated or '<none>'}, identity={identity or '<none>'}, "
+                f"hidden={hidden})"
+            )
         expected_type = _normalize_strict_storage_type(_definition_type(definition))
         normalized_actual_type = _normalize_strict_storage_type(actual_type)
         compatible_type = _strict_storage_type_is_compatible(normalized_actual_type, expected_type)
@@ -1813,6 +1824,55 @@ def validate_hc_record(record: dict, table_name: str | None = None) -> bool:
     return True
 
 
+def _sqlite_schema_code(definition: str) -> str:
+    """Remove SQLite comments and quoted tokens before keyword inspection."""
+
+    code: list[str] = []
+    index = 0
+    while index < len(definition):
+        current = definition[index]
+        following = definition[index + 1] if index + 1 < len(definition) else ""
+        if current == "-" and following == "-":
+            index += 2
+            while index < len(definition) and definition[index] not in "\r\n":
+                index += 1
+            code.append("\n")
+            continue
+        if current == "/" and following == "*":
+            end = definition.find("*/", index + 2)
+            index = len(definition) if end < 0 else end + 2
+            code.append(" ")
+            continue
+        if current in {"'", '"', "`"}:
+            quote = current
+            index += 1
+            while index < len(definition):
+                if definition[index] == quote:
+                    if index + 1 < len(definition) and definition[index + 1] == quote:
+                        index += 2
+                        continue
+                    index += 1
+                    break
+                index += 1
+            code.append(" ")
+            continue
+        if current == "[":
+            index += 1
+            while index < len(definition):
+                if definition[index] == "]":
+                    if index + 1 < len(definition) and definition[index + 1] == "]":
+                        index += 2
+                        continue
+                    index += 1
+                    break
+                index += 1
+            code.append(" ")
+            continue
+        code.append(current)
+        index += 1
+    return "".join(code)
+
+
 def _verify_tc_no_unapproved_constraints(
     database: BaseDatabase,
     table_name: str,
@@ -1838,7 +1898,11 @@ def _verify_tc_no_unapproved_constraints(
             (table_name,),
         )
         definition = str((row or {}).get("sql") or "")
-        if re.search(r"\bCHECK\s*\(", definition, flags=re.IGNORECASE):
+        if re.search(
+            r"\bCHECK\s*\(",
+            _sqlite_schema_code(definition),
+            flags=re.IGNORECASE,
+        ):
             raise SchemaMigrationError(
                 f"TC storage {table_name} has unsupported CHECK constraints"
             )

--- a/src/importer/importer.py
+++ b/src/importer/importer.py
@@ -139,6 +139,18 @@ def resolve_standard_table_name(database: BaseDatabase, native_table_name: str) 
             "as KISYU_CHANGE and reimport current 161-byte source records."
         )
     if (
+        native_table_name == "NL_TC"
+        and database.is_connected()
+        and database.table_exists("COMMENT")
+        and not database.table_exists(standard_name)
+    ):
+        raise SchemaMigrationError(
+            "Legacy standard table COMMENT exists but canonical "
+            "HASSOU_JIKOKU_CHANGE does not. Automatic TC import is refused; "
+            "rebuild the standard table as HASSOU_JIKOKU_CHANGE and reimport "
+            "current 45-byte source records."
+        )
+    if (
         native_table_name == "NL_WF"
         and database.is_connected()
         and database.table_exists(_WF_LEGACY_STANDARD_TABLE)
@@ -576,8 +588,27 @@ _HC_LOSSLESS_TEXT_WIDTHS = {
         "KettoNum": 10,
     },
 }
+_TC_STORAGE_TABLES = frozenset({"NL_TC", "RT_TC", "HASSOU_JIKOKU_CHANGE"})
+_TC_KEY_COLUMNS = ("Year", "MonthDay", "JyoCD", "Kaiji", "Nichiji", "RaceNum")
+_TC_LOSSLESS_TEXT_WIDTHS = {
+    table_name: {
+        "RecordSpec": 2,
+        "DataKubun": 1,
+        "JyoCD": 2,
+        "HappyoTime": 8,
+        "AtoJi": 2,
+        "AtoFun": 2,
+        "MaeJi": 2,
+        "MaeFun": 2,
+    }
+    for table_name in _TC_STORAGE_TABLES
+}
 _PROVIDER_OPERATION_COUNT_STORAGE_TABLES = (
-    _AV_STORAGE_TABLES | _HR_STORAGE_TABLES | _HS_STORAGE_TABLES | _HC_STORAGE_TABLES
+    _AV_STORAGE_TABLES
+    | _HR_STORAGE_TABLES
+    | _HS_STORAGE_TABLES
+    | _HC_STORAGE_TABLES
+    | _TC_STORAGE_TABLES
 )
 _JC_STORAGE_TABLES = frozenset({"NL_JC", "RT_JC", "KISYU_CHANGE"})
 _JC_KEY_COLUMNS = (
@@ -637,6 +668,7 @@ _STRICT_NONADDITIVE_STANDARD_TABLES = frozenset(
         "HARAI",
         "SALE",
         "HANRO",
+        "HASSOU_JIKOKU_CHANGE",
         "KISYU_CHANGE",
         "TORIKESI_JYOGAI",
         "TENKO_BABA",
@@ -649,6 +681,7 @@ _LEGACY_STANDARD_PREFLIGHT_NATIVE_TABLES = (
     "NL_JG",
     "NL_AV",
     "NL_JC",
+    "NL_TC",
     "NL_SK",
     "NL_BR",
     "NL_HY",
@@ -1780,6 +1813,110 @@ def validate_hc_record(record: dict, table_name: str | None = None) -> bool:
     return True
 
 
+def _verify_tc_no_unapproved_constraints(
+    database: BaseDatabase,
+    table_name: str,
+) -> None:
+    """Reject constraints beyond TC's one official immediate primary key."""
+
+    from src.database.migration import _migration_targets
+
+    targets = _migration_targets(database)
+    if targets != (database,):
+        for target in targets:
+            _verify_tc_no_unapproved_constraints(target, table_name)
+        return
+
+    db_type = database.get_db_type()
+    if db_type == "sqlite":
+        if database.fetch_all(f'PRAGMA foreign_key_list("{table_name}")'):
+            raise SchemaMigrationError(
+                f"TC storage {table_name} has unsupported FOREIGN KEY constraints"
+            )
+        row = database.fetch_one(
+            "SELECT sql FROM sqlite_master WHERE type = 'table' AND name = ?",
+            (table_name,),
+        )
+        definition = str((row or {}).get("sql") or "")
+        if re.search(r"\bCHECK\s*\(", definition, flags=re.IGNORECASE):
+            raise SchemaMigrationError(
+                f"TC storage {table_name} has unsupported CHECK constraints"
+            )
+        return
+    if db_type == "postgresql":
+        unexpected = database.fetch_all(
+            "SELECT conname AS constraint_name, contype AS constraint_type "
+            "FROM pg_constraint WHERE conrelid = to_regclass(?) "
+            "AND contype NOT IN ('p', 'n') ORDER BY conname",
+            (table_name.lower(),),
+        )
+        if unexpected:
+            raise SchemaMigrationError(
+                f"TC storage {table_name} has unsupported additional constraints: "
+                f"{unexpected}"
+            )
+        return
+    raise SchemaMigrationError(
+        f"TC constraints cannot be verified for database type {db_type!r}"
+    )
+
+
+def verify_tc_storage_schema(database: BaseDatabase, table_name: str) -> bool:
+    """Fail closed unless TC storage preserves every field and official key."""
+
+    if table_name not in _TC_STORAGE_TABLES:
+        return False
+    transaction_snapshot = _snapshot_validation_transactions(database)
+    from src.database.migration import verify_table_schema
+    from src.database.schema import SCHEMAS
+    from src.database.schema_jravan import JRAVAN_SCHEMAS
+
+    try:
+        schema_sql = SCHEMAS.get(table_name) or JRAVAN_SCHEMAS.get(table_name)
+        if schema_sql is None:
+            raise SchemaMigrationError(f"TC storage schema is undefined: {table_name}")
+        verify_table_schema(database, table_name, schema_sql)
+        _verify_strict_storage_column_contract(
+            database,
+            table_name,
+            schema_sql,
+            allow_missing_columns=False,
+            storage_label="TC",
+            lossless_text_widths=_TC_LOSSLESS_TEXT_WIDTHS[table_name],
+            allow_extra_columns=False,
+        )
+        _verify_tc_no_unapproved_constraints(database, table_name)
+        _verify_replacement_key_constraints(database, table_name, "TC storage")
+        return True
+    except Exception:
+        _rollback_call_created_validation_transactions(
+            transaction_snapshot,
+            context="failed TC schema validation",
+        )
+        raise
+
+
+def validate_tc_record(record: dict, table_name: str | None = None) -> bool:
+    """Validate one caller-built TC row before coercion or mutation."""
+
+    if table_name is not None and table_name not in _TC_STORAGE_TABLES:
+        return False
+    if _record_type_from_record(record) != "TC":
+        if table_name is None:
+            return False
+        raise SchemaMigrationError(f"{table_name} received a non-TC record")
+
+    from src.parser.tc_parser import TCParser
+
+    try:
+        if resolve_record_data_kubun(record) != "1":
+            raise ValueError("TC DataKubun must be current official value 1")
+        TCParser.validate_current_fields(record)
+    except ValueError as error:
+        raise SchemaMigrationError(str(error)) from error
+    return True
+
+
 def _verify_jc_key_storage_types(database: BaseDatabase, table_name: str) -> None:
     """Reject affinities that can coerce or split one JC identity."""
 
@@ -2898,6 +3035,8 @@ def _preflight_standard_schema_migrations(
             verify_hs_storage_schema(database, standard_name)
         if standard_name == "HANRO":
             verify_hc_storage_schema(database, standard_name)
+        if standard_name == "HASSOU_JIKOKU_CHANGE":
+            verify_tc_storage_schema(database, standard_name)
         if standard_name == "KISYU_CHANGE":
             verify_jc_storage_schema(database, standard_name)
         if standard_name in {"UMA", "COURSE"}:
@@ -3552,6 +3691,8 @@ def validate_import_record_header(record: dict) -> tuple[str, str]:
             validate_hs_record(record)
         if record_type == "HC":
             validate_hc_record(record)
+        if record_type == "TC":
+            validate_tc_record(record)
         if record_type == "JC":
             validate_jc_record(record)
         return record_type, data_kubun
@@ -6097,6 +6238,7 @@ class DataImporter:
         self._verified_hr_tables: set[str] = set()
         self._verified_hs_tables: set[str] = set()
         self._verified_hc_tables: set[str] = set()
+        self._verified_tc_tables: set[str] = set()
         self._verified_jc_tables: set[str] = set()
         self._verified_cs_tables: set[str] = set()
         self._verified_jg_tables: set[str] = set()
@@ -6452,6 +6594,10 @@ class DataImporter:
                     if verify_hc_storage_schema(self.database, table_name):
                         self._verified_hc_tables.add(table_name)
                 validate_hc_record(record, table_name)
+                if table_name not in self._verified_tc_tables:
+                    if verify_tc_storage_schema(self.database, table_name):
+                        self._verified_tc_tables.add(table_name)
+                validate_tc_record(record, table_name)
                 if table_name not in self._verified_jc_tables:
                     if verify_jc_storage_schema(self.database, table_name):
                         self._verified_jc_tables.add(table_name)
@@ -7187,6 +7333,10 @@ class DataImporter:
                 if verify_hc_storage_schema(self.database, table_name):
                     self._verified_hc_tables.add(table_name)
             validate_hc_record(record, table_name)
+            if table_name not in self._verified_tc_tables:
+                if verify_tc_storage_schema(self.database, table_name):
+                    self._verified_tc_tables.add(table_name)
+            validate_tc_record(record, table_name)
             if table_name not in self._verified_jc_tables:
                 if verify_jc_storage_schema(self.database, table_name):
                     self._verified_jc_tables.add(table_name)

--- a/src/importer/importer_optimized.py
+++ b/src/importer/importer_optimized.py
@@ -73,6 +73,7 @@ from src.importer.importer import (
     validate_jc_record,
     validate_jg_record,
     validate_se_record,
+    validate_tc_record,
     validate_wc_record,
     validate_we_record,
     validate_wf_record,
@@ -91,6 +92,7 @@ from src.importer.importer import (
     verify_mining_native_schema,
     verify_rc_storage_schema,
     verify_se_storage_schema,
+    verify_tc_storage_schema,
     verify_tk_coupled_tables,
     verify_wc_storage_schema,
     verify_we_storage_schema,
@@ -139,6 +141,7 @@ class OptimizedDataImporter:
         self._verified_hr_tables: set[str] = set()
         self._verified_hs_tables: set[str] = set()
         self._verified_hc_tables: set[str] = set()
+        self._verified_tc_tables: set[str] = set()
         self._verified_jc_tables: set[str] = set()
         self._verified_cs_tables: set[str] = set()
         self._verified_jg_tables: set[str] = set()
@@ -454,6 +457,10 @@ class OptimizedDataImporter:
                     if verify_hc_storage_schema(self.database, table_name):
                         self._verified_hc_tables.add(table_name)
                 validate_hc_record(record, table_name)
+                if table_name not in self._verified_tc_tables:
+                    if verify_tc_storage_schema(self.database, table_name):
+                        self._verified_tc_tables.add(table_name)
+                validate_tc_record(record, table_name)
                 if table_name not in self._verified_jc_tables:
                     if verify_jc_storage_schema(self.database, table_name):
                         self._verified_jc_tables.add(table_name)

--- a/src/parser/tc_parser.py
+++ b/src/parser/tc_parser.py
@@ -1,22 +1,135 @@
-"""Parser for TC record - Generated from reference schema.
+"""Parser for the official TC start-time-change record."""
 
-This parser uses correct field positions calculated from schema field lengths.
-"""
-
-from typing import List
+from collections.abc import Mapping
+from datetime import date
+from typing import Any, List
 
 from src.parser.base import BaseParser, FieldDef
+from src.parser.code_domains import OFFICIAL_JYO_CODES_2001
 
 
 class TCParser(BaseParser):
     """Parser for TC record with accurate field positions.
 
-    Total record length: 43 bytes
-    Fields: 14
+    Total record length: 45 bytes
+    Fields: 15
     """
 
     record_type = "TC"
     RECORD_LENGTH = 45
+    KEY_COLUMNS = (
+        "Year",
+        "MonthDay",
+        "JyoCD",
+        "Kaiji",
+        "Nichiji",
+        "RaceNum",
+    )
+    OFFICIAL_JYO_CODES = OFFICIAL_JYO_CODES_2001
+
+    @staticmethod
+    def _require_date(field_name: str, value: object) -> date:
+        if isinstance(value, date):
+            return value
+        if (
+            not isinstance(value, str)
+            or len(value) != 8
+            or not value.isascii()
+            or not value.isdigit()
+        ):
+            raise ValueError(f"TC {field_name} must be exactly 8 ASCII digits")
+        try:
+            return date(int(value[:4]), int(value[4:6]), int(value[6:]))
+        except ValueError as error:
+            raise ValueError(f"TC {field_name} must be a real YYYYMMDD date") from error
+
+    @staticmethod
+    def _require_fixed_integer(field_name: str, value: object, width: int) -> int:
+        if isinstance(value, bool):
+            raise ValueError(f"TC {field_name} must be an official {width}-digit integer")
+        if isinstance(value, int):
+            if 0 <= value < 10**width:
+                return value
+        elif isinstance(value, str) and len(value) == width and value.isascii() and value.isdigit():
+            return int(value)
+        raise ValueError(f"TC {field_name} must be an official {width}-digit integer")
+
+    @classmethod
+    def validate_key_fields(cls, record: Mapping[str, object]) -> int:
+        """Validate the complete official six-part race identity before coercion."""
+
+        cls._require_date("MakeDate", record.get("MakeDate"))
+        year = cls._require_fixed_integer("Year", record.get("Year"), 4)
+        if year < 1000:
+            raise ValueError("TC Year must remain a four-digit Gregorian year")
+        month_day = cls._require_fixed_integer("MonthDay", record.get("MonthDay"), 4)
+        try:
+            date(year, month_day // 100, month_day % 100)
+        except ValueError as error:
+            raise ValueError("TC Year and MonthDay must form a real date") from error
+        if record.get("JyoCD") not in cls.OFFICIAL_JYO_CODES:
+            raise ValueError("TC JyoCD is not in official code table 2001")
+        for field_name in ("Kaiji", "Nichiji", "RaceNum"):
+            cls._require_fixed_integer(field_name, record.get(field_name), 2)
+        return year
+
+    @staticmethod
+    def _require_mdhm(value: object, year: int) -> None:
+        if (
+            not isinstance(value, str)
+            or len(value) != 8
+            or not value.isascii()
+            or not value.isdigit()
+        ):
+            raise ValueError("TC HappyoTime must be exactly 8 ASCII digits")
+        if value == "00000000":
+            return
+        try:
+            date(year, int(value[:2]), int(value[2:4]))
+        except ValueError as error:
+            raise ValueError("TC HappyoTime must contain a real MMDD date") from error
+        if int(value[4:6]) > 23 or int(value[6:]) > 59:
+            raise ValueError("TC HappyoTime must contain a real hhmm time")
+
+    @staticmethod
+    def _require_hhmm_part(field_name: str, value: object, maximum: int) -> None:
+        if (
+            not isinstance(value, str)
+            or len(value) != 2
+            or not value.isascii()
+            or not value.isdigit()
+            or int(value) > maximum
+        ):
+            raise ValueError(f"TC {field_name} is not a valid two-digit time component")
+
+    @classmethod
+    def validate_current_fields(cls, record: Mapping[str, object]) -> None:
+        """Validate one current live TC row; the official status domain is only 1."""
+
+        year = cls.validate_key_fields(record)
+        cls._require_mdhm(record.get("HappyoTime"), year)
+        for field_name in ("AtoJi", "MaeJi"):
+            cls._require_hhmm_part(field_name, record.get(field_name), 23)
+        for field_name in ("AtoFun", "MaeFun"):
+            cls._require_hhmm_part(field_name, record.get(field_name), 59)
+
+    def parse(self, record: bytes) -> dict[str, Any]:
+        """Parse and strictly validate one current 45-byte TC record."""
+
+        parsed = super().parse(record)
+        # BaseParser intentionally converts numeric fields for the public
+        # parsed shape. Validate the original fixed-width text as well so a
+        # lossy converter can never turn ``20A6`` into a plausible key.
+        raw_fields = {
+            field.name: record[field.start : field.start + field.length]
+            .decode("cp932", errors="strict")
+            .strip()
+            for field in self._fields
+            if field.name != "RecordDelimiter"
+        }
+        self.validate_current_fields(raw_fields)
+        self.validate_current_fields(parsed)
+        return parsed
 
     def _define_fields(self) -> List[FieldDef]:
         """Define field positions calculated from schema.
@@ -39,4 +152,5 @@ class TCParser(BaseParser):
             FieldDef("AtoFun", 37, 2),
             FieldDef("MaeJi", 39, 2),
             FieldDef("MaeFun", 41, 2),
+            FieldDef("RecordDelimiter", 43, 2),
         ]

--- a/src/parser/tc_parser.py
+++ b/src/parser/tc_parser.py
@@ -1,7 +1,7 @@
 """Parser for the official TC start-time-change record."""
 
 from collections.abc import Mapping
-from datetime import date
+from datetime import date, datetime
 from typing import Any, List
 
 from src.parser.base import BaseParser, FieldDef
@@ -29,6 +29,8 @@ class TCParser(BaseParser):
 
     @staticmethod
     def _require_date(field_name: str, value: object) -> date:
+        if isinstance(value, datetime):
+            raise ValueError(f"TC {field_name} must not contain a time component")
         if isinstance(value, date):
             return value
         if (

--- a/src/realtime/updater.py
+++ b/src/realtime/updater.py
@@ -20,12 +20,14 @@ from src.importer.importer import (
     validate_hr_record,
     validate_jc_record,
     validate_se_record,
+    validate_tc_record,
     validate_we_record,
     validate_wf_record,
     verify_av_storage_schema,
     verify_hr_storage_schema,
     verify_jc_storage_schema,
     verify_se_storage_schema,
+    verify_tc_storage_schema,
     verify_we_storage_schema,
     verify_wf_storage_schema,
 )
@@ -204,6 +206,7 @@ class RealtimeUpdater:
         self._verified_we_tables: set[str] = set()
         self._verified_av_tables: set[str] = set()
         self._verified_hr_tables: set[str] = set()
+        self._verified_tc_tables: set[str] = set()
         self._verified_jc_tables: set[str] = set()
         self._verified_wf_tables: set[str] = set()
 
@@ -212,7 +215,7 @@ class RealtimeUpdater:
     # Realtime tables whose caller-built rows are revalidated against the
     # official contract before any coercion or mutation.
     STRICT_RECORD_TABLES = frozenset(
-        {"RT_SE", "RT_WE", "RT_AV", "RT_HR", "RT_JC", "RT_WF"}
+        {"RT_SE", "RT_WE", "RT_AV", "RT_HR", "RT_TC", "RT_JC", "RT_WF"}
     )
 
     def _canonicalize_strict_record_aliases(
@@ -275,6 +278,11 @@ class RealtimeUpdater:
                     if verify_hr_storage_schema(self.database, table_name):
                         self._verified_hr_tables.add(table_name)
                 validate_hr_record(record, table_name)
+            elif table_name == "RT_TC":
+                if table_name not in self._verified_tc_tables:
+                    if verify_tc_storage_schema(self.database, table_name):
+                        self._verified_tc_tables.add(table_name)
+                validate_tc_record(record, table_name)
             elif table_name == "RT_JC":
                 if table_name not in self._verified_jc_tables:
                     if verify_jc_storage_schema(self.database, table_name):

--- a/src/realtime/updater.py
+++ b/src/realtime/updater.py
@@ -279,10 +279,12 @@ class RealtimeUpdater:
                         self._verified_hr_tables.add(table_name)
                 validate_hr_record(record, table_name)
             elif table_name == "RT_TC":
+                # Reject malformed caller data before a PostgreSQL catalog
+                # read can lazily open a transaction owned by this call.
+                validate_tc_record(record, table_name)
                 if table_name not in self._verified_tc_tables:
                     if verify_tc_storage_schema(self.database, table_name):
                         self._verified_tc_tables.add(table_name)
-                validate_tc_record(record, table_name)
             elif table_name == "RT_JC":
                 if table_name not in self._verified_jc_tables:
                     if verify_jc_storage_schema(self.database, table_name):

--- a/tests/fixtures/official_layout/README.md
+++ b/tests/fixtures/official_layout/README.md
@@ -36,6 +36,10 @@ JV-Data. They do not contain provider records or a copy of the SDK source.
   four-part identity, status domain, tenths-of-a-second timing fields, and the
   same-layout Miho measurement-distance history independently transcribed from
   both pinned current workbooks.
+- `tc_contract_4901.json` records the current 45-byte start-time-change layout,
+  six-part race identity, status-1-only domain, announcement/change time spans,
+  provider contexts, and unchanged history independently transcribed from both
+  pinned current workbooks.
 
 The manifest is intentionally independent of jrvltsql parser and schema code.
 When the official source changes, regenerate it from a separately obtained SDK

--- a/tests/fixtures/official_layout/tc_contract_4901.json
+++ b/tests/fixtures/official_layout/tc_contract_4901.json
@@ -1,0 +1,62 @@
+{
+  "record_type": "TC",
+  "record_length": 45,
+  "format_sources": [
+    {
+      "artifact": "JV-Data4802.xlsx",
+      "sha256": "6a567f10b601115eca350571f36d27d9d28bd2d3835ea72b5bc057711155d4a7",
+      "sheet": "フォーマット",
+      "rows": "1509-1528"
+    },
+    {
+      "artifact": "JV-Data4901.xlsx",
+      "sha256": "23bafd375f704acbdd696b5032ac1619f17d47e882587d6e7954b610527a8234",
+      "sheet": "フォーマット",
+      "rows": "1509-1528"
+    }
+  ],
+  "sdk_source": {
+    "artifact": "JRA-VAN Data Lab. SDK Ver5.0.0/JVData_Struct.cs",
+    "sha256": "605057bb211eb6a94056a54496f3dd30f864ac2ad140fcfc8840ac8a6ed9e4fe",
+    "struct": "JV_TC_INFO"
+  },
+  "fields": [
+    ["RecordSpec", 1, 2],
+    ["DataKubun", 3, 1],
+    ["MakeDate", 4, 8],
+    ["Year", 12, 4],
+    ["MonthDay", 16, 4],
+    ["JyoCD", 20, 2],
+    ["Kaiji", 22, 2],
+    ["Nichiji", 24, 2],
+    ["RaceNum", 26, 2],
+    ["HappyoTime", 28, 8],
+    ["AtoJi", 36, 2],
+    ["AtoFun", 38, 2],
+    ["MaeJi", 40, 2],
+    ["MaeFun", 42, 2],
+    ["RecordDelimiter", 44, 2]
+  ],
+  "primary_key": [
+    "Year",
+    "MonthDay",
+    "JyoCD",
+    "Kaiji",
+    "Nichiji",
+    "RaceNum"
+  ],
+  "current_data_kubun": ["1"],
+  "history": {
+    "added": "2004-05-25",
+    "version": "1.1.6",
+    "physical_layout_changed": false,
+    "sources": [
+      "JV-Data4901.xlsx:変更履歴:216,220",
+      "JV-Data4802.xlsx:変更履歴:173,177"
+    ]
+  },
+  "current_provider_specs": ["0B14", "0B16"],
+  "snapshot_provider_spec": "0B14",
+  "snapshot_policy_source": "JV-Data4901.xlsx:データ提供タイミング・提供単位:60",
+  "cancellation_note_source": "JV-Data4901.xlsx:特記事項:264"
+}

--- a/tests/test_current_record_validation.py
+++ b/tests/test_current_record_validation.py
@@ -38,7 +38,7 @@ PREVIOUS_OFFICIAL_LENGTHS = tuple(
 # These parsers also require populated domain-specific arrays or master fields.
 # Their valid payloads are covered by dedicated official-contract tests; this
 # module limits their positive case to the shared physical-record envelope.
-# AV, CS, HR, HS, JG, SE, WC, WE, and WF additionally require their official fixed-width keys,
+# AV, CS, HR, HS, JG, SE, TC, WC, WE, and WF additionally require their official fixed-width keys,
 # bodies, race composites, and current status/code domains, so a generic
 # space-filled envelope is not valid.
 DOMAIN_PAYLOAD_REQUIRED = {
@@ -53,6 +53,7 @@ DOMAIN_PAYLOAD_REQUIRED = {
     "JC",
     "KS",
     "SE",
+    "TC",
     "TK",
     "TM",
     "WC",

--- a/tests/test_daily_update.py
+++ b/tests/test_daily_update.py
@@ -446,9 +446,13 @@ def test_sync_0b14_replaces_stale_date_snapshot(rt_database):
     updater = RealtimeUpdater(rt_database)
     rt_database.execute(
         "INSERT INTO RT_TC "
-        "(Year, MonthDay, JyoCD, Kaiji, Nichiji, RaceNum, HappyoTime) "
-        "VALUES (?, ?, ?, ?, ?, ?, ?)",
-        ("2026", "0607", "05", "1", "1", "1", "1200"),
+        "(RecordSpec, DataKubun, MakeDate, Year, MonthDay, JyoCD, Kaiji, "
+        "Nichiji, RaceNum, HappyoTime, AtoJi, AtoFun, MaeJi, MaeFun) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        (
+            "TC", "1", "20260607", "2026", "0607", "05", "1", "1", "1",
+            "06071200", "12", "10", "12", "00",
+        ),
     )
     rt_database.commit()
 
@@ -483,9 +487,13 @@ def test_sync_0b14_keeps_snapshot_when_no_data_is_published(rt_database):
     updater = RealtimeUpdater(rt_database)
     rt_database.execute(
         "INSERT INTO RT_TC "
-        "(Year, MonthDay, JyoCD, Kaiji, Nichiji, RaceNum, HappyoTime) "
-        "VALUES (?, ?, ?, ?, ?, ?, ?)",
-        ("2026", "0607", "05", "1", "1", "1", "1200"),
+        "(RecordSpec, DataKubun, MakeDate, Year, MonthDay, JyoCD, Kaiji, "
+        "Nichiji, RaceNum, HappyoTime, AtoJi, AtoFun, MaeJi, MaeFun) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        (
+            "TC", "1", "20260607", "2026", "0607", "05", "1", "1", "1",
+            "06071200", "12", "10", "12", "00",
+        ),
     )
     rt_database.commit()
 

--- a/tests/test_happyo_time_contract.py
+++ b/tests/test_happyo_time_contract.py
@@ -69,6 +69,8 @@ def _record(record_type: str, length: int, announcement_start: int) -> bytes:
         record[158:159] = b"9"
     if record_type == "WE":
         record[33:40] = b"1111000"
+    if record_type == "TC":
+        record[35:43] = b"12101200"
     record[-2:] = b"\r\n"
     return bytes(record)
 

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -256,6 +256,20 @@ class TestIndividualParsers:
                 mutable[25:33] = b"06010930"
                 mutable[33:40] = b"1111000"
                 data = bytes(mutable)
+            if record_type == "TC":
+                # TC requires its complete six-part race key plus valid
+                # announcement and before/after start times.
+                mutable = bytearray(data)
+                mutable[11:15] = b"2024"
+                mutable[15:19] = b"0601"
+                mutable[19:21] = b"05"
+                mutable[21:23] = b"03"
+                mutable[23:25] = b"08"
+                mutable[25:27] = b"11"
+                mutable[27:35] = b"06010930"
+                mutable[35:39] = b"1015"
+                mutable[39:43] = b"1005"
+                data = bytes(mutable)
             if record_type == "TK":
                 mutable = bytearray(data)
                 mutable[11:15] = b"2024"

--- a/tests/test_realtime.py
+++ b/tests/test_realtime.py
@@ -1696,7 +1696,10 @@ class TestRealtimeUpdater(unittest.TestCase):
         self.mock_db.insert_many.assert_not_called()
         self.mock_db.execute.assert_not_called()
 
-    def test_matching_legacy_aliases_are_canonicalized_before_batch_routing(self):
+    @patch("src.realtime.updater.verify_tc_storage_schema", return_value=True)
+    def test_matching_legacy_aliases_are_canonicalized_before_batch_routing(
+        self, _verify_tc
+    ):
         updater = RealtimeUpdater(self.mock_db)
         record = {
             "headRecordSpec": "TC",
@@ -1705,9 +1708,14 @@ class TestRealtimeUpdater(unittest.TestCase):
             "Year": "2026",
             "MonthDay": "0817",
             "JyoCD": "05",
-            "Kaiji": "3",
-            "Nichiji": "8",
+            "Kaiji": "03",
+            "Nichiji": "08",
             "RaceNum": "11",
+            "HappyoTime": "08171200",
+            "AtoJi": "12",
+            "AtoFun": "10",
+            "MaeJi": "12",
+            "MaeFun": "00",
         }
 
         result = updater.process_parsed_records_batch([record])

--- a/tests/test_realtime.py
+++ b/tests/test_realtime.py
@@ -1184,7 +1184,7 @@ class TestRealtimeUpdater(unittest.TestCase):
         for call_args in self.mock_db.execute.call_args_list:
             self.assertEqual(call_args.args[1], (2026, 715))
 
-    def test_drain_0b14_replaces_date_snapshot_before_import(self):
+    def test_drain_0b14_replaces_date_snapshot_but_0b16_does_not(self):
         monitor = RealtimeMonitor(database=self.mock_db)
         jvlink = MagicMock()
         jvlink.jv_rt_open.return_value = (0, 0)
@@ -1197,6 +1197,14 @@ class TestRealtimeUpdater(unittest.TestCase):
 
         self.assertEqual((imported, failed), (0, 0))
         updater.replace_date_snapshot.assert_called_once_with("20260715")
+
+        updater.reset_mock()
+        imported, failed = monitor._drain_key(
+            jvlink, updater, "0B16", "event-key"
+        )
+
+        self.assertEqual((imported, failed), (0, 0))
+        updater.replace_date_snapshot.assert_not_called()
 
     def test_drain_0b14_interruption_rejects_partial_snapshot(self):
         monitor = RealtimeMonitor(database=self.mock_db)

--- a/tests/test_tc_official_contract.py
+++ b/tests/test_tc_official_contract.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import os
+from datetime import datetime
 from pathlib import Path
 from uuid import uuid4
 
@@ -204,7 +205,8 @@ def test_tc_native_standard_and_realtime_schemas_encode_the_official_identity() 
     for table_name in ("NL_TC", "RT_TC", "HASSOU_JIKOKU_CHANGE"):
         assert tuple(get_table_primary_key_columns(table_name)) == OFFICIAL_KEY
         nullability = get_table_column_nullability(table_name)
-        assert all(nullability[column] is False for column in OFFICIAL_KEY)
+        assert set(nullability) == NATIVE_FIELDS
+        assert all(nullability[column] is False for column in NATIVE_FIELDS)
     assert set(get_table_column_types("NL_TC")) == NATIVE_FIELDS
     assert set(get_table_column_types("RT_TC")) == NATIVE_FIELDS
     assert set(get_table_column_types("HASSOU_JIKOKU_CHANGE")) == STANDARD_FIELDS
@@ -255,6 +257,7 @@ def test_tc_caller_validation_precedes_coercion_and_mutation(
     invalid_rows = []
     for field_name, invalid_value in (
         ("MakeDate", "20260230"),
+        ("MakeDate", datetime(2026, 8, 18, 12, 34, 56)),
         ("Year", "20A6"),
         ("Year", 26),
         ("MonthDay", "0230"),
@@ -290,6 +293,11 @@ def _defective_schema(table_name: str, defect: str) -> str:
             "Year                           SMALLINT NOT NULL",
             "Year                           SMALLINT         ",
         )
+    if defect == "nullable-body":
+        return schema.replace("AtoFun TEXT NOT NULL", "AtoFun TEXT").replace(
+            "AtoFun                         VARCHAR(2) NOT NULL",
+            "AtoFun                         VARCHAR(2)         ",
+        )
     if defect == "wrong-type":
         return schema.replace("Year INTEGER NOT NULL", "Year TEXT NOT NULL").replace(
             "Year                           SMALLINT NOT NULL",
@@ -306,6 +314,9 @@ def _defective_schema(table_name: str, defect: str) -> str:
     if defect == "extra-check":
         body, close = schema.rsplit(")", 1)
         return f"{body}, CHECK (AtoJi = '00')\n        ){close}"
+    if defect == "obfuscated-check":
+        body, close = schema.rsplit(")", 1)
+        return f"{body}, CHECK /* official-looking comment */ (AtoJi = '00')\n        ){close}"
     if defect == "extra-foreign-key":
         body, close = schema.rsplit(")", 1)
         return (
@@ -330,6 +341,14 @@ def _defective_schema(table_name: str, defect: str) -> str:
             f"{body}, ExternalRequired TEXT GENERATED ALWAYS AS (NULL) "
             f"VIRTUAL NOT NULL\n        ){close}"
         )
+    if defect == "generated-official-column":
+        return schema.replace(
+            "AtoFun TEXT NOT NULL",
+            "AtoFun TEXT GENERATED ALWAYS AS ('00') STORED NOT NULL",
+        ).replace(
+            "AtoFun                         VARCHAR(2) NOT NULL",
+            "AtoFun                         VARCHAR(2) GENERATED ALWAYS AS ('00') STORED NOT NULL",
+        )
     raise AssertionError(defect)
 
 
@@ -339,10 +358,12 @@ def _defective_schema(table_name: str, defect: str) -> str:
     [
         "wrong-key",
         "nullable-key",
+        "nullable-body",
         "wrong-type",
         "short-text",
         "extra-unique",
         "extra-check",
+        "obfuscated-check",
         "extra-foreign-key",
         "extra-required-column",
         "extra-generated-required-column",
@@ -385,6 +406,39 @@ def test_tc_schema_manager_preflights_before_an_additive_column_change(tmp_path)
         assert safe.fetch_one("SELECT COUNT(*) AS n FROM NL_TC") == {"n": 0}
 
 
+@pytest.mark.parametrize("importer_class", (DataImporter, OptimizedDataImporter))
+@pytest.mark.parametrize("legacy_target", ("primary", "secondary"))
+def test_tc_legacy_standard_alias_stops_dual_migration_before_any_alter(
+    tmp_path, importer_class, legacy_target: str
+) -> None:
+    race_without_youbi = JRAVAN_SCHEMAS["RACE"].replace(
+        "            YoubiCD                        VARCHAR(1)          ,  -- 文字列(1)\n",
+        "",
+    )
+    assert race_without_youbi != JRAVAN_SCHEMAS["RACE"]
+    legacy_tc = JRAVAN_SCHEMAS["HASSOU_JIKOKU_CHANGE"].replace("HASSOU_JIKOKU_CHANGE", "COMMENT", 1)
+    primary = SQLiteDatabase({"path": str(tmp_path / "legacy-primary.db")})
+    secondary = SQLiteDatabase({"path": str(tmp_path / "legacy-secondary.db")})
+    with primary, secondary:
+        for database in (primary, secondary):
+            database.execute(race_without_youbi)
+            database.commit()
+        legacy_database = primary if legacy_target == "primary" else secondary
+        legacy_database.execute(legacy_tc)
+        legacy_database.commit()
+        before_primary = primary.fetch_all('PRAGMA table_info("RACE")')
+        before_secondary = secondary.fetch_all('PRAGMA table_info("RACE")')
+
+        with pytest.raises(SchemaMigrationError, match=r"COMMENT.*HASSOU_JIKOKU_CHANGE"):
+            importer_class(
+                DualDatabase(primary, secondary),
+                use_jravan_schema=True,
+            ).import_records(iter([]))
+
+        assert primary.fetch_all('PRAGMA table_info("RACE")') == before_primary
+        assert secondary.fetch_all('PRAGMA table_info("RACE")') == before_secondary
+
+
 @pytest.mark.parametrize("auto_commit", (True, False), ids=("owned", "caller"))
 @pytest.mark.parametrize("table_name,standard", [("NL_TC", False), ("HASSOU_JIKOKU_CHANGE", True)])
 def test_tc_single_record_uses_the_same_fail_closed_validator(
@@ -412,7 +466,9 @@ def test_tc_realtime_uses_the_same_fail_closed_validator(tmp_path) -> None:
             realtime.execute(SCHEMAS[table_name])
         realtime.commit()
         updater = RealtimeUpdater(realtime)
-        inserted = updater.process_parsed_records_batch([parsed_tc()])
+        inserted = updater.process_parsed_records_batch(
+            [parsed_tc(RaceNum="10"), parsed_tc(RaceNum="11")]
+        )
         invalid = parsed_tc()
         invalid["HappyoTime"] = "08189999"
         rejected = updater.process_parsed_records_batch([invalid])
@@ -420,13 +476,13 @@ def test_tc_realtime_uses_the_same_fail_closed_validator(tmp_path) -> None:
         revised = updater.process_parsed_records_batch(
             [parsed_tc(HappyoTime="08181205", AtoJi="12", AtoFun="20")]
         )
-        rows = realtime.fetch_all("SELECT HappyoTime, AtoFun FROM RT_TC")
+        rows = realtime.fetch_all("SELECT RaceNum, HappyoTime, AtoFun FROM RT_TC ORDER BY RaceNum")
 
     assert inserted["success"] is True
     assert rejected["success"] is False
     assert rejected["inserted"] == 0
     assert revised["success"] is True
-    assert rows == [{"HappyoTime": "08181205", "AtoFun": "20"}]
+    assert rows == [{"RaceNum": 11, "HappyoTime": "08181205", "AtoFun": "20"}]
 
 
 def test_tc_header_validator_rejects_missing_blank_and_conflicting_aliases() -> None:
@@ -506,12 +562,14 @@ def test_tc_postgresql_all_entrypoints_preserve_provider_revision_order(
     "defect",
     [
         "wrong-key",
+        "nullable-body",
         "wrong-type",
         "short-text",
         "extra-unique",
         "extra-check",
         "extra-foreign-key",
         "extra-required-column",
+        "generated-official-column",
         "deferrable-primary-key",
     ],
 )
@@ -536,20 +594,30 @@ def test_tc_postgresql_schema_defects_fail_before_mutation(
 
 def test_tc_postgresql_realtime_gate(postgresql_db) -> None:
     postgresql_db.execute(SCHEMAS["RT_TC"])
+    postgresql_db.execute("CREATE TABLE TC_CALLER_MARKER (id INTEGER PRIMARY KEY)")
     postgresql_db.commit()
     updater = RealtimeUpdater(postgresql_db)
+    invalid = parsed_tc()
+    invalid["AtoFun"] = "60"
+    rejected = updater.process_parsed_record(invalid)
+    assert rejected["success"] is False
+    assert postgresql_db.has_pending_transaction() is False
+
+    postgresql_db.begin_transaction()
+    postgresql_db.execute("INSERT INTO TC_CALLER_MARKER (id) VALUES (1)")
+    borrowed_rejection = updater.process_parsed_record(invalid)
+    assert borrowed_rejection["success"] is False
+    assert postgresql_db.has_pending_transaction() is True
+    assert postgresql_db.fetch_one('SELECT COUNT(*) AS "n" FROM TC_CALLER_MARKER') == {"n": 1}
+    postgresql_db.rollback()
+
     result = updater.process_parsed_records_batch(
         [parsed_tc(), parsed_tc(HappyoTime="08181205", AtoFun="20")]
     )
-    invalid = parsed_tc()
-    invalid["AtoFun"] = "60"
-    rejected = updater.process_parsed_records_batch([invalid])
     assert result["success"] is True
     assert result["inserted"] == 2
     assert result["errors"] == 0
     assert result["tables"] == ["RT_TC"]
-    assert rejected["success"] is False
-    assert rejected["inserted"] == 0
     assert postgresql_db.fetch_all(
         'SELECT HappyoTime AS "HappyoTime", AtoFun AS "AtoFun" FROM RT_TC'
     ) == [{"HappyoTime": "08181205", "AtoFun": "20"}]
@@ -565,11 +633,12 @@ def test_tc_dual_rejects_an_unsafe_target_before_either_database_changes(
     standard: bool,
 ) -> None:
     safe = JRAVAN_SCHEMAS[table_name] if standard else SCHEMAS[table_name]
-    unsafe = _defective_schema(table_name, "extra-required-column")
+    sqlite_unsafe = _defective_schema(table_name, "obfuscated-check")
+    postgresql_unsafe = _defective_schema(table_name, "generated-official-column")
     sqlite = SQLiteDatabase({"path": str(tmp_path / f"{table_name}-{unsafe_target}.db")})
     with sqlite:
-        sqlite.execute(unsafe if unsafe_target == "primary" else safe)
-        postgresql_db.execute(unsafe if unsafe_target == "secondary" else safe)
+        sqlite.execute(sqlite_unsafe if unsafe_target == "primary" else safe)
+        postgresql_db.execute(postgresql_unsafe if unsafe_target == "secondary" else safe)
         sqlite.commit()
         postgresql_db.commit()
         primary, secondary = (
@@ -579,7 +648,7 @@ def test_tc_dual_rejects_an_unsafe_target_before_either_database_changes(
             DataImporter(
                 DualDatabase(primary, secondary),
                 use_jravan_schema=standard,
-            ).import_records(iter([parsed_tc()]))
+            ).import_records(iter([parsed_tc()]), auto_commit=True)
         assert sqlite.fetch_one(f"SELECT COUNT(*) AS n FROM {table_name}") == {"n": 0}
         assert postgresql_db.fetch_one(f'SELECT COUNT(*) AS "n" FROM {table_name}') == {"n": 0}
 

--- a/tests/test_tc_official_contract.py
+++ b/tests/test_tc_official_contract.py
@@ -1,0 +1,612 @@
+"""Official TC start-time-change contract from pinned JRA-VAN sources."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from uuid import uuid4
+
+import pytest
+
+from src.database.dual_handler import DualDatabase
+from src.database.migration import SchemaMigrationError
+from src.database.schema import SCHEMAS, SchemaManager
+from src.database.schema_jravan import JRAVAN_SCHEMAS
+from src.database.schema_metadata import TABLE_METADATA
+from src.database.schema_types import (
+    get_table_column_nullability,
+    get_table_column_types,
+    get_table_primary_key_columns,
+)
+from src.database.sqlite_handler import SQLiteDatabase
+from src.importer.importer import DataImporter, validate_import_record_header
+from src.importer.importer_optimized import OptimizedDataImporter
+from src.parser.factory import ParserFactory
+from src.parser.status_domain import CURRENT_ACCUMULATED_DATA_KUBUN
+from src.parser.tc_parser import TCParser
+from src.realtime.updater import RealtimeUpdater
+
+FIXTURES = Path(__file__).parent / "fixtures" / "official_layout"
+CONTRACT = json.loads((FIXTURES / "tc_contract_4901.json").read_text(encoding="utf-8"))
+MANIFEST = json.loads((FIXTURES / "jvdata_sdk500_manifest.json").read_text(encoding="utf-8"))
+
+FIELDS = (
+    ("RecordSpec", 1, 2, b"TC"),
+    ("DataKubun", 3, 1, b"1"),
+    ("MakeDate", 4, 8, b"20260818"),
+    ("Year", 12, 4, b"2026"),
+    ("MonthDay", 16, 4, b"0818"),
+    ("JyoCD", 20, 2, b"05"),
+    ("Kaiji", 22, 2, b"03"),
+    ("Nichiji", 24, 2, b"08"),
+    ("RaceNum", 26, 2, b"11"),
+    ("HappyoTime", 28, 8, b"08181200"),
+    ("AtoJi", 36, 2, b"12"),
+    ("AtoFun", 38, 2, b"10"),
+    ("MaeJi", 40, 2, b"12"),
+    ("MaeFun", 42, 2, b"00"),
+    ("RecordDelimiter", 44, 2, b"\r\n"),
+)
+OFFICIAL_KEY = ("Year", "MonthDay", "JyoCD", "Kaiji", "Nichiji", "RaceNum")
+NATIVE_FIELDS = {name for name, _, _, _ in FIELDS} - {"RecordDelimiter"}
+STANDARD_FIELDS = set(NATIVE_FIELDS)
+
+
+def _put(record: bytearray, start: int, width: int, value: str) -> None:
+    encoded = value.encode("cp932", errors="strict")
+    assert len(encoded) <= width
+    record[start : start + width] = encoded.ljust(width, b" ")
+
+
+def build_tc_record(**overrides: str) -> bytes:
+    values = {name: default.decode("cp932") for name, _, _, default in FIELDS[:-1]}
+    values.update(overrides)
+    record = bytearray(b" " * TCParser.RECORD_LENGTH)
+    for name, position, width, _ in FIELDS[:-1]:
+        _put(record, position - 1, width, values[name])
+    record[-2:] = b"\r\n"
+    assert len(record) == 45
+    return bytes(record)
+
+
+def parsed_tc(**overrides: str) -> dict:
+    parsed = TCParser().parse(build_tc_record(**overrides))
+    assert parsed is not None
+    return parsed
+
+
+def import_tc_records(
+    database,
+    entrypoint: str,
+    records: list[dict],
+    *,
+    standard: bool,
+    auto_commit: bool,
+) -> dict:
+    if entrypoint == "single":
+        importer = DataImporter(database, use_jravan_schema=standard)
+        for record in records:
+            assert importer.import_single_record(record, auto_commit=auto_commit)
+        return importer.get_statistics()
+    importer_class = DataImporter if entrypoint == "data-batch" else OptimizedDataImporter
+    return importer_class(
+        database,
+        batch_size=1000,
+        use_jravan_schema=standard,
+    ).import_records(iter(records), auto_commit=auto_commit)
+
+
+def test_tc_oracle_binds_both_workbooks_sdk_and_every_parser_span() -> None:
+    assert CONTRACT["record_length"] == 45
+    assert CONTRACT["format_sources"] == [
+        {
+            "artifact": "JV-Data4802.xlsx",
+            "sha256": "6a567f10b601115eca350571f36d27d9d28bd2d3835ea72b5bc057711155d4a7",
+            "sheet": "フォーマット",
+            "rows": "1509-1528",
+        },
+        {
+            "artifact": "JV-Data4901.xlsx",
+            "sha256": "23bafd375f704acbdd696b5032ac1619f17d47e882587d6e7954b610527a8234",
+            "sheet": "フォーマット",
+            "rows": "1509-1528",
+        },
+    ]
+    assert CONTRACT["fields"] == [[name, position, width] for name, position, width, _ in FIELDS]
+    assert tuple(CONTRACT["primary_key"]) == OFFICIAL_KEY
+    assert CONTRACT["current_data_kubun"] == ["1"]
+    assert CURRENT_ACCUMULATED_DATA_KUBUN["TC"] == frozenset({"1"})
+    assert CONTRACT["history"] == {
+        "added": "2004-05-25",
+        "version": "1.1.6",
+        "physical_layout_changed": False,
+        "sources": [
+            "JV-Data4901.xlsx:変更履歴:216,220",
+            "JV-Data4802.xlsx:変更履歴:173,177",
+        ],
+    }
+    assert CONTRACT["current_provider_specs"] == ["0B14", "0B16"]
+    assert CONTRACT["snapshot_provider_spec"] == "0B14"
+
+    parser_spans = [(field.name, field.start + 1, field.length) for field in TCParser()._fields]
+    assert parser_spans == [(name, position, width) for name, position, width, _ in FIELDS]
+    direct = TCParser().parse(build_tc_record())
+    factory = ParserFactory().parse(build_tc_record())
+    assert direct == factory
+    assert direct is not None
+    assert direct["HappyoTime"] == "08181200"
+    assert tuple(direct[name] for name in ("AtoJi", "AtoFun", "MaeJi", "MaeFun")) == (
+        "12",
+        "10",
+        "12",
+        "00",
+    )
+
+    assert MANIFEST["root_records"]["TC"] == {"struct": "JV_TC_INFO", "length": 45}
+    structures = MANIFEST["structures"]
+    assert [
+        (field["name"], field["start"], field["width"], field.get("struct"))
+        for field in structures["JV_TC_INFO"]["fields"]
+    ] == [
+        ("head", 1, 11, "RECORD_ID"),
+        ("id", 12, 16, "RACE_ID"),
+        ("HappyoTime", 28, 8, "MDHM"),
+        ("TCInfoAfter", 36, 4, "TC_INFO"),
+        ("TCInfoBefore", 40, 4, "TC_INFO"),
+        ("crlf", 44, 2, None),
+    ]
+    assert [
+        (field["name"], field["start"], field["width"]) for field in structures["TC_INFO"]["fields"]
+    ] == [
+        ("Ji", 1, 2),
+        ("Fun", 3, 2),
+    ]
+
+
+@pytest.mark.parametrize(
+    "overrides",
+    [
+        {"DataKubun": "0"},
+        {"MakeDate": "20260230"},
+        {"Year": "20A6"},
+        {"MonthDay": "0230"},
+        {"JyoCD": "ZZ"},
+        {"Kaiji": "A1"},
+        {"Nichiji": "0A"},
+        {"RaceNum": "1X"},
+        {"HappyoTime": "08189999"},
+        {"AtoJi": "24"},
+        {"AtoFun": "60"},
+        {"MaeJi": "25"},
+        {"MaeFun": "61"},
+    ],
+)
+def test_tc_parser_rejects_nonofficial_header_key_and_time_values(
+    overrides: dict[str, str],
+) -> None:
+    with pytest.raises(ValueError):
+        TCParser().parse(build_tc_record(**overrides))
+
+
+def test_tc_zero_initialized_time_values_remain_lossless() -> None:
+    parsed = parsed_tc(HappyoTime="00000000", AtoJi="00", AtoFun="00", MaeJi="00", MaeFun="00")
+    assert parsed["HappyoTime"] == "00000000"
+    assert tuple(parsed[name] for name in ("AtoJi", "AtoFun", "MaeJi", "MaeFun")) == (
+        "00",
+        "00",
+        "00",
+        "00",
+    )
+
+
+def test_tc_native_standard_and_realtime_schemas_encode_the_official_identity() -> None:
+    for table_name in ("NL_TC", "RT_TC", "HASSOU_JIKOKU_CHANGE"):
+        assert tuple(get_table_primary_key_columns(table_name)) == OFFICIAL_KEY
+        nullability = get_table_column_nullability(table_name)
+        assert all(nullability[column] is False for column in OFFICIAL_KEY)
+    assert set(get_table_column_types("NL_TC")) == NATIVE_FIELDS
+    assert set(get_table_column_types("RT_TC")) == NATIVE_FIELDS
+    assert set(get_table_column_types("HASSOU_JIKOKU_CHANGE")) == STANDARD_FIELDS
+    metadata = TABLE_METADATA["NL_TC"]
+    assert metadata["primary_key"] == list(OFFICIAL_KEY)
+    assert [(column["name"], column["type"]) for column in metadata["columns"]] == list(
+        get_table_column_types("NL_TC").items()
+    )
+
+
+@pytest.mark.parametrize(
+    ("importer_class", "table_name", "standard"),
+    [
+        (DataImporter, "NL_TC", False),
+        (OptimizedDataImporter, "NL_TC", False),
+        (DataImporter, "HASSOU_JIKOKU_CHANGE", True),
+        (OptimizedDataImporter, "HASSOU_JIKOKU_CHANGE", True),
+    ],
+)
+@pytest.mark.parametrize("auto_commit", (True, False), ids=("owned", "caller"))
+def test_tc_provider_revision_replaces_one_official_identity(
+    tmp_path, importer_class, table_name: str, standard: bool, auto_commit: bool
+) -> None:
+    database = SQLiteDatabase({"path": str(tmp_path / f"ordered-{table_name}.db")})
+    schema = JRAVAN_SCHEMAS[table_name] if standard else SCHEMAS[table_name]
+    first = parsed_tc()
+    revised = parsed_tc(HappyoTime="08181205", AtoJi="12", AtoFun="20")
+    with database:
+        database.execute(schema)
+        database.commit()
+        result = importer_class(database, batch_size=1, use_jravan_schema=standard).import_records(
+            iter([first, revised]), auto_commit=auto_commit
+        )
+        rows = database.fetch_all(f"SELECT HappyoTime, AtoJi, AtoFun FROM {table_name}")
+    assert result["records_imported"] == 2
+    assert result["records_failed"] == 0
+    assert rows == [{"HappyoTime": "08181205", "AtoJi": "12", "AtoFun": "20"}]
+
+
+@pytest.mark.parametrize("importer_class", (DataImporter, OptimizedDataImporter))
+@pytest.mark.parametrize("auto_commit", (True, False), ids=("owned", "caller"))
+@pytest.mark.parametrize("table_name,standard", [("NL_TC", False), ("HASSOU_JIKOKU_CHANGE", True)])
+def test_tc_caller_validation_precedes_coercion_and_mutation(
+    tmp_path, importer_class, auto_commit: bool, table_name: str, standard: bool
+) -> None:
+    database = SQLiteDatabase({"path": str(tmp_path / f"invalid-{table_name}.db")})
+    schema = JRAVAN_SCHEMAS[table_name] if standard else SCHEMAS[table_name]
+    invalid_rows = []
+    for field_name, invalid_value in (
+        ("MakeDate", "20260230"),
+        ("Year", "20A6"),
+        ("Year", 26),
+        ("MonthDay", "0230"),
+        ("JyoCD", "ZZ"),
+        ("Kaiji", "A1"),
+        ("HappyoTime", "08189999"),
+        ("AtoJi", "24"),
+        ("AtoFun", "60"),
+        ("MaeJi", "25"),
+        ("MaeFun", "61"),
+    ):
+        row = parsed_tc()
+        row[field_name] = invalid_value
+        invalid_rows.append(row)
+
+    with database:
+        database.execute(schema)
+        database.commit()
+        importer = importer_class(database, use_jravan_schema=standard)
+        for invalid in invalid_rows:
+            with pytest.raises(SchemaMigrationError):
+                importer.import_records(iter([invalid]), auto_commit=auto_commit)
+        assert database.fetch_one(f"SELECT COUNT(*) AS n FROM {table_name}") == {"n": 0}
+
+
+def _defective_schema(table_name: str, defect: str) -> str:
+    schema = SCHEMAS[table_name] if table_name == "NL_TC" else JRAVAN_SCHEMAS[table_name]
+    key = "PRIMARY KEY (Year, MonthDay, JyoCD, Kaiji, Nichiji, RaceNum)"
+    if defect == "wrong-key":
+        return schema.replace(key, "PRIMARY KEY (Year, MonthDay, JyoCD, Kaiji, Nichiji)")
+    if defect == "nullable-key":
+        return schema.replace("Year INTEGER NOT NULL", "Year INTEGER").replace(
+            "Year                           SMALLINT NOT NULL",
+            "Year                           SMALLINT         ",
+        )
+    if defect == "wrong-type":
+        return schema.replace("Year INTEGER NOT NULL", "Year TEXT NOT NULL").replace(
+            "Year                           SMALLINT NOT NULL",
+            "Year                           VARCHAR(4) NOT NULL",
+        )
+    if defect == "short-text":
+        return schema.replace("HappyoTime TEXT NOT NULL", "HappyoTime VARCHAR(7) NOT NULL").replace(
+            "HappyoTime                     VARCHAR(8) NOT NULL",
+            "HappyoTime                     VARCHAR(7) NOT NULL",
+        )
+    if defect == "extra-unique":
+        body, close = schema.rsplit(")", 1)
+        return f"{body}, UNIQUE (HappyoTime)\n        ){close}"
+    if defect == "extra-check":
+        body, close = schema.rsplit(")", 1)
+        return f"{body}, CHECK (AtoJi = '00')\n        ){close}"
+    if defect == "extra-foreign-key":
+        body, close = schema.rsplit(")", 1)
+        return (
+            f"{body}, FOREIGN KEY (Year, MonthDay, JyoCD, Kaiji, Nichiji, RaceNum) "
+            f"REFERENCES {table_name} "
+            "(Year, MonthDay, JyoCD, Kaiji, Nichiji, RaceNum) ON DELETE CASCADE\n"
+            f"        ){close}"
+        )
+    if defect == "extra-required-column":
+        if key in schema:
+            return schema.replace(key, f"ExternalRequired TEXT NOT NULL, {key}")
+        body, close = schema.rsplit(")", 1)
+        return f"{body}, ExternalRequired TEXT NOT NULL\n        ){close}"
+    if defect == "extra-generated-required-column":
+        if key in schema:
+            return schema.replace(
+                key,
+                "ExternalRequired TEXT GENERATED ALWAYS AS (NULL) " f"VIRTUAL NOT NULL, {key}",
+            )
+        body, close = schema.rsplit(")", 1)
+        return (
+            f"{body}, ExternalRequired TEXT GENERATED ALWAYS AS (NULL) "
+            f"VIRTUAL NOT NULL\n        ){close}"
+        )
+    raise AssertionError(defect)
+
+
+@pytest.mark.parametrize("table_name,standard", [("NL_TC", False), ("HASSOU_JIKOKU_CHANGE", True)])
+@pytest.mark.parametrize(
+    "defect",
+    [
+        "wrong-key",
+        "nullable-key",
+        "wrong-type",
+        "short-text",
+        "extra-unique",
+        "extra-check",
+        "extra-foreign-key",
+        "extra-required-column",
+        "extra-generated-required-column",
+    ],
+)
+def test_tc_schema_defects_fail_before_any_row_mutation(
+    tmp_path, table_name: str, standard: bool, defect: str
+) -> None:
+    database = SQLiteDatabase({"path": str(tmp_path / f"{table_name}-{defect}.db")})
+    with database:
+        database.execute(_defective_schema(table_name, defect))
+        database.commit()
+        before = database.fetch_one(
+            "SELECT sql FROM sqlite_master WHERE type='table' AND name=?", (table_name,)
+        )
+        with pytest.raises(SchemaMigrationError):
+            DataImporter(database, use_jravan_schema=standard).import_records(iter([parsed_tc()]))
+        assert (
+            database.fetch_one(
+                "SELECT sql FROM sqlite_master WHERE type='table' AND name=?", (table_name,)
+            )
+            == before
+        )
+        assert database.fetch_one(f"SELECT COUNT(*) AS n FROM {table_name}") == {"n": 0}
+
+
+def test_tc_schema_manager_preflights_before_an_additive_column_change(tmp_path) -> None:
+    unsafe = _defective_schema("NL_TC", "extra-unique").replace("MaeFun TEXT NOT NULL,", "")
+    database = SQLiteDatabase({"path": str(tmp_path / "manager-unsafe.db")})
+    with database:
+        database.execute(unsafe)
+        database.commit()
+        before = database.fetch_all('PRAGMA table_xinfo("NL_TC")')
+        assert SchemaManager(database).create_table("NL_TC") is False
+        assert database.fetch_all('PRAGMA table_xinfo("NL_TC")') == before
+
+    safe = SQLiteDatabase({"path": str(tmp_path / "manager-safe.db")})
+    with safe:
+        assert SchemaManager(safe).create_table("NL_TC") is True
+        assert safe.fetch_one("SELECT COUNT(*) AS n FROM NL_TC") == {"n": 0}
+
+
+@pytest.mark.parametrize("auto_commit", (True, False), ids=("owned", "caller"))
+@pytest.mark.parametrize("table_name,standard", [("NL_TC", False), ("HASSOU_JIKOKU_CHANGE", True)])
+def test_tc_single_record_uses_the_same_fail_closed_validator(
+    tmp_path, auto_commit: bool, table_name: str, standard: bool
+) -> None:
+    database = SQLiteDatabase({"path": str(tmp_path / f"single-{table_name}.db")})
+    schema = JRAVAN_SCHEMAS[table_name] if standard else SCHEMAS[table_name]
+    with database:
+        database.execute(schema)
+        database.commit()
+        importer = DataImporter(database, use_jravan_schema=standard)
+        assert importer.import_single_record(parsed_tc(), auto_commit=auto_commit)
+        invalid = parsed_tc()
+        invalid["AtoFun"] = "60"
+        with pytest.raises(SchemaMigrationError):
+            importer.import_single_record(invalid, auto_commit=auto_commit)
+        expected = 1 if auto_commit else 0
+        assert database.fetch_one(f"SELECT COUNT(*) AS n FROM {table_name}") == {"n": expected}
+
+
+def test_tc_realtime_uses_the_same_fail_closed_validator(tmp_path) -> None:
+    realtime = SQLiteDatabase({"path": str(tmp_path / "realtime.db")})
+    with realtime:
+        for table_name in RealtimeUpdater.DATE_SNAPSHOT_TABLES:
+            realtime.execute(SCHEMAS[table_name])
+        realtime.commit()
+        updater = RealtimeUpdater(realtime)
+        inserted = updater.process_parsed_records_batch([parsed_tc()])
+        invalid = parsed_tc()
+        invalid["HappyoTime"] = "08189999"
+        rejected = updater.process_parsed_records_batch([invalid])
+        updater.replace_date_snapshot("20260818")
+        revised = updater.process_parsed_records_batch(
+            [parsed_tc(HappyoTime="08181205", AtoJi="12", AtoFun="20")]
+        )
+        rows = realtime.fetch_all("SELECT HappyoTime, AtoFun FROM RT_TC")
+
+    assert inserted["success"] is True
+    assert rejected["success"] is False
+    assert rejected["inserted"] == 0
+    assert revised["success"] is True
+    assert rows == [{"HappyoTime": "08181205", "AtoFun": "20"}]
+
+
+def test_tc_header_validator_rejects_missing_blank_and_conflicting_aliases() -> None:
+    valid = parsed_tc()
+    assert validate_import_record_header(valid) == ("TC", "1")
+    for row in (
+        {key: value for key, value in valid.items() if key != "DataKubun"},
+        {**valid, "DataKubun": ""},
+        {**valid, "headDataKubun": "0"},
+        {**valid, "headRecordSpec": "CC"},
+    ):
+        with pytest.raises(SchemaMigrationError):
+            validate_import_record_header(row)
+
+
+@pytest.fixture
+def postgresql_db():
+    if os.getenv("JLTSQL_RUN_POSTGRESQL_INTEGRATION") != "1":
+        pytest.skip("Set JLTSQL_RUN_POSTGRESQL_INTEGRATION=1 to run PostgreSQL tests")
+
+    from scripts.setup_pg_test_db import postgresql_test_config
+    from src.database.postgresql_handler import PostgreSQLDatabase
+
+    database = PostgreSQLDatabase(postgresql_test_config())
+    schema_name = f"jlt_tc_{uuid4().hex[:12]}"
+    database.connect()
+    try:
+        database.execute(f"CREATE SCHEMA {schema_name}")
+        database.execute(f"SET search_path TO {schema_name}")
+        database.commit()
+        yield database
+    finally:
+        try:
+            try:
+                database.rollback()
+            except Exception:
+                pass
+            database.execute(f"DROP SCHEMA IF EXISTS {schema_name} CASCADE")
+            database.commit()
+        finally:
+            database.disconnect()
+
+
+@pytest.mark.parametrize("table_name,standard", [("NL_TC", False), ("HASSOU_JIKOKU_CHANGE", True)])
+@pytest.mark.parametrize("entrypoint", ("data-batch", "optimized-batch", "single"))
+@pytest.mark.parametrize("auto_commit", (True, False), ids=("owned", "caller"))
+def test_tc_postgresql_all_entrypoints_preserve_provider_revision_order(
+    postgresql_db,
+    table_name: str,
+    standard: bool,
+    entrypoint: str,
+    auto_commit: bool,
+) -> None:
+    schema = JRAVAN_SCHEMAS[table_name] if standard else SCHEMAS[table_name]
+    postgresql_db.execute(schema)
+    postgresql_db.commit()
+    first = parsed_tc()
+    revised = parsed_tc(HappyoTime="08181205", AtoJi="12", AtoFun="20")
+    stats = import_tc_records(
+        postgresql_db,
+        entrypoint,
+        [first, revised],
+        standard=standard,
+        auto_commit=auto_commit,
+    )
+    if not auto_commit:
+        postgresql_db.commit()
+    assert stats["records_imported"] == 2
+    assert stats["records_failed"] == 0
+    assert postgresql_db.fetch_all(
+        f'SELECT HappyoTime AS "HappyoTime", AtoFun AS "AtoFun" FROM {table_name}'
+    ) == [{"HappyoTime": "08181205", "AtoFun": "20"}]
+
+
+@pytest.mark.parametrize("table_name,standard", [("NL_TC", False), ("HASSOU_JIKOKU_CHANGE", True)])
+@pytest.mark.parametrize(
+    "defect",
+    [
+        "wrong-key",
+        "wrong-type",
+        "short-text",
+        "extra-unique",
+        "extra-check",
+        "extra-foreign-key",
+        "extra-required-column",
+        "deferrable-primary-key",
+    ],
+)
+def test_tc_postgresql_schema_defects_fail_before_mutation(
+    postgresql_db, table_name: str, standard: bool, defect: str
+) -> None:
+    if defect == "deferrable-primary-key":
+        schema = JRAVAN_SCHEMAS[table_name] if standard else SCHEMAS[table_name]
+        schema = schema.replace(
+            "PRIMARY KEY (Year, MonthDay, JyoCD, Kaiji, Nichiji, RaceNum)",
+            "PRIMARY KEY (Year, MonthDay, JyoCD, Kaiji, Nichiji, RaceNum) "
+            "DEFERRABLE INITIALLY DEFERRED",
+        )
+    else:
+        schema = _defective_schema(table_name, defect)
+    postgresql_db.execute(schema)
+    postgresql_db.commit()
+    with pytest.raises(SchemaMigrationError):
+        DataImporter(postgresql_db, use_jravan_schema=standard).import_records(iter([parsed_tc()]))
+    assert postgresql_db.fetch_one(f'SELECT COUNT(*) AS "n" FROM {table_name}') == {"n": 0}
+
+
+def test_tc_postgresql_realtime_gate(postgresql_db) -> None:
+    postgresql_db.execute(SCHEMAS["RT_TC"])
+    postgresql_db.commit()
+    updater = RealtimeUpdater(postgresql_db)
+    result = updater.process_parsed_records_batch(
+        [parsed_tc(), parsed_tc(HappyoTime="08181205", AtoFun="20")]
+    )
+    invalid = parsed_tc()
+    invalid["AtoFun"] = "60"
+    rejected = updater.process_parsed_records_batch([invalid])
+    assert result["success"] is True
+    assert result["inserted"] == 2
+    assert result["errors"] == 0
+    assert result["tables"] == ["RT_TC"]
+    assert rejected["success"] is False
+    assert rejected["inserted"] == 0
+    assert postgresql_db.fetch_all(
+        'SELECT HappyoTime AS "HappyoTime", AtoFun AS "AtoFun" FROM RT_TC'
+    ) == [{"HappyoTime": "08181205", "AtoFun": "20"}]
+
+
+@pytest.mark.parametrize("unsafe_target", ("primary", "secondary"))
+@pytest.mark.parametrize("table_name,standard", [("NL_TC", False), ("HASSOU_JIKOKU_CHANGE", True)])
+def test_tc_dual_rejects_an_unsafe_target_before_either_database_changes(
+    postgresql_db,
+    tmp_path,
+    unsafe_target: str,
+    table_name: str,
+    standard: bool,
+) -> None:
+    safe = JRAVAN_SCHEMAS[table_name] if standard else SCHEMAS[table_name]
+    unsafe = _defective_schema(table_name, "extra-required-column")
+    sqlite = SQLiteDatabase({"path": str(tmp_path / f"{table_name}-{unsafe_target}.db")})
+    with sqlite:
+        sqlite.execute(unsafe if unsafe_target == "primary" else safe)
+        postgresql_db.execute(unsafe if unsafe_target == "secondary" else safe)
+        sqlite.commit()
+        postgresql_db.commit()
+        primary, secondary = (
+            (sqlite, postgresql_db) if unsafe_target == "primary" else (postgresql_db, sqlite)
+        )
+        with pytest.raises(SchemaMigrationError):
+            DataImporter(
+                DualDatabase(primary, secondary),
+                use_jravan_schema=standard,
+            ).import_records(iter([parsed_tc()]))
+        assert sqlite.fetch_one(f"SELECT COUNT(*) AS n FROM {table_name}") == {"n": 0}
+        assert postgresql_db.fetch_one(f'SELECT COUNT(*) AS "n" FROM {table_name}') == {"n": 0}
+
+
+@pytest.mark.parametrize("table_name,standard", [("NL_TC", False), ("HASSOU_JIKOKU_CHANGE", True)])
+def test_tc_dual_preserves_one_provider_revision_on_both_targets(
+    postgresql_db, tmp_path, table_name: str, standard: bool
+) -> None:
+    schema = JRAVAN_SCHEMAS[table_name] if standard else SCHEMAS[table_name]
+    sqlite = SQLiteDatabase({"path": str(tmp_path / f"{table_name}-safe-dual.db")})
+    with sqlite:
+        sqlite.execute(schema)
+        postgresql_db.execute(schema)
+        sqlite.commit()
+        postgresql_db.commit()
+        dual = DualDatabase(sqlite, postgresql_db)
+        stats = DataImporter(dual, use_jravan_schema=standard).import_records(
+            iter([parsed_tc(), parsed_tc(HappyoTime="08181205", AtoFun="20")]),
+            auto_commit=False,
+        )
+        dual.commit()
+        assert stats["records_imported"] == 2
+        expected = [{"HappyoTime": "08181205", "AtoFun": "20"}]
+        assert sqlite.fetch_all(f"SELECT HappyoTime, AtoFun FROM {table_name}") == expected
+        assert (
+            postgresql_db.fetch_all(
+                f'SELECT HappyoTime AS "HappyoTime", AtoFun AS "AtoFun" FROM {table_name}'
+            )
+            == expected
+        )


### PR DESCRIPTION
## Summary

- bind TC (発走時刻変更) to the pinned official 4.9.0.1 / SDK 5.0.0 contract: 45 bytes, DataKubun `1`, and the six-column official key
- validate raw and caller-built records before schema/catalog mutation across both importers and realtime paths
- make native, realtime, and JRAVAN-compatible storage fail closed on key, type, nullability, generated/identity columns, unsafe constraints, and legacy COMMENT schemas
- preserve provider semantics: 0B14 replaces the complete date snapshot, while 0B16 remains event-scoped
- add the official fixture, red-first regression contract, public data-support notes, and tracked worklog

## Root cause

TC previously relied on generic parsing and schema handling. That allowed malformed headers and times, incomplete or unsafe schemas, inconsistent Dual targets, and realtime snapshot behavior that was not bound directly to the official contract.

## Impact

Malformed or ambiguous TC data is rejected before mutation. Existing incompatible TC schemas require operator repair/recreation instead of being silently accepted. No production/provider release claim is made by this PR.

## Validation

Exact candidate: `b9fc9d4b71f3d302883a6e535bf4ba47d6d40d15`

Red-first evidence:
- base candidate: `33 failed, 5 passed`
- review findings against the first implementation: SQLite `12 failed, 54 passed, 39 skipped`; PostgreSQL `19 failed, 85 passed`
- snapshot-delete mutant leaves the stale race and is detected by the durable readback test

Final green evidence:
- SQLite TC: `66 passed, 39 skipped`
- fresh PostgreSQL 16 TC: `104 passed`
- affected suites: `1413 passed, 309 skipped, 9 subtests passed`
- full non-E2E suite: `3402 passed, 373 skipped, 20 subtests passed`
- fatal flake8, repository test gate, `uv lock --check`, Black (changed parser/test), and strict MkDocs: passed
- git-archive wheel/sdist content gate and extracted-wheel init smoke: passed
- wheel SHA-256: `2e4f09373ef3333b51c91389cac2966d4ecb56b00a71d1354ee14780893c4c00`
- sdist SHA-256: `360fb1d0ecbc10d389f2700c6c4e168d76cbe725badfdbd7d82383c7980a4b34`

Three independent bounded reviews of the final SHA returned GREEN with P0/P1/P2 = 0. The worktree was clean at push.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added comprehensive support for official TC start-time change records.
  * Enforced the current 45-byte format, six-part race identity, valid dates and times, and supported status values.
  * Preserved time values losslessly in fixed-width format.
  * Added validation across standard, realtime, batch, and single-record imports.

* **Bug Fixes**
  * Improved snapshot replacement so stale realtime data is removed only after successful full-date updates.
  * Legacy or incompatible TC tables now stop safely and require rebuilding and reimporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->