### PR TITLE
Bind CC course changes to the official contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,13 @@
 
 ### Fixed
 
+- `CC`を公式50バイト配置と6項目race keyへ結び付け、発表`MMDDhhmm`、変更前後の
+  4桁距離・track code、事由区分をlosslessに検証・保存する。native `NL_CC`、
+  速報`RT_CC`、標準名`COURSE_CHANGE`でprovider順の改訂を1行へ反映し、current
+  status 1以外、不正日付/競馬場/track/reason、nullable・keyless・wrong-type・
+  追加constraintをmutation前に拒否する。status 0 deleteは作らず、`0B14`の
+  正常完了後だけ日単位の完全snapshot置換を行う。旧unsafe tableはbackup・
+  rebuild・reimportを要求する
 - `TC`を公式45バイト配置と6項目race keyへ結び付け、発表`MMDDhhmm`と変更前後
   `HHmm`をlosslessに検証・保存する。native `NL_TC`、速報`RT_TC`、標準名
   `HASSOU_JIKOKU_CHANGE`でprovider順の改訂を1行へ反映し、current status 1以外、

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -39,6 +39,14 @@ Public API replacements:
   require backup, rebuild, and reimport. TC does not invent a status-0 delete:
   stale realtime changes are removed only by a successfully completed 0B14
   full-date snapshot replacement
+- CC course changes now use the official 50-byte layout and exact six-part
+  race identity in `NL_CC`, `RT_CC`, and `COURSE_CHANGE`. Announcement time,
+  four-digit before/after distances, official track codes, and reason codes
+  remain lossless, including documented zero-initial values. Existing
+  keyless, nullable, wrong-type, extended, or otherwise unsafe CC tables must
+  be backed up, rebuilt, and reimported. Current status 1 is the only accepted
+  status; stale realtime rows are removed only after a successful 0B14
+  full-date snapshot, while 0B16 remains event-oriented.
 - native and standard schemas now verify primary keys, types, capacities,
   child-table constraints, and cancellation/delete behavior before mutation;
   several record families gained complete child storage or corrected keys

--- a/docs/data_support.md
+++ b/docs/data_support.md
@@ -203,6 +203,27 @@ backupして該当TC tableをcurrent schemaでrebuildし、保持期間内の`0B
 または対応する蓄積sourceからreimportしてください。旧標準名`COMMENT`しかない構成を
 `HASSOU_JIKOKU_CHANGE`へ自動転用しません。
 
+### CC（コース変更）の現行契約
+
+`CC` は現行JV-Data 4.9.0.1 / SDK 5.0.0の50バイト配置だけを受け付けます。
+identityは `Year`, `MonthDay`, `JyoCD`, `Kaiji`, `Nichiji`, `RaceNum` の
+6項目です。native `NL_CC`、速報 `RT_CC`、JRA-VAN標準名 `COURSE_CHANGE`
+は同じordered primary keyと必須15列を使います。`HappyoTime` は
+`MMDDhhmm`、変更前後の距離は4桁、track codeは公式コード表2009の
+`00`, `10`〜`29`, `51`〜`59`、事由区分は初期値`0`または`1`〜`4`です。
+`00000000`、距離`0000`、track `00`、事由`0`は欠損へ変換しません。
+
+現行の公式 `DataKubun` は `1` だけで、CC単体のstatus 0 deleteはありません。
+`0B14`の正常完了後だけ上記の日単位snapshot置換を行い、後続snapshotから
+消えたCCを削除します。`0B16`はイベント指定更新なので日単位置換を行いません。
+開催中止決定前に発表済みのCCは、公式仕様どおり中止後も提供対象です。
+
+既存のnullable、keyless、wrong-key、wrong-type、容量不足、generated/identity列、
+追加列または追加UNIQUE/FK/CHECKを持つCC tableは、失われたidentityや値を安全に
+復元できないため自動修復しません。DBをbackupし、該当3表をcurrent schemaで
+rebuildして、保持期間内の`0B14`/`0B16`または対応する蓄積sourceから
+reimportしてください。
+
 ## JVRTOpen オッズ・票数
 
 | データ種別 | 内容 | 想定レコード種別 | 通常速報モードの保存先 | 時系列モードの保存先 | キー形式 | JRA-VAN 側の保持 | 運用コマンド |

--- a/specs/operations/20260818_cc_official_contract_worklog.md
+++ b/specs/operations/20260818_cc_official_contract_worklog.md
@@ -46,6 +46,18 @@
   Codex implementation plus independent critical reviews rather than silently
   weakening the gate.
 
+### Claude execution result
+
+- Claude Code `2.1.233` was invoked after the start-worklog commit with
+  `--model fable` and session id
+  `839154eb-0967-4b4d-87e4-785f2dfdce64`. It exited before reading or editing
+  the repository because the OAuth session was expired and could not be
+  refreshed. The CLI also emitted non-fatal warnings about obsolete `Write`
+  permission-rule spellings in the parent settings. No Claude implementation
+  or review evidence exists for this iteration. Codex will implement the
+  bounded contract with independent official-oracle and critical review as the
+  recorded fallback.
+
 ## Known preliminary risks (not yet official findings)
 
 - `CCParser` declares `RECORD_LENGTH=50` while its docstring says 48 bytes and

--- a/specs/operations/20260818_cc_official_contract_worklog.md
+++ b/specs/operations/20260818_cc_official_contract_worklog.md
@@ -226,22 +226,25 @@
   but did not directly bind the runtime `CCParser` track/reason sets to those
   fixture domains. The runtime sets themselves were already correct.
 - The existing oracle test was minimally extended with the two direct runtime
-  equality assertions. Before retaining that test change, a temporary mutant
-  added unsupported track `30` and reason `5` to the runtime sets; the oracle
-  failed exactly at the new binding with extra item `30`. The mutant was
-  removed and the provider-valid runtime remained unchanged. This is the
-  recorded red-first proof that the corrected oracle can reject domain drift.
+  equality assertions. Before retaining that test change, one temporary mutant
+  added unsupported track `30`; the oracle failed at the track binding with
+  extra item `30`. After restoring it, a separate reason-only mutant added
+  unsupported reason `5`; the oracle passed the track assertion and failed at
+  the reason binding with extra item `5`. Both mutants were removed and the
+  provider-valid runtime remained unchanged. These are the recorded red-first
+  proofs that both corrected oracle branches can reject domain drift.
 - Both reviewers also identified that the prior `Next` paragraph described
   steps already completed by `8b9761a...`; the current next step is publication
   and PR gating, not another evidence commit or broad review cycle.
 
 ## Next safe command and STOP conditions
 
-- Next: run the compact CC test on the final test/worklog-only delta, commit it,
-  push one branch, open one PR, request the single native Copilot review,
+- Next: from the current clean committed HEAD, push one branch, open one PR,
+  request the single native Copilot review,
   address actionable comments in one batch, require unresolved thread count
   zero, and merge only after the applicable checks and exact-head evidence are
-  green. Do not rerun the already-green broad suite for this two-assertion
+  green. The compact CC test is green after both temporary mutants were
+  removed. Do not rerun the already-green broad suite for this two-assertion
   oracle-only delta unless the exact change expands.
 - STOP on non-worklog drift, a material disagreement among pinned official
   sources, backend divergence that is not explained and tested, or any need

--- a/specs/operations/20260818_cc_official_contract_worklog.md
+++ b/specs/operations/20260818_cc_official_contract_worklog.md
@@ -1,0 +1,67 @@
+# CC official contract iteration worklog
+
+## Start state (2026-08-18)
+
+- Objective: bind the JRA `CC` course-change record to the pinned official
+  physical layout, current status/key/body domains, native/standard/realtime
+  storage, exact schema preflight, provider ordering, and transaction safety.
+- Minimal scope: `CC` only. Do not fold unrelated HC/HS/TC cleanup or later
+  record formats into this iteration.
+- Repository: `miyamamoto/jrvltsql`.
+- Worktree: `/home/keiba/scratch/20260818_jrvltsql_cc_official`.
+- Branch: `agent/cc-official-contract-20260818`.
+- Base and starting HEAD: `6e9a9f500f2353d7b423e5f1e12b07c30275f8d1`
+  (`origin/master`, TC PR #214 squash merge).
+- Package version: `2.0.0.dev0`; latest published release remains `v1.6.10`.
+  This iteration is not itself a release or production-adoption claim.
+- Dependency order: TC is merged; CC is the next independent official-contract
+  iteration and must be merged before another record format begins.
+- Working tree was clean at creation.
+
+## Planned contract and evidence
+
+1. Re-derive the CC byte spans, total length, ordered key, current status,
+   history, code domains, and 0B14/0B16 delivery behavior from pinned JV-Data
+   4.8/4.9 workbooks plus SDK 5 source/manifest before production edits.
+2. Extend or add one compact official-contract test module. Every new or
+   changed parser/validator/schema gate must first be red on this exact base,
+   with paired provider-valid green cases.
+3. Cover direct/factory parsing; caller aliases; native `NL_CC`; standard
+   `COURSE_CHANGE`; `RT_CC`; both batch importers; single-record import;
+   realtime single/batch; SQLite, fresh PostgreSQL, Dual orientation,
+   caller-owned transactions, provider-order replacement, and fail-before-
+   mutation migration.
+4. Update executable metadata, public support/migration documentation, release
+   notes/changelog, and this worklog only where required by proven CC facts.
+5. Freeze one full candidate SHA, aggregate independent official-oracle and
+   critical reviews, apply at most one consolidated repair batch, then run
+   focused/workflow/package gates before one PR and merge.
+
+## Coding-agent choice
+
+- This is complex fail-closed parser/schema/migration work, so the planned
+  Claude Code model is `--model fable`, session id
+  `839154eb-0967-4b4d-87e4-785f2dfdce64`. The same session will be resumed for
+  review repairs. If authentication/quota blocks it, record the failure and use
+  Codex implementation plus independent critical reviews rather than silently
+  weakening the gate.
+
+## Known preliminary risks (not yet official findings)
+
+- `CCParser` declares `RECORD_LENGTH=50` while its docstring says 48 bytes and
+  it does not expose the terminal CRLF field.
+- Current parser has no CC-specific key/body validator. Native/realtime schemas
+  are nullable, while standard `COURSE_CHANGE` is keyless and nullable.
+- Existing status-domain work already restricts current CC to status `1`, but
+  all parser/caller/schema boundaries and code domains still require an
+  independent official audit.
+
+## Next safe command and STOP conditions
+
+- Next: invoke the recorded Fable session, independently extract the official
+  CC oracle, then write the smallest red-first contract before production edits.
+- STOP on non-worklog drift, a material disagreement among pinned official
+  sources, backend divergence that is not explained and tested, or any need
+  for destructive/provider action beyond the authorized local test scope.
+- Credentials, provider identifiers, and connection strings must not be
+  written to this worklog.

--- a/specs/operations/20260818_cc_official_contract_worklog.md
+++ b/specs/operations/20260818_cc_official_contract_worklog.md
@@ -68,10 +68,44 @@
   all parser/caller/schema boundaries and code domains still require an
   independent official audit.
 
+## Official oracle and red-first evidence
+
+- Pinned JV-Data 4.8.0.2 and 4.9.0.1 `フォーマット` rows 1531–1553 and
+  SDK 5 `JV_CC_INFO` agree on a 50-byte layout with 16 spans including CRLF,
+  current status `1`, and ordered key
+  `(Year, MonthDay, JyoCD, Kaiji, Nichiji, RaceNum)`.
+- The current track-code domain is `00`, `10`–`29`, and `51`–`59`; the reason
+  domain is initial `0` plus `1`–`4`. Distances retain exactly four ASCII
+  digits including `0000`; `HappyoTime` accepts `00000000` or a real
+  `MMDDhhmm` value.
+- CC was added on 2004-05-25 in Ver.1.1.6. No later physical-layout change was
+  found. `0B14` is the date-snapshot source and `0B16` is event-oriented.
+- Before production edits, added
+  `tests/fixtures/official_layout/cc_contract_4901.json` and one grouped
+  `tests/test_cc_official_contract.py` covering the physical oracle, strict
+  negatives/initial sentinels, native/standard identity, schema negatives,
+  both batch importers, single import, realtime, snapshot replacement, and
+  header aliases.
+- Red command on unchanged production HEAD
+  `da1da38e46ffcda90254108a737820a9b8867015`:
+  `python -m pytest -q -o addopts='' tests/test_cc_official_contract.py`.
+  Result: `51 failed, 7 passed`. Failures include the missing delimiter span,
+  15 malformed raw cases being accepted, nullable/keyless or unsafe schemas,
+  standard revision duplication, caller/single/realtime invalid-body
+  acceptance, and schema-manager fail-open. Passing controls include official
+  initial sentinels, current header aliases, native provider replacement, and
+  the existing CC date-snapshot behavior.
+- Three independent read-only reviewers audited the committed pre-production
+  HEAD. Two completed before the intentional red files appeared and one was
+  told those files were primary-owned. Their non-duplicated findings match the
+  red contract: strict parser/caller/realtime validation, exact three-table
+  storage/preflight, and a CC-specific durable 0B14 assertion are required.
+
 ## Next safe command and STOP conditions
 
-- Next: invoke the recorded Fable session, independently extract the official
-  CC oracle, then write the smallest red-first contract before production edits.
+- Next: commit this red-first contract, implement the bounded CC parser/schema/
+  importer/realtime repair once, then run focused SQLite and fresh PostgreSQL/
+  Dual validation before freezing one review candidate.
 - STOP on non-worklog drift, a material disagreement among pinned official
   sources, backend divergence that is not explained and tested, or any need
   for destructive/provider action beyond the authorized local test scope.

--- a/specs/operations/20260818_cc_official_contract_worklog.md
+++ b/specs/operations/20260818_cc_official_contract_worklog.md
@@ -95,6 +95,13 @@
   acceptance, and schema-manager fail-open. Passing controls include official
   initial sentinels, current header aliases, native provider replacement, and
   the existing CC date-snapshot behavior.
+- Before production edits, the grouped schema contract was extended with
+  generated/required-column and Dual-orientation negatives plus opt-in
+  PostgreSQL deferrable/generated/UNIQUE and provider-operation-count cases.
+  The unchanged production result became `57 failed, 7 passed, 5 skipped`;
+  both Dual unsafe orientations failed to stop before mutation. PostgreSQL
+  cases were intentionally skipped in this local red run and are to be run
+  against a fresh PostgreSQL instance after implementation.
 - Three independent read-only reviewers audited the committed pre-production
   HEAD. Two completed before the intentional red files appeared and one was
   told those files were primary-owned. Their non-duplicated findings match the

--- a/specs/operations/20260818_cc_official_contract_worklog.md
+++ b/specs/operations/20260818_cc_official_contract_worklog.md
@@ -108,11 +108,48 @@
   red contract: strict parser/caller/realtime validation, exact three-table
   storage/preflight, and a CC-specific durable 0B14 assertion are required.
 
+## Implementation and local validation
+
+- Implemented one bounded CC repair after the grouped red run:
+  - `CCParser` now binds all 16 official spans, including CRLF, and validates
+    the six-part identity, real dates and announcement time, exact distance
+    widths, official venue/track domains, and reason domain before returning a
+    parsed row;
+  - native `NL_CC`/`RT_CC` and standard `COURSE_CHANGE` now expose the same
+    complete required payload and exact ordered primary key;
+  - both batch importers, single-record import, realtime dict entry points,
+    SchemaManager, standard preflight, metadata, and provider-operation
+    counting share the CC validator and strict schema verifier;
+  - the verifier rejects missing/extra/generated/identity columns, wrong
+    affinities/capacities/nullability, wrong/deferrable PostgreSQL keys, and
+    unapproved UNIQUE/FK/CHECK constraints on every Dual migration target;
+  - public support, migration and release documents now state the current-only
+    status-1 contract and distinguish 0B14 snapshot replacement from 0B16
+    event updates.
+- Fresh SQLite compact contract after implementation: `64 passed, 5 skipped`.
+- Fresh disposable PostgreSQL 16 compact contract, including native/standard
+  same-key provider ordering, unsafe schema rejection, first-invalid realtime
+  transaction state, and mixed SQLite/PostgreSQL Dual orientations:
+  `77 passed`.
+- The adjacent affected aggregate (`CC`, announcement-time, realtime,
+  migration, schema/index, importer and prior `TC` contract) passed
+  `295 passed, 56 skipped, 9 subtests passed` under Python 3.13.5.
+- `scripts/validate_test_gate.py` reported `TEST GATE PASS`; workflow-fatal
+  flake8 (`E9,F63,F7,F82`) reported zero; `uv lock --check`, compileall,
+  strict MkDocs, import-order lint for newly touched imports, and
+  `git diff --check` passed. Generic project-wide Ruff debt was not formatted
+  or mixed into this scoped change.
+- The disposable PostgreSQL container remains intentionally running only until
+  the exact committed candidate and final bounded reviews are complete. No
+  provider, production, GitHub, release-lock, KPS data, or model state was
+  changed.
+
 ## Next safe command and STOP conditions
 
-- Next: commit this red-first contract, implement the bounded CC parser/schema/
-  importer/realtime repair once, then run focused SQLite and fresh PostgreSQL/
-  Dual validation before freezing one review candidate.
+- Next: commit the completed implementation/docs/worklog batch, run the
+  workflow-equivalent suite and package gates on its exact full SHA, then
+  freeze one clean candidate for the already-planned independent bounded
+  reviews. Aggregate concrete findings before any repair commit.
 - STOP on non-worklog drift, a material disagreement among pinned official
   sources, backend divergence that is not explained and tested, or any need
   for destructive/provider action beyond the authorized local test scope.

--- a/specs/operations/20260818_cc_official_contract_worklog.md
+++ b/specs/operations/20260818_cc_official_contract_worklog.md
@@ -134,6 +134,16 @@
 - The adjacent affected aggregate (`CC`, announcement-time, realtime,
   migration, schema/index, importer and prior `TC` contract) passed
   `295 passed, 56 skipped, 9 subtests passed` under Python 3.13.5.
+- The first workflow-equivalent broad run on exact committed candidate
+  `686f6018f8f83f7e102fb55d1fb2f539514e9a43` finished `3448 passed,
+  386 skipped, 14 deselected, 20 subtests passed` with four CC failures.
+  All four were the same pre-existing false-positive fixture class: generic
+  parser tests supplied an all-blank CC key/body and expected it to be valid.
+  The strict parser was not weakened. `CC` was added to the generic envelope's
+  domain-payload-required set and the shared parser sample now supplies one
+  complete official-valid CC row. The exact affected selection then passed
+  `152 passed`; the candidate-wide suite must be rerun after this test-only
+  repair.
 - `scripts/validate_test_gate.py` reported `TEST GATE PASS`; workflow-fatal
   flake8 (`E9,F63,F7,F82`) reported zero; `uv lock --check`, compileall,
   strict MkDocs, import-order lint for newly touched imports, and

--- a/specs/operations/20260818_cc_official_contract_worklog.md
+++ b/specs/operations/20260818_cc_official_contract_worklog.md
@@ -154,12 +154,72 @@
   provider, production, GitHub, release-lock, KPS data, or model state was
   changed.
 
+## Frozen-candidate reviews and one repair batch
+
+- The first frozen review candidate was
+  `7dffe3b1c6fea6099e0c57715f0f1f86a229f3d1`, with base
+  `6e9a9f500f2353d7b423e5f1e12b07c30275f8d1` and a clean worktree.
+  Three independent read-only reviews were aggregated before any repair:
+  - the database reviewer found that caller-built integer distances were
+    accepted but stored to standard `COURSE_CHANGE` as `"0"`/`"12"` rather
+    than the lossless official four-character `"0000"`/`"0012"` form;
+  - the same reviewer found that failed public `SchemaManager.create_table`
+    and `create_all_tables` CC preflights could leave a PostgreSQL catalog-read
+    transaction pending because ownership was sampled after the first read;
+  - the official-oracle reviewer demonstrated that forged workbook/SDK source
+    fields, code domains, history fields, and `JV_CC_INFO` spans were not
+    truth-bound by the initial oracle test, and also identified the wrong
+    Unicode separator in the recorded timing-sheet locator;
+  - the release reviewer found no code or package blocker, but correctly
+    rejected the stale worklog as incomplete release provenance. Its parser
+    offset, code-domain, schema fail-open, provider-count, stale-snapshot, and
+    routing mutants all made the corresponding tests fail.
+- Red-first follow-up was committed as
+  `a5a47249edde6afbacb643e47c4c0052be07d273`. On the unrepaired production
+  candidate, the grouped review regressions produced five failures: one exact
+  official-locator/oracle failure, two importer distance-normalization
+  failures, and two PostgreSQL SchemaManager transaction-closure failures.
+  Provider-valid controls remained green.
+- One consolidated repair was committed as
+  `6caa56b9d39bbb5c6cb27b634f82fc5000ecb2f3`:
+  - standard CC translation formats accepted integer distances to exactly four
+    digits after shared validation;
+  - strict SchemaManager preflight snapshots ownership before every catalog
+    read and closes only a transaction created by the failing call;
+  - the compact oracle now binds both workbook sources and hashes, SDK source
+    and hash, every `JV_CC_INFO` field span, exact track/reason domains,
+    history/provider facts, and the real U+FF65 worksheet separator.
+  All five previously red review regressions passed after this repair.
+
+## Final local evidence before publication
+
+- Compact CC contract on SQLite: `66 passed, 15 skipped`.
+- Compact CC contract against the fresh disposable PostgreSQL 16 instance:
+  `81 passed`.
+- Workflow-equivalent suite on exact
+  `6caa56b9d39bbb5c6cb27b634f82fc5000ecb2f3`: `3454 passed, 388 skipped,
+  14 deselected, 20 subtests passed`.
+- Python 3.12 affected suite on the same production/test tree: `715 passed,
+  58 skipped, 9 subtests passed`.
+- Workflow-fatal flake8 (`E9,F63,F7,F82`) returned `0`; the repository test
+  gate reported `TEST GATE PASS`; `uv lock --check`, strict MkDocs, and
+  `git diff --check` passed.
+- A git-archive-derived wheel and sdist for `2.0.0.dev0` built successfully.
+  The official distribution-content gate passed for both artifacts, and the
+  isolated wheel initialization smoke passed. No `specs/` worklog is included
+  in the distributable artifacts.
+- No provider, production, GitHub, release-lock, KPS data, or model state was
+  changed by these local validations. The PostgreSQL instance is disposable
+  and will be removed after the final carry-forward review.
+
 ## Next safe command and STOP conditions
 
-- Next: commit the completed implementation/docs/worklog batch, run the
-  workflow-equivalent suite and package gates on its exact full SHA, then
-  freeze one clean candidate for the already-planned independent bounded
-  reviews. Aggregate concrete findings before any repair commit.
+- Next: commit this final evidence update, freeze the resulting clean full SHA,
+  run one bounded carry-forward review of the consolidated repair/provenance,
+  then push one branch, open one PR, request the single native Copilot review,
+  address actionable comments in one batch, require unresolved thread count
+  zero, and merge only after the applicable checks and exact-head evidence are
+  green.
 - STOP on non-worklog drift, a material disagreement among pinned official
   sources, backend divergence that is not explained and tested, or any need
   for destructive/provider action beyond the authorized local test scope.

--- a/specs/operations/20260818_cc_official_contract_worklog.md
+++ b/specs/operations/20260818_cc_official_contract_worklog.md
@@ -212,14 +212,37 @@
   changed by these local validations. The PostgreSQL instance is disposable
   and will be removed after the final carry-forward review.
 
+## Final carry-forward review closure
+
+- Two bounded read-only reviewers audited exact clean candidate
+  `8b9761a63c73687c41d809a5467afd046cfcdb44` after the consolidated repair.
+  The database reviewer independently replayed the five red cases, both
+  importer distance paths on SQLite and fresh PostgreSQL, and the eight
+  safe/unsafe/caller-owned SchemaManager paths. It found no remaining database
+  P0/P1/P2.
+- The official reviewer reconfirmed both workbook hashes, SDK hash and all
+  spans, provider/history facts, and the corrected worksheet locator. It found
+  one test-gate gap: the compact oracle compared fixture domains to literals
+  but did not directly bind the runtime `CCParser` track/reason sets to those
+  fixture domains. The runtime sets themselves were already correct.
+- The existing oracle test was minimally extended with the two direct runtime
+  equality assertions. Before retaining that test change, a temporary mutant
+  added unsupported track `30` and reason `5` to the runtime sets; the oracle
+  failed exactly at the new binding with extra item `30`. The mutant was
+  removed and the provider-valid runtime remained unchanged. This is the
+  recorded red-first proof that the corrected oracle can reject domain drift.
+- Both reviewers also identified that the prior `Next` paragraph described
+  steps already completed by `8b9761a...`; the current next step is publication
+  and PR gating, not another evidence commit or broad review cycle.
+
 ## Next safe command and STOP conditions
 
-- Next: commit this final evidence update, freeze the resulting clean full SHA,
-  run one bounded carry-forward review of the consolidated repair/provenance,
-  then push one branch, open one PR, request the single native Copilot review,
+- Next: run the compact CC test on the final test/worklog-only delta, commit it,
+  push one branch, open one PR, request the single native Copilot review,
   address actionable comments in one batch, require unresolved thread count
   zero, and merge only after the applicable checks and exact-head evidence are
-  green.
+  green. Do not rerun the already-green broad suite for this two-assertion
+  oracle-only delta unless the exact change expands.
 - STOP on non-worklog drift, a material disagreement among pinned official
   sources, backend divergence that is not explained and tested, or any need
   for destructive/provider action beyond the authorized local test scope.

--- a/specs/operations/20260818_cc_official_contract_worklog.md
+++ b/specs/operations/20260818_cc_official_contract_worklog.md
@@ -237,15 +237,42 @@
   steps already completed by `8b9761a...`; the current next step is publication
   and PR gating, not another evidence commit or broad review cycle.
 
+## GitHub publication gate
+
+- Branch `agent/cc-official-contract-20260818` was pushed and PR #215 was
+  opened at `https://github.com/miyamamoto/jrvltsql/pull/215` against exact base
+  `6e9a9f500f2353d7b423e5f1e12b07c30275f8d1`. The reviewed code/test head was
+  `22c89b704cd316e4c8aa0393d16bb3035a779255`; the worktree was clean.
+- The one GitHub-native Copilot review was requested after the PR became ready.
+  Copilot returned only its quota-limit notice and supplied no code finding.
+  It was not re-requested.
+- GitHub Actions on `22c89b7...` completed successfully for `test`, `lint`, and
+  `windows-batch-syntax`; `performance-test` was intentionally skipped by its
+  workflow condition. CodeRabbit completed successfully.
+- CodeRabbit opened three threads. All were answered with direct evidence and
+  resolved without code churn:
+  - the absolute disposable worktree path is intentionally retained because
+    repository policy requires the exact worktree in tracked handoff evidence;
+  - `6caa56b9...` is explicitly the broad/Python-3.12/package-gated production
+    artifact, while later commits are recorded as worklog/oracle-test-only, so
+    broad suites were not repeated contrary to the review-loop policy;
+  - CC status is already rejected centrally by `validate_fixed_record` /
+    `status_domain.validate_data_kubun` for raw rows and explicitly by
+    `validate_cc_record` for caller dictionaries. Raw and caller statuses 0/9
+    were independently rejected, so a duplicate CC-local domain was not added.
+- Thread-aware GraphQL readback reported three total review threads and zero
+  unresolved. The final worklog-only provenance commit will receive its normal
+  GitHub checks; exact final-head check and merge evidence belong in PR metadata
+  to avoid a self-referential worklog commit loop.
+
 ## Next safe command and STOP conditions
 
-- Next: from the current clean committed HEAD, push one branch, open one PR,
-  request the single native Copilot review,
-  address actionable comments in one batch, require unresolved thread count
-  zero, and merge only after the applicable checks and exact-head evidence are
-  green. The compact CC test is green after both temporary mutants were
-  removed. Do not rerun the already-green broad suite for this two-assertion
-  oracle-only delta unless the exact change expands.
+- Next: commit and push this worklog-only GitHub evidence update, confirm the
+  resulting exact PR head, required checks, unresolved thread count zero, and
+  clean worktree, then squash-merge PR #215. After cleanup, start a fresh
+  latest-master inventory iteration that maps all 38 official formats to their
+  merged PRs/tests and identifies the concrete remaining formats before any
+  further implementation.
 - STOP on non-worklog drift, a material disagreement among pinned official
   sources, backend divergence that is not explained and tested, or any need
   for destructive/provider action beyond the authorized local test scope.

--- a/src/database/schema.py
+++ b/src/database/schema.py
@@ -213,21 +213,21 @@ SCHEMAS = {
 
     "NL_CC": """
         CREATE TABLE IF NOT EXISTS NL_CC (
-            RecordSpec TEXT,
-            DataKubun TEXT,
-            MakeDate TEXT,
-            Year INTEGER,
-            MonthDay INTEGER,
-            JyoCD TEXT,
-            Kaiji INTEGER,
-            Nichiji INTEGER,
-            RaceNum INTEGER,
-            HappyoTime TEXT,
-            AtoKyori INTEGER,
-            AtoTruckCD TEXT,
-            MaeKyori INTEGER,
-            MaeTruckCD TEXT,
-            JiyuCD TEXT,
+            RecordSpec TEXT NOT NULL,
+            DataKubun TEXT NOT NULL,
+            MakeDate TEXT NOT NULL,
+            Year INTEGER NOT NULL,
+            MonthDay INTEGER NOT NULL,
+            JyoCD TEXT NOT NULL,
+            Kaiji INTEGER NOT NULL,
+            Nichiji INTEGER NOT NULL,
+            RaceNum INTEGER NOT NULL,
+            HappyoTime TEXT NOT NULL,
+            AtoKyori INTEGER NOT NULL,
+            AtoTruckCD TEXT NOT NULL,
+            MaeKyori INTEGER NOT NULL,
+            MaeTruckCD TEXT NOT NULL,
+            JiyuCD TEXT NOT NULL,
             PRIMARY KEY (Year, MonthDay, JyoCD, Kaiji, Nichiji, RaceNum)
         )
     """,
@@ -1629,21 +1629,21 @@ SCHEMAS = {
     """,
     "RT_CC": """
         CREATE TABLE IF NOT EXISTS RT_CC (
-            RecordSpec TEXT,
-            DataKubun TEXT,
-            MakeDate TEXT,
-            Year INTEGER,
-            MonthDay INTEGER,
-            JyoCD TEXT,
-            Kaiji INTEGER,
-            Nichiji INTEGER,
-            RaceNum INTEGER,
-            HappyoTime TEXT,
-            AtoKyori INTEGER,
-            AtoTruckCD TEXT,
-            MaeKyori INTEGER,
-            MaeTruckCD TEXT,
-            JiyuCD TEXT,
+            RecordSpec TEXT NOT NULL,
+            DataKubun TEXT NOT NULL,
+            MakeDate TEXT NOT NULL,
+            Year INTEGER NOT NULL,
+            MonthDay INTEGER NOT NULL,
+            JyoCD TEXT NOT NULL,
+            Kaiji INTEGER NOT NULL,
+            Nichiji INTEGER NOT NULL,
+            RaceNum INTEGER NOT NULL,
+            HappyoTime TEXT NOT NULL,
+            AtoKyori INTEGER NOT NULL,
+            AtoTruckCD TEXT NOT NULL,
+            MaeKyori INTEGER NOT NULL,
+            MaeTruckCD TEXT NOT NULL,
+            JiyuCD TEXT NOT NULL,
             PRIMARY KEY (Year, MonthDay, JyoCD, Kaiji, Nichiji, RaceNum)
         )
     """,
@@ -2761,6 +2761,7 @@ STRICT_HR_STORAGE_TABLES = frozenset({"NL_HR", "RT_HR"})
 STRICT_HS_STORAGE_TABLES = frozenset({"NL_HS"})
 STRICT_HC_STORAGE_TABLES = frozenset({"NL_HC"})
 STRICT_TC_STORAGE_TABLES = frozenset({"NL_TC", "RT_TC"})
+STRICT_CC_STORAGE_TABLES = frozenset({"NL_CC", "RT_CC"})
 STRICT_JC_STORAGE_TABLES = frozenset({"NL_JC", "RT_JC"})
 
 
@@ -2770,6 +2771,7 @@ def _preflight_existing_strict_storage(db: BaseDatabase) -> None:
     from src.database.migration import _migration_targets
     from src.importer.importer import (
         verify_av_storage_schema,
+        verify_cc_storage_schema,
         verify_hc_storage_schema,
         verify_hr_storage_schema,
         verify_hs_storage_schema,
@@ -2818,6 +2820,9 @@ def _preflight_existing_strict_storage(db: BaseDatabase) -> None:
         for table_name in STRICT_TC_STORAGE_TABLES:
             if target.table_exists_strict(table_name):
                 verify_tc_storage_schema(target, table_name)
+        for table_name in STRICT_CC_STORAGE_TABLES:
+            if target.table_exists_strict(table_name):
+                verify_cc_storage_schema(target, table_name)
         for table_name in STRICT_JC_STORAGE_TABLES:
             if target.table_exists_strict(table_name):
                 verify_jc_storage_schema(target, table_name)
@@ -2916,6 +2921,10 @@ class SchemaManager:
                 from src.importer.importer import verify_tc_storage_schema
 
                 verify_tc_storage_schema(self.db, table_name)
+            if table_name in STRICT_CC_STORAGE_TABLES:
+                from src.importer.importer import verify_cc_storage_schema
+
+                verify_cc_storage_schema(self.db, table_name)
             if table_name in STRICT_JC_STORAGE_TABLES:
                 from src.importer.importer import verify_jc_storage_schema
 
@@ -2986,6 +2995,10 @@ class SchemaManager:
                     from src.importer.importer import verify_tc_storage_schema
 
                     verify_tc_storage_schema(self.db, table_name)
+                if table_name in STRICT_CC_STORAGE_TABLES:
+                    from src.importer.importer import verify_cc_storage_schema
+
+                    verify_cc_storage_schema(self.db, table_name)
                 if table_name in STRICT_JC_STORAGE_TABLES:
                     from src.importer.importer import verify_jc_storage_schema
 
@@ -3359,6 +3372,10 @@ def create_all_tables(db: BaseDatabase) -> None:
                 from src.importer.importer import verify_tc_storage_schema
 
                 verify_tc_storage_schema(db, table_name)
+            if table_name in STRICT_CC_STORAGE_TABLES:
+                from src.importer.importer import verify_cc_storage_schema
+
+                verify_cc_storage_schema(db, table_name)
             if table_name in STRICT_JC_STORAGE_TABLES:
                 from src.importer.importer import verify_jc_storage_schema
 

--- a/src/database/schema.py
+++ b/src/database/schema.py
@@ -2768,6 +2768,25 @@ STRICT_JC_STORAGE_TABLES = frozenset({"NL_JC", "RT_JC"})
 def _preflight_existing_strict_storage(db: BaseDatabase) -> None:
     """Reject unsafe strict identities before unrelated additive migration."""
 
+    from src.importer.importer import (
+        _rollback_call_created_validation_transactions,
+        _snapshot_validation_transactions,
+    )
+
+    transaction_snapshot = _snapshot_validation_transactions(db)
+    try:
+        _verify_existing_strict_storage_targets(db)
+    except Exception:
+        _rollback_call_created_validation_transactions(
+            transaction_snapshot,
+            context="failed strict-storage preflight",
+        )
+        raise
+
+
+def _verify_existing_strict_storage_targets(db: BaseDatabase) -> None:
+    """Verify every physical strict-storage target without owning recovery."""
+
     from src.database.migration import _migration_targets
     from src.importer.importer import (
         verify_av_storage_schema,

--- a/src/database/schema_jravan.py
+++ b/src/database/schema_jravan.py
@@ -177,21 +177,22 @@ JRAVAN_SCHEMAS: Dict[str, str] = {
     """,
     "COURSE_CHANGE": """
         CREATE TABLE IF NOT EXISTS COURSE_CHANGE (
-            RecordSpec                     CHAR(2)             ,  -- レコード種別ID
-            DataKubun                      CHAR(1)             ,  -- データ区分
-            MakeDate                       DATE                ,  -- YYYYMMDD形式の日付
-            Year                           SMALLINT            ,  -- 年(4桁)
-            MonthDay                       SMALLINT            ,  -- 月日(MMDD)
-            JyoCD                          CHAR(2)             ,  -- 競馬場コード
-            Kaiji                          SMALLINT            ,  -- 開催回
-            Nichiji                        SMALLINT            ,  -- 開催日目
-            RaceNum                        SMALLINT            ,  -- レース番号
-            HappyoTime                     VARCHAR(8)          ,  -- 発表月日時分(MMDDhhmm)
-            AtoKyori                       VARCHAR(4)          ,  -- 文字列(4)
-            AtoTruckCD                     VARCHAR(2)          ,  -- 文字列(2)
-            MaeKyori                       VARCHAR(4)          ,  -- 文字列(4)
-            MaeTruckCD                     VARCHAR(2)          ,  -- 文字列(2)
-            JiyuCD                         VARCHAR(1)            -- 文字列(1)
+            RecordSpec                     CHAR(2) NOT NULL    ,  -- レコード種別ID
+            DataKubun                      CHAR(1) NOT NULL    ,  -- データ区分
+            MakeDate                       DATE NOT NULL       ,  -- YYYYMMDD形式の日付
+            Year                           SMALLINT NOT NULL   ,  -- 年(4桁)
+            MonthDay                       SMALLINT NOT NULL   ,  -- 月日(MMDD)
+            JyoCD                          CHAR(2) NOT NULL    ,  -- 競馬場コード
+            Kaiji                          SMALLINT NOT NULL   ,  -- 開催回
+            Nichiji                        SMALLINT NOT NULL   ,  -- 開催日目
+            RaceNum                        SMALLINT NOT NULL   ,  -- レース番号
+            HappyoTime                     VARCHAR(8) NOT NULL ,  -- 発表月日時分(MMDDhhmm)
+            AtoKyori                       VARCHAR(4) NOT NULL ,  -- 文字列(4)
+            AtoTruckCD                     VARCHAR(2) NOT NULL ,  -- 文字列(2)
+            MaeKyori                       VARCHAR(4) NOT NULL ,  -- 文字列(4)
+            MaeTruckCD                     VARCHAR(2) NOT NULL ,  -- 文字列(2)
+            JiyuCD                         VARCHAR(1) NOT NULL ,  -- 文字列(1)
+            PRIMARY KEY (Year, MonthDay, JyoCD, Kaiji, Nichiji, RaceNum)
         )
     """,
     "HANRO": """

--- a/src/database/schema_metadata.py
+++ b/src/database/schema_metadata.py
@@ -831,25 +831,16 @@ TABLE_METADATA: Dict[str, TableMetadata] = {
         "indexes": ["開催年", "開催月日", "競馬場コード", "レース番号"]
     },
 
-    "NL_CC": {
-        "table_name": "NL_CC",
-        "record_type": "CC",
-        "description": "コース変更情報",
-        "purpose": "レースのコース（距離・トラック種別）変更情報を格納",
-        "columns": [
-            {"name": "レコード種別ID", "type": "TEXT", "description": "レコード種別識別子（'CC'）", "example": "CC", "nullable": False},
-            {"name": "開催年月日", "type": "TEXT", "description": "レース開催日", "example": "20240601", "nullable": False},
-            {"name": "競馬場コード", "type": "TEXT", "description": "競馬場コード", "example": "05", "nullable": False},
-            {"name": "レース番号", "type": "TEXT", "description": "レース番号", "example": "11", "nullable": False},
-            {"name": "変更後_距離", "type": "TEXT", "description": "変更後の距離（メートル）", "example": "2000", "nullable": True},
-            {"name": "変更後_トラックコード", "type": "TEXT", "description": "変更後のトラック（10-23=芝、24-29=ダート）", "example": "10", "nullable": True},
-            {"name": "変更前_距離", "type": "TEXT", "description": "変更前の距離", "example": "2400", "nullable": True},
-            {"name": "変更前_トラックコード", "type": "TEXT", "description": "変更前のトラック", "example": "10", "nullable": True},
-            {"name": "事由区分", "type": "TEXT", "description": "変更理由", "example": "1", "nullable": True}
-        ],
-        "primary_key": ["開催年月日", "競馬場コード", "レース番号"],
-        "indexes": ["開催年月日"]
-    },
+    "NL_CC": _schema_backed_metadata(
+        "NL_CC",
+        record_type="CC",
+        description="コース変更情報",
+        purpose=(
+            "開催6列の公式キーでコース変更の改訂を1行に保持し、発表時刻、"
+            "変更前後の距離・トラックコード、事由区分をlosslessに格納"
+        ),
+        indexes=["Year", "MonthDay", "JyoCD", "RaceNum"],
+    ),
 
     "NL_DM": {
         "table_name": "NL_DM",
@@ -1184,22 +1175,16 @@ TABLE_METADATA: Dict[str, TableMetadata] = {
         "indexes": ["開催年", "開催月日", "競馬場コード", "レース番号"]
     },
 
-    "RT_CC": {
-        "table_name": "RT_CC",
-        "record_type": "CC",
-        "description": "コース変更情報（速報）",
-        "purpose": "リアルタイムでのコース変更情報を格納（NL_CCと同構造）",
-        "columns": [
-            {"name": "レコード種別ID", "type": "TEXT", "description": "レコード種別識別子（'CC'）", "example": "CC", "nullable": False},
-            {"name": "開催年月日", "type": "TEXT", "description": "レース開催日", "example": "20240601", "nullable": False},
-            {"name": "競馬場コード", "type": "TEXT", "description": "競馬場コード", "example": "05", "nullable": False},
-            {"name": "レース番号", "type": "TEXT", "description": "レース番号", "example": "11", "nullable": False},
-            {"name": "変更後_距離", "type": "TEXT", "description": "変更後の距離", "example": "2000", "nullable": True},
-            {"name": "変更後_トラックコード", "type": "TEXT", "description": "変更後のトラック", "example": "10", "nullable": True}
-        ],
-        "primary_key": ["開催年月日", "競馬場コード", "レース番号"],
-        "indexes": ["開催年月日"]
-    },
+    "RT_CC": _schema_backed_metadata(
+        "RT_CC",
+        record_type="CC",
+        description="コース変更情報（速報）",
+        purpose=(
+            "0B14/0B16のコース変更を開催6列の公式キーで保持し、0B14の"
+            "正常完了時は日単位snapshotとして置換"
+        ),
+        indexes=["Year", "MonthDay", "JyoCD", "RaceNum"],
+    ),
 
     "RT_DM": {
         "table_name": "RT_DM",

--- a/src/importer/importer.py
+++ b/src/importer/importer.py
@@ -606,12 +606,46 @@ _TC_LOSSLESS_TEXT_WIDTHS = {
     }
     for table_name in _TC_STORAGE_TABLES
 }
+_CC_STORAGE_TABLES = frozenset({"NL_CC", "RT_CC", "COURSE_CHANGE"})
+_CC_KEY_COLUMNS = ("Year", "MonthDay", "JyoCD", "Kaiji", "Nichiji", "RaceNum")
+_CC_LOSSLESS_TEXT_WIDTHS = {
+    "NL_CC": {
+        "RecordSpec": 2,
+        "DataKubun": 1,
+        "JyoCD": 2,
+        "HappyoTime": 8,
+        "AtoTruckCD": 2,
+        "MaeTruckCD": 2,
+        "JiyuCD": 1,
+    },
+    "RT_CC": {
+        "RecordSpec": 2,
+        "DataKubun": 1,
+        "JyoCD": 2,
+        "HappyoTime": 8,
+        "AtoTruckCD": 2,
+        "MaeTruckCD": 2,
+        "JiyuCD": 1,
+    },
+    "COURSE_CHANGE": {
+        "RecordSpec": 2,
+        "DataKubun": 1,
+        "JyoCD": 2,
+        "HappyoTime": 8,
+        "AtoKyori": 4,
+        "AtoTruckCD": 2,
+        "MaeKyori": 4,
+        "MaeTruckCD": 2,
+        "JiyuCD": 1,
+    },
+}
 _PROVIDER_OPERATION_COUNT_STORAGE_TABLES = (
     _AV_STORAGE_TABLES
     | _HR_STORAGE_TABLES
     | _HS_STORAGE_TABLES
     | _HC_STORAGE_TABLES
     | _TC_STORAGE_TABLES
+    | _CC_STORAGE_TABLES
 )
 _JC_STORAGE_TABLES = frozenset({"NL_JC", "RT_JC", "KISYU_CHANGE"})
 _JC_KEY_COLUMNS = (
@@ -672,6 +706,7 @@ _STRICT_NONADDITIVE_STANDARD_TABLES = frozenset(
         "SALE",
         "HANRO",
         "HASSOU_JIKOKU_CHANGE",
+        "COURSE_CHANGE",
         "KISYU_CHANGE",
         "TORIKESI_JYOGAI",
         "TENKO_BABA",
@@ -1981,6 +2016,114 @@ def validate_tc_record(record: dict, table_name: str | None = None) -> bool:
     return True
 
 
+def _verify_cc_no_unapproved_constraints(
+    database: BaseDatabase,
+    table_name: str,
+) -> None:
+    """Reject constraints beyond CC's one official immediate primary key."""
+
+    from src.database.migration import _migration_targets
+
+    targets = _migration_targets(database)
+    if targets != (database,):
+        for target in targets:
+            _verify_cc_no_unapproved_constraints(target, table_name)
+        return
+
+    db_type = database.get_db_type()
+    if db_type == "sqlite":
+        if database.fetch_all(f'PRAGMA foreign_key_list("{table_name}")'):
+            raise SchemaMigrationError(
+                f"CC storage {table_name} has unsupported FOREIGN KEY constraints"
+            )
+        row = database.fetch_one(
+            "SELECT sql FROM sqlite_master WHERE type = 'table' AND name = ?",
+            (table_name,),
+        )
+        definition = str((row or {}).get("sql") or "")
+        if re.search(
+            r"\bCHECK\s*\(",
+            _sqlite_schema_code(definition),
+            flags=re.IGNORECASE,
+        ):
+            raise SchemaMigrationError(
+                f"CC storage {table_name} has unsupported CHECK constraints"
+            )
+        return
+    if db_type == "postgresql":
+        unexpected = database.fetch_all(
+            "SELECT conname AS constraint_name, contype AS constraint_type "
+            "FROM pg_constraint WHERE conrelid = to_regclass(?) "
+            "AND contype NOT IN ('p', 'n') ORDER BY conname",
+            (table_name.lower(),),
+        )
+        if unexpected:
+            raise SchemaMigrationError(
+                f"CC storage {table_name} has unsupported additional constraints: "
+                f"{unexpected}"
+            )
+        return
+    raise SchemaMigrationError(
+        f"CC constraints cannot be verified for database type {db_type!r}"
+    )
+
+
+def verify_cc_storage_schema(database: BaseDatabase, table_name: str) -> bool:
+    """Fail closed unless CC storage preserves every field and official key."""
+
+    if table_name not in _CC_STORAGE_TABLES:
+        return False
+    transaction_snapshot = _snapshot_validation_transactions(database)
+    from src.database.migration import verify_table_schema
+    from src.database.schema import SCHEMAS
+    from src.database.schema_jravan import JRAVAN_SCHEMAS
+
+    try:
+        schema_sql = SCHEMAS.get(table_name) or JRAVAN_SCHEMAS.get(table_name)
+        if schema_sql is None:
+            raise SchemaMigrationError(f"CC storage schema is undefined: {table_name}")
+        verify_table_schema(database, table_name, schema_sql)
+        _verify_strict_storage_column_contract(
+            database,
+            table_name,
+            schema_sql,
+            allow_missing_columns=False,
+            storage_label="CC",
+            lossless_text_widths=_CC_LOSSLESS_TEXT_WIDTHS[table_name],
+            allow_extra_columns=False,
+        )
+        _verify_cc_no_unapproved_constraints(database, table_name)
+        _verify_replacement_key_constraints(database, table_name, "CC storage")
+        return True
+    except Exception:
+        _rollback_call_created_validation_transactions(
+            transaction_snapshot,
+            context="failed CC schema validation",
+        )
+        raise
+
+
+def validate_cc_record(record: dict, table_name: str | None = None) -> bool:
+    """Validate one caller-built CC row before coercion or mutation."""
+
+    if table_name is not None and table_name not in _CC_STORAGE_TABLES:
+        return False
+    if _record_type_from_record(record) != "CC":
+        if table_name is None:
+            return False
+        raise SchemaMigrationError(f"{table_name} received a non-CC record")
+
+    from src.parser.cc_parser import CCParser
+
+    try:
+        if resolve_record_data_kubun(record) != "1":
+            raise ValueError("CC DataKubun must be current official value 1")
+        CCParser.validate_current_fields(record)
+    except ValueError as error:
+        raise SchemaMigrationError(str(error)) from error
+    return True
+
+
 def _verify_jc_key_storage_types(database: BaseDatabase, table_name: str) -> None:
     """Reject affinities that can coerce or split one JC identity."""
 
@@ -3101,6 +3244,8 @@ def _preflight_standard_schema_migrations(
             verify_hc_storage_schema(database, standard_name)
         if standard_name == "HASSOU_JIKOKU_CHANGE":
             verify_tc_storage_schema(database, standard_name)
+        if standard_name == "COURSE_CHANGE":
+            verify_cc_storage_schema(database, standard_name)
         if standard_name == "KISYU_CHANGE":
             verify_jc_storage_schema(database, standard_name)
         if standard_name in {"UMA", "COURSE"}:
@@ -3757,6 +3902,8 @@ def validate_import_record_header(record: dict) -> tuple[str, str]:
             validate_hc_record(record)
         if record_type == "TC":
             validate_tc_record(record)
+        if record_type == "CC":
+            validate_cc_record(record)
         if record_type == "JC":
             validate_jc_record(record)
         return record_type, data_kubun
@@ -6303,6 +6450,7 @@ class DataImporter:
         self._verified_hs_tables: set[str] = set()
         self._verified_hc_tables: set[str] = set()
         self._verified_tc_tables: set[str] = set()
+        self._verified_cc_tables: set[str] = set()
         self._verified_jc_tables: set[str] = set()
         self._verified_cs_tables: set[str] = set()
         self._verified_jg_tables: set[str] = set()
@@ -6662,6 +6810,10 @@ class DataImporter:
                     if verify_tc_storage_schema(self.database, table_name):
                         self._verified_tc_tables.add(table_name)
                 validate_tc_record(record, table_name)
+                if table_name not in self._verified_cc_tables:
+                    if verify_cc_storage_schema(self.database, table_name):
+                        self._verified_cc_tables.add(table_name)
+                validate_cc_record(record, table_name)
                 if table_name not in self._verified_jc_tables:
                     if verify_jc_storage_schema(self.database, table_name):
                         self._verified_jc_tables.add(table_name)
@@ -7401,6 +7553,10 @@ class DataImporter:
                 if verify_tc_storage_schema(self.database, table_name):
                     self._verified_tc_tables.add(table_name)
             validate_tc_record(record, table_name)
+            if table_name not in self._verified_cc_tables:
+                if verify_cc_storage_schema(self.database, table_name):
+                    self._verified_cc_tables.add(table_name)
+            validate_cc_record(record, table_name)
             if table_name not in self._verified_jc_tables:
                 if verify_jc_storage_schema(self.database, table_name):
                     self._verified_jc_tables.add(table_name)

--- a/src/importer/importer.py
+++ b/src/importer/importer.py
@@ -436,6 +436,13 @@ def translate_standard_field_names(record: dict, table_name: str) -> dict:
     """Translate legacy native parser names for a standard-name table."""
     if table_name == "UMA":
         record = _expand_standard_uma_fields(record)
+    if table_name == "COURSE_CHANGE":
+        translated_cc = dict(record)
+        for field_name in ("AtoKyori", "MaeKyori"):
+            value = translated_cc.get(field_name)
+            if isinstance(value, int) and not isinstance(value, bool):
+                translated_cc[field_name] = f"{value:04d}"
+        record = translated_cc
     aliases = _STANDARD_FIELD_ALIASES.get(table_name)
     if not aliases:
         return record

--- a/src/importer/importer_optimized.py
+++ b/src/importer/importer_optimized.py
@@ -66,6 +66,7 @@ from src.importer.importer import (
     resolve_standard_table_name,
     rollback_failed_import,
     validate_av_record,
+    validate_cc_record,
     validate_hc_record,
     validate_hr_record,
     validate_hs_record,
@@ -79,6 +80,7 @@ from src.importer.importer import (
     validate_wf_record,
     verify_av_storage_schema,
     verify_bt_storage_schema,
+    verify_cc_storage_schema,
     verify_ch_coupled_table,
     verify_ck_coupled_tables,
     verify_cs_storage_schema,
@@ -142,6 +144,7 @@ class OptimizedDataImporter:
         self._verified_hs_tables: set[str] = set()
         self._verified_hc_tables: set[str] = set()
         self._verified_tc_tables: set[str] = set()
+        self._verified_cc_tables: set[str] = set()
         self._verified_jc_tables: set[str] = set()
         self._verified_cs_tables: set[str] = set()
         self._verified_jg_tables: set[str] = set()
@@ -461,6 +464,10 @@ class OptimizedDataImporter:
                     if verify_tc_storage_schema(self.database, table_name):
                         self._verified_tc_tables.add(table_name)
                 validate_tc_record(record, table_name)
+                if table_name not in self._verified_cc_tables:
+                    if verify_cc_storage_schema(self.database, table_name):
+                        self._verified_cc_tables.add(table_name)
+                validate_cc_record(record, table_name)
                 if table_name not in self._verified_jc_tables:
                     if verify_jc_storage_schema(self.database, table_name):
                         self._verified_jc_tables.add(table_name)

--- a/src/parser/cc_parser.py
+++ b/src/parser/cc_parser.py
@@ -1,22 +1,125 @@
-"""Parser for CC record - Generated from reference schema.
+"""Parser for the official CC course-change record."""
 
-This parser uses correct field positions calculated from schema field lengths.
-"""
-
-from typing import List
+from collections.abc import Mapping
+from datetime import date, datetime
+from typing import Any, List
 
 from src.parser.base import BaseParser, FieldDef
+from src.parser.code_domains import OFFICIAL_JYO_CODES_2001, OFFICIAL_TRACK_CODES_2009
 
 
 class CCParser(BaseParser):
     """Parser for CC record with accurate field positions.
 
-    Total record length: 48 bytes
-    Fields: 15
+    Total record length: 50 bytes
+    Fields: 16
     """
 
     record_type = "CC"
     RECORD_LENGTH = 50
+    KEY_COLUMNS = ("Year", "MonthDay", "JyoCD", "Kaiji", "Nichiji", "RaceNum")
+    OFFICIAL_JYO_CODES = OFFICIAL_JYO_CODES_2001
+    OFFICIAL_TRACK_CODES = OFFICIAL_TRACK_CODES_2009
+    REASON_CODES = frozenset({"0", "1", "2", "3", "4"})
+
+    @staticmethod
+    def _require_date(field_name: str, value: object) -> date:
+        if isinstance(value, datetime):
+            raise ValueError(f"CC {field_name} must not contain a time component")
+        if isinstance(value, date):
+            return value
+        if (
+            not isinstance(value, str)
+            or len(value) != 8
+            or not value.isascii()
+            or not value.isdigit()
+        ):
+            raise ValueError(f"CC {field_name} must be exactly 8 ASCII digits")
+        try:
+            return date(int(value[:4]), int(value[4:6]), int(value[6:]))
+        except ValueError as error:
+            raise ValueError(f"CC {field_name} must be a real YYYYMMDD date") from error
+
+    @staticmethod
+    def _require_fixed_integer(field_name: str, value: object, width: int) -> int:
+        if isinstance(value, bool):
+            raise ValueError(f"CC {field_name} must be an official {width}-digit integer")
+        if isinstance(value, int):
+            if 0 <= value < 10**width:
+                return value
+        elif isinstance(value, str) and len(value) == width and value.isascii() and value.isdigit():
+            return int(value)
+        raise ValueError(f"CC {field_name} must be an official {width}-digit integer")
+
+    @classmethod
+    def validate_key_fields(cls, record: Mapping[str, object]) -> int:
+        """Validate the complete official six-part race identity."""
+
+        cls._require_date("MakeDate", record.get("MakeDate"))
+        year = cls._require_fixed_integer("Year", record.get("Year"), 4)
+        if year < 1000:
+            raise ValueError("CC Year must remain a four-digit Gregorian year")
+        month_day = cls._require_fixed_integer("MonthDay", record.get("MonthDay"), 4)
+        try:
+            date(year, month_day // 100, month_day % 100)
+        except ValueError as error:
+            raise ValueError("CC Year and MonthDay must form a real date") from error
+        if record.get("JyoCD") not in cls.OFFICIAL_JYO_CODES:
+            raise ValueError("CC JyoCD is not in official code table 2001")
+        for field_name in ("Kaiji", "Nichiji", "RaceNum"):
+            cls._require_fixed_integer(field_name, record.get(field_name), 2)
+        return year
+
+    @staticmethod
+    def _require_mdhm(value: object, year: int) -> None:
+        if (
+            not isinstance(value, str)
+            or len(value) != 8
+            or not value.isascii()
+            or not value.isdigit()
+        ):
+            raise ValueError("CC HappyoTime must be exactly 8 ASCII digits")
+        if value == "00000000":
+            return
+        try:
+            date(year, int(value[:2]), int(value[2:4]))
+        except ValueError as error:
+            raise ValueError("CC HappyoTime must contain a real MMDD date") from error
+        if int(value[4:6]) > 23 or int(value[6:]) > 59:
+            raise ValueError("CC HappyoTime must contain a real hhmm time")
+
+    @classmethod
+    def _require_distance(cls, field_name: str, value: object) -> None:
+        cls._require_fixed_integer(field_name, value, 4)
+
+    @classmethod
+    def validate_current_fields(cls, record: Mapping[str, object]) -> None:
+        """Validate one current live CC row; the official status domain is only 1."""
+
+        year = cls.validate_key_fields(record)
+        cls._require_mdhm(record.get("HappyoTime"), year)
+        for field_name in ("AtoKyori", "MaeKyori"):
+            cls._require_distance(field_name, record.get(field_name))
+        for field_name in ("AtoTruckCD", "MaeTruckCD"):
+            if record.get(field_name) not in cls.OFFICIAL_TRACK_CODES:
+                raise ValueError(f"CC {field_name} is not in official code table 2009")
+        if record.get("JiyuCD") not in cls.REASON_CODES:
+            raise ValueError("CC JiyuCD must be an official value from 0 through 4")
+
+    def parse(self, record: bytes) -> dict[str, Any]:
+        """Parse and strictly validate one current 50-byte CC record."""
+
+        parsed = super().parse(record)
+        raw_fields = {
+            field.name: record[field.start : field.start + field.length]
+            .decode("cp932", errors="strict")
+            .strip()
+            for field in self._fields
+            if field.name != "RecordDelimiter"
+        }
+        self.validate_current_fields(raw_fields)
+        self.validate_current_fields(parsed)
+        return parsed
 
     def _define_fields(self) -> List[FieldDef]:
         """Define field positions calculated from schema.
@@ -40,4 +143,5 @@ class CCParser(BaseParser):
             FieldDef("MaeKyori", 41, 4),
             FieldDef("MaeTruckCD", 45, 2),
             FieldDef("JiyuCD", 47, 1),
+            FieldDef("RecordDelimiter", 48, 2),
         ]

--- a/src/realtime/updater.py
+++ b/src/realtime/updater.py
@@ -17,6 +17,7 @@ from src.importer.importer import (
     resolve_record_data_kubun,
     rollback_failed_import,
     validate_av_record,
+    validate_cc_record,
     validate_hr_record,
     validate_jc_record,
     validate_se_record,
@@ -24,6 +25,7 @@ from src.importer.importer import (
     validate_we_record,
     validate_wf_record,
     verify_av_storage_schema,
+    verify_cc_storage_schema,
     verify_hr_storage_schema,
     verify_jc_storage_schema,
     verify_se_storage_schema,
@@ -207,6 +209,7 @@ class RealtimeUpdater:
         self._verified_av_tables: set[str] = set()
         self._verified_hr_tables: set[str] = set()
         self._verified_tc_tables: set[str] = set()
+        self._verified_cc_tables: set[str] = set()
         self._verified_jc_tables: set[str] = set()
         self._verified_wf_tables: set[str] = set()
 
@@ -215,7 +218,7 @@ class RealtimeUpdater:
     # Realtime tables whose caller-built rows are revalidated against the
     # official contract before any coercion or mutation.
     STRICT_RECORD_TABLES = frozenset(
-        {"RT_SE", "RT_WE", "RT_AV", "RT_HR", "RT_TC", "RT_JC", "RT_WF"}
+        {"RT_SE", "RT_WE", "RT_AV", "RT_HR", "RT_TC", "RT_CC", "RT_JC", "RT_WF"}
     )
 
     def _canonicalize_strict_record_aliases(
@@ -285,6 +288,13 @@ class RealtimeUpdater:
                 if table_name not in self._verified_tc_tables:
                     if verify_tc_storage_schema(self.database, table_name):
                         self._verified_tc_tables.add(table_name)
+            elif table_name == "RT_CC":
+                # Reject malformed caller data before a PostgreSQL catalog
+                # read can lazily open a transaction owned by this call.
+                validate_cc_record(record, table_name)
+                if table_name not in self._verified_cc_tables:
+                    if verify_cc_storage_schema(self.database, table_name):
+                        self._verified_cc_tables.add(table_name)
             elif table_name == "RT_JC":
                 if table_name not in self._verified_jc_tables:
                     if verify_jc_storage_schema(self.database, table_name):

--- a/tests/fixtures/official_layout/README.md
+++ b/tests/fixtures/official_layout/README.md
@@ -40,6 +40,10 @@ JV-Data. They do not contain provider records or a copy of the SDK source.
   six-part race identity, status-1-only domain, announcement/change time spans,
   provider contexts, and unchanged history independently transcribed from both
   pinned current workbooks.
+- `cc_contract_4901.json` records the current 50-byte course-change layout,
+  six-part race identity, status-1-only domain, announcement/distance/track/
+  reason spans and code domains, and 0B14/0B16 provider behavior independently
+  transcribed from both pinned current workbooks.
 
 The manifest is intentionally independent of jrvltsql parser and schema code.
 When the official source changes, regenerate it from a separately obtained SDK

--- a/tests/fixtures/official_layout/cc_contract_4901.json
+++ b/tests/fixtures/official_layout/cc_contract_4901.json
@@ -64,6 +64,6 @@
   },
   "current_provider_specs": ["0B14", "0B16"],
   "snapshot_provider_spec": "0B14",
-  "snapshot_policy_source": "JV-Data4901.xlsx:データ提供タイミング・提供単位:60",
+  "snapshot_policy_source": "JV-Data4901.xlsx:データ提供タイミング･提供単位:60",
   "cancellation_note_source": "JV-Data4901.xlsx:特記事項:265"
 }

--- a/tests/fixtures/official_layout/cc_contract_4901.json
+++ b/tests/fixtures/official_layout/cc_contract_4901.json
@@ -1,0 +1,69 @@
+{
+  "record_type": "CC",
+  "record_length": 50,
+  "format_sources": [
+    {
+      "artifact": "JV-Data4802.xlsx",
+      "sha256": "6a567f10b601115eca350571f36d27d9d28bd2d3835ea72b5bc057711155d4a7",
+      "sheet": "フォーマット",
+      "rows": "1531-1553"
+    },
+    {
+      "artifact": "JV-Data4901.xlsx",
+      "sha256": "23bafd375f704acbdd696b5032ac1619f17d47e882587d6e7954b610527a8234",
+      "sheet": "フォーマット",
+      "rows": "1531-1553"
+    }
+  ],
+  "sdk_source": {
+    "artifact": "JRA-VAN Data Lab. SDK Ver5.0.0/JVData_Struct.cs",
+    "sha256": "605057bb211eb6a94056a54496f3dd30f864ac2ad140fcfc8840ac8a6ed9e4fe",
+    "struct": "JV_CC_INFO"
+  },
+  "fields": [
+    ["RecordSpec", 1, 2],
+    ["DataKubun", 3, 1],
+    ["MakeDate", 4, 8],
+    ["Year", 12, 4],
+    ["MonthDay", 16, 4],
+    ["JyoCD", 20, 2],
+    ["Kaiji", 22, 2],
+    ["Nichiji", 24, 2],
+    ["RaceNum", 26, 2],
+    ["HappyoTime", 28, 8],
+    ["AtoKyori", 36, 4],
+    ["AtoTruckCD", 40, 2],
+    ["MaeKyori", 42, 4],
+    ["MaeTruckCD", 46, 2],
+    ["JiyuCD", 48, 1],
+    ["RecordDelimiter", 49, 2]
+  ],
+  "primary_key": [
+    "Year",
+    "MonthDay",
+    "JyoCD",
+    "Kaiji",
+    "Nichiji",
+    "RaceNum"
+  ],
+  "current_data_kubun": ["1"],
+  "track_codes": [
+    "00", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19",
+    "20", "21", "22", "23", "24", "25", "26", "27", "28", "29",
+    "51", "52", "53", "54", "55", "56", "57", "58", "59"
+  ],
+  "reason_codes": ["0", "1", "2", "3", "4"],
+  "history": {
+    "added": "2004-05-25",
+    "version": "1.1.6",
+    "physical_layout_changed": false,
+    "sources": [
+      "JV-Data4901.xlsx:変更履歴:217,221",
+      "JV-Data4802.xlsx:変更履歴:174,178"
+    ]
+  },
+  "current_provider_specs": ["0B14", "0B16"],
+  "snapshot_provider_spec": "0B14",
+  "snapshot_policy_source": "JV-Data4901.xlsx:データ提供タイミング・提供単位:60",
+  "cancellation_note_source": "JV-Data4901.xlsx:特記事項:265"
+}

--- a/tests/test_cc_official_contract.py
+++ b/tests/test_cc_official_contract.py
@@ -10,15 +10,14 @@ from uuid import uuid4
 
 import pytest
 
-from src.database.migration import SchemaMigrationError
 from src.database.dual_handler import DualDatabase
-from src.database.schema import SCHEMAS
-from src.database.schema import SchemaManager
+from src.database.migration import SchemaMigrationError
+from src.database.schema import SCHEMAS, SchemaManager
 from src.database.schema_jravan import JRAVAN_SCHEMAS
 from src.database.schema_metadata import TABLE_METADATA
 from src.database.schema_types import (
-    get_table_column_types,
     get_table_column_nullability,
+    get_table_column_types,
     get_table_primary_key_columns,
 )
 from src.database.sqlite_handler import SQLiteDatabase
@@ -216,7 +215,10 @@ def _defective_schema(table_name: str, defect: str) -> str:
                 "ExternalRequired TEXT GENERATED ALWAYS AS (NULL) VIRTUAL NOT NULL"
             ),
         }
-        return f"{body}, {additions[defect]}\n        ){close}"
+        addition = additions[defect]
+        if defect in {"extra-required-column", "extra-generated-required-column"}:
+            return schema.replace(key, f"{addition}, {key}")
+        return f"{body}, {addition}\n        ){close}"
     mutated = schema.replace(old, new)
     assert mutated != schema
     return mutated
@@ -328,15 +330,24 @@ def test_cc_caller_validation_precedes_coercion_and_mutation(
 ) -> None:
     database = SQLiteDatabase({"path": str(tmp_path / f"invalid-{table_name}.db")})
     schema = JRAVAN_SCHEMAS[table_name] if standard else SCHEMAS[table_name]
-    invalid = parsed_cc()
-    invalid["JiyuCD"] = "9"
+    invalid_rows = []
+    for field_name, invalid_value in (
+        ("MakeDate", datetime(2026, 8, 18, 12, 34, 56)),
+        ("Year", 26),
+        ("AtoKyori", True),
+        ("AtoTruckCD", "ZZ"),
+        ("JiyuCD", "9"),
+    ):
+        invalid = parsed_cc()
+        invalid[field_name] = invalid_value
+        invalid_rows.append(invalid)
     with database:
         database.execute(schema)
         database.commit()
-        with pytest.raises(SchemaMigrationError):
-            importer_class(database, use_jravan_schema=standard).import_records(
-                iter([invalid]), auto_commit=auto_commit
-            )
+        importer = importer_class(database, use_jravan_schema=standard)
+        for invalid in invalid_rows:
+            with pytest.raises(SchemaMigrationError):
+                importer.import_records(iter([invalid]), auto_commit=auto_commit)
         assert database.fetch_one(f"SELECT COUNT(*) AS n FROM {table_name}") == {"n": 0}
 
 
@@ -435,33 +446,80 @@ def postgresql_db():
 
 
 @pytest.mark.parametrize("importer_class", (DataImporter, OptimizedDataImporter))
+@pytest.mark.parametrize("table_name,standard", [("NL_CC", False), ("COURSE_CHANGE", True)])
 def test_cc_postgresql_counts_both_same_key_provider_operations(
-    postgresql_db, importer_class
+    postgresql_db, importer_class, table_name: str, standard: bool
 ) -> None:
-    postgresql_db.execute(SCHEMAS["NL_CC"])
+    schema = JRAVAN_SCHEMAS[table_name] if standard else SCHEMAS[table_name]
+    postgresql_db.execute(schema)
     postgresql_db.commit()
-    result = importer_class(postgresql_db).import_records(
-        iter([parsed_cc(), parsed_cc(HappyoTime="08181205")]), auto_commit=True
+    result = importer_class(postgresql_db, use_jravan_schema=standard).import_records(
+        iter([parsed_cc(), parsed_cc(HappyoTime="08181205")]),
+        auto_commit=True,
     )
     assert result["records_imported"] == 2
     assert result["records_failed"] == 0
-    assert postgresql_db.fetch_one('SELECT COUNT(*) AS "n" FROM NL_CC') == {"n": 1}
+    assert postgresql_db.fetch_one(f'SELECT COUNT(*) AS "n" FROM {table_name}') == {"n": 1}
 
 
+@pytest.mark.parametrize("table_name,standard", [("NL_CC", False), ("COURSE_CHANGE", True)])
 @pytest.mark.parametrize(
     "defect", ("extra-unique", "generated-official-column", "deferrable-primary-key")
 )
-def test_cc_postgresql_schema_defects_fail_before_mutation(postgresql_db, defect: str) -> None:
+def test_cc_postgresql_schema_defects_fail_before_mutation(
+    postgresql_db, defect: str, table_name: str, standard: bool
+) -> None:
     if defect == "deferrable-primary-key":
-        schema = SCHEMAS["NL_CC"].replace(
+        source = JRAVAN_SCHEMAS[table_name] if standard else SCHEMAS[table_name]
+        schema = source.replace(
             "PRIMARY KEY (Year, MonthDay, JyoCD, Kaiji, Nichiji, RaceNum)",
             "PRIMARY KEY (Year, MonthDay, JyoCD, Kaiji, Nichiji, RaceNum) "
             "DEFERRABLE INITIALLY DEFERRED",
         )
     else:
-        schema = _defective_schema("NL_CC", defect)
+        schema = _defective_schema(table_name, defect)
     postgresql_db.execute(schema)
     postgresql_db.commit()
     with pytest.raises(SchemaMigrationError):
-        DataImporter(postgresql_db).import_records(iter([parsed_cc()]))
-    assert postgresql_db.fetch_one('SELECT COUNT(*) AS "n" FROM NL_CC') == {"n": 0}
+        DataImporter(postgresql_db, use_jravan_schema=standard).import_records(iter([parsed_cc()]))
+    assert postgresql_db.fetch_one(f'SELECT COUNT(*) AS "n" FROM {table_name}') == {"n": 0}
+
+
+def test_cc_postgresql_realtime_rejects_before_catalog_transaction(postgresql_db) -> None:
+    postgresql_db.execute(SCHEMAS["RT_CC"])
+    postgresql_db.commit()
+    invalid = parsed_cc()
+    invalid["JiyuCD"] = "9"
+    result = RealtimeUpdater(postgresql_db).process_parsed_record(invalid)
+    assert result["success"] is False
+    assert postgresql_db.has_pending_transaction() is False
+    assert postgresql_db.fetch_one('SELECT COUNT(*) AS "n" FROM RT_CC') == {"n": 0}
+
+
+@pytest.mark.parametrize("unsafe_target", ("primary", "secondary"))
+def test_cc_postgresql_dual_rejects_unsafe_target_before_either_mutates(
+    postgresql_db, tmp_path, unsafe_target: str
+) -> None:
+    sqlite = SQLiteDatabase({"path": str(tmp_path / f"dual-{unsafe_target}.db")})
+    with sqlite:
+        sqlite.execute(
+            _defective_schema("NL_CC", "extra-check")
+            if unsafe_target == "primary"
+            else SCHEMAS["NL_CC"]
+        )
+        postgresql_db.execute(
+            _defective_schema("NL_CC", "generated-official-column")
+            if unsafe_target == "secondary"
+            else SCHEMAS["NL_CC"]
+        )
+        sqlite.commit()
+        postgresql_db.commit()
+        primary, secondary = (
+            (sqlite, postgresql_db) if unsafe_target == "primary" else (postgresql_db, sqlite)
+        )
+        with pytest.raises(SchemaMigrationError):
+            DataImporter(DualDatabase(primary, secondary)).import_records(
+                iter([parsed_cc()]), auto_commit=True
+            )
+        assert sqlite.fetch_one("SELECT COUNT(*) AS n FROM NL_CC") == {"n": 0}
+        assert postgresql_db.fetch_one('SELECT COUNT(*) AS "n" FROM NL_CC') == {"n": 0}

--- a/tests/test_cc_official_contract.py
+++ b/tests/test_cc_official_contract.py
@@ -3,12 +3,15 @@
 from __future__ import annotations
 
 import json
+import os
 from datetime import datetime
 from pathlib import Path
+from uuid import uuid4
 
 import pytest
 
 from src.database.migration import SchemaMigrationError
+from src.database.dual_handler import DualDatabase
 from src.database.schema import SCHEMAS
 from src.database.schema import SchemaManager
 from src.database.schema_jravan import JRAVAN_SCHEMAS
@@ -185,7 +188,17 @@ def _defective_schema(table_name: str, defect: str) -> str:
             "HappyoTime                     VARCHAR(7) NOT NULL",
         ),
     }
-    if table_name != "NL_CC" and defect in standard_replacements:
+    if defect == "generated-official-column":
+        if table_name == "NL_CC":
+            old = "AtoTruckCD TEXT NOT NULL"
+            new = "AtoTruckCD TEXT GENERATED ALWAYS AS ('00') STORED NOT NULL"
+        else:
+            old = "AtoTruckCD                     VARCHAR(2) NOT NULL"
+            new = (
+                "AtoTruckCD                     VARCHAR(2) "
+                "GENERATED ALWAYS AS ('00') STORED NOT NULL"
+            )
+    elif table_name != "NL_CC" and defect in standard_replacements:
         old, new = standard_replacements[defect]
     elif defect in replacements:
         old, new = replacements[defect]
@@ -199,6 +212,9 @@ def _defective_schema(table_name: str, defect: str) -> str:
                 f"({', '.join(OFFICIAL_KEY)}) ON DELETE CASCADE"
             ),
             "extra-required-column": "ExternalRequired TEXT NOT NULL",
+            "extra-generated-required-column": (
+                "ExternalRequired TEXT GENERATED ALWAYS AS (NULL) VIRTUAL NOT NULL"
+            ),
         }
         return f"{body}, {additions[defect]}\n        ){close}"
     mutated = schema.replace(old, new)
@@ -218,6 +234,8 @@ def _defective_schema(table_name: str, defect: str) -> str:
         "extra-check",
         "extra-foreign-key",
         "extra-required-column",
+        "extra-generated-required-column",
+        "generated-official-column",
     ],
 )
 def test_cc_schema_defects_fail_before_any_row_or_schema_mutation(
@@ -249,6 +267,33 @@ def test_cc_schema_manager_does_not_mutate_an_unsafe_existing_table(tmp_path) ->
         before = database.fetch_all('PRAGMA table_xinfo("NL_CC")')
         assert SchemaManager(database).create_table("NL_CC") is False
         assert database.fetch_all('PRAGMA table_xinfo("NL_CC")') == before
+
+
+@pytest.mark.parametrize("unsafe_target", ("primary", "secondary"))
+def test_cc_dual_rejects_an_unsafe_target_before_either_database_changes(
+    tmp_path, unsafe_target: str
+) -> None:
+    primary = SQLiteDatabase({"path": str(tmp_path / "dual-primary.db")})
+    secondary = SQLiteDatabase({"path": str(tmp_path / "dual-secondary.db")})
+    with primary, secondary:
+        primary.execute(
+            _defective_schema("NL_CC", "extra-required-column")
+            if unsafe_target == "primary"
+            else SCHEMAS["NL_CC"]
+        )
+        secondary.execute(
+            _defective_schema("NL_CC", "extra-required-column")
+            if unsafe_target == "secondary"
+            else SCHEMAS["NL_CC"]
+        )
+        primary.commit()
+        secondary.commit()
+        with pytest.raises(SchemaMigrationError):
+            DataImporter(DualDatabase(primary, secondary)).import_records(
+                iter([parsed_cc()]), auto_commit=True
+            )
+        assert primary.fetch_one("SELECT COUNT(*) AS n FROM NL_CC") == {"n": 0}
+        assert secondary.fetch_one("SELECT COUNT(*) AS n FROM NL_CC") == {"n": 0}
 
 
 @pytest.mark.parametrize("importer_class", (DataImporter, OptimizedDataImporter))
@@ -361,3 +406,62 @@ def test_cc_header_validator_rejects_missing_blank_and_conflicting_aliases() -> 
     ):
         with pytest.raises(SchemaMigrationError):
             validate_import_record_header(row)
+
+
+@pytest.fixture
+def postgresql_db():
+    if os.getenv("JLTSQL_RUN_POSTGRESQL_INTEGRATION") != "1":
+        pytest.skip("Set JLTSQL_RUN_POSTGRESQL_INTEGRATION=1 to run PostgreSQL tests")
+
+    from scripts.setup_pg_test_db import postgresql_test_config
+    from src.database.postgresql_handler import PostgreSQLDatabase
+
+    database = PostgreSQLDatabase(postgresql_test_config())
+    schema_name = f"jlt_cc_{uuid4().hex[:12]}"
+    database.connect()
+    try:
+        database.execute(f"CREATE SCHEMA {schema_name}")
+        database.execute(f"SET search_path TO {schema_name}")
+        database.commit()
+        yield database
+    finally:
+        try:
+            database.rollback()
+        except Exception:
+            pass
+        database.execute(f"DROP SCHEMA IF EXISTS {schema_name} CASCADE")
+        database.commit()
+        database.disconnect()
+
+
+@pytest.mark.parametrize("importer_class", (DataImporter, OptimizedDataImporter))
+def test_cc_postgresql_counts_both_same_key_provider_operations(
+    postgresql_db, importer_class
+) -> None:
+    postgresql_db.execute(SCHEMAS["NL_CC"])
+    postgresql_db.commit()
+    result = importer_class(postgresql_db).import_records(
+        iter([parsed_cc(), parsed_cc(HappyoTime="08181205")]), auto_commit=True
+    )
+    assert result["records_imported"] == 2
+    assert result["records_failed"] == 0
+    assert postgresql_db.fetch_one('SELECT COUNT(*) AS "n" FROM NL_CC') == {"n": 1}
+
+
+@pytest.mark.parametrize(
+    "defect", ("extra-unique", "generated-official-column", "deferrable-primary-key")
+)
+def test_cc_postgresql_schema_defects_fail_before_mutation(postgresql_db, defect: str) -> None:
+    if defect == "deferrable-primary-key":
+        schema = SCHEMAS["NL_CC"].replace(
+            "PRIMARY KEY (Year, MonthDay, JyoCD, Kaiji, Nichiji, RaceNum)",
+            "PRIMARY KEY (Year, MonthDay, JyoCD, Kaiji, Nichiji, RaceNum) "
+            "DEFERRABLE INITIALLY DEFERRED",
+        )
+    else:
+        schema = _defective_schema("NL_CC", defect)
+    postgresql_db.execute(schema)
+    postgresql_db.commit()
+    with pytest.raises(SchemaMigrationError):
+        DataImporter(postgresql_db).import_records(iter([parsed_cc()]))
+    assert postgresql_db.fetch_one('SELECT COUNT(*) AS "n" FROM NL_CC') == {"n": 0}

--- a/tests/test_cc_official_contract.py
+++ b/tests/test_cc_official_contract.py
@@ -119,10 +119,7 @@ def test_cc_oracle_binds_both_workbooks_sdk_and_every_parser_span() -> None:
     }
     assert CONTRACT["current_provider_specs"] == ["0B14", "0B16"]
     assert CONTRACT["snapshot_provider_spec"] == "0B14"
-    assert (
-        CONTRACT["snapshot_policy_source"]
-        == "JV-Data4901.xlsx:データ提供タイミング･提供単位:60"
-    )
+    assert CONTRACT["snapshot_policy_source"] == "JV-Data4901.xlsx:データ提供タイミング･提供単位:60"
     assert CONTRACT["cancellation_note_source"] == "JV-Data4901.xlsx:特記事項:265"
 
     parser_spans = [(field.name, field.start + 1, field.length) for field in CCParser()._fields]
@@ -142,7 +139,13 @@ def test_cc_oracle_binds_both_workbooks_sdk_and_every_parser_span() -> None:
             {"name": "id", "kind": "nested", "start": 12, "width": 16, "struct": "RACE_ID"},
             {"name": "HappyoTime", "kind": "nested", "start": 28, "width": 8, "struct": "MDHM"},
             {"name": "CCInfoAfter", "kind": "nested", "start": 36, "width": 6, "struct": "CC_INFO"},
-            {"name": "CCInfoBefore", "kind": "nested", "start": 42, "width": 6, "struct": "CC_INFO"},
+            {
+                "name": "CCInfoBefore",
+                "kind": "nested",
+                "start": 42,
+                "width": 6,
+                "struct": "CC_INFO",
+            },
             {"name": "JiyuCd", "kind": "scalar", "start": 48, "width": 1, "decoder": "text"},
             {"name": "crlf", "kind": "scalar", "start": 49, "width": 2, "decoder": "text"},
         ],

--- a/tests/test_cc_official_contract.py
+++ b/tests/test_cc_official_contract.py
@@ -1,0 +1,363 @@
+"""Official CC course-change contract from pinned JRA-VAN sources."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from pathlib import Path
+
+import pytest
+
+from src.database.migration import SchemaMigrationError
+from src.database.schema import SCHEMAS
+from src.database.schema import SchemaManager
+from src.database.schema_jravan import JRAVAN_SCHEMAS
+from src.database.schema_metadata import TABLE_METADATA
+from src.database.schema_types import (
+    get_table_column_types,
+    get_table_column_nullability,
+    get_table_primary_key_columns,
+)
+from src.database.sqlite_handler import SQLiteDatabase
+from src.importer.importer import DataImporter, validate_import_record_header
+from src.importer.importer_optimized import OptimizedDataImporter
+from src.parser.cc_parser import CCParser
+from src.parser.factory import ParserFactory
+from src.parser.status_domain import CURRENT_ACCUMULATED_DATA_KUBUN
+from src.realtime.updater import RealtimeUpdater
+
+FIXTURES = Path(__file__).parent / "fixtures" / "official_layout"
+CONTRACT = json.loads((FIXTURES / "cc_contract_4901.json").read_text(encoding="utf-8"))
+MANIFEST = json.loads((FIXTURES / "jvdata_sdk500_manifest.json").read_text(encoding="utf-8"))
+
+FIELDS = (
+    ("RecordSpec", 1, 2, b"CC"),
+    ("DataKubun", 3, 1, b"1"),
+    ("MakeDate", 4, 8, b"20260818"),
+    ("Year", 12, 4, b"2026"),
+    ("MonthDay", 16, 4, b"0818"),
+    ("JyoCD", 20, 2, b"05"),
+    ("Kaiji", 22, 2, b"03"),
+    ("Nichiji", 24, 2, b"08"),
+    ("RaceNum", 26, 2, b"11"),
+    ("HappyoTime", 28, 8, b"08181200"),
+    ("AtoKyori", 36, 4, b"2000"),
+    ("AtoTruckCD", 40, 2, b"18"),
+    ("MaeKyori", 42, 4, b"1800"),
+    ("MaeTruckCD", 46, 2, b"17"),
+    ("JiyuCD", 48, 1, b"1"),
+    ("RecordDelimiter", 49, 2, b"\r\n"),
+)
+OFFICIAL_KEY = ("Year", "MonthDay", "JyoCD", "Kaiji", "Nichiji", "RaceNum")
+STORAGE_FIELDS = {name for name, _, _, _ in FIELDS} - {"RecordDelimiter"}
+
+
+def _put(record: bytearray, start: int, width: int, value: str) -> None:
+    encoded = value.encode("cp932", errors="strict")
+    assert len(encoded) <= width
+    record[start : start + width] = encoded.ljust(width, b" ")
+
+
+def build_cc_record(**overrides: str) -> bytes:
+    values = {name: default.decode("cp932") for name, _, _, default in FIELDS[:-1]}
+    values.update(overrides)
+    record = bytearray(b" " * CCParser.RECORD_LENGTH)
+    for name, position, width, _ in FIELDS[:-1]:
+        _put(record, position - 1, width, values[name])
+    record[-2:] = b"\r\n"
+    assert len(record) == 50
+    return bytes(record)
+
+
+def parsed_cc(**overrides: str) -> dict:
+    parsed = CCParser().parse(build_cc_record(**overrides))
+    assert parsed is not None
+    return parsed
+
+
+def test_cc_oracle_binds_both_workbooks_sdk_and_every_parser_span() -> None:
+    assert CONTRACT["record_length"] == 50
+    assert CONTRACT["fields"] == [[name, position, width] for name, position, width, _ in FIELDS]
+    assert tuple(CONTRACT["primary_key"]) == OFFICIAL_KEY
+    assert CONTRACT["current_data_kubun"] == ["1"]
+    assert CURRENT_ACCUMULATED_DATA_KUBUN["CC"] == frozenset({"1"})
+    assert CONTRACT["history"]["physical_layout_changed"] is False
+    assert CONTRACT["current_provider_specs"] == ["0B14", "0B16"]
+    assert CONTRACT["snapshot_provider_spec"] == "0B14"
+
+    parser_spans = [(field.name, field.start + 1, field.length) for field in CCParser()._fields]
+    assert parser_spans == [(name, position, width) for name, position, width, _ in FIELDS]
+    direct = CCParser().parse(build_cc_record())
+    assert direct == ParserFactory().parse(build_cc_record())
+    assert direct is not None
+    assert tuple(
+        direct[name] for name in ("AtoKyori", "AtoTruckCD", "MaeKyori", "MaeTruckCD", "JiyuCD")
+    ) == ("2000", "18", "1800", "17", "1")
+
+    assert MANIFEST["root_records"]["CC"] == {"struct": "JV_CC_INFO", "length": 50}
+    assert [
+        (field["name"], field["start"], field["width"])
+        for field in MANIFEST["structures"]["CC_INFO"]["fields"]
+    ] == [("Kyori", 1, 4), ("TruckCd", 5, 2)]
+
+
+@pytest.mark.parametrize(
+    "overrides",
+    [
+        {"MakeDate": "20260230"},
+        {"Year": "20A6"},
+        {"MonthDay": "0230"},
+        {"JyoCD": "ZZ"},
+        {"Kaiji": "A1"},
+        {"Nichiji": "0A"},
+        {"RaceNum": "1X"},
+        {"HappyoTime": "08189999"},
+        {"HappyoTime": "8181200"},
+        {"AtoKyori": "2X00"},
+        {"AtoKyori": "200"},
+        {"AtoTruckCD": "ZZ"},
+        {"MaeKyori": "18Y0"},
+        {"MaeTruckCD": "99"},
+        {"JiyuCD": "9"},
+    ],
+)
+def test_cc_parser_rejects_nonofficial_header_key_and_body_values(
+    overrides: dict[str, str],
+) -> None:
+    with pytest.raises(ValueError):
+        CCParser().parse(build_cc_record(**overrides))
+
+
+def test_cc_explicit_initial_values_remain_accepted_and_lossless() -> None:
+    parsed = parsed_cc(
+        HappyoTime="00000000",
+        AtoKyori="0000",
+        AtoTruckCD="00",
+        MaeKyori="0000",
+        MaeTruckCD="00",
+        JiyuCD="0",
+    )
+    assert tuple(
+        parsed[name]
+        for name in ("HappyoTime", "AtoKyori", "AtoTruckCD", "MaeKyori", "MaeTruckCD", "JiyuCD")
+    ) == ("00000000", "0000", "00", "0000", "00", "0")
+
+
+def test_cc_storage_schemas_encode_the_complete_official_identity() -> None:
+    for table_name in ("NL_CC", "RT_CC", "COURSE_CHANGE"):
+        assert tuple(get_table_primary_key_columns(table_name)) == OFFICIAL_KEY
+        nullability = get_table_column_nullability(table_name)
+        assert set(nullability) == STORAGE_FIELDS
+        assert all(nullability[column] is False for column in STORAGE_FIELDS)
+        assert set(get_table_column_types(table_name)) == STORAGE_FIELDS
+    assert TABLE_METADATA["NL_CC"]["primary_key"] == list(OFFICIAL_KEY)
+
+
+def _defective_schema(table_name: str, defect: str) -> str:
+    schema = SCHEMAS[table_name] if table_name == "NL_CC" else JRAVAN_SCHEMAS[table_name]
+    key = "PRIMARY KEY (Year, MonthDay, JyoCD, Kaiji, Nichiji, RaceNum)"
+    replacements = {
+        "wrong-key": (key, "PRIMARY KEY (Year, MonthDay, JyoCD, Kaiji, Nichiji)"),
+        "nullable-body": (
+            "AtoTruckCD TEXT NOT NULL",
+            "AtoTruckCD TEXT",
+        ),
+        "wrong-type": (
+            "Year INTEGER NOT NULL",
+            "Year TEXT NOT NULL",
+        ),
+        "short-text": (
+            "HappyoTime TEXT NOT NULL",
+            "HappyoTime VARCHAR(7) NOT NULL",
+        ),
+    }
+    standard_replacements = {
+        "nullable-body": (
+            "AtoTruckCD                     VARCHAR(2) NOT NULL",
+            "AtoTruckCD                     VARCHAR(2)         ",
+        ),
+        "wrong-type": (
+            "Year                           SMALLINT NOT NULL",
+            "Year                           VARCHAR(4) NOT NULL",
+        ),
+        "short-text": (
+            "HappyoTime                     VARCHAR(8) NOT NULL",
+            "HappyoTime                     VARCHAR(7) NOT NULL",
+        ),
+    }
+    if table_name != "NL_CC" and defect in standard_replacements:
+        old, new = standard_replacements[defect]
+    elif defect in replacements:
+        old, new = replacements[defect]
+    else:
+        body, close = schema.rsplit(")", 1)
+        additions = {
+            "extra-unique": "UNIQUE (HappyoTime)",
+            "extra-check": "CHECK (JiyuCD = '0')",
+            "extra-foreign-key": (
+                f"FOREIGN KEY ({', '.join(OFFICIAL_KEY)}) REFERENCES {table_name} "
+                f"({', '.join(OFFICIAL_KEY)}) ON DELETE CASCADE"
+            ),
+            "extra-required-column": "ExternalRequired TEXT NOT NULL",
+        }
+        return f"{body}, {additions[defect]}\n        ){close}"
+    mutated = schema.replace(old, new)
+    assert mutated != schema
+    return mutated
+
+
+@pytest.mark.parametrize("table_name,standard", [("NL_CC", False), ("COURSE_CHANGE", True)])
+@pytest.mark.parametrize(
+    "defect",
+    [
+        "wrong-key",
+        "nullable-body",
+        "wrong-type",
+        "short-text",
+        "extra-unique",
+        "extra-check",
+        "extra-foreign-key",
+        "extra-required-column",
+    ],
+)
+def test_cc_schema_defects_fail_before_any_row_or_schema_mutation(
+    tmp_path, table_name: str, standard: bool, defect: str
+) -> None:
+    database = SQLiteDatabase({"path": str(tmp_path / f"{table_name}-{defect}.db")})
+    with database:
+        database.execute(_defective_schema(table_name, defect))
+        database.commit()
+        before = database.fetch_one(
+            "SELECT sql FROM sqlite_master WHERE type='table' AND name=?", (table_name,)
+        )
+        with pytest.raises(SchemaMigrationError):
+            DataImporter(database, use_jravan_schema=standard).import_records(iter([parsed_cc()]))
+        assert (
+            database.fetch_one(
+                "SELECT sql FROM sqlite_master WHERE type='table' AND name=?", (table_name,)
+            )
+            == before
+        )
+        assert database.fetch_one(f"SELECT COUNT(*) AS n FROM {table_name}") == {"n": 0}
+
+
+def test_cc_schema_manager_does_not_mutate_an_unsafe_existing_table(tmp_path) -> None:
+    database = SQLiteDatabase({"path": str(tmp_path / "manager-unsafe.db")})
+    with database:
+        database.execute(_defective_schema("NL_CC", "extra-unique"))
+        database.commit()
+        before = database.fetch_all('PRAGMA table_xinfo("NL_CC")')
+        assert SchemaManager(database).create_table("NL_CC") is False
+        assert database.fetch_all('PRAGMA table_xinfo("NL_CC")') == before
+
+
+@pytest.mark.parametrize("importer_class", (DataImporter, OptimizedDataImporter))
+@pytest.mark.parametrize("auto_commit", (True, False), ids=("owned", "caller"))
+@pytest.mark.parametrize("table_name,standard", [("NL_CC", False), ("COURSE_CHANGE", True)])
+def test_cc_provider_revision_replaces_one_official_identity(
+    tmp_path, importer_class, auto_commit: bool, table_name: str, standard: bool
+) -> None:
+    database = SQLiteDatabase({"path": str(tmp_path / f"revision-{table_name}.db")})
+    schema = JRAVAN_SCHEMAS[table_name] if standard else SCHEMAS[table_name]
+    first = parsed_cc()
+    revised = parsed_cc(HappyoTime="08181205", AtoKyori="2200", AtoTruckCD="19")
+    with database:
+        database.execute(schema)
+        database.commit()
+        result = importer_class(database, batch_size=1, use_jravan_schema=standard).import_records(
+            iter([first, revised]), auto_commit=auto_commit
+        )
+        rows = database.fetch_all(f"SELECT HappyoTime, AtoKyori, AtoTruckCD FROM {table_name}")
+    assert result["records_imported"] == 2
+    assert result["records_failed"] == 0
+    assert rows == [
+        {"HappyoTime": "08181205", "AtoKyori": 2200 if not standard else "2200", "AtoTruckCD": "19"}
+    ]
+
+
+@pytest.mark.parametrize("importer_class", (DataImporter, OptimizedDataImporter))
+@pytest.mark.parametrize("auto_commit", (True, False), ids=("owned", "caller"))
+@pytest.mark.parametrize("table_name,standard", [("NL_CC", False), ("COURSE_CHANGE", True)])
+def test_cc_caller_validation_precedes_coercion_and_mutation(
+    tmp_path, importer_class, auto_commit: bool, table_name: str, standard: bool
+) -> None:
+    database = SQLiteDatabase({"path": str(tmp_path / f"invalid-{table_name}.db")})
+    schema = JRAVAN_SCHEMAS[table_name] if standard else SCHEMAS[table_name]
+    invalid = parsed_cc()
+    invalid["JiyuCD"] = "9"
+    with database:
+        database.execute(schema)
+        database.commit()
+        with pytest.raises(SchemaMigrationError):
+            importer_class(database, use_jravan_schema=standard).import_records(
+                iter([invalid]), auto_commit=auto_commit
+            )
+        assert database.fetch_one(f"SELECT COUNT(*) AS n FROM {table_name}") == {"n": 0}
+
+
+def test_cc_realtime_rejects_invalid_body_before_mutation(tmp_path) -> None:
+    database = SQLiteDatabase({"path": str(tmp_path / "realtime.db")})
+    with database:
+        database.execute(SCHEMAS["RT_CC"])
+        database.commit()
+        invalid = parsed_cc()
+        invalid["AtoTruckCD"] = "ZZ"
+        result = RealtimeUpdater(database).process_parsed_records_batch([invalid])
+        assert result["success"] is False
+        assert result["inserted"] == 0
+        assert database.fetch_one("SELECT COUNT(*) AS n FROM RT_CC") == {"n": 0}
+
+
+@pytest.mark.parametrize("auto_commit", (True, False), ids=("owned", "caller"))
+@pytest.mark.parametrize("table_name,standard", [("NL_CC", False), ("COURSE_CHANGE", True)])
+def test_cc_single_record_uses_the_same_fail_closed_contract(
+    tmp_path, auto_commit: bool, table_name: str, standard: bool
+) -> None:
+    database = SQLiteDatabase({"path": str(tmp_path / f"single-{table_name}.db")})
+    schema = JRAVAN_SCHEMAS[table_name] if standard else SCHEMAS[table_name]
+    with database:
+        database.execute(schema)
+        database.commit()
+        importer = DataImporter(database, use_jravan_schema=standard)
+        assert importer.import_single_record(parsed_cc(), auto_commit=auto_commit)
+        invalid = parsed_cc()
+        invalid["JiyuCD"] = "9"
+        with pytest.raises(SchemaMigrationError):
+            importer.import_single_record(invalid, auto_commit=auto_commit)
+        expected = 1 if auto_commit else 0
+        assert database.fetch_one(f"SELECT COUNT(*) AS n FROM {table_name}") == {"n": expected}
+
+
+def test_cc_date_snapshot_removes_only_stale_cc_rows(tmp_path) -> None:
+    database = SQLiteDatabase({"path": str(tmp_path / "snapshot.db")})
+    with database:
+        for table_name in RealtimeUpdater.DATE_SNAPSHOT_TABLES:
+            database.execute(SCHEMAS[table_name])
+        database.commit()
+        updater = RealtimeUpdater(database)
+        seeded = updater.process_parsed_records_batch(
+            [parsed_cc(RaceNum="10"), parsed_cc(RaceNum="11")]
+        )
+        updater.replace_date_snapshot("20260818")
+        revised = updater.process_parsed_records_batch(
+            [parsed_cc(RaceNum="11", HappyoTime="08181205", AtoKyori="2200")]
+        )
+        rows = database.fetch_all(
+            "SELECT RaceNum, HappyoTime, AtoKyori FROM RT_CC ORDER BY RaceNum"
+        )
+    assert seeded["success"] is True
+    assert revised["success"] is True
+    assert rows == [{"RaceNum": 11, "HappyoTime": "08181205", "AtoKyori": 2200}]
+
+
+def test_cc_header_validator_rejects_missing_blank_and_conflicting_aliases() -> None:
+    valid = parsed_cc()
+    assert validate_import_record_header(valid) == ("CC", "1")
+    for row in (
+        {key: value for key, value in valid.items() if key != "DataKubun"},
+        {**valid, "DataKubun": ""},
+        {**valid, "headDataKubun": "0"},
+        {**valid, "headRecordSpec": "TC"},
+    ):
+        with pytest.raises(SchemaMigrationError):
+            validate_import_record_header(row)

--- a/tests/test_cc_official_contract.py
+++ b/tests/test_cc_official_contract.py
@@ -79,13 +79,51 @@ def parsed_cc(**overrides: str) -> dict:
 
 def test_cc_oracle_binds_both_workbooks_sdk_and_every_parser_span() -> None:
     assert CONTRACT["record_length"] == 50
+    assert CONTRACT["format_sources"] == [
+        {
+            "artifact": "JV-Data4802.xlsx",
+            "sha256": "6a567f10b601115eca350571f36d27d9d28bd2d3835ea72b5bc057711155d4a7",
+            "sheet": "フォーマット",
+            "rows": "1531-1553",
+        },
+        {
+            "artifact": "JV-Data4901.xlsx",
+            "sha256": "23bafd375f704acbdd696b5032ac1619f17d47e882587d6e7954b610527a8234",
+            "sheet": "フォーマット",
+            "rows": "1531-1553",
+        },
+    ]
+    assert CONTRACT["sdk_source"] == {
+        "artifact": "JRA-VAN Data Lab. SDK Ver5.0.0/JVData_Struct.cs",
+        "sha256": "605057bb211eb6a94056a54496f3dd30f864ac2ad140fcfc8840ac8a6ed9e4fe",
+        "struct": "JV_CC_INFO",
+    }
     assert CONTRACT["fields"] == [[name, position, width] for name, position, width, _ in FIELDS]
     assert tuple(CONTRACT["primary_key"]) == OFFICIAL_KEY
     assert CONTRACT["current_data_kubun"] == ["1"]
+    assert CONTRACT["track_codes"] == [
+        "00",
+        *[str(value) for value in range(10, 30)],
+        *[str(value) for value in range(51, 60)],
+    ]
+    assert CONTRACT["reason_codes"] == ["0", "1", "2", "3", "4"]
     assert CURRENT_ACCUMULATED_DATA_KUBUN["CC"] == frozenset({"1"})
-    assert CONTRACT["history"]["physical_layout_changed"] is False
+    assert CONTRACT["history"] == {
+        "added": "2004-05-25",
+        "version": "1.1.6",
+        "physical_layout_changed": False,
+        "sources": [
+            "JV-Data4901.xlsx:変更履歴:217,221",
+            "JV-Data4802.xlsx:変更履歴:174,178",
+        ],
+    }
     assert CONTRACT["current_provider_specs"] == ["0B14", "0B16"]
     assert CONTRACT["snapshot_provider_spec"] == "0B14"
+    assert (
+        CONTRACT["snapshot_policy_source"]
+        == "JV-Data4901.xlsx:データ提供タイミング･提供単位:60"
+    )
+    assert CONTRACT["cancellation_note_source"] == "JV-Data4901.xlsx:特記事項:265"
 
     parser_spans = [(field.name, field.start + 1, field.length) for field in CCParser()._fields]
     assert parser_spans == [(name, position, width) for name, position, width, _ in FIELDS]
@@ -97,6 +135,19 @@ def test_cc_oracle_binds_both_workbooks_sdk_and_every_parser_span() -> None:
     ) == ("2000", "18", "1800", "17", "1")
 
     assert MANIFEST["root_records"]["CC"] == {"struct": "JV_CC_INFO", "length": 50}
+    assert MANIFEST["structures"]["JV_CC_INFO"] == {
+        "width": 50,
+        "fields": [
+            {"name": "head", "kind": "nested", "start": 1, "width": 11, "struct": "RECORD_ID"},
+            {"name": "id", "kind": "nested", "start": 12, "width": 16, "struct": "RACE_ID"},
+            {"name": "HappyoTime", "kind": "nested", "start": 28, "width": 8, "struct": "MDHM"},
+            {"name": "CCInfoAfter", "kind": "nested", "start": 36, "width": 6, "struct": "CC_INFO"},
+            {"name": "CCInfoBefore", "kind": "nested", "start": 42, "width": 6, "struct": "CC_INFO"},
+            {"name": "JiyuCd", "kind": "scalar", "start": 48, "width": 1, "decoder": "text"},
+            {"name": "crlf", "kind": "scalar", "start": 49, "width": 2, "decoder": "text"},
+        ],
+        "expanded_leaf_count": 21,
+    }
     assert [
         (field["name"], field["start"], field["width"])
         for field in MANIFEST["structures"]["CC_INFO"]["fields"]
@@ -143,6 +194,24 @@ def test_cc_explicit_initial_values_remain_accepted_and_lossless() -> None:
         parsed[name]
         for name in ("HappyoTime", "AtoKyori", "AtoTruckCD", "MaeKyori", "MaeTruckCD", "JiyuCD")
     ) == ("00000000", "0000", "00", "0000", "00", "0")
+
+
+@pytest.mark.parametrize("importer_class", (DataImporter, OptimizedDataImporter))
+def test_cc_standard_normalizes_caller_integer_distances_to_four_digits(
+    tmp_path, importer_class
+) -> None:
+    database = SQLiteDatabase({"path": str(tmp_path / "integer-distances.db")})
+    row = parsed_cc()
+    row["AtoKyori"] = 0
+    row["MaeKyori"] = 12
+    with database:
+        database.execute(JRAVAN_SCHEMAS["COURSE_CHANGE"])
+        database.commit()
+        result = importer_class(database, use_jravan_schema=True).import_records(iter([row]))
+        stored = database.fetch_one("SELECT AtoKyori, MaeKyori FROM COURSE_CHANGE")
+    assert result["records_imported"] == 1
+    assert result["records_failed"] == 0
+    assert stored == {"AtoKyori": "0000", "MaeKyori": "0012"}
 
 
 def test_cc_storage_schemas_encode_the_complete_official_identity() -> None:
@@ -494,6 +563,20 @@ def test_cc_postgresql_realtime_rejects_before_catalog_transaction(postgresql_db
     assert result["success"] is False
     assert postgresql_db.has_pending_transaction() is False
     assert postgresql_db.fetch_one('SELECT COUNT(*) AS "n" FROM RT_CC') == {"n": 0}
+
+
+@pytest.mark.parametrize("operation", ("create_table", "create_all_tables"))
+def test_cc_postgresql_schema_manager_closes_failed_preflight_transaction(
+    postgresql_db, operation: str
+) -> None:
+    postgresql_db.execute(_defective_schema("NL_CC", "extra-unique"))
+    postgresql_db.commit()
+    manager = SchemaManager(postgresql_db)
+    if operation == "create_table":
+        assert manager.create_table("NL_CC") is False
+    else:
+        assert manager.create_all_tables()["NL_CC"] is False
+    assert postgresql_db.has_pending_transaction() is False
 
 
 @pytest.mark.parametrize("unsafe_target", ("primary", "secondary"))

--- a/tests/test_cc_official_contract.py
+++ b/tests/test_cc_official_contract.py
@@ -107,6 +107,8 @@ def test_cc_oracle_binds_both_workbooks_sdk_and_every_parser_span() -> None:
         *[str(value) for value in range(51, 60)],
     ]
     assert CONTRACT["reason_codes"] == ["0", "1", "2", "3", "4"]
+    assert CCParser.OFFICIAL_TRACK_CODES == frozenset(CONTRACT["track_codes"])
+    assert CCParser.REASON_CODES == frozenset(CONTRACT["reason_codes"])
     assert CURRENT_ACCUMULATED_DATA_KUBUN["CC"] == frozenset({"1"})
     assert CONTRACT["history"] == {
         "added": "2004-05-25",

--- a/tests/test_current_record_validation.py
+++ b/tests/test_current_record_validation.py
@@ -43,6 +43,7 @@ PREVIOUS_OFFICIAL_LENGTHS = tuple(
 # space-filled envelope is not valid.
 DOMAIN_PAYLOAD_REQUIRED = {
     "AV",
+    "CC",
     "CK",
     "CS",
     "DM",

--- a/tests/test_happyo_time_contract.py
+++ b/tests/test_happyo_time_contract.py
@@ -69,6 +69,8 @@ def _record(record_type: str, length: int, announcement_start: int) -> bytes:
         record[158:159] = b"9"
     if record_type == "WE":
         record[33:40] = b"1111000"
+    if record_type == "CC":
+        record[35:48] = b"2000181800171"
     if record_type == "TC":
         record[35:43] = b"12101200"
     record[-2:] = b"\r\n"

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -270,6 +270,23 @@ class TestIndividualParsers:
                 mutable[35:39] = b"1015"
                 mutable[39:43] = b"1005"
                 data = bytes(mutable)
+            if record_type == "CC":
+                # CC requires its complete six-part race key plus valid
+                # announcement, distance, track, and reason fields.
+                mutable = bytearray(data)
+                mutable[11:15] = b"2024"
+                mutable[15:19] = b"0601"
+                mutable[19:21] = b"05"
+                mutable[21:23] = b"03"
+                mutable[23:25] = b"08"
+                mutable[25:27] = b"11"
+                mutable[27:35] = b"06010930"
+                mutable[35:39] = b"2000"
+                mutable[39:41] = b"18"
+                mutable[41:45] = b"1800"
+                mutable[45:47] = b"17"
+                mutable[47:48] = b"1"
+                data = bytes(mutable)
             if record_type == "TK":
                 mutable = bytearray(data)
                 mutable[11:15] = b"2024"


### PR DESCRIPTION
## Summary

- bind the JRA `CC` course-change record to the pinned 4.8/4.9 workbook and SDK 5 `JV_CC_INFO` 50-byte layout
- enforce the official six-column identity, status/body domains, and exact native/standard/realtime schemas before mutation
- preserve provider ordering and 0B14 date-snapshot semantics across both importers, single-record import, realtime updates, SQLite, PostgreSQL, and Dual targets
- add executable metadata, migration guidance, release notes, and a tracked iteration worklog

## Root cause and impact

The previous CC path accepted malformed keys/body values, exposed nullable or keyless storage, and did not fail closed on unsafe existing schemas. Standard revisions could duplicate, realtime caller dictionaries could bypass parser validation, and schema defects could surface only after writes. This change centralizes the CC parser/caller/schema contract and verifies all physical targets before mutation.

## Red-first evidence

- initial official-contract test on unchanged production: `51 failed, 7 passed`
- expanded backend rejection contract on unchanged production: `57 failed, 7 passed, 5 skipped`
- aggregated independent-review regressions on the unrepaired candidate: `5 failed` (official oracle locator/binding, two distance-normalization paths, two PostgreSQL SchemaManager transaction-closure paths)
- all corresponding provider-valid controls remained green; all five review regressions pass after the consolidated repair

## Exact-head validation

Candidate: `08f3a64cd16aecbce7e1b600287bcf78539b3094`

- full workflow-equivalent suite: `3454 passed, 388 skipped, 14 deselected, 20 subtests passed`
- Python 3.12 affected suite: `715 passed, 58 skipped, 9 subtests passed`
- CC SQLite contract: `66 passed, 15 skipped`
- fresh PostgreSQL 16 CC contract: `81 passed`
- fatal flake8 (`E9,F63,F7,F82`): `0`
- repository test gate: `PASS`
- `uv lock --check`: pass
- strict MkDocs: pass
- git-archive wheel/sdist build, distribution-content gate, and isolated wheel initialization smoke: pass
- `git diff --check`: pass; worktree clean

The final two-assertion oracle-only delta binds the runtime track/reason sets
directly to the official fixture. Separate temporary track-`30` and reason-`5`
mutants each failed their corresponding new assertion; the provider-valid
compact contract remained `66 passed, 15 skipped`.

## Review scope

Three independent reviews were aggregated on the first frozen candidate. Their actionable findings were repaired once and are recorded in `specs/operations/20260818_cc_official_contract_worklog.md`. A final bounded carry-forward review is being attached to this exact candidate. This PR does not change the production release lock or make a provider/runtime adoption claim.
