### PR TITLE
docs: split data_support into a reader entry page and per-record contracts

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ powershell -NoProfile -ExecutionPolicy Bypass -File install_tasks.ps1 -DbType po
 | --- | --- |
 | [はじめに](docs/getting_started.md) | 目的別の実行順序 |
 | [対応データ種別一覧](docs/data_support.md) | JVOpen / JVRTOpen spec と保存先 |
+| [レコード別の公式契約と移行手順](docs/record_contracts.md) | レコード種別ごとの公式レイアウト・主キー・`DataKubun`・既存 DB の移行手順 |
 | [時系列オッズ](docs/timeseries_odds.md) | `0B41/0B42` と `0B30` 系の違い |
 | [PostgreSQL](docs/postgresql.md) | PostgreSQL 保存と日次同期 |
 | [CLI](docs/CLI.md) | CLI リファレンス |

--- a/docs/data_support.md
+++ b/docs/data_support.md
@@ -5,18 +5,18 @@
 
 jrvltsql は JRA / 中央競馬専用です。NAR / 地方競馬はこのリポジトリの対象外です。
 
-## 先に結論
+## このページの読み方
 
-| 知りたいこと | 結論 | 使うコマンド / 保存先 |
+ドキュメントは次の 3 層に分かれています。上から順に読めば、3 分で結論、
+必要に応じて参照表、さらに必要なら契約の詳細へ進めます。
+
+| 層 | 内容 | 場所 |
 | --- | --- | --- |
-| 出馬表、成績、払戻を保存できるか | できます。 | `quickstart.bat` または `quickstart_timeseries.bat`。主に `NL_RA`, `NL_SE`, `NL_HR` に保存します。 |
-| 確定オッズを保存できるか | 全賭式でできます。 | `RACE` 取得で `NL_O1`〜`NL_O6` に保存します。ただし投資判断時点のオッズではありません。 |
-| 過去1年分の時系列オッズをまとめて取れるか | 単複枠・馬連だけできます。 | `0B41` / `0B42` を `TS_O1` / `TS_O2` に保存します。SQLite でも PostgreSQL でも保存できます。 |
-| 三連複・三連単の締切前オッズを長期評価できるか | 開催週から蓄積していればできます。 | `0B30` または `0B35` / `0B36` を `TS_SOKUHO_O5` / `TS_SOKUHO_O6` に保存します。JRA-VAN 側の保持は約1週間です。 |
-| `daily_sync.bat` は SQLite / PostgreSQL の両方で使えるか | 使えます。 | `daily_sync.bat --db sqlite` または `daily_sync.bat --db postgresql` で通常データ、公式時系列、開催週速報を更新します。通常データだけにする場合は `--no-timeseries --no-realtime` を指定します。 |
-| NAR / 地方競馬も取れるか | このリポジトリでは取れません。 | JRA 専用です。 |
+| 1. 要約 | 「先に結論」の表。できること・できないことと使うコマンド | このページの「先に結論」（すぐ下） |
+| 2. 参照表 | 取得系統、JVOpen 蓄積系データ、JVRTOpen 速報、オッズ・票数、レコード種別→テーブル、対象外 | このページの各表 |
+| 3. 契約詳細 | レコード種別ごとの公式レイアウト・主キー・`DataKubun`・既存 DB からの移行手順、および共通の検証・transaction 規約 | [レコード別の公式契約と移行手順](record_contracts.md) |
 
-## 表の見方
+### 表の見方
 
 | 表記 | 意味 |
 | --- | --- |
@@ -32,6 +32,17 @@ jrvltsql は JRA / 中央競馬専用です。NAR / 地方競馬はこのリポ�
 - `src/database/table_mappings.py`
 - `src/database/schema.py`
 - `src/cli/main.py`
+
+## 先に結論
+
+| 知りたいこと | 結論 | 使うコマンド / 保存先 |
+| --- | --- | --- |
+| 出馬表、成績、払戻を保存できるか | できます。 | `quickstart.bat` または `quickstart_timeseries.bat`。主に `NL_RA`, `NL_SE`, `NL_HR` に保存します。 |
+| 確定オッズを保存できるか | 全賭式でできます。 | `RACE` 取得で `NL_O1`〜`NL_O6` に保存します。ただし投資判断時点のオッズではありません。 |
+| 過去1年分の時系列オッズをまとめて取れるか | 単複枠・馬連だけできます。 | `0B41` / `0B42` を `TS_O1` / `TS_O2` に保存します。SQLite でも PostgreSQL でも保存できます。 |
+| 三連複・三連単の締切前オッズを長期評価できるか | 開催週から蓄積していればできます。 | `0B30` または `0B35` / `0B36` を `TS_SOKUHO_O5` / `TS_SOKUHO_O6` に保存します。JRA-VAN 側の保持は約1週間です。 |
+| `daily_sync.bat` は SQLite / PostgreSQL の両方で使えるか | 使えます。 | `daily_sync.bat --db sqlite` または `daily_sync.bat --db postgresql` で通常データ、公式時系列、開催週速報を更新します。通常データだけにする場合は `--no-timeseries --no-realtime` を指定します。 |
+| NAR / 地方競馬も取れるか | このリポジトリでは取れません。 | JRA 専用です。 |
 
 ## 取得系統
 
@@ -50,37 +61,28 @@ jrvltsql は JRA / 中央競馬専用です。NAR / 地方競馬はこのリポ�
 | --- | --- | --- | --- | --- | --- | --- | --- | --- |
 | `TOKU` | - | 特別登録馬 | `TK` | `NL_TK_RACE`（レース）、`NL_TK`（登録馬） | はい | はい | はい | 21,657バイトの300頭枠を全て扱います。standard / full quickstart に含めています。 |
 | `RACE` | - | レース、出走馬、払戻、確定オッズ、票数、WIN5、除外情報 | `RA`, `SE`, `HR`, `H1`, `H6`, `O1`〜`O6`, `WF`, `JG` | `NL_RA`, `NL_SE`, `NL_HR`, `NL_H1`, `NL_H6`, `NL_O1`〜`NL_O6`, `NL_WF`, `NL_JG` | はい | はい | はい | 中核データです。`NL_O*` は確定オッズで、投資判断時点のオッズではありません。 |
-| `DIFN` | `DIFF` | 蓄積系マスタ差分 | `UM`, `KS`, `CH`, `BR`, `BN`, `RC` | `NL_UM`, `NL_KS`, `NL_KS_SEISEKI`, `NL_CH`, `NL_CH_SEISEKI`, `NL_BR`, `NL_BN`, `NL_RC` | はい | いいえ | はい | 旧名 `DIFF` は受け付けません（下記参照）。 |
-| `BLDN` | `BLOD` | 血統情報 | `HN`, `SK`, `BT` | `NL_HN`, `NL_SK`, `NL_BT` | はい | いいえ | はい | 旧名 `BLOD` は受け付けません（下記参照）。 |
+| `DIFN` | `DIFF` | 蓄積系マスタ差分 | `UM`, `KS`, `CH`, `BR`, `BN`, `RC` | `NL_UM`, `NL_KS`, `NL_KS_SEISEKI`, `NL_CH`, `NL_CH_SEISEKI`, `NL_BR`, `NL_BN`, `NL_RC` | はい | いいえ | はい | 旧名 `DIFF` は受け付けません（[旧仕様 dataspec 名](record_contracts.md#dataspec-diff-blod-snap-hose-tcov-rcov) 参照）。 |
+| `BLDN` | `BLOD` | 血統情報 | `HN`, `SK`, `BT` | `NL_HN`, `NL_SK`, `NL_BT` | はい | いいえ | はい | 旧名 `BLOD` は受け付けません（同上）。 |
 | `MING` | - | データマイニング予想 | `DM`, `TM` | `NL_DM`, `NL_TM` | はい | いいえ | はい | full quickstart に含めています。 |
 | `SLOP` | - | 坂路調教関連 | `HC` | `NL_HC`（native）、`HANRO`（標準名モード） | はい | いいえ | はい | 現行`DataKubun=1`は60バイトの全項目を保存します。`DataKubun=0`は本文を保存せず、公式4項目キーでexact deleteします。standard / full quickstart に含めています。 |
 | `WOOD` | - | ウッドチップ調教関連 | `WC` | `NL_WC`（native）、`WOOD`（標準名モード） | はい | いいえ | はい | 現行105バイトを全項目保存します。公式キーはトレセン区分・調教年月日・調教時刻・血統登録番号の4項目で、`0` は同じキーの削除です。standard / full quickstart に含めています。 |
 | `YSCH` | - | 開催スケジュール | `YS` | `NL_YS` | はい | いいえ | はい | 開催カレンダー保守に使います。 |
-| `HOSN` | `HOSE` | 競走馬市場取引価格 | `HS` | `NL_HS` | はい | いいえ | はい | 旧名 `HOSE` は受け付けません（下記参照）。 |
+| `HOSN` | `HOSE` | 競走馬市場取引価格 | `HS` | `NL_HS` | はい | いいえ | はい | 旧名 `HOSE` は受け付けません（同上）。 |
 | `HOYU` | - | 馬名の意味由来 | `HY` | `NL_HY` | はい | いいえ | はい | standard / full quickstart に含めています。 |
 | `COMM` | - | 各種解説・コース情報 | `CS` | `NL_CS`（native）、`COURSE`（標準名モード） | はい | いいえ | はい | 現行6,829バイトと6,800バイトのコース説明を完全保存します。full quickstart に含めています。 |
-| `SNPN` | `SNAP` | 出走時点情報 | `CK` | `NL_CK`、`NL_CK_CHAKU`、`NL_CK_RUIKEI` | はい | はい | はい | 現行6,870バイトをnative名モードで完全格納します。既定 quickstart では使っていません。旧名 `SNAP` は受け付けません（下記参照）。 |
-| `TCVN` | `TCOV` | 特別登録馬情報補填 | 複数のマスタ・レース系レコード | レコード種別に応じた既存 `NL_*` テーブル | いいえ | はい | いいえ | 今週データ更新で使います。旧名 `TCOV` は受け付けません（下記参照）。 |
-| `RCVN` | `RCOV` | レース情報補填 | 複数のマスタ・レース系レコード | レコード種別に応じた既存 `NL_*` テーブル | いいえ | はい | いいえ | 今週データ更新で使います。旧名 `RCOV` は受け付けません（下記参照）。 |
+| `SNPN` | `SNAP` | 出走時点情報 | `CK` | `NL_CK`、`NL_CK_CHAKU`、`NL_CK_RUIKEI` | はい | はい | はい | 現行6,870バイトをnative名モードで完全格納します。既定 quickstart では使っていません。旧名 `SNAP` は受け付けません（同上）。 |
+| `TCVN` | `TCOV` | 特別登録馬情報補填 | 複数のマスタ・レース系レコード | レコード種別に応じた既存 `NL_*` テーブル | いいえ | はい | いいえ | 今週データ更新で使います。旧名 `TCOV` は受け付けません（同上）。 |
+| `RCVN` | `RCOV` | レース情報補填 | 複数のマスタ・レース系レコード | レコード種別に応じた既存 `NL_*` テーブル | いいえ | はい | いいえ | 今週データ更新で使います。旧名 `RCOV` は受け付けません（同上）。 |
 
 `O1`〜`O6` は `RACE` や速報系ストリームに含まれるレコード種別IDであり、
 単独の `JVOpen` データ種別IDではありません。確定オッズは `RACE` を取得して
 `NL_O1`〜`NL_O6` へ保存します。JV-Link APIと `jltsql fetch` は、同じoptionで
 有効な4文字のデータ種別IDを `RACEDIFN` のように連結した指定にも対応します。
 
-### jrvltsql で非対応の旧仕様 dataspec
-
-`DIFF` / `BLOD` / `SNAP` / `HOSE` / `TCOV` / `RCOV` は jrvltsql では
-受け付けません。`fetch` / `cache build` / `cache rebuild` は取り込みや既存
-cache の変更に入る前に、対応する現行種別名を示して停止します。JRA-VAN の
-仕様表には旧名も掲載されており、公式API全体で廃止されたという意味ではありません。
-
-**旧名は新名の別名ではありません。** 2023-08 の JV-Data 仕様変更で桁数が変わって
-おり（繁殖登録番号 8→10 / 生産者コード 6→8 / 生産者名 70→72）、旧名を要求すると
-現行のパーサが解釈できない旧仕様のバイト列が返ります。桁がずれたまま取り込むと、
-レコードの途中から後ろが全て壊れます。
-
-`RACE` はこの仕様変更の対象外なので、これまでどおり使えます。
+旧仕様名（`DIFF` / `BLOD` / `SNAP` / `HOSE` / `TCOV` / `RCOV`）を受け付けない
+理由と、`RACE` がその影響を受けないことは
+[旧仕様 dataspec 名](record_contracts.md#dataspec-diff-blod-snap-hose-tcov-rcov)
+にまとめています。
 
 ## JVRTOpen 速報レース・開催情報
 
@@ -95,134 +97,14 @@ cache の変更に入る前に、対応する現行種別名を示して停止�
 | `0B17` | 速報対戦型データマイニング予想 | `TM` | `RT_TM` | `YYYYMMDD` | 対応済み |
 | `0B51` | 速報重勝式 WIN5 | `WF` | `RT_WF` | `YYYYMMDD` または WIN5 開催キー | 公式7,215-byte形式（対象5レース・有効票数5件・払戻243件）に対応。速報系のデータ区分は0/1/2/3/9で、蓄積系のみの7は受け付けません |
 
-### 公式データ区分の検証
-
-パーサー、通常インポート、1件インポート、速報保存は、レコード種別ごとの
-公式`DataKubun`を共通契約で検証します。値が無い、空欄、1文字でない、別名の値が
-食い違う、または下表に無いレコードは、そのレコードを使ったtable routing、cache
-書き込み、DB更新より前に拒否します。未指定値を新規登録`1`として補うことは
-ありません。
-
-通常インポートはstreaming処理です。`auto_commit=True`では完了したbatchを順次commit
-するため、後続レコードの検証失敗より前に確定済みの正常batchと、開始時のstandard
-schema preflightによる変更は保持されます。呼び出し全体をall-or-nothingにする場合は
-`auto_commit=False`を使います。この場合、後続検証失敗は同じ呼び出しまたは同じ
-caller-owned transactionで先に書いた行と統計をrollbackします。
-このrollback要否を判定するtransaction状態を取得できない場合は、未確定行をcommit可能な
-接続として残さず接続を無効化し、`TransactionRecoveryError`で停止します。統計のrollbackは
-同じtransaction generationに属する未確定分だけに限定します。callerが前のtransactionを
-commit済みの場合、その確定行と累積統計を後続transactionの状態判定失敗で巻き戻しません。
-状態判定と接続無効化の両方が失敗した場合は、接続上の未確定分を安全に分類できないため
-`TransactionRecoveryError`を送出し、既存の統計も成功・失敗のどちらへも推測更新しません。
-
-下表は全38形式について、通常import/parserで使うcurrent base domainを示します。
-providerがその形式を蓄積系・速報系のどちらで提供するかを表すavailability表では
-ありません。速報では、このbase domainから明示的な差分を次表で適用します。
-
-| current base domainのレコード種別 | 現行の公式値 |
-| --- | --- |
-| `WH`, `WE`, `JC`, `TC`, `CC` | `1` |
-| `AV` | `1`, `2` |
-| `RC`, `HC`, `HS`, `HY`, `JG`, `WC` | `0`, `1` |
-| `TK`, `KS`, `CH`, `BR`, `BN`, `HN`, `SK`, `CK`, `BT`, `CS` | `0`, `1`, `2` |
-| `HR` | `0`, `1`, `2`, `9` |
-| `DM`, `TM` | `0`, `1`, `2`, `3`, `7` |
-| `YS` | `0`, `1`, `2`, `3`, `9` |
-| `H1`, `H6` | `0`, `2`, `4`, `5`, `9` |
-| `UM` | `0`, `1`, `2`, `3`, `4`, `9` |
-| `WF` | `0`, `1`, `2`, `3`, `7`, `9` |
-| `O1`〜`O6` | `0`, `1`, `2`, `3`, `4`, `5`, `9` |
-| `RA`, `SE` | `0`, `1`, `2`, `3`, `4`, `5`, `6`, `7`, `9`, `A`, `B` |
-
-速報では、公式に蓄積系限定とされる`7`を`DM`, `TM`, `WF`で受け付けません。
-したがって速報の`DM`/`TM`は`0`, `1`, `2`, `3`、`WF`は`0`, `1`, `2`, `3`,
-`9`です。それ以外の形式では、公式資料に明記されない速報独自の制限を推測で
-追加していません。
-
-同じ物理長の旧データも、公式変更日の前であることを`MakeDate`から確認できる場合に
-限り扱います。`RC=2`は2005-09-29より前、`WH`/`WE`/`AV`/`JC=0`は
-2003-07-11より前だけです。`UM=9`は2003-04-22より前のデータでは拒否します。
-日付が無い、読めない、または境界日以後なら現行仕様として検証します。
-
-### WH テーブルの互換性に関する注意
-
-`WH` は公式 format 101 の847バイト馬体重レコードです。1レコード内の
-18頭配列を `NL_WH` / `RT_WH` の馬ごとの行へ展開し、レース識別子と馬番を
-主キーにします。`HappyoTime` は訂正発表の時刻として保存しますが、同一レース・
-同一馬の新しい発表は最新値として置き換わります。
-JRA-VAN標準名モードの `BATAIJYU` は展開せず、18頭分を1行に保持する公式の
-横持ち表現です。1つの公式WHレコードにつき、レース主キーの1行を保存します。
-
-旧 jrvltsql が作成した `NL_WH` / `RT_WH` は、誤って天候変更の40バイト相当の
-列と主キーを持っていました。この物理テーブルが存在する環境では、起動時の
-schema migration は主キー不一致を検出して停止します。JRA-VAN標準名モードの
-旧 `BATAIJYU` も主キーが無いため、同様にオペレーター移行が必要です。自動dropや
-暗黙変換は行いません。DBをバックアップしたうえで、オペレーターが対象を
-`NL_WH` / `RT_WH` / `BATAIJYU` のうち実在する旧テーブルだけに限定して削除し、
-`jltsql create-tables --db <sqlite|postgresql>` または標準名テーブルの初期化手順で
-再作成してください。`RT_WH` はその後 `jltsql realtime start --specs 0B11` で、
-JRA-VANの保持期間内に再取得します。旧 `NL_WH` / `RT_WH` の行は公式WHではない
-ため、馬体重履歴として移植しないでください。
-
-### 発表月日時分の保存形式と旧標準名テーブル
-
-`WH`, `WE`, `AV`, `JC`, `TC`, `CC` と `O1`〜`O6` の公式
-`HappyoTime` は、年を含まない8バイトの `MMDDhhmm` です。SQLの `TIME` や
-`TIMESTAMP` には変換せず、先頭ゼロを含む文字列として保存します。速報開催情報の
-JRA-VAN標準名は `TENKO_BABA`, `TORIKESI_JYOGAI`, `KISYU_CHANGE`,
-`HASSOU_JIKOKU_CHANGE`, `COURSE_CHANGE` です。旧来の英語別名は読み取り側の
-互換性のため残しますが、新しい標準名インポート先には使いません。
-
-旧版が作成したこれらの標準名テーブル、および `ODDS_*_HEAD` テーブルで
-`HappyoTime` が `TIMESTAMP` の場合、起動時検証は型不一致として停止します。
-月日を欠いた旧値から公式8桁値を復元できないため、自動 `ALTER` や暗黙変換は
-行いません。DBをバックアップし、対象テーブルだけを退避または削除して現行の
-標準名スキーマ（`VARCHAR(8)`）で再作成した後、JRA-VANの保持期間内のデータを
-再取得してください。既存値を時刻部分だけで移植しないでください。
-
-### TC（発走時刻変更）の現行契約
-
-`TC` は現行JV-Data 4.9.0.1 / SDK 5.0.0の45バイト配置だけを受け付けます。
-identityは `Year`, `MonthDay`, `JyoCD`, `Kaiji`, `Nichiji`, `RaceNum` の
-6項目です。native `NL_TC`、速報 `RT_TC`、JRA-VAN標準名
-`HASSOU_JIKOKU_CHANGE` は同じordered primary key、必須header/key/body、
-公式field capacityを使います。`HappyoTime` は `MMDDhhmm`、変更後・変更前の
-時刻は各 `HHmm` として先頭ゼロを保ったまま保存します。公式の初期値
-`00000000` / `0000` も欠損へ変換しません。
-
-現行の公式 `DataKubun` は `1` だけです。`0`をTC単体の削除指示として扱いません。
-`0B14` は指定日の完全な開催変更snapshotなので、正常終了を確認した同一transaction
-内で当該日の `RT_WE` / `RT_AV` / `RT_JC` / `RT_TC` / `RT_CC` を置換し、後続snapshot
-から消えた変更を除去します。`0B16` は指定イベントの更新であり、この日単位置換とは
-別です。
-
-既存のnullable、keyless、wrong-key、wrong-type、容量不足、generated/identity列、
-追加列または追加UNIQUE/FK/CHECKを持つTC tableは自動修復せず、mutation前に
-停止します。DBを
-backupして該当TC tableをcurrent schemaでrebuildし、保持期間内の`0B14`/`0B16`
-または対応する蓄積sourceからreimportしてください。旧標準名`COMMENT`しかない構成を
-`HASSOU_JIKOKU_CHANGE`へ自動転用しません。
-
-### CC（コース変更）の現行契約
-
-`CC` は現行JV-Data 4.9.0.1 / SDK 5.0.0の50バイト配置だけを受け付けます。
-identityは `Year`, `MonthDay`, `JyoCD`, `Kaiji`, `Nichiji`, `RaceNum` の
-6項目です。native `NL_CC`、速報 `RT_CC`、JRA-VAN標準名 `COURSE_CHANGE`
-は同じordered primary keyと必須15列を使います。`HappyoTime` は
-`MMDDhhmm`、変更前後の距離は4桁、track codeは公式コード表2009の
-`00`, `10`〜`29`, `51`〜`59`、事由区分は初期値`0`または`1`〜`4`です。
-`00000000`、距離`0000`、track `00`、事由`0`は欠損へ変換しません。
-
-現行の公式 `DataKubun` は `1` だけで、CC単体のstatus 0 deleteはありません。
-`0B14`の正常完了後だけ上記の日単位snapshot置換を行い、後続snapshotから
-消えたCCを削除します。`0B16`はイベント指定更新なので日単位置換を行いません。
-開催中止決定前に発表済みのCCは、公式仕様どおり中止後も提供対象です。
-
-既存のnullable、keyless、wrong-key、wrong-type、容量不足、generated/identity列、
-追加列または追加UNIQUE/FK/CHECKを持つCC tableは、失われたidentityや値を安全に
-復元できないため自動修復しません。DBをbackupし、該当3表をcurrent schemaで
-rebuildして、保持期間内の`0B14`/`0B16`または対応する蓄積sourceから
-reimportしてください。
+速報保存を含む各入口が行う公式 `DataKubun` の検証（全 38 形式の base domain
+表と速報での差分）、`0B14` の日単位 snapshot 置換と `0B16` の関係、
+`HappyoTime`（`MMDDhhmm`）の保存形式は、
+[レコード別の公式契約と移行手順](record_contracts.md) の共通規則
+（[公式 DataKubun の検証](record_contracts.md#datakubun)、
+[0B14 の日単位 snapshot 置換と 0B16](record_contracts.md#0b14-snapshot-0b16)、
+[HappyoTime の保存形式](record_contracts.md#happyotimemmddhhmm)）を
+参照してください。
 
 ## JVRTOpen オッズ・票数
 
@@ -274,377 +156,51 @@ jrvltsql は現在、以下 38 種類の JRA レコード種別に対してパ�
 `TS_O1` / `TS_O2`、開催週速報オッズは `TS_SOKUHO_O1`〜`TS_SOKUHO_O6`
 に保存します。
 
-`HN`（繁殖馬マスタ）は現行JV-Data 4.9.0.1 / SDK 5.0.0の251バイト配置だけを
-受け付け、旧245バイト配置は拒否します。公式identityは10桁の
-`HansyokuNum`です。native `NL_HN`と標準名`HANSYOKU`は同じordered primary
-key、必須header/key/body、公式field capacityを使い、status 1/2をprovider順に
-同じ行へ反映します。`DataKubun=0`はこのkeyだけを使う物理exact eraseです。
-削除指示の非key本文をdecodeしない扱いはeraseを失わせないためのproject policyで、
-provider仕様が任意binary本文を規定するという意味ではありません。
-公式に空欄になり得る`BameiKana`・`BameiEng`・`SanchiName`は、両tableとも
-`NULL`ではなく空文字で保持します（他のtableの「空欄→`NULL`」規則の例外）。
-欠落した項目や`None`は検証で拒否され、`NULL`として保存されません。
+## レコード別の契約・移行手順（要点）
 
-既存のnullable、keyless、wrong-key、wrong-type、容量不足、generated/identity列、
-追加列または追加UNIQUE/FK/CHECKを持つ`NL_HN`/`HANSYOKU`は自動修復せず、
-mutation前に停止します。DBをbackupして両tableをcurrent schemaでrebuildし、
-保持中の`BLDN` sourceからreimportしてください。HNは蓄積系masterだけであり、
-`RT_HN`は作成しません。
+レコード種別ごとの公式レイアウト、identity（主キー）、保存先、`DataKubun`、
+既存 DB からの移行手順の全文は
+[レコード別の公式契約と移行手順](record_contracts.md) にあります。
+ここでは要点だけを 1 行にまとめます。
 
-`HC`（坂路調教）は現行JV-Data 4.9.0.1 / SDK 5.0.0の60バイト配置だけを
-受け付けます。identityは`TresenKubun`, `ChokyoDate`, `ChokyoTime`,
-`KettoNum`の4項目です。native `NL_HC`と標準名`HANRO`は同じordered primary
-key、必須header/key/body、公式field capacityを使用し、7つの走破・lap timeを
-0.1秒単位のprovider整数から秒へ正規化します。公式の測定不能値`0000`/`000`は
-0.0秒として欠損と混同せず保持します。
+共通規則（同ページ）:
 
-`DataKubun=0`は4項目keyだけを使うexact eraseです。非key本文をdecodeしないのは
-削除指示を失わせないためのproject policyであり、provider仕様が任意binary本文を
-規定するという意味ではありません。既存のnullable、keyless、wrong-key、wrong-type、
-追加列または追加UNIQUE/FK/CHECKを持つ`NL_HC`/`HANRO`は自動修復せず、
-mutation前に停止します。
-backup後にcurrent schemaでrebuildし、`SLOP`を再importしてください。HCは蓄積系のみで
-`RT_HC`は作成しません。美浦の測定距離は2004-11-30に600mから800mへ変わりましたが、
-物理record長と4項目identityは変わりません。
+| 項目 | 要点 | 詳細 |
+| --- | --- | --- |
+| 公式 `DataKubun` の検証 | 全 38 形式の base domain 表。値が無い・空欄・1文字でない・別名が食い違う・表に無いレコードは table routing、cache 書き込み、DB 更新より前に拒否。未指定値を `1` で補わない | [公式 DataKubun の検証](record_contracts.md#datakubun) |
+| 通常インポートの transaction / rollback | streaming 処理。`auto_commit=True` は batch ごとに commit、`auto_commit=False` は呼び出し全体を all-or-nothing。transaction 状態を取得できない場合は接続を無効化して `TransactionRecoveryError` | [通常インポートの transaction / rollback 規約](record_contracts.md#transaction-rollback) |
+| 速報 grouped batch と時系列 CLI | caller 側 transaction を勝手に commit しない。DB 書込が 1 件でも失敗すれば grouped mutation 全体を rollback して `inserted=0`, `transaction_rolled_back=true` | [速報 grouped batch と時系列 CLI の transaction 境界](record_contracts.md#grouped-batch-cli-transaction) |
+| `HappyoTime`（`MMDDhhmm`） | 年を含まない 8 バイト文字列として保存し、`TIME` / `TIMESTAMP` に変換しない。旧 `TIMESTAMP` 列の標準名テーブルは起動時検証で停止 | [HappyoTime の保存形式](record_contracts.md#happyotimemmddhhmm) |
+| `0B14` / `0B16` | `0B14` は指定日の完全 snapshot として、正常終了を確認した同一 transaction 内で `RT_WE`/`RT_AV`/`RT_JC`/`RT_TC`/`RT_CC` を置換。`0B16` はイベント指定更新で日単位置換とは別 | [0B14 の日単位 snapshot 置換と 0B16](record_contracts.md#0b14-snapshot-0b16) |
+| 既存 DB からの移行 | バックアップ → 対象テーブルだけ現行 schema で再作成 → 保持期間内の source から再取込 / 再取得。停止条件に当たる既存テーブルは自動修復せず停止 | [既存 DB からの移行の共通手順](record_contracts.md#db) |
+| 旧仕様 dataspec 名 | `DIFF` / `BLOD` / `SNAP` / `HOSE` / `TCOV` / `RCOV` は受け付けず、`fetch` / `cache build` / `cache rebuild` は現行種別名を示して停止 | [旧仕様 dataspec 名](record_contracts.md#dataspec-diff-blod-snap-hose-tcov-rcov) |
 
-`HS`（競走馬市場取引価格）は現行JV-Data 4.9.0.1 / SDK 5.0.0の
-200バイト配置だけを受け付け、旧196バイト配置は常に拒否します。公式の保存identityは
-`KettoNum`, `SaleCode`, `FromDate`の3項目です。native `NL_HS`と標準名`SALE`は
-同じordered primary key、必須header/key、公式field capacityを使います。
-`DataKubun=0`はこのkeyだけを使うexact eraseです。非key本文をdecodeしない扱いは
-exact eraseを失わせないためのproject policyであり、provider仕様が任意binary本文を
-規定しているという意味ではありません。
+レコード別:
 
-現行parserまたは同等のcaller validationを通った行には
-`CurrentLayoutVersion=200`を保存します。v2以前の`NL_HS`/`SALE`は、空tableも含めて
-父母繁殖登録番号の値長などから世代を推測して自動移行しません。backup後にtableを
-rebuildし、現行200バイトsourceからreimportしてください。唯一の加算移行対象は、
-現行schemaと既存列が完全に互換で、行が空であり、native `NL_HS`の
-`CurrentLayoutVersion`/`RecordDelimiter`だけが欠ける場合です。現行10バイトの
-`HansyokuFNum`/`HansyokuMNum`欄には8桁値＋space paddingも正当に存在するため、
-strip後の8文字は旧世代判定の根拠になりません。過去recordの`Barei`は公式setupで
-2001年以降の算出方法へ統一済みであり、`MakeDate`から再解釈しません。一方、
-`SaleName`はproviderが保持する当時表記をそのまま保存します。HSは蓄積系のみで、`RT_HS`は作成せず、
-realtime入口へ渡されたHSはDBとlocal realtime cacheの両方を変更せず拒否します。
-`auto_commit=False`の同一呼出しで後続HSが検証失敗した場合は、先行する未確定行と
-その統計をrollbackします。`auto_commit=True`では既に確定したprovider operationを
-残すincremental semanticsであり、失敗した後続recordを成功件数へ加えません。
-
-`HR`（払戻）はJV-Data 4.8.0.2 / 4.9.0.1とSDK 5.0.0の719バイト配置へ
-結び付けています。公式キーは`Year`, `MonthDay`, `JyoCD`, `Kaiji`, `Nichiji`,
-`RaceNum`の6項目、現行データ区分は`0`, `1`, `2`, `9`です。`9`は中止状態として
-保持し、削除には使いません。公式仕様は`9`の本文値を確定していないため、raw由来の
-位置28〜717は`OpaqueStatus9Body28_717Hex`へhexで保持し、通常の払戻列へは意味変換
-しません。caller-builtの`9`はキーと状態だけを保存します。`0`だけが6項目の完全一致に
-よる物理削除で、本文は解釈しません。lossless保持というproject policyに従い、rawの
-`0`/`9`は位置28〜717をtext decodeせず、2004-08-14より前の通常recordは位置604〜717を
-decodeせずに扱います。header、6項目キー、およびそれ以外の解釈対象範囲は引き続き
-strict CP932検査を通します。
-
-単勝3、複勝5、枠連3、馬連3、ワイド7、予備3、馬単6、三連複3、三連単6の
-全repeatを保存します。native名は`NL_HR`/`RT_HR`、標準名モードは`HARAI`で、
-いずれも同じ順序の`NOT NULL`主キーを使います。標準名モードでも払戻・人気・
-予備をNULLへ落としません。予備3件は数値として意味付けせず、4/9/3バイトの各区画を
-文字列で保持します。不成立・特払・返還の3つの券種flag配列は、6件目が公式予備のため
-`0`だけを受け付けます。返還馬番28件、返還枠番8件、返還同枠8件は全要素が通常の
-返還対象flagであり、6件目も`0`または`1`を受け付けます。
-速報では着順確定前の人気が空欄になり得るため、空欄を
-正常値として扱います。この挙動は公式スタッフの
-[説明](https://developer.jra-van.jp/t/topic/304)と一致します。provider flagを
-理由に本文を間引かず、公式固定配置の各値を独立して保存します。
-
-公式変更履歴の2004-03-02の記録はレコード長を変えず、位置604〜717の予備領域を
-三連単関連へ転用しています。別の公式特記事項が示す三連単発売開始日
-2004-08-14より前のraceでは、この114バイトを
-三連単として解釈せず`LegacyReserved604_717Hex`へhexでlossless保持し、canonical
-三連単列はNULLにします。境界は訂正・再提供日になり得る`MakeDate`ではなく
-`Year`+`MonthDay`のrace dateで判定します。これにより旧予備値を推測せず、変更前と
-変更後を同じ719バイトenvelopeで区別します。
-
-旧nullable key、主キーなし、予備2・3件目の列欠落、予備列の数値型、型・容量不一致、追加の
-`UNIQUE`/exclusion、PostgreSQLのdeferrable主キーがある表は、取込や他表のadditive
-migrationより前に停止します。欠けた旧払戻を既存行から復元できないため、自動ALTERで
-完全扱いにせず、DBをバックアップして`NL_HR`/`RT_HR`/`HARAI`を現行DDLで再作成し、
-保持範囲に合う`RACE` sourceを再取込してください。
-
-`SE`（馬毎レース情報）はJV-Data 4.8.0.2 / 4.9.0.1とSDK 5.0.0の
-現行555バイト配置だけを受け付けます。2003-04-22より前の547バイト配置は、
-変更履歴から追加された8バイトは分かっても旧レイアウト全体を復元できないため、
-推測で解釈せず明示的に拒否します。現行の公式キーは`Year`, `MonthDay`,
-`JyoCD`, `Kaiji`, `Nichiji`, `RaceNum`, `Umaban`, `KettoNum`の8項目です。
-nativeの`NL_SE`/`RT_SE`と標準名モードの`UMA_RACE`はこの順序の`NOT NULL`
-主キーを使い、`DataKubun=0`は8項目が完全に一致する1頭だけを削除します。
-
-旧7項目キーまたは主キーなしの表、キー型の不一致、追加の`UNIQUE`/exclusion、
-PostgreSQLのdeferrable主キーは取込や他表のadditive migrationより前に拒否します。
-自動で主キーを作り替えず、DBをバックアップして対象表を現行schemaで再作成し、
-`RACE`から再取込してください。正しい8項目キーを持つ表への非キー列の安全な
-additive migrationは維持します。標準名モードでは4つの予約領域も
-`reserved1`〜`reserved4`へ保持します。馬体重と増減はkgの整数であり、nativeでも
-508kg/+3kgを508/3として保存します。status Aでは公式availabilityに従い、
-本賞金0円は実値0、付加賞金の初期値0はNULLとして区別します。この賞金の根拠は
-公式フォーマット表の本賞金・付加賞金行です。騎手見習や着差など、別のA/B項目で
-実データに合わせてavailability表が訂正された背景は、公式スタッフの
-[回答](https://developer.jra-van.jp/t/topic/61)を参照してください。
-
-`WE`（天候・馬場状態変更）はJV-Data 4.8.0.2 / 4.9.0.1とSDK 5.0.0で
-同一の42バイト配置です。公式キーは`Year`, `MonthDay`, `JyoCD`, `Kaiji`,
-`Nichiji`, `HappyoTime`, `HenkoID`の7項目で、`HappyoTime=00000000`の
-初期発表と、その後の複数発表時刻を別行として保持します。最新状態を読む場合は
-`HenkoID`の大小ではなく最新の`HappyoTime`を選びます。この運用は公式スタッフの
-[説明](https://developer.jra-van.jp/t/topic/331)および複数時刻が共存する
-[事例](https://developer.jra-van.jp/t/topic/164)・
-[事例](https://developer.jra-van.jp/t/topic/141)とも一致します。
-
-現行のデータ区分は`1`です。2003-07-11より前の`MakeDate`でだけ旧区分`0`を
-受け付け、7項目が完全一致する1発表を物理削除します。削除レコードの6つの
-天候・芝・ダート本文値は解釈しませんが、キーに含まれる`HenkoID`は必須です。
-通常行は変更識別`1`〜`3`、天候`0`〜`6`、芝・ダート`0`〜`4`を検証し、
-変更識別`2`では馬場4項目、`3`では天候2項目が公式初期値`0`であることを
-確認します。これを超える状態間の推測規則は適用しません。
-
-nativeの`NL_WE`/`RT_WE`と標準名モードの`TENKO_BABA`は同じ順序の
-`NOT NULL`主キーを使います。公式幅を保てる非paddingの文字列型と、公式幅ちょうどの
-`CHAR`はlossless storageとして許容します。通常行で必須の6つの本文コードは、
-既存表側の`NOT NULL`も安全です。旧6項目キー、主キーなし、容量不足・数値化など
-losslessでないキー型、キーのNULL許容、追加の`UNIQUE`/exclusion、PostgreSQLの
-遅延主キーがある既存表は、取込や他表のadditive migrationより前に停止します。
-時刻別履歴や重複行から正しいキーを
-自動復元できないため、自動ALTERは行いません。DBをバックアップし、対象表を
-現行DDLで再作成して、保持範囲に合う公式42バイトWE sourceを再取込してください。
-`0B14`の新しい応答が前回の日付snapshotを置換する既存の一括更新契約は維持し、
-1応答内では上記7項目キーで各発表を保持します。
-
-`AV`（出走取消・競走除外）はJV-Data 4.8.0.2 / 4.9.0.1とSDK 5.0.0で
-同一の78バイト配置です。公式キーは`Year`, `MonthDay`, `JyoCD`, `Kaiji`,
-`Nichiji`, `RaceNum`, `Umaban`の7項目であり、`HappyoTime`は発表情報として
-保存しますがキーではありません。同一馬の後続発表は同じ行を更新します。
-現行のデータ区分は`1=出走取消`と`2=競走除外`です。2003-07-11より前の
-`MakeDate`でだけ旧区分`0`を受け付け、7項目が完全に一致する行を物理削除します。
-旧削除レコードでは発表時刻・馬名・事由の本文を解釈しません。
-
-事由区分はblankと`000`〜`003`を受け付けます。2021-01-25の仕様変更は
-初期値表記を`000`からspaceへ変えた同長変更であり、履歴データのprovenanceが
-不明な場合にどちらかを過剰拒否しません。nativeの`NL_AV`/`RT_AV`と標準名
-モードの`TORIKESI_JYOGAI`は同じ順序の`NOT NULL`主キーを使います。旧nullable
-key、主キーなし・誤順序、losslessでない型や容量、追加の`UNIQUE`/exclusion、
-PostgreSQLの遅延主キーを持つ既存表はmutation前に停止します。自動的なPK変更は
-行わないため、DBをバックアップし、対象表だけを現行DDLで再作成して保持範囲内を
-再取込してください。NULLまたは不完全なidentityを持つ旧行は正しい7項目キーへ
-安全にbackfillできないため、バックアップには残しても現行表へ再利用せず、公式provider
-から再取得してください。旧標準名`AVOIDENCE`だけが存在する構成も、自動移行や別表への
-誤保存を行わず、すべてのDB targetを変更前に停止します。標準名は
-`TORIKESI_JYOGAI`へ再作成してください。
-
-`0B14`は開催日単位の完全な現行snapshotです。現行の取消が撤回された場合は
-status `0`が届くのではなく、次のsnapshotからAV行が消えるため、同一transactionで
-その日の`RT_AV`を置換します。個別イベントは`0B16`/`JVWatchEvent`で受けられる
-という公式サポートの[説明](https://developer.jra-van.jp/t/topic/195)があります。
-
-`JC`（騎手変更）はJV-Data 4.8.0.2 / 4.9.0.1とSDK 5.0.0で同一の
-161バイト配置です。公式キーは`Year`, `MonthDay`, `JyoCD`, `Kaiji`,
-`Nichiji`, `RaceNum`, `HappyoTime`, `Umaban`の8項目です。同一馬について
-「未定」の発表と確定後の発表など複数時刻が存在し得るため、発表月日時分を省いた
-最新1行への上書きは行いません。nativeの`NL_JC`/`RT_JC`と標準名モードの
-`KISYU_CHANGE`は、同じ順序の`NOT NULL`主キーで再取込を冪等にします。
-
-現行のデータ区分は`1`です。2003-07-11より前の`MakeDate`に限って旧区分`0`を
-受け付け、8項目が完全一致する1発表だけを物理削除します。削除本文は解釈しません。
-現在の取消・訂正を旧区分`0`で合成せず、`0B14`の日付単位完全snapshotが前回応答を
-置換する既存契約を使用します。速報更新は
-[公式スタッフの説明](https://developer.jra-van.jp/t/topic/331)で確認でき、
-複数発表時刻は
-[コミュニティで報告された実例](https://developer.jra-van.jp/t/topic/164)でも確認できます。
-
-負担重量は提供値が0.1kg単位なので、native/速報の`REAL`列では`550`を
-`55.0`kgへ正規化します。標準名モードの`VARCHAR(3)`は公式3バイト表現`550`を
-そのまま保持します。旧7項目キー、主キーなし、キーのNULL許容、容量不足や誤型、
-追加の`UNIQUE`/exclusion、PostgreSQLの遅延主キーを持つ既存表は、取込または
-他表のschema変更より前に拒否します。発表履歴や重複行から正しい8項目identityを
-自動復元できないため、DBをバックアップし、該当する`NL_JC`/`RT_JC`/
-`KISYU_CHANGE`だけを現行DDLで再作成して保持期間内の`0B14`/`0B16`または
-対応する蓄積データから再取込してください。
-
-`CS`（コース情報）はJV-Data 4.8.0.2 / 4.9.0.1とSDK 5.0.0で同一の
-6,829バイト配置です。公式キーは競馬場コード・距離・トラックコード・
-コース改修年月日（改修後に最初に開催された日）の4項目で、6,800バイトの
-`CourseEx`をnative `NL_CS`と標準名モード`COURSE`の両方へ保存します。
-競馬場コードとトラックコードは公式コード表2001/2009の有効値に限定し、
-未定義・未使用コードや物理幅を超える本文は取込前に拒否します。
-`DataKubun=2`は行だけでなく別途取得したコース図も更新される場合があるため、
-`JVCourseFile`/`JVCourseFile2`の結果を独自保存する利用者は図も更新してください。
-旧jrvltsqlの3項目主キー`NL_CS`、主キーなしの`COURSE`、本文列がないまま
-既存行を持つ`COURSE`、追加の一意制約を持つ表は、別改修日の履歴消失・本文欠損・
-再取込重複を避けるため取込前に拒否します。正しい4項目主キーを持つ空の`COURSE`
-だけは、欠けている列が`CourseEx`だけなら安全に追加します。それ以外は既存表を
-バックアップし、現行DDLで再作成して`COMM`を再取込してください。
-2009年の導入直後に仕様書の誤記訂正履歴はありますが、根拠のない旧binary layoutは
-受け付けません。また、2023年には異常長のCSデータが配信され、
-[公式サポートが不備を認めて再提供した事例](https://developer.jra-van.jp/t/topic/237)が
-あるため、6,829バイト以外を推測補正せず拒否します。
-
-`WC`はJV-Data 4.9.0.1とSDK 5.0.0の105バイト配置を使用し、10ハロンから
-1ハロンまでの合計・ラップを保存します。4.7.0.1で追記されたのは美浦・栗東の
-提供開始時期と計測距離の説明であり、別の物理レイアウトではありません。
-`Course`（コース）や馬場周りは公式キーではありません。旧版jrvltsqlが作成した
-`Course`入り・トレセン区分なしの主キーは自動修復せず、取込前に拒否します。
-`WOOD`はデータ種別名とSDK構造に対応させたjrvltsqlの標準名モード上の
-canonical table名であり、提供元がSQL DDLやテーブル名を規定しているという意味ではありません。
-4項目キーは[JRA-VANソフトサポートの回答](https://developer.jra-van.jp/t/topic/99)とも一致します。
-タイムが全桁9のデータは規定内として配信されるため、欠損へ置換せず数値sentinelとして保存します
-（[スタッフ回答](https://developer.jra-van.jp/t/topic/367)）。
-
-`KS`は公式4173バイトを1物理レコードとして扱い、nativeでは`NL_KS`と
-`NL_KS_SEISEKI`、JRA-VAN標準名モードでは`KISYU`と`KISYU_SEISEKI`へ
-原子的に保存します。旧772バイトの復元データは取得元レコードとして受け付けません。
-既存の標準名テーブルが主キー契約を満たさない場合は行を変更せず停止します。
-現行schemaで再作成した後、`DIFN`のoption 3/4で全件を再取得してください。
-
-`CH`は公式3862バイトを1物理レコードとして扱い、nativeでは`NL_CH`と
-`NL_CH_SEISEKI`、JRA-VAN標準名モードでは`CHOKYO`と`CHOKYO_SEISEKI`へ
-原子的に保存します。旧592バイトの復元データは取得元レコードとして受け付けません。
-旧標準名テーブルは主キーと文字列日付の契約を満たさないため、自動変換せず停止します。
-バックアップ後に両テーブルを現行schemaで再作成し、保持期間内の現行データを
-再取得してください。
-
-`UM`は公式1609バイトを扱い、血統登録番号`KettoNum`を10文字のまま保存します。
-native名モードの`NL_UM`とJRA-VAN標準名モードの`UMA`は、どちらもこの1列だけを
-主キーとして同じ登録馬の更新を置き換え、異なる登録馬を共存させます。現行の標準名
-`UMA`では、公式レコード内の27組×6着回数、4脚質、登録レース数も個別列へ
-欠落なく展開し、抹消年月日の`00000000`は8文字のまま保持します。`KettoNum`は
-正確な10桁ASCII数字だけを受け付けます。公式主キー以外の`UNIQUE`/exclusion制約や、
-PostgreSQLで`ON CONFLICT`に使えない遅延主キーがある既存テーブルも、行を置換して
-消失させるおそれがあるため変更前に拒否します。
-
-旧版が作成した
-標準名`UMA`は`KettoNum`列と主キーを欠いていたため、安全に既存行の識別子を復元できません。
-この旧テーブルまたは別の主キーを持つテーブルが存在する場合は、列追加や行更新より前に
-停止します。DBをバックアップし、対象`UMA`を現行schemaで再作成してから`DIFN`で
-競走馬マスタを再取得してください。
-
-`BT`は現行公式6,889バイトを扱い、10文字の`HansyokuNum`、`KeitoId`、
-`KeitoName`、最大6,800バイトの`KeitoEx`を保存します。native名モードの保存先は
-`NL_BT`、JRA-VAN標準名モードの保存先は公式名`KEITO`で、どちらも
-`HansyokuNum`を主キーに更新し、`DataKubun=0`では同じキーの行を物理削除します。
-旧名`BLOOD`は読み取り側の名前解決互換として残しますが、新規import先には使いません。
-標準名モードの開始時は既存の標準名テーブルを変更前に一括検証するため、再構築が必要な
-旧`KEITO`またはlegacy-only tableが残るDBでは、BT以外のimportもschema変更前に停止します。
-
-旧6,887バイトBTは8文字の繁殖登録番号を前提とするため、現行layoutとして受け付けません。
-主キーのない部分的な`KEITO`、10文字未満のkey列、6,800文字未満の説明列、または
-旧名`BLOOD`しか存在しない標準名DBは、欠落値を安全に復元できないため行やschemaを
-自動変更せず停止します。DBをバックアップして対象テーブルを現行schemaで再作成し、
-`BLDN`のoption 3/4で現行データを再取得してください。
-
-`JG`は現行公式80バイト（Ver.4.1.0で追加、Ver.4.1.1は血統登録番号の初期値を追記した
-のみでlayout不変）を扱い、`DataKubun`は公式どおり0/1のみ、出走区分・除外状態区分は
-公式コードのみを受け付けます。native名モードの保存先は`NL_JG`（互換名`Num`、
-`SyussoKubun`、`JyogaiStateKubun`）、JRA-VAN標準名モードの保存先はSDK構造体
-`JV_JG_JOGAIBA`から採ったproject canonical名`JOGAIBA`（`ShutsubaTohyoJun`、
-`ShussoKubun`、`JogaiJotaiKubun`）です。どちらも公式8列キー（開催キー6列＋
-`KettoNum`＋出馬投票受付順番）で更新するため、同一馬の再投票行は共存し、
-`DataKubun=0`では同じ8列キーの行だけを提供順に物理削除します。
-旧名`WEIGHT_CHANGE`は読み取り側の名前解決互換として残しますが、新規import先には
-使わず、`WEIGHT_CHANGE`しか存在しない標準名DBは行を変更せず停止します。
-旧7列キー（受付順番を含まない）の`NL_JG`/`JOGAIBA`や列の欠けた`JOGAIBA`は、
-再投票行を安全に復元できないため自動`ALTER`せず停止します。DBをバックアップして
-対象テーブルを現行schemaで再作成し、`RACE`で保持期間内の現行データを再取得してください。
-
-`WF`（重勝式・WIN5）は現行公式7,215バイト（JV-Data 4.8.0.2 / 4.9.0.1、SDK 5.0.0
-`JV_WF_INFO`）を1物理レコードとして扱い、公式キーは開催年・開催月日の2列です。
-データ区分は蓄積系が0/1/2/3/7/9、速報系（`0B51`）が0/1/2/3/9で、それ以外は取り込み前に
-拒否します。対象5レースの競馬場・回・日・レース番号、発売票数、有効票数5件、返還・不成立・
-的中無フラグ、キャリーオーバー金額初期・残高、払戻情報243枠を全て保存します。
-対象レースの競馬場は同版の公式コード表2001に掲載された値から初期値・未使用値を除いたコードを検証し、
-廃止済みの競馬場・国を含むため現在使用中の会場一覧とは扱いません。初期値`00`、
-使用しないと明記されたコード、未掲載コード、小文字表記は受け付けません。公式コードが追加された
-場合は、固定した仕様manifestと検証集合を同じ変更で更新する必要があります。
-値の有無は公式の状態別規定に従い、`1`（詳細発表時）は発売票数・有効票数・残高・払戻が初期値、
-`2`/`9`はこれらの値が設定される場合とされない場合が混在し、`3`/`7`では必須として検証します。
-各フラグは未設定時の公式初期値も`0`なので、非削除レコードでは常に`0`か`1`です。予備領域も
-公式初期値`00`/`000000`だけを受け付けます。払戻枠は空欄か
-組番・払戻金・的中票数の揃った組だけを受け付けます。キャリーオーバー金額初期はVer.4.2.0
-（2012年2月21日）以降に作成されたデータでは全状態で必須です。それ以前は`1`で空欄のみ、
-`2`/`9`で空欄または数値を許容します。
-払戻が確定する`3`/`7`で的中無フラグが`1`の場合は、組番を保持したうえで払戻金
-`000000000`・的中票数`0000000000`の公式表現だけを受け付けます。中止状態`9`は下記の
-中止用払戻が優先されるため、この的中無規則を一律には適用しません。
-Ver.4.1.1とVer.4.2.0はいずれも項目名・初期値・設定有無の変更であり、別の物理レイアウトでは
-ありません。旧jrvltsqlの169バイト復元データは取得元レコードとして受け付けません。
-
-native名モードの保存先は`NL_WF`/`RT_WF`（1レコード1行、払戻243枠は`PayoutsJson`）、
-JRA-VAN標準名モードの保存先はproject canonical名`JYUSYOSIKI_HEAD`（ヘッダー、
-主キー開催年・開催月日）と子テーブル`JYUSYOSIKI`（払戻243枠を`Num`=1〜243の行として
-空欄枠も保存、主キー開催年・開催月日・`Num`、親への複合外部キー`ON DELETE CASCADE`）です。
-1物理レコードにつきヘッダー1行と子243行を提供順にtransactionで置き換え、`DataKubun=0`は
-同じキーの親子を物理削除し、`9`（中止）は払戻が設定される場合に公式の中止用払戻組
-（組番`0000000000`・払戻金`000000100`・的中票数`0000000000`）ごと状態として保持します。
-`DataKubun=0`ではheaderと公式キーだけを解釈し、仕様が定義しないbody値やbody aliasの差を
-削除拒否の根拠にしません。native・標準名・速報の各WF書込はbatch途中のDB例外で全体を
-rollbackし、行単位fallbackによる部分成功や、rollbackされた操作を成功件数へ残すことを許しません。
-`inserted`は最終行数ではなく、提供順に正常適用された操作数です。
-速報の通常grouped batchも、SQLite/psycopgが暗黙に開始したcaller側transactionを所有済みとして
-扱い、成功時に勝手にcommitしません。DB書込が1件でも失敗した場合は同じcallのgrouped mutationを
-全てrollbackして`inserted=0`と`transaction_rolled_back=true`を返し、後続rollbackで消える行を
-部分成功として数えません。削除を含む提供順処理も同じatomic境界を使います。false結果を受け取った
-callerは、validation-only拒否かDB rollback済みかにかかわらず、その取込単位を必ず中断してください。
-psycopgではSELECTだけでもtransactionが開始されるため、独立した取込単位へ移るcallerは明示的に
-commitまたはrollbackして境界を閉じてください。transaction状態を判定できない場合は書込前に失敗します。
-batch開始時にcaller側transactionが無かった場合、schema/catalog検証のSELECTが暗黙に開始した
-transactionはvalidation-only拒否時にもrollbackして閉じます。開始時からcaller側transactionが
-存在した場合は、validation-only拒否だけではそのtransactionをcommit/rollbackしません。
-時系列取得CLIは保存先table作成を先にcommitしてbatchごとの境界を分離し、1batchでも拒否された場合は
-`[OK]`を出さず非0終了します。
-`WIN5`は読み取り側の名前解決互換用のaliasであり、新規import先には使いません。
-主キーや`HatubaiHyosu`のない旧`JYUSYOSIKI_HEAD`、`Num`・主キー・外部キーのない旧`JYUSYOSIKI`、
-親子の片方だけが存在するDB、`WIN5`しか存在しない標準名DBは自動`ALTER`せず、
-行やschemaを変更する前に停止します。DBをバックアップして両テーブルを現行schema
-（親を先に作成）で再作成し、`RACE`で保持期間内の現行データを再取得してください。
-WF保存先は全列の型・文字容量と主キーを取込前に検証します。PostgreSQLの主キーは
-`ON CONFLICT`で使用できるvalid・ready・即時・非deferrableでなければならず、公式キー以外の
-追加`UNIQUE`/排他制約も、置換時に別開催を消し得るため拒否します。検索用の非一意indexは
-保持できます。
-
-`CK`は現行公式6,870バイトの1,729 scalar leafを扱います。PostgreSQLの
-1テーブル列数上限を超えないよう、native名モードでは互換親`NL_CK`と
-`NL_CK_CHAKU` 278行、`NL_CK_RUIKEI` 8行を1物理レコード単位のtransactionで
-更新します。`DataKubun=0`は7列の公式キーで親子を削除します。旧6,864バイトは
-現行offsetと混同せず拒否します。
-
-既存`NL_CK`には完全展開していない行があるため、追加される
-`CKStorageVersion`が`NULL`の行を完全格納済みと扱ってはいけません。現行`SNPN`を
-再取得して`CKStorageVersion=1`、子行数278/8をキーごとに確認してください。
-CKのJRA-VAN標準名モードはまだ実装しておらず、`CHOKYO_DETAIL`へ誤って部分保存せず
-明示的に停止します。
-
-`DM`は公式303バイトの18頭配列を扱います。native名モードでは`NL_DM`/`RT_DM`へ
-馬ごとの行として保存し、JRA-VAN標準名モードでは`MINING`へ1レース1行のwide形式で
-保存します。`DMTime`は公式SDKと同じ5桁文字列（9分99秒99）を保持します。
-旧48バイト復元データ、旧標準名`DATA_MASTER`、主キーのない`MINING`、数値型の
-`DMTime1`〜`DMTime18`は安全に自動変換できないため、取り込みを停止して再構築を求めます。
-
-`TM`は公式141バイトの18頭配列を扱います。native名モードでは`NL_TM`/`RT_TM`へ
-馬ごとの行として保存し、JRA-VAN標準名モードでは`TAISENGATA_MINING`へ
-1レース1行のwide形式で保存します。`TMScore`は公式SDKと同じ4桁文字列を保持し、
-右端1桁が小数第一位です。旧39バイト復元データ、旧標準名`TIME_MASTER`、主キーのない
-`TAISENGATA_MINING`、`TMScore`が整数型の旧nativeテーブルは安全に自動変換できないため、
-取り込みを停止して再構築を求めます。
-速報の非削除DM/TMは、1物理レコードから展開された同一種別・同一`DataKubun`の
-1〜18頭を完全なlistとして渡す必要があります。共通metadata、展開index、馬番
-（`01`〜`18`、重複なし）、metadata内と展開後の正規化済み各行内容が完全一致しないlist、
-または19頭以上はDBへ到達する前に拒否します。`process_parsed_record`へ渡すlistは1物理
-スナップショットだけを表し、他種別との混在を拒否します。非削除の1行dictを完全snapshotとは
-扱いません。
-`DataKubun=0`だけはmetadataを持たない単一の削除レコードとして受け付けます。
-`process_parsed_records_batch`は、先頭行の展開indexとmetadata件数で複数のDM/TM物理
-スナップショットを分割し、間にある削除や他種別レコードも提供順の1 transactionで処理します。
-途中の不完全な展開、metadataの無い非削除行、または1操作でもDB書込に失敗したbatchは、
-先行操作も含めて全てrollbackし、`inserted=0`を返します。成功時の`inserted`は最終行数ではなく、
-提供順に正常適用した展開行と隣接レコードの操作数です。
-DM/TMのnative速報スナップショット置換は、既存レース行の削除後に書込が失敗した場合、caller所有を
-含むactive transaction全体をrollbackします。rollback不能時は接続を無効化し、それも失敗した場合は
-batch・optimized・single・速報の全入口から`TransactionRecoveryError`を送出し、通常の失敗結果へ
-変換しません。
+| レコード種別 | 要点 | 詳細 |
+| --- | --- | --- |
+| `WH` | 公式 format 101 の 847 バイト。`NL_WH` / `RT_WH` は 18 頭配列を馬ごとの行へ展開（主キー: レース識別子＋馬番）、標準名 `BATAIJYU` は 18 頭横持ちの 1 行。旧 `NL_WH` / `RT_WH`（主キー不一致で起動時に停止）と旧 `BATAIJYU` はオペレーター移行が必要 | [WH](record_contracts.md#wh) |
+| `WE` | 42 バイト。`HappyoTime`, `HenkoID` を含む 7 項目キーで複数発表を別行保持。現行 `1`、旧 `0` は 2003-07-11 より前の `MakeDate` だけ | [WE](record_contracts.md#we) |
+| `AV` | 78 バイト。7 項目キー（`HappyoTime` はキーでない）。現行 `1`=出走取消、`2`=競走除外。旧標準名 `AVOIDENCE` だけの構成は停止 | [AV](record_contracts.md#av) |
+| `JC` | 161 バイト。`HappyoTime` を含む 8 項目キー。負担重量は native / 速報の `REAL` 列で `550` を `55.0`kg へ正規化 | [JC](record_contracts.md#jc) |
+| `TC` | 45 バイト。6 項目キー。現行 `1` だけで、`0` を TC 単体の削除指示として扱わない。旧標準名 `COMMENT` は自動転用しない | [TC](record_contracts.md#tc) |
+| `CC` | 50 バイト。6 項目キーと必須 15 列。現行 `1` だけで、CC 単体の status 0 delete はない | [CC](record_contracts.md#cc) |
+| `HR` | 719 バイト。6 項目キー。`0` だけが物理削除、`9` は中止状態として保持。2004-08-14 より前の race は位置 604〜717 を hex 保持 | [HR](record_contracts.md#hr) |
+| `SE` | 現行 555 バイト（547 バイトは拒否）。8 項目キー。`0` は 8 項目一致の 1 頭だけ削除 | [SE](record_contracts.md#se) |
+| `JG` | 80 バイト。受付順番を含む 8 列キーで再投票行を共存。`DataKubun` は 0/1 のみ | [JG](record_contracts.md#jg) |
+| `WF` | 7,215 バイト。キーは開催年・開催月日。native は 1 行（`PayoutsJson`）、標準名は `JYUSYOSIKI_HEAD`＋子 `JYUSYOSIKI` 243 行。蓄積系 0/1/2/3/7/9、速報 0/1/2/3/9 | [WF](record_contracts.md#wf-win5) |
+| `HN` | 251 バイト（245 は拒否）。キー `HansyokuNum`。`0` は key だけの exact erase。`RT_HN` なし | [HN](record_contracts.md#hn) |
+| `UM` | 1609 バイト。キー `KettoNum`（10 桁）。旧標準名 `UMA`（`KettoNum` 列と主キーなし）は停止 | [UM](record_contracts.md#um) |
+| `BT` | 6,889 バイト（6,887 は拒否）。キー `HansyokuNum`。標準名 `KEITO`、旧名 `BLOOD` は読み取り互換のみ | [BT](record_contracts.md#bt) |
+| `KS` | 4173 バイト（772 は拒否）。`NL_KS`＋`NL_KS_SEISEKI` / `KISYU`＋`KISYU_SEISEKI` へ原子的に保存 | [KS](record_contracts.md#ks) |
+| `CH` | 3862 バイト（592 は拒否）。`NL_CH`＋`NL_CH_SEISEKI` / `CHOKYO`＋`CHOKYO_SEISEKI` へ原子的に保存 | [CH](record_contracts.md#ch) |
+| `HS` | 200 バイト（196 は拒否）。3 項目キー。`CurrentLayoutVersion=200`。`RT_HS` なし | [HS](record_contracts.md#hs) |
+| `HC` | 60 バイト。4 項目キー。`0` は key だけの exact erase。`RT_HC` なし | [HC](record_contracts.md#hc) |
+| `WC` | 105 バイト。4 項目キー（`Course` はキーでない）。標準名 `WOOD` | [WC](record_contracts.md#wc) |
+| `CS` | 6,829 バイト（`CourseEx` 6,800）。4 項目キー。6,829 バイト以外は拒否 | [CS](record_contracts.md#cs) |
+| `CK` | 6,870 バイト（6,864 は拒否）。親 `NL_CK`＋`NL_CK_CHAKU` 278 行＋`NL_CK_RUIKEI` 8 行。標準名モードは未実装で停止 | [CK](record_contracts.md#ck) |
+| `DM` | 303 バイト・18 頭配列。native は馬ごとの行、標準名 `MINING` は 1 レース 1 行 | [DM](record_contracts.md#dm) |
+| `TM` | 141 バイト・18 頭配列。native は馬ごとの行、標準名 `TAISENGATA_MINING` は 1 レース 1 行 | [TM](record_contracts.md#tm) |
 
 ## 対象外
 
@@ -653,3 +209,4 @@ batch・optimized・single・速報の全入口から`TransactionRecoveryError`�
 | NAR / 地方競馬 | 非対応 | このリポジトリは JRA 専用です。地方競馬は別コレクタ / 別リポジトリの対象です。 |
 | ワイド・馬単・三連複・三連単の長期公式時系列 | JRA-VAN の長期公式 spec では取得不可 | 開催週に `0B30` または `0B33`〜`0B36` で蓄積する必要があります。 |
 | 投資判断スナップショット | 下流システム側の責務 | jrvltsql は raw / 確定 / 時系列データを保存します。投資判断時刻は保存済みデータから利用側が選びます。 |
+| 旧仕様 dataspec 名 `DIFF` / `BLOD` / `SNAP` / `HOSE` / `TCOV` / `RCOV` | jrvltsql では受け付けません | 旧名は新名の別名ではなく、現行のパーサが解釈できない旧仕様のバイト列が返るためです。[旧仕様 dataspec 名](record_contracts.md#dataspec-diff-blod-snap-hose-tcov-rcov) を参照してください。 |

--- a/docs/data_support.md
+++ b/docs/data_support.md
@@ -13,10 +13,21 @@ jrvltsql は JRA / 中央競馬専用です。NAR / 地方競馬はこのリポ�
 | 層 | 内容 | 場所 |
 | --- | --- | --- |
 | 1. 要約 | 「先に結論」の表。できること・できないことと使うコマンド | このページの「先に結論」（すぐ下） |
-| 2. 参照表 | 取得系統、JVOpen 蓄積系データ、JVRTOpen 速報、オッズ・票数、レコード種別→テーブル、対象外 | このページの各表 |
-| 3. 契約詳細 | レコード種別ごとの公式レイアウト・主キー・`DataKubun`・既存 DB からの移行手順、および共通の検証・transaction 規約 | [レコード別の公式契約と移行手順](record_contracts.md) |
+| 2. 参照表 | 取得系統 / JVOpen 蓄積系データ / JVRTOpen 速報レース・開催情報 / JVRTOpen オッズ・票数 / パーサー・テーブル対応 / 対象外 | このページの各表 |
+| 3. 契約詳細 | レコード種別ごとの公式レイアウト・主キー・`DataKubun`・既存 DB からの移行手順、および共通の検証・transaction 規約 | 要点はこのページの「レコード別の契約・移行手順（要点）」、全文は [レコード別の公式契約と移行手順](record_contracts.md) |
 
-### 表の見方
+## 先に結論
+
+| 知りたいこと | 結論 | 使うコマンド / 保存先 |
+| --- | --- | --- |
+| 出馬表、成績、払戻を保存できるか | できます。 | `quickstart.bat` または `quickstart_timeseries.bat`。主に `NL_RA`, `NL_SE`, `NL_HR` に保存します。 |
+| 確定オッズを保存できるか | 全賭式でできます。 | `RACE` 取得で `NL_O1`〜`NL_O6` に保存します。ただし投資判断時点のオッズではありません。 |
+| 過去1年分の時系列オッズをまとめて取れるか | 単複枠・馬連だけできます。 | `0B41` / `0B42` を `TS_O1` / `TS_O2` に保存します。SQLite でも PostgreSQL でも保存できます。 |
+| 三連複・三連単の締切前オッズを長期評価できるか | 開催週から蓄積していればできます。 | `0B30` または `0B35` / `0B36` を `TS_SOKUHO_O5` / `TS_SOKUHO_O6` に保存します。JRA-VAN 側の保持は約1週間です。 |
+| `daily_sync.bat` は SQLite / PostgreSQL の両方で使えるか | 使えます。 | `daily_sync.bat --db sqlite` または `daily_sync.bat --db postgresql` で通常データ、公式時系列、開催週速報を更新します。通常データだけにする場合は `--no-timeseries --no-realtime` を指定します。 |
+| NAR / 地方競馬も取れるか | このリポジトリでは取れません。 | JRA 専用です。 |
+
+## 表の見方
 
 | 表記 | 意味 |
 | --- | --- |
@@ -32,17 +43,6 @@ jrvltsql は JRA / 中央競馬専用です。NAR / 地方競馬はこのリポ�
 - `src/database/table_mappings.py`
 - `src/database/schema.py`
 - `src/cli/main.py`
-
-## 先に結論
-
-| 知りたいこと | 結論 | 使うコマンド / 保存先 |
-| --- | --- | --- |
-| 出馬表、成績、払戻を保存できるか | できます。 | `quickstart.bat` または `quickstart_timeseries.bat`。主に `NL_RA`, `NL_SE`, `NL_HR` に保存します。 |
-| 確定オッズを保存できるか | 全賭式でできます。 | `RACE` 取得で `NL_O1`〜`NL_O6` に保存します。ただし投資判断時点のオッズではありません。 |
-| 過去1年分の時系列オッズをまとめて取れるか | 単複枠・馬連だけできます。 | `0B41` / `0B42` を `TS_O1` / `TS_O2` に保存します。SQLite でも PostgreSQL でも保存できます。 |
-| 三連複・三連単の締切前オッズを長期評価できるか | 開催週から蓄積していればできます。 | `0B30` または `0B35` / `0B36` を `TS_SOKUHO_O5` / `TS_SOKUHO_O6` に保存します。JRA-VAN 側の保持は約1週間です。 |
-| `daily_sync.bat` は SQLite / PostgreSQL の両方で使えるか | 使えます。 | `daily_sync.bat --db sqlite` または `daily_sync.bat --db postgresql` で通常データ、公式時系列、開催週速報を更新します。通常データだけにする場合は `--no-timeseries --no-realtime` を指定します。 |
-| NAR / 地方競馬も取れるか | このリポジトリでは取れません。 | JRA 専用です。 |
 
 ## 取得系統
 
@@ -64,7 +64,7 @@ jrvltsql は JRA / 中央競馬専用です。NAR / 地方競馬はこのリポ�
 | `DIFN` | `DIFF` | 蓄積系マスタ差分 | `UM`, `KS`, `CH`, `BR`, `BN`, `RC` | `NL_UM`, `NL_KS`, `NL_KS_SEISEKI`, `NL_CH`, `NL_CH_SEISEKI`, `NL_BR`, `NL_BN`, `NL_RC` | はい | いいえ | はい | 旧名 `DIFF` は受け付けません（[旧仕様 dataspec 名](record_contracts.md#dataspec-diff-blod-snap-hose-tcov-rcov) 参照）。 |
 | `BLDN` | `BLOD` | 血統情報 | `HN`, `SK`, `BT` | `NL_HN`, `NL_SK`, `NL_BT` | はい | いいえ | はい | 旧名 `BLOD` は受け付けません（同上）。 |
 | `MING` | - | データマイニング予想 | `DM`, `TM` | `NL_DM`, `NL_TM` | はい | いいえ | はい | full quickstart に含めています。 |
-| `SLOP` | - | 坂路調教関連 | `HC` | `NL_HC`（native）、`HANRO`（標準名モード） | はい | いいえ | はい | 現行`DataKubun=1`は60バイトの全項目を保存します。`DataKubun=0`は本文を保存せず、公式4項目キーでexact deleteします。standard / full quickstart に含めています。 |
+| `SLOP` | - | 坂路調教関連 | `HC` | `NL_HC`（native）、`HANRO`（標準名モード） | はい | いいえ | はい | 現行`DataKubun=1`は60バイトの全項目を保存します。`DataKubun=0`は本文を保存せず、公式4項目キーでexact eraseします。standard / full quickstart に含めています。 |
 | `WOOD` | - | ウッドチップ調教関連 | `WC` | `NL_WC`（native）、`WOOD`（標準名モード） | はい | いいえ | はい | 現行105バイトを全項目保存します。公式キーはトレセン区分・調教年月日・調教時刻・血統登録番号の4項目で、`0` は同じキーの削除です。standard / full quickstart に含めています。 |
 | `YSCH` | - | 開催スケジュール | `YS` | `NL_YS` | はい | いいえ | はい | 開催カレンダー保守に使います。 |
 | `HOSN` | `HOSE` | 競走馬市場取引価格 | `HS` | `NL_HS` | はい | いいえ | はい | 旧名 `HOSE` は受け付けません（同上）。 |
@@ -97,20 +97,21 @@ jrvltsql は JRA / 中央競馬専用です。NAR / 地方競馬はこのリポ�
 | `0B17` | 速報対戦型データマイニング予想 | `TM` | `RT_TM` | `YYYYMMDD` | 対応済み |
 | `0B51` | 速報重勝式 WIN5 | `WF` | `RT_WF` | `YYYYMMDD` または WIN5 開催キー | 公式7,215-byte形式（対象5レース・有効票数5件・払戻243件）に対応。速報系のデータ区分は0/1/2/3/9で、蓄積系のみの7は受け付けません |
 
-速報保存を含む各入口が行う公式 `DataKubun` の検証（全 38 形式の base domain
-表と速報での差分）、`0B14` の日単位 snapshot 置換と `0B16` の関係、
-`HappyoTime`（`MMDDhhmm`）の保存形式は、
-[レコード別の公式契約と移行手順](record_contracts.md) の共通規則
-（[公式 DataKubun の検証](record_contracts.md#datakubun)、
-[0B14 の日単位 snapshot 置換と 0B16](record_contracts.md#0b14-snapshot-0b16)、
-[HappyoTime の保存形式](record_contracts.md#happyotimemmddhhmm)）を
-参照してください。
+この表に関わる共通規則は [レコード別の公式契約と移行手順](record_contracts.md)
+にあります。
+
+- 速報保存を含む各入口が行う公式 `DataKubun` の検証（全 38 形式の base domain
+  表と速報での差分）: [公式 DataKubun の検証](record_contracts.md#datakubun)
+- `0B14` の日単位 snapshot 置換と `0B16` の関係:
+  [0B14 の日単位 snapshot 置換と 0B16](record_contracts.md#0b14-snapshot-0b16)
+- `HappyoTime`（`MMDDhhmm`）の保存形式:
+  [HappyoTime の保存形式](record_contracts.md#happyotimemmddhhmm)
 
 ## JVRTOpen オッズ・票数
 
 | データ種別 | 内容 | 想定レコード種別 | 通常速報モードの保存先 | 時系列モードの保存先 | キー形式 | JRA-VAN 側の保持 | 運用コマンド |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| `0B20` | 速報票数 | `H1`, `H6` | `RT_H1`, `RT_H6` | 対象外 | `YYYYMMDDJJRR` | 約1週間 | パーサー・スキーマ対応。推奨 batch helper は未整備 |
+| `0B20` | 速報票数 | `H1`, `H6` | `RT_H1`, `RT_H6` | 対象外 | `YYYYMMDDJJRR` | 約1週間 | パーサー・スキーマのみ。推奨 batch helper は未整備 |
 | `0B30` | 全賭式の速報オッズ | `O1`〜`O6` | `RT_O1`〜`RT_O6` | `TS_SOKUHO_O1`〜`TS_SOKUHO_O6` | `YYYYMMDDJJRR` | 約1週間 | `jltsql realtime odds-sokuho-timeseries` |
 | `0B31` | 単勝・複勝・枠連の速報オッズ | `O1` | `RT_O1` | `TS_SOKUHO_O1` | `YYYYMMDDJJRR` | 約1週間 | `jltsql realtime timeseries --spec 0B31` |
 | `0B32` | 馬連の速報オッズ | `O2` | `RT_O2` | `TS_SOKUHO_O2` | `YYYYMMDDJJRR` | 約1週間 | `jltsql realtime timeseries --spec 0B32` |
@@ -169,13 +170,15 @@ jrvltsql は現在、以下 38 種類の JRA レコード種別に対してパ�
 | --- | --- | --- |
 | 公式 `DataKubun` の検証 | 全 38 形式の base domain 表。値が無い・空欄・1文字でない・別名が食い違う・表に無いレコードは table routing、cache 書き込み、DB 更新より前に拒否。未指定値を `1` で補わない | [公式 DataKubun の検証](record_contracts.md#datakubun) |
 | 通常インポートの transaction / rollback | streaming 処理。`auto_commit=True` は batch ごとに commit、`auto_commit=False` は呼び出し全体を all-or-nothing。transaction 状態を取得できない場合は接続を無効化して `TransactionRecoveryError` | [通常インポートの transaction / rollback 規約](record_contracts.md#transaction-rollback) |
-| 速報 grouped batch と時系列 CLI | caller 側 transaction を勝手に commit しない。DB 書込が 1 件でも失敗すれば grouped mutation 全体を rollback して `inserted=0`, `transaction_rolled_back=true` | [速報 grouped batch と時系列 CLI の transaction 境界](record_contracts.md#grouped-batch-cli-transaction) |
-| `HappyoTime`（`MMDDhhmm`） | 年を含まない 8 バイト文字列として保存し、`TIME` / `TIMESTAMP` に変換しない。旧 `TIMESTAMP` 列の標準名テーブルは起動時検証で停止 | [HappyoTime の保存形式](record_contracts.md#happyotimemmddhhmm) |
+| 速報 grouped batch と時系列 CLI | 成功時に caller 側 transaction を勝手に commit しない。DB 書込が 1 件でも失敗すれば grouped mutation 全体を rollback して `inserted=0`, `transaction_rolled_back=true` | [速報 grouped batch と時系列 CLI の transaction 境界](record_contracts.md#grouped-batch-cli-transaction) |
+| `HappyoTime`（`MMDDhhmm`） | 年を含まない 8 バイト文字列として保存し、`TIME` / `TIMESTAMP` に変換しない。旧版の速報開催情報標準名テーブル・`ODDS_*_HEAD` の `HappyoTime` が `TIMESTAMP` なら起動時検証で停止 | [HappyoTime の保存形式](record_contracts.md#happyotimemmddhhmm) |
 | `0B14` / `0B16` | `0B14` は指定日の完全 snapshot として、正常終了を確認した同一 transaction 内で `RT_WE`/`RT_AV`/`RT_JC`/`RT_TC`/`RT_CC` を置換。`0B16` はイベント指定更新で日単位置換とは別 | [0B14 の日単位 snapshot 置換と 0B16](record_contracts.md#0b14-snapshot-0b16) |
-| 既存 DB からの移行 | バックアップ → 対象テーブルだけ現行 schema で再作成 → 保持期間内の source から再取込 / 再取得。停止条件に当たる既存テーブルは自動修復せず停止 | [既存 DB からの移行の共通手順](record_contracts.md#db) |
+| 既存 DB からの移行 | バックアップ → 対象テーブルを現行 schema で再作成 → 各節の source から再取込 / 再取得。停止条件に当たる既存テーブルは自動修復せず停止 | [既存 DB からの移行の共通手順](record_contracts.md#db) |
 | 旧仕様 dataspec 名 | `DIFF` / `BLOD` / `SNAP` / `HOSE` / `TCOV` / `RCOV` は受け付けず、`fetch` / `cache build` / `cache rebuild` は現行種別名を示して停止 | [旧仕様 dataspec 名](record_contracts.md#dataspec-diff-blod-snap-hose-tcov-rcov) |
 
-レコード別:
+レコード別（グループ分けは詳細ページと同じ）:
+
+**[速報馬体重・開催情報系（WH / WE / AV / JC / TC / CC）](record_contracts.md#wh-we-av-jc-tc-cc)**
 
 | レコード種別 | 要点 | 詳細 |
 | --- | --- | --- |
@@ -183,21 +186,41 @@ jrvltsql は現在、以下 38 種類の JRA レコード種別に対してパ�
 | `WE` | 42 バイト。`HappyoTime`, `HenkoID` を含む 7 項目キーで複数発表を別行保持。現行 `1`、旧 `0` は 2003-07-11 より前の `MakeDate` だけ | [WE](record_contracts.md#we) |
 | `AV` | 78 バイト。7 項目キー（`HappyoTime` はキーでない）。現行 `1`=出走取消、`2`=競走除外。旧標準名 `AVOIDENCE` だけの構成は停止 | [AV](record_contracts.md#av) |
 | `JC` | 161 バイト。`HappyoTime` を含む 8 項目キー。負担重量は native / 速報の `REAL` 列で `550` を `55.0`kg へ正規化 | [JC](record_contracts.md#jc) |
-| `TC` | 45 バイト。6 項目キー。現行 `1` だけで、`0` を TC 単体の削除指示として扱わない。旧標準名 `COMMENT` は自動転用しない | [TC](record_contracts.md#tc) |
+| `TC` | 45 バイト。6 項目キー。現行 `1` だけで、`0` を TC 単体の削除指示として扱わない。旧標準名 `COMMENT` しかない構成を `HASSOU_JIKOKU_CHANGE` へ自動転用しない | [TC](record_contracts.md#tc) |
 | `CC` | 50 バイト。6 項目キーと必須 15 列。現行 `1` だけで、CC 単体の status 0 delete はない | [CC](record_contracts.md#cc) |
-| `HR` | 719 バイト。6 項目キー。`0` だけが物理削除、`9` は中止状態として保持。2004-08-14 より前の race は位置 604〜717 を hex 保持 | [HR](record_contracts.md#hr) |
+
+**[レース系（HR / SE / JG / WF）](record_contracts.md#hr-se-jg-wf)**
+
+| レコード種別 | 要点 | 詳細 |
+| --- | --- | --- |
+| `HR` | 719 バイト。6 項目キー。`0` だけが物理削除、`9` は中止状態として保持。2004-08-14 より前の通常 record は位置 604〜717 を hex 保持 | [HR](record_contracts.md#hr) |
 | `SE` | 現行 555 バイト（547 バイトは拒否）。8 項目キー。`0` は 8 項目一致の 1 頭だけ削除 | [SE](record_contracts.md#se) |
 | `JG` | 80 バイト。受付順番を含む 8 列キーで再投票行を共存。`DataKubun` は 0/1 のみ | [JG](record_contracts.md#jg) |
 | `WF` | 7,215 バイト。キーは開催年・開催月日。native は 1 行（`PayoutsJson`）、標準名は `JYUSYOSIKI_HEAD`＋子 `JYUSYOSIKI` 243 行。蓄積系 0/1/2/3/7/9、速報 0/1/2/3/9 | [WF](record_contracts.md#wf-win5) |
+
+**[マスタ系（HN / UM / BT / KS / CH / HS）](record_contracts.md#hn-um-bt-ks-ch-hs)**
+
+| レコード種別 | 要点 | 詳細 |
+| --- | --- | --- |
 | `HN` | 251 バイト（245 は拒否）。キー `HansyokuNum`。`0` は key だけの exact erase。`RT_HN` なし | [HN](record_contracts.md#hn) |
 | `UM` | 1609 バイト。キー `KettoNum`（10 桁）。旧標準名 `UMA`（`KettoNum` 列と主キーなし）は停止 | [UM](record_contracts.md#um) |
 | `BT` | 6,889 バイト（6,887 は拒否）。キー `HansyokuNum`。標準名 `KEITO`、旧名 `BLOOD` は読み取り互換のみ | [BT](record_contracts.md#bt) |
-| `KS` | 4173 バイト（772 は拒否）。`NL_KS`＋`NL_KS_SEISEKI` / `KISYU`＋`KISYU_SEISEKI` へ原子的に保存 | [KS](record_contracts.md#ks) |
-| `CH` | 3862 バイト（592 は拒否）。`NL_CH`＋`NL_CH_SEISEKI` / `CHOKYO`＋`CHOKYO_SEISEKI` へ原子的に保存 | [CH](record_contracts.md#ch) |
+| `KS` | 4173 バイト（旧 772 バイト復元データは受け付けない）。`NL_KS`＋`NL_KS_SEISEKI` / `KISYU`＋`KISYU_SEISEKI` へ原子的に保存 | [KS](record_contracts.md#ks) |
+| `CH` | 3862 バイト（旧 592 バイト復元データは受け付けない）。`NL_CH`＋`NL_CH_SEISEKI` / `CHOKYO`＋`CHOKYO_SEISEKI` へ原子的に保存 | [CH](record_contracts.md#ch) |
 | `HS` | 200 バイト（196 は拒否）。3 項目キー。`CurrentLayoutVersion=200`。`RT_HS` なし | [HS](record_contracts.md#hs) |
+
+**[調教・コース系（HC / WC / CS）](record_contracts.md#hc-wc-cs)**
+
+| レコード種別 | 要点 | 詳細 |
+| --- | --- | --- |
 | `HC` | 60 バイト。4 項目キー。`0` は key だけの exact erase。`RT_HC` なし | [HC](record_contracts.md#hc) |
 | `WC` | 105 バイト。4 項目キー（`Course` はキーでない）。標準名 `WOOD` | [WC](record_contracts.md#wc) |
 | `CS` | 6,829 バイト（`CourseEx` 6,800）。4 項目キー。6,829 バイト以外は拒否 | [CS](record_contracts.md#cs) |
+
+**[出走時点情報・マイニング系（CK / DM / TM）](record_contracts.md#ck-dm-tm)**
+
+| レコード種別 | 要点 | 詳細 |
+| --- | --- | --- |
 | `CK` | 6,870 バイト（6,864 は拒否）。親 `NL_CK`＋`NL_CK_CHAKU` 278 行＋`NL_CK_RUIKEI` 8 行。標準名モードは未実装で停止 | [CK](record_contracts.md#ck) |
 | `DM` | 303 バイト・18 頭配列。native は馬ごとの行、標準名 `MINING` は 1 レース 1 行 | [DM](record_contracts.md#dm) |
 | `TM` | 141 バイト・18 頭配列。native は馬ごとの行、標準名 `TAISENGATA_MINING` は 1 レース 1 行 | [TM](record_contracts.md#tm) |

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,9 +11,10 @@ Windows 向けツールです。NAR / 地方競馬は対象外です。
 2. [時系列オッズ](timeseries_odds.md): 公式時系列と開催週速報オッズの違い
 3. [PostgreSQL](postgresql.md): PostgreSQL 運用と日次同期
 4. [対応データ種別一覧](data_support.md): JVOpen / JVRTOpen spec と保存先
-5. [CLI](CLI.md): `jltsql` の主要コマンド
-6. [スクリプト一覧](scripts.md): batch / PowerShell の役割
-7. [アーキテクチャ](architecture.md): 実装構成
+5. [レコード別の公式契約と移行手順](record_contracts.md): レコード種別ごとの公式レイアウト・主キー・`DataKubun`・既存 DB の移行手順
+6. [CLI](CLI.md): `jltsql` の主要コマンド
+7. [スクリプト一覧](scripts.md): batch / PowerShell の役割
+8. [アーキテクチャ](architecture.md): 実装構成
 
 ## まず使うコマンド
 

--- a/docs/record_contracts.md
+++ b/docs/record_contracts.md
@@ -1,0 +1,1115 @@
+# レコード別の公式契約と移行手順
+
+このページは [対応データ種別一覧](data_support.md) の詳細ページです。
+jrvltsql が各レコード種別をどの公式レイアウトで受け付け、どのキーで
+保存し、既存 DB をどう移行するかを、レコード種別ごとに同じ構成でまとめます。
+
+## このページの読み方
+
+- 「共通規則」には、複数のレコード種別に共通する検証・transaction・
+  保存形式・移行手順を 1 回だけ書きます。
+- 「レコード別の契約」は、レコード種別ごとに次の小見出しで揃えます。
+  レコード固有の値の扱いがある場合は「値の扱い」を追加します。
+    - 公式レイアウト
+    - identity（主キー）
+    - 保存先
+    - DataKubun
+    - 既存 DB からの移行手順
+- 移行手順の共通の流れは「既存 DB からの移行の共通手順」に書き、
+  各節にはそのレコードの停止条件と再取込元だけを書きます。
+- 用語: 本ページで「native」は `NL_*` / `RT_*` テーブル、「標準名」は
+  JRA-VAN 標準名モードのテーブル（`HANSYOKU`, `HARAI` など。一部は
+  project canonical 名。各節参照）を指します。「蓄積系」は `JVOpen`、
+  「速報」は `JVRTOpen` で取得するデータです。
+
+実装上の正本は以下です。
+
+- `src/jvlink/constants.py`
+- `src/parser/factory.py`
+- `src/database/table_mappings.py`
+- `src/database/schema.py`
+- `src/cli/main.py`
+
+## 共通規則
+
+### 公式 DataKubun の検証
+
+パーサー、通常インポート、1件インポート、速報保存は、レコード種別ごとの
+公式 `DataKubun` を共通契約で検証します。次のいずれかに当たるレコードは、
+そのレコードを使った table routing、cache 書き込み、DB 更新より前に
+拒否します。
+
+- 値が無い
+- 空欄
+- 1文字でない
+- 別名の値が食い違う
+- 下表に無い
+
+未指定値を新規登録 `1` として補うことはありません。
+
+下表は全38形式について、通常 import / parser で使う current base domain を
+示します。provider がその形式を蓄積系・速報系のどちらで提供するかを表す
+availability 表ではありません。速報では、この base domain から明示的な差分
+（後述）を適用します。
+
+| current base domain のレコード種別 | 現行の公式値 |
+| --- | --- |
+| `WH`, `WE`, `JC`, `TC`, `CC` | `1` |
+| `AV` | `1`, `2` |
+| `RC`, `HC`, `HS`, `HY`, `JG`, `WC` | `0`, `1` |
+| `TK`, `KS`, `CH`, `BR`, `BN`, `HN`, `SK`, `CK`, `BT`, `CS` | `0`, `1`, `2` |
+| `HR` | `0`, `1`, `2`, `9` |
+| `DM`, `TM` | `0`, `1`, `2`, `3`, `7` |
+| `YS` | `0`, `1`, `2`, `3`, `9` |
+| `H1`, `H6` | `0`, `2`, `4`, `5`, `9` |
+| `UM` | `0`, `1`, `2`, `3`, `4`, `9` |
+| `WF` | `0`, `1`, `2`, `3`, `7`, `9` |
+| `O1`〜`O6` | `0`, `1`, `2`, `3`, `4`, `5`, `9` |
+| `RA`, `SE` | `0`, `1`, `2`, `3`, `4`, `5`, `6`, `7`, `9`, `A`, `B` |
+
+速報での差分:
+
+- 速報では、公式に蓄積系限定とされる `7` を `DM`, `TM`, `WF` で
+  受け付けません。したがって速報の `DM`/`TM` は `0`, `1`, `2`, `3`、
+  `WF` は `0`, `1`, `2`, `3`, `9` です。
+- それ以外の形式では、公式資料に明記されない速報独自の制限を推測で
+  追加していません。
+
+旧データ（`MakeDate` 境界）:
+
+- 同じ物理長の旧データも、公式変更日の前であることを `MakeDate` から
+  確認できる場合に限り扱います。
+- `RC=2` は 2005-09-29 より前、`WH`/`WE`/`AV`/`JC=0` は 2003-07-11 より
+  前だけです。
+- `UM=9` は 2003-04-22 より前のデータでは拒否します。
+- 日付が無い、読めない、または境界日以後なら現行仕様として検証します。
+
+### 通常インポートの transaction / rollback 規約
+
+- 通常インポートは streaming 処理です。
+- `auto_commit=True` では完了した batch を順次 commit するため、後続
+  レコードの検証失敗より前に確定済みの正常 batch と、開始時の standard
+  schema preflight による変更は保持されます。
+- 呼び出し全体を all-or-nothing にする場合は `auto_commit=False` を
+  使います。この場合、後続検証失敗は同じ呼び出しまたは同じ caller-owned
+  transaction で先に書いた行と統計を rollback します。
+- この rollback 要否を判定する transaction 状態を取得できない場合は、
+  未確定行を commit 可能な接続として残さず接続を無効化し、
+  `TransactionRecoveryError` で停止します。
+- 統計の rollback は同じ transaction generation に属する未確定分だけに
+  限定します。caller が前の transaction を commit 済みの場合、その確定行と
+  累積統計を後続 transaction の状態判定失敗で巻き戻しません。
+- 状態判定と接続無効化の両方が失敗した場合は、接続上の未確定分を安全に
+  分類できないため `TransactionRecoveryError` を送出し、既存の統計も
+  成功・失敗のどちらへも推測更新しません。
+
+レコード別の差分は各節に書きます（[HS](#hs) の `auto_commit` 別の
+扱い、[WF](#wf-win5) の batch 全体 rollback、[DM / TM](#dm-tm-snapshot-transaction) の
+速報 snapshot 置換と `TransactionRecoveryError`）。
+
+### 速報 grouped batch と時系列 CLI の transaction 境界
+
+- 速報の通常 grouped batch は、SQLite / psycopg が暗黙に開始した caller 側
+  transaction を所有済みとして扱い、成功時に勝手に commit しません。
+- DB 書込が 1 件でも失敗した場合は同じ call の grouped mutation を全て
+  rollback して `inserted=0` と `transaction_rolled_back=true` を返し、
+  後続 rollback で消える行を部分成功として数えません。削除を含む提供順
+  処理も同じ atomic 境界を使います。
+- false 結果を受け取った caller は、validation-only 拒否か DB rollback 済み
+  かにかかわらず、その取込単位を必ず中断してください。
+- psycopg では SELECT だけでも transaction が開始されるため、独立した
+  取込単位へ移る caller は明示的に commit または rollback して境界を
+  閉じてください。transaction 状態を判定できない場合は書込前に失敗します。
+- batch 開始時に caller 側 transaction が無かった場合、schema / catalog
+  検証の SELECT が暗黙に開始した transaction は validation-only 拒否時にも
+  rollback して閉じます。開始時から caller 側 transaction が存在した場合は、
+  validation-only 拒否だけではその transaction を commit / rollback しません。
+- 時系列取得 CLI は保存先 table 作成を先に commit して batch ごとの境界を
+  分離し、1 batch でも拒否された場合は `[OK]` を出さず非 0 終了します。
+
+### HappyoTime（MMDDhhmm）の保存形式と旧標準名テーブル
+
+- `WH`, `WE`, `AV`, `JC`, `TC`, `CC` と `O1`〜`O6` の公式 `HappyoTime` は、
+  年を含まない 8 バイトの `MMDDhhmm` です。SQL の `TIME` や `TIMESTAMP` には
+  変換せず、先頭ゼロを含む文字列として保存します。
+- 速報開催情報の JRA-VAN 標準名は `TENKO_BABA`, `TORIKESI_JYOGAI`,
+  `KISYU_CHANGE`, `HASSOU_JIKOKU_CHANGE`, `COURSE_CHANGE` です。旧来の英語
+  別名は読み取り側の互換性のため残しますが、新しい標準名インポート先には
+  使いません。
+- 旧版が作成したこれらの標準名テーブル、および `ODDS_*_HEAD` テーブルで
+  `HappyoTime` が `TIMESTAMP` の場合、起動時検証は型不一致として停止します。
+  月日を欠いた旧値から公式 8 桁値を復元できないため、自動 `ALTER` や暗黙
+  変換は行いません。
+- 移行手順: DB をバックアップし、対象テーブルだけを退避または削除して
+  現行の標準名スキーマ（`VARCHAR(8)`）で再作成した後、JRA-VAN の保持期間内の
+  データを再取得してください。既存値を時刻部分だけで移植しないでください。
+
+### 0B14 の日単位 snapshot 置換と 0B16
+
+- `0B14` は指定日の完全な開催変更 snapshot なので、正常終了を確認した
+  同一 transaction 内で当該日の `RT_WE` / `RT_AV` / `RT_JC` / `RT_TC` /
+  `RT_CC` を置換し、後続 snapshot から消えた変更を除去します。
+- `0B16` は指定イベントの更新であり、この日単位置換とは別です。
+- レコード別の補足は [WE](#we)、[AV](#av)、[JC](#jc)、[TC](#tc)、
+  [CC](#cc) の各節に書きます。
+
+### 既存 DB からの移行の共通手順
+
+各レコードの節に挙げた停止条件に当たる既存テーブルは、自動修復せず停止します
+（各節の記載を参照）。停止のタイミング（mutation 前 / 取込前 / 他表の
+additive migration 前）と停止条件はレコードごとに異なるため、各節に書きます。
+
+移行の共通の流れは次のとおりです。
+
+1. DB をバックアップします。
+2. 対象テーブルだけを現行 schema（DDL）で再作成します。
+3. 各節に書かれた source から、保持期間内のデータを再取込 / 再取得します。
+
+各節には、対象テーブル、再取込元、そのレコード固有の注意（旧行を移植しない、
+親を先に作成する、など）だけを書きます。
+
+### 旧仕様 dataspec 名（DIFF / BLOD / SNAP / HOSE / TCOV / RCOV）
+
+`DIFF` / `BLOD` / `SNAP` / `HOSE` / `TCOV` / `RCOV` は jrvltsql では
+受け付けません。`fetch` / `cache build` / `cache rebuild` は取り込みや既存
+cache の変更に入る前に、対応する現行種別名を示して停止します。JRA-VAN の
+仕様表には旧名も掲載されており、公式API全体で廃止されたという意味ではありません。
+
+**旧名は新名の別名ではありません。** 2023-08 の JV-Data 仕様変更で桁数が変わって
+おり（繁殖登録番号 8→10 / 生産者コード 6→8 / 生産者名 70→72）、旧名を要求すると
+現行のパーサが解釈できない旧仕様のバイト列が返ります。桁がずれたまま取り込むと、
+レコードの途中から後ろが全て壊れます。
+
+`RACE` はこの仕様変更の対象外なので、これまでどおり使えます。
+
+| 旧名 | 現行名 |
+| --- | --- |
+| `DIFF` | `DIFN` |
+| `BLOD` | `BLDN` |
+| `SNAP` | `SNPN` |
+| `HOSE` | `HOSN` |
+| `TCOV` | `TCVN` |
+| `RCOV` | `RCVN` |
+
+## レコード別の契約
+
+### 速報開催情報系（WH / WE / AV / JC / TC / CC）
+
+#### WH（速報馬体重）
+
+公式レイアウト:
+
+- 公式 format 101 の 847 バイト馬体重レコードです。1 レコード内に 18 頭の
+  配列を持ちます。
+
+identity（主キー）:
+
+- native `NL_WH` / `RT_WH` は 18 頭配列を馬ごとの行へ展開し、レース識別子と
+  馬番を主キーにします。
+- `HappyoTime` は訂正発表の時刻として保存しますが、同一レース・同一馬の
+  新しい発表は最新値として置き換わります。
+
+保存先:
+
+- native `NL_WH` / 速報 `RT_WH`（馬ごとの行）。
+- JRA-VAN 標準名モードの `BATAIJYU` は展開せず、18 頭分を 1 行に保持する
+  公式の横持ち表現です。1 つの公式 WH レコードにつき、レース主キーの 1 行を
+  保存します。
+
+DataKubun:
+
+- 現行 `1`（[公式 DataKubun の検証](#datakubun) の表を参照）。旧区分 `0` の
+  `MakeDate` 境界も同節を参照してください。
+
+既存 DB からの移行手順:
+
+- 旧 jrvltsql が作成した `NL_WH` / `RT_WH` は、誤って天候変更の 40 バイト
+  相当の列と主キーを持っていました。この物理テーブルが存在する環境では、
+  起動時の schema migration は主キー不一致を検出して停止します。
+- JRA-VAN 標準名モードの旧 `BATAIJYU` も主キーが無いため、同様に
+  オペレーター移行が必要です。自動 drop や暗黙変換は行いません。
+- DB をバックアップしたうえで、オペレーターが対象を `NL_WH` / `RT_WH` /
+  `BATAIJYU` のうち実在する旧テーブルだけに限定して削除し、
+  `jltsql create-tables --db <sqlite|postgresql>` または標準名テーブルの
+  初期化手順で再作成してください。
+- `RT_WH` はその後 `jltsql realtime start --specs 0B11` で、JRA-VAN の
+  保持期間内に再取得します。
+- 旧 `NL_WH` / `RT_WH` の行は公式 WH ではないため、馬体重履歴として
+  移植しないでください。
+
+#### WE（天候・馬場状態変更）
+
+公式レイアウト:
+
+- JV-Data 4.8.0.2 / 4.9.0.1 と SDK 5.0.0 で同一の 42 バイト配置です。
+
+identity（主キー）:
+
+- 公式キーは `Year`, `MonthDay`, `JyoCD`, `Kaiji`, `Nichiji`, `HappyoTime`,
+  `HenkoID` の 7 項目です。
+- `HappyoTime=00000000` の初期発表と、その後の複数発表時刻を別行として
+  保持します。最新状態を読む場合は `HenkoID` の大小ではなく最新の
+  `HappyoTime` を選びます。この運用は公式スタッフの
+  [説明](https://developer.jra-van.jp/t/topic/331)および複数時刻が共存する
+  [事例](https://developer.jra-van.jp/t/topic/164)・
+  [事例](https://developer.jra-van.jp/t/topic/141)とも一致します。
+
+保存先:
+
+- native `NL_WE` / `RT_WE` と標準名モードの `TENKO_BABA` は同じ順序の
+  `NOT NULL` 主キーを使います。
+- 公式幅を保てる非 padding の文字列型と、公式幅ちょうどの `CHAR` は
+  lossless storage として許容します。通常行で必須の 6 つの本文コードは、
+  既存表側の `NOT NULL` も安全です。
+
+DataKubun:
+
+- 現行のデータ区分は `1` です。
+- 2003-07-11 より前の `MakeDate` でだけ旧区分 `0` を受け付け、7 項目が完全
+  一致する 1 発表を物理削除します。削除レコードの 6 つの天候・芝・ダート
+  本文値は解釈しませんが、キーに含まれる `HenkoID` は必須です。
+
+値の扱い:
+
+- 通常行は変更識別 `1`〜`3`、天候 `0`〜`6`、芝・ダート `0`〜`4` を検証し、
+  変更識別 `2` では馬場 4 項目、`3` では天候 2 項目が公式初期値 `0` である
+  ことを確認します。これを超える状態間の推測規則は適用しません。
+- `0B14` の新しい応答が前回の日付 snapshot を置換する既存の一括更新契約は
+  維持し、1 応答内では上記 7 項目キーで各発表を保持します。
+
+既存 DB からの移行手順:
+
+- 旧 6 項目キー、主キーなし、容量不足・数値化など lossless でないキー型、
+  キーの NULL 許容、追加の `UNIQUE`/exclusion、PostgreSQL の遅延主キーがある
+  既存表は、取込や他表の additive migration より前に停止します。
+- 時刻別履歴や重複行から正しいキーを自動復元できないため、自動 ALTER は
+  行いません。
+- DB をバックアップし、対象表を現行 DDL で再作成して、保持範囲に合う公式
+  42 バイト WE source を再取込してください。
+
+#### AV（出走取消・競走除外）
+
+公式レイアウト:
+
+- JV-Data 4.8.0.2 / 4.9.0.1 と SDK 5.0.0 で同一の 78 バイト配置です。
+
+identity（主キー）:
+
+- 公式キーは `Year`, `MonthDay`, `JyoCD`, `Kaiji`, `Nichiji`, `RaceNum`,
+  `Umaban` の 7 項目です。`HappyoTime` は発表情報として保存しますがキーでは
+  ありません。同一馬の後続発表は同じ行を更新します。
+
+保存先:
+
+- native `NL_AV` / `RT_AV` と標準名モードの `TORIKESI_JYOGAI` は同じ順序の
+  `NOT NULL` 主キーを使います。
+
+DataKubun:
+
+- 現行のデータ区分は `1=出走取消` と `2=競走除外` です。
+- 2003-07-11 より前の `MakeDate` でだけ旧区分 `0` を受け付け、7 項目が完全に
+  一致する行を物理削除します。旧削除レコードでは発表時刻・馬名・事由の
+  本文を解釈しません。
+
+値の扱い:
+
+- 事由区分は blank と `000`〜`003` を受け付けます。2021-01-25 の仕様変更は
+  初期値表記を `000` から space へ変えた同長変更であり、履歴データの
+  provenance が不明な場合にどちらかを過剰拒否しません。
+- `0B14` は開催日単位の完全な現行 snapshot です。現行の取消が撤回された
+  場合は status `0` が届くのではなく、次の snapshot から AV 行が消えるため、
+  同一 transaction でその日の `RT_AV` を置換します。個別イベントは
+  `0B16`/`JVWatchEvent` で受けられるという公式サポートの
+  [説明](https://developer.jra-van.jp/t/topic/195)があります。
+
+既存 DB からの移行手順:
+
+- 旧 nullable key、主キーなし・誤順序、lossless でない型や容量、追加の
+  `UNIQUE`/exclusion、PostgreSQL の遅延主キーを持つ既存表は mutation 前に
+  停止します。自動的な PK 変更は行いません。
+- DB をバックアップし、対象表だけを現行 DDL で再作成して保持範囲内を
+  再取込してください。
+- NULL または不完全な identity を持つ旧行は正しい 7 項目キーへ安全に
+  backfill できないため、バックアップには残しても現行表へ再利用せず、
+  公式 provider から再取得してください。
+- 旧標準名 `AVOIDENCE` だけが存在する構成も、自動移行や別表への誤保存を
+  行わず、すべての DB target を変更前に停止します。標準名は
+  `TORIKESI_JYOGAI` へ再作成してください。
+
+#### JC（騎手変更）
+
+公式レイアウト:
+
+- JV-Data 4.8.0.2 / 4.9.0.1 と SDK 5.0.0 で同一の 161 バイト配置です。
+
+identity（主キー）:
+
+- 公式キーは `Year`, `MonthDay`, `JyoCD`, `Kaiji`, `Nichiji`, `RaceNum`,
+  `HappyoTime`, `Umaban` の 8 項目です。
+- 同一馬について「未定」の発表と確定後の発表など複数時刻が存在し得るため、
+  発表月日時分を省いた最新 1 行への上書きは行いません。
+
+保存先:
+
+- native `NL_JC` / `RT_JC` と標準名モードの `KISYU_CHANGE` は、同じ順序の
+  `NOT NULL` 主キーで再取込を冪等にします。
+
+DataKubun:
+
+- 現行のデータ区分は `1` です。
+- 2003-07-11 より前の `MakeDate` に限って旧区分 `0` を受け付け、8 項目が
+  完全一致する 1 発表だけを物理削除します。削除本文は解釈しません。
+- 現在の取消・訂正を旧区分 `0` で合成せず、`0B14` の日付単位完全 snapshot が
+  前回応答を置換する既存契約を使用します。速報更新は
+  [公式スタッフの説明](https://developer.jra-van.jp/t/topic/331)で確認でき、
+  複数発表時刻は
+  [コミュニティで報告された実例](https://developer.jra-van.jp/t/topic/164)でも
+  確認できます。
+
+値の扱い:
+
+- 負担重量は提供値が 0.1kg 単位なので、native / 速報の `REAL` 列では `550` を
+  `55.0`kg へ正規化します。標準名モードの `VARCHAR(3)` は公式 3 バイト表現
+  `550` をそのまま保持します。
+
+既存 DB からの移行手順:
+
+- 旧 7 項目キー、主キーなし、キーの NULL 許容、容量不足や誤型、追加の
+  `UNIQUE`/exclusion、PostgreSQL の遅延主キーを持つ既存表は、取込または
+  他表の schema 変更より前に拒否します。
+- 発表履歴や重複行から正しい 8 項目 identity を自動復元できないため、DB を
+  バックアップし、該当する `NL_JC` / `RT_JC` / `KISYU_CHANGE` だけを現行 DDL で
+  再作成して保持期間内の `0B14`/`0B16` または対応する蓄積データから
+  再取込してください。
+
+#### TC（発走時刻変更）
+
+公式レイアウト:
+
+- 現行 JV-Data 4.9.0.1 / SDK 5.0.0 の 45 バイト配置だけを受け付けます。
+
+identity（主キー）:
+
+- `Year`, `MonthDay`, `JyoCD`, `Kaiji`, `Nichiji`, `RaceNum` の 6 項目です。
+
+保存先:
+
+- native `NL_TC`、速報 `RT_TC`、JRA-VAN 標準名 `HASSOU_JIKOKU_CHANGE` は同じ
+  ordered primary key、必須 header/key/body、公式 field capacity を使います。
+
+DataKubun:
+
+- 現行の公式 `DataKubun` は `1` だけです。`0` を TC 単体の削除指示として
+  扱いません。
+- `0B14` / `0B16` の扱いは [0B14 の日単位 snapshot 置換と 0B16](#0b14-snapshot-0b16)
+  を参照してください。
+
+値の扱い:
+
+- `HappyoTime` は `MMDDhhmm`、変更後・変更前の時刻は各 `HHmm` として先頭ゼロを
+  保ったまま保存します。公式の初期値 `00000000` / `0000` も欠損へ変換しません。
+
+既存 DB からの移行手順:
+
+- 既存の nullable、keyless、wrong-key、wrong-type、容量不足、generated /
+  identity 列、追加列または追加 UNIQUE/FK/CHECK を持つ TC table は自動修復
+  せず、mutation 前に停止します。
+- DB をバックアップして該当 TC table を現行 schema で再作成し、保持期間内の
+  `0B14`/`0B16` または対応する蓄積 source から再取込してください。
+- 旧標準名 `COMMENT` しかない構成を `HASSOU_JIKOKU_CHANGE` へ自動転用しません。
+
+#### CC（コース変更）
+
+公式レイアウト:
+
+- 現行 JV-Data 4.9.0.1 / SDK 5.0.0 の 50 バイト配置だけを受け付けます。
+
+identity（主キー）:
+
+- `Year`, `MonthDay`, `JyoCD`, `Kaiji`, `Nichiji`, `RaceNum` の 6 項目です。
+
+保存先:
+
+- native `NL_CC`、速報 `RT_CC`、JRA-VAN 標準名 `COURSE_CHANGE` は同じ ordered
+  primary key と必須 15 列を使います。
+
+DataKubun:
+
+- 現行の公式 `DataKubun` は `1` だけで、CC 単体の status 0 delete はありません。
+- `0B14` の正常完了後だけ日単位 snapshot 置換を行い、後続 snapshot から消えた
+  CC を削除します。`0B16` はイベント指定更新なので日単位置換を行いません。
+- 開催中止決定前に発表済みの CC は、公式仕様どおり中止後も提供対象です。
+
+値の扱い:
+
+- `HappyoTime` は `MMDDhhmm`、変更前後の距離は 4 桁、track code は公式コード表
+  2009 の `00`, `10`〜`29`, `51`〜`59`、事由区分は初期値 `0` または `1`〜`4`
+  です。
+- `00000000`、距離 `0000`、track `00`、事由 `0` は欠損へ変換しません。
+
+既存 DB からの移行手順:
+
+- 既存の nullable、keyless、wrong-key、wrong-type、容量不足、generated /
+  identity 列、追加列または追加 UNIQUE/FK/CHECK を持つ CC table は、失われた
+  identity や値を安全に復元できないため自動修復しません。
+- DB をバックアップし、該当 3 表を現行 schema で再作成して、保持期間内の
+  `0B14`/`0B16` または対応する蓄積 source から再取込してください。
+
+### レース系（HR / SE / JG / WF）
+
+#### HR（払戻）
+
+公式レイアウト:
+
+- JV-Data 4.8.0.2 / 4.9.0.1 と SDK 5.0.0 の 719 バイト配置へ結び付けています。
+- 単勝 3、複勝 5、枠連 3、馬連 3、ワイド 7、予備 3、馬単 6、三連複 3、
+  三連単 6 の全 repeat を保存します。
+
+identity（主キー）:
+
+- 公式キーは `Year`, `MonthDay`, `JyoCD`, `Kaiji`, `Nichiji`, `RaceNum` の
+  6 項目です。
+
+保存先:
+
+- native 名は `NL_HR` / `RT_HR`、標準名モードは `HARAI` で、いずれも同じ順序の
+  `NOT NULL` 主キーを使います。標準名モードでも払戻・人気・予備を NULL へ
+  落としません。
+
+DataKubun:
+
+- 現行データ区分は `0`, `1`, `2`, `9` です。
+- `9` は中止状態として保持し、削除には使いません。公式仕様は `9` の本文値を
+  確定していないため、raw 由来の位置 28〜717 は `OpaqueStatus9Body28_717Hex`
+  へ hex で保持し、通常の払戻列へは意味変換しません。caller-built の `9` は
+  キーと状態だけを保存します。
+- `0` だけが 6 項目の完全一致による物理削除で、本文は解釈しません。
+- lossless 保持という project policy に従い、raw の `0`/`9` は位置 28〜717 を
+  text decode せず、2004-08-14 より前の通常 record は位置 604〜717 を decode
+  せずに扱います。header、6 項目キー、およびそれ以外の解釈対象範囲は
+  引き続き strict CP932 検査を通します。
+
+値の扱い:
+
+- 予備 3 件は数値として意味付けせず、4/9/3 バイトの各区画を文字列で保持します。
+- 不成立・特払・返還の 3 つの券種 flag 配列は、6 件目が公式予備のため `0`
+  だけを受け付けます。返還馬番 28 件、返還枠番 8 件、返還同枠 8 件は全要素が
+  通常の返還対象 flag であり、6 件目も `0` または `1` を受け付けます。
+- 速報では着順確定前の人気が空欄になり得るため、空欄を正常値として扱います。
+  この挙動は公式スタッフの[説明](https://developer.jra-van.jp/t/topic/304)と
+  一致します。provider flag を理由に本文を間引かず、公式固定配置の各値を
+  独立して保存します。
+- 公式変更履歴の 2004-03-02 の記録はレコード長を変えず、位置 604〜717 の
+  予備領域を三連単関連へ転用しています。別の公式特記事項が示す三連単発売
+  開始日 2004-08-14 より前の race では、この 114 バイトを三連単として解釈せず
+  `LegacyReserved604_717Hex` へ hex で lossless 保持し、canonical 三連単列は
+  NULL にします。境界は訂正・再提供日になり得る `MakeDate` ではなく
+  `Year`+`MonthDay` の race date で判定します。これにより旧予備値を推測せず、
+  変更前と変更後を同じ 719 バイト envelope で区別します。
+
+既存 DB からの移行手順:
+
+- 旧 nullable key、主キーなし、予備 2・3 件目の列欠落、予備列の数値型、
+  型・容量不一致、追加の `UNIQUE`/exclusion、PostgreSQL の deferrable 主キーが
+  ある表は、取込や他表の additive migration より前に停止します。
+- 欠けた旧払戻を既存行から復元できないため、自動 ALTER で完全扱いにせず、
+  DB をバックアップして `NL_HR` / `RT_HR` / `HARAI` を現行 DDL で再作成し、
+  保持範囲に合う `RACE` source を再取込してください。
+
+#### SE（馬毎レース情報）
+
+公式レイアウト:
+
+- JV-Data 4.8.0.2 / 4.9.0.1 と SDK 5.0.0 の現行 555 バイト配置だけを
+  受け付けます。
+- 2003-04-22 より前の 547 バイト配置は、変更履歴から追加された 8 バイトは
+  分かっても旧レイアウト全体を復元できないため、推測で解釈せず明示的に
+  拒否します。
+
+identity（主キー）:
+
+- 現行の公式キーは `Year`, `MonthDay`, `JyoCD`, `Kaiji`, `Nichiji`, `RaceNum`,
+  `Umaban`, `KettoNum` の 8 項目です。
+
+保存先:
+
+- native の `NL_SE` / `RT_SE` と標準名モードの `UMA_RACE` はこの順序の
+  `NOT NULL` 主キーを使います。
+- 標準名モードでは 4 つの予約領域も `reserved1`〜`reserved4` へ保持します。
+
+DataKubun:
+
+- `DataKubun=0` は 8 項目が完全に一致する 1 頭だけを削除します。
+- base domain は [公式 DataKubun の検証](#datakubun) の表を参照してください。
+
+値の扱い:
+
+- 馬体重と増減は kg の整数であり、native でも 508kg/+3kg を 508/3 として
+  保存します。
+- status A では公式 availability に従い、本賞金 0 円は実値 0、付加賞金の
+  初期値 0 は NULL として区別します。この賞金の根拠は公式フォーマット表の
+  本賞金・付加賞金行です。騎手見習や着差など、別の A/B 項目で実データに
+  合わせて availability 表が訂正された背景は、公式スタッフの
+  [回答](https://developer.jra-van.jp/t/topic/61)を参照してください。
+
+既存 DB からの移行手順:
+
+- 旧 7 項目キーまたは主キーなしの表、キー型の不一致、追加の `UNIQUE`/
+  exclusion、PostgreSQL の deferrable 主キーは取込や他表の additive migration
+  より前に拒否します。
+- 自動で主キーを作り替えず、DB をバックアップして対象表を現行 schema で
+  再作成し、`RACE` から再取込してください。
+- 正しい 8 項目キーを持つ表への非キー列の安全な additive migration は
+  維持します。
+
+#### JG（競走馬除外情報）
+
+公式レイアウト:
+
+- 現行公式 80 バイト（Ver.4.1.0 で追加、Ver.4.1.1 は血統登録番号の初期値を
+  追記したのみで layout 不変）を扱います。
+
+identity（主キー）:
+
+- 公式 8 列キー（開催キー 6 列＋`KettoNum`＋出馬投票受付順番）で更新するため、
+  同一馬の再投票行は共存します。
+
+保存先:
+
+- native 名モードの保存先は `NL_JG`（互換名 `Num`、`SyussoKubun`、
+  `JyogaiStateKubun`）です。
+- JRA-VAN 標準名モードの保存先は SDK 構造体 `JV_JG_JOGAIBA` から採った
+  project canonical 名 `JOGAIBA`（`ShutsubaTohyoJun`、`ShussoKubun`、
+  `JogaiJotaiKubun`）です。
+- 旧名 `WEIGHT_CHANGE` は読み取り側の名前解決互換として残しますが、新規
+  import 先には使いません。
+
+DataKubun:
+
+- `DataKubun` は公式どおり 0/1 のみ、出走区分・除外状態区分は公式コードのみを
+  受け付けます。
+- `DataKubun=0` では同じ 8 列キーの行だけを提供順に物理削除します。
+
+既存 DB からの移行手順:
+
+- `WEIGHT_CHANGE` しか存在しない標準名 DB は行を変更せず停止します。
+- 旧 7 列キー（受付順番を含まない）の `NL_JG` / `JOGAIBA` や列の欠けた
+  `JOGAIBA` は、再投票行を安全に復元できないため自動 `ALTER` せず停止します。
+- DB をバックアップして対象テーブルを現行 schema で再作成し、`RACE` で
+  保持期間内の現行データを再取得してください。
+
+#### WF（重勝式 WIN5）
+
+公式レイアウト:
+
+- 現行公式 7,215 バイト（JV-Data 4.8.0.2 / 4.9.0.1、SDK 5.0.0 `JV_WF_INFO`）を
+  1 物理レコードとして扱います。
+- 対象 5 レースの競馬場・回・日・レース番号、発売票数、有効票数 5 件、返還・
+  不成立・的中無フラグ、キャリーオーバー金額初期・残高、払戻情報 243 枠を
+  全て保存します。
+- Ver.4.1.1 と Ver.4.2.0 はいずれも項目名・初期値・設定有無の変更であり、別の
+  物理レイアウトではありません。旧 jrvltsql の 169 バイト復元データは取得元
+  レコードとして受け付けません。
+
+identity（主キー）:
+
+- 公式キーは開催年・開催月日の 2 列です。
+
+保存先:
+
+- native 名モードの保存先は `NL_WF` / `RT_WF`（1 レコード 1 行、払戻 243 枠は
+  `PayoutsJson`）です。
+- JRA-VAN 標準名モードの保存先は project canonical 名 `JYUSYOSIKI_HEAD`
+  （ヘッダー、主キー開催年・開催月日）と子テーブル `JYUSYOSIKI`（払戻 243 枠を
+  `Num`=1〜243 の行として空欄枠も保存、主キー開催年・開催月日・`Num`、親への
+  複合外部キー `ON DELETE CASCADE`）です。
+- 1 物理レコードにつきヘッダー 1 行と子 243 行を提供順に transaction で
+  置き換えます。
+- `WIN5` は読み取り側の名前解決互換用の alias であり、新規 import 先には
+  使いません。
+
+DataKubun:
+
+- データ区分は蓄積系が 0/1/2/3/7/9、速報系（`0B51`）が 0/1/2/3/9 で、それ以外は
+  取り込み前に拒否します。
+- `DataKubun=0` は同じキーの親子を物理削除します。`DataKubun=0` では header と
+  公式キーだけを解釈し、仕様が定義しない body 値や body alias の差を削除拒否の
+  根拠にしません。
+- `9`（中止）は払戻が設定される場合に公式の中止用払戻組（組番 `0000000000`・
+  払戻金 `000000100`・的中票数 `0000000000`）ごと状態として保持します。
+- 値の有無は公式の状態別規定に従い、`1`（詳細発表時）は発売票数・有効票数・
+  残高・払戻が初期値、`2`/`9` はこれらの値が設定される場合とされない場合が
+  混在し、`3`/`7` では必須として検証します。
+
+値の扱い:
+
+- 対象レースの競馬場は同版の公式コード表 2001 に掲載された値から初期値・
+  未使用値を除いたコードを検証し、廃止済みの競馬場・国を含むため現在使用中の
+  会場一覧とは扱いません。初期値 `00`、使用しないと明記されたコード、
+  未掲載コード、小文字表記は受け付けません。公式コードが追加された場合は、
+  固定した仕様 manifest と検証集合を同じ変更で更新する必要があります。
+- 各フラグは未設定時の公式初期値も `0` なので、非削除レコードでは常に `0` か
+  `1` です。予備領域も公式初期値 `00`/`000000` だけを受け付けます。
+- 払戻枠は空欄か組番・払戻金・的中票数の揃った組だけを受け付けます。
+- キャリーオーバー金額初期は Ver.4.2.0（2012年2月21日）以降に作成された
+  データでは全状態で必須です。それ以前は `1` で空欄のみ、`2`/`9` で空欄または
+  数値を許容します。
+- 払戻が確定する `3`/`7` で的中無フラグが `1` の場合は、組番を保持したうえで
+  払戻金 `000000000`・的中票数 `0000000000` の公式表現だけを受け付けます。
+  中止状態 `9` は上記の中止用払戻が優先されるため、この的中無規則を一律には
+  適用しません。
+
+transaction:
+
+- native・標準名・速報の各 WF 書込は batch 途中の DB 例外で全体を rollback し、
+  行単位 fallback による部分成功や、rollback された操作を成功件数へ残すことを
+  許しません。
+- `inserted` は最終行数ではなく、提供順に正常適用された操作数です。
+- 速報 grouped batch と時系列 CLI の境界は
+  [共通規則](#grouped-batch-cli-transaction) を参照してください。
+
+既存 DB からの移行手順:
+
+- 主キーや `HatubaiHyosu` のない旧 `JYUSYOSIKI_HEAD`、`Num`・主キー・外部キーの
+  ない旧 `JYUSYOSIKI`、親子の片方だけが存在する DB、`WIN5` しか存在しない
+  標準名 DB は自動 `ALTER` せず、行や schema を変更する前に停止します。
+- DB をバックアップして両テーブルを現行 schema（親を先に作成）で再作成し、
+  `RACE` で保持期間内の現行データを再取得してください。
+- WF 保存先は全列の型・文字容量と主キーを取込前に検証します。PostgreSQL の
+  主キーは `ON CONFLICT` で使用できる valid・ready・即時・非 deferrable で
+  なければならず、公式キー以外の追加 `UNIQUE`/排他制約も、置換時に別開催を
+  消し得るため拒否します。検索用の非一意 index は保持できます。
+
+### マスタ系（HN / UM / BT / KS / CH / HS）
+
+#### HN（繁殖馬マスタ）
+
+公式レイアウト:
+
+- 現行 JV-Data 4.9.0.1 / SDK 5.0.0 の 251 バイト配置だけを受け付け、旧 245
+  バイト配置は拒否します。
+
+identity（主キー）:
+
+- 公式 identity は 10 桁の `HansyokuNum` です。
+
+保存先:
+
+- native `NL_HN` と標準名 `HANSYOKU` は同じ ordered primary key、必須
+  header/key/body、公式 field capacity を使い、status 1/2 を provider 順に
+  同じ行へ反映します。
+- HN は蓄積系 master だけであり、`RT_HN` は作成しません。
+
+DataKubun:
+
+- `DataKubun=0` はこの key だけを使う物理 exact erase です。削除指示の非 key
+  本文を decode しない扱いは erase を失わせないための project policy で、
+  provider 仕様が任意 binary 本文を規定するという意味ではありません。
+
+値の扱い:
+
+- 公式に空欄になり得る `BameiKana`・`BameiEng`・`SanchiName` は、両 table とも
+  `NULL` ではなく空文字で保持します（他の table の「空欄→`NULL`」規則の例外）。
+- 欠落した項目や `None` は検証で拒否され、`NULL` として保存されません。
+
+既存 DB からの移行手順:
+
+- 既存の nullable、keyless、wrong-key、wrong-type、容量不足、generated /
+  identity 列、追加列または追加 UNIQUE/FK/CHECK を持つ `NL_HN` / `HANSYOKU`
+  は自動修復せず、mutation 前に停止します。
+- DB をバックアップして両 table を現行 schema で再作成し、保持中の `BLDN`
+  source から再取込してください。
+
+#### UM（競走馬マスタ）
+
+公式レイアウト:
+
+- 公式 1609 バイトを扱い、血統登録番号 `KettoNum` を 10 文字のまま保存します。
+
+identity（主キー）:
+
+- native 名モードの `NL_UM` と JRA-VAN 標準名モードの `UMA` は、どちらも
+  `KettoNum` の 1 列だけを主キーとして同じ登録馬の更新を置き換え、異なる
+  登録馬を共存させます。
+- `KettoNum` は正確な 10 桁 ASCII 数字だけを受け付けます。
+
+保存先:
+
+- native `NL_UM`、標準名 `UMA`。
+- 現行の標準名 `UMA` では、公式レコード内の 27 組×6 着回数、4 脚質、登録
+  レース数も個別列へ欠落なく展開し、抹消年月日の `00000000` は 8 文字のまま
+  保持します。
+
+DataKubun:
+
+- base domain は [公式 DataKubun の検証](#datakubun) の表と `UM=9` の
+  `MakeDate` 境界を参照してください。
+
+既存 DB からの移行手順:
+
+- 公式主キー以外の `UNIQUE`/exclusion 制約や、PostgreSQL で `ON CONFLICT` に
+  使えない遅延主キーがある既存テーブルも、行を置換して消失させるおそれが
+  あるため変更前に拒否します。
+- 旧版が作成した標準名 `UMA` は `KettoNum` 列と主キーを欠いていたため、安全に
+  既存行の識別子を復元できません。この旧テーブルまたは別の主キーを持つ
+  テーブルが存在する場合は、列追加や行更新より前に停止します。
+- DB をバックアップし、対象 `UMA` を現行 schema で再作成してから `DIFN` で
+  競走馬マスタを再取得してください。
+
+#### BT（系統情報）
+
+公式レイアウト:
+
+- 現行公式 6,889 バイトを扱い、10 文字の `HansyokuNum`、`KeitoId`、
+  `KeitoName`、最大 6,800 バイトの `KeitoEx` を保存します。
+- 旧 6,887 バイト BT は 8 文字の繁殖登録番号を前提とするため、現行 layout
+  として受け付けません。
+
+identity（主キー）:
+
+- `HansyokuNum` を主キーに更新します。
+
+保存先:
+
+- native 名モードの保存先は `NL_BT`、JRA-VAN 標準名モードの保存先は公式名
+  `KEITO` です。
+- 旧名 `BLOOD` は読み取り側の名前解決互換として残しますが、新規 import 先には
+  使いません。
+
+DataKubun:
+
+- `DataKubun=0` では同じキーの行を物理削除します。
+
+既存 DB からの移行手順:
+
+- 標準名モードの開始時は既存の標準名テーブルを変更前に一括検証するため、
+  再構築が必要な旧 `KEITO` または legacy-only table が残る DB では、BT 以外の
+  import も schema 変更前に停止します。
+- 主キーのない部分的な `KEITO`、10 文字未満の key 列、6,800 文字未満の説明列、
+  または旧名 `BLOOD` しか存在しない標準名 DB は、欠落値を安全に復元できない
+  ため行や schema を自動変更せず停止します。
+- DB をバックアップして対象テーブルを現行 schema で再作成し、`BLDN` の
+  option 3/4 で現行データを再取得してください。
+
+#### KS（騎手マスタ）
+
+公式レイアウト:
+
+- 公式 4173 バイトを 1 物理レコードとして扱います。旧 772 バイトの復元データは
+  取得元レコードとして受け付けません。
+
+保存先:
+
+- native では `NL_KS` と `NL_KS_SEISEKI`、JRA-VAN 標準名モードでは `KISYU` と
+  `KISYU_SEISEKI` へ原子的に保存します。
+- `NL_KS` は基本情報・初騎乗/初勝利・最近重賞 3 件、`NL_KS_SEISEKI` は
+  本年・前年・累計の 3 行を保持します。
+
+既存 DB からの移行手順:
+
+- 既存の標準名テーブルが主キー契約を満たさない場合は行を変更せず停止します。
+- 現行 schema で再作成した後、`DIFN` の option 3/4 で全件を再取得してください。
+
+#### CH（調教師マスタ）
+
+公式レイアウト:
+
+- 公式 3862 バイトを 1 物理レコードとして扱います。旧 592 バイトの復元データは
+  取得元レコードとして受け付けません。
+
+保存先:
+
+- native では `NL_CH` と `NL_CH_SEISEKI`、JRA-VAN 標準名モードでは `CHOKYO` と
+  `CHOKYO_SEISEKI` へ原子的に保存します。
+- `NL_CH` は header・最近重賞 3 件、`NL_CH_SEISEKI` は本年・前年・累計の 3 行を
+  保持します。
+
+既存 DB からの移行手順:
+
+- 旧標準名テーブルは主キーと文字列日付の契約を満たさないため、自動変換せず
+  停止します。
+- バックアップ後に両テーブルを現行 schema で再作成し、保持期間内の現行データを
+  再取得してください。
+
+#### HS（競走馬市場取引価格）
+
+公式レイアウト:
+
+- 現行 JV-Data 4.9.0.1 / SDK 5.0.0 の 200 バイト配置だけを受け付け、旧 196
+  バイト配置は常に拒否します。
+
+identity（主キー）:
+
+- 公式の保存 identity は `KettoNum`, `SaleCode`, `FromDate` の 3 項目です。
+
+保存先:
+
+- native `NL_HS` と標準名 `SALE` は同じ ordered primary key、必須 header/key、
+  公式 field capacity を使います。
+- HS は蓄積系のみで、`RT_HS` は作成せず、realtime 入口へ渡された HS は DB と
+  local realtime cache の両方を変更せず拒否します。
+- 現行 parser または同等の caller validation を通った行には
+  `CurrentLayoutVersion=200` を保存します。
+
+DataKubun:
+
+- `DataKubun=0` はこの key だけを使う exact erase です。非 key 本文を decode
+  しない扱いは exact erase を失わせないための project policy であり、
+  provider 仕様が任意 binary 本文を規定しているという意味ではありません。
+
+値の扱い:
+
+- 現行 10 バイトの `HansyokuFNum` / `HansyokuMNum` 欄には 8 桁値＋space
+  padding も正当に存在するため、strip 後の 8 文字は旧世代判定の根拠に
+  なりません。
+- 過去 record の `Barei` は公式 setup で 2001 年以降の算出方法へ統一済みであり、
+  `MakeDate` から再解釈しません。一方、`SaleName` は provider が保持する当時
+  表記をそのまま保存します。
+
+transaction:
+
+- `auto_commit=False` の同一呼出しで後続 HS が検証失敗した場合は、先行する
+  未確定行とその統計を rollback します。
+- `auto_commit=True` では既に確定した provider operation を残す incremental
+  semantics であり、失敗した後続 record を成功件数へ加えません。
+
+既存 DB からの移行手順:
+
+- v2 以前の `NL_HS` / `SALE` は、空 table も含めて父母繁殖登録番号の値長などから
+  世代を推測して自動移行しません。バックアップ後に table を再作成し、現行 200
+  バイト source から再取込してください。
+- 唯一の加算移行対象は、現行 schema と既存列が完全に互換で、行が空であり、
+  native `NL_HS` の `CurrentLayoutVersion` / `RecordDelimiter` だけが欠ける
+  場合です。
+
+### 調教・コース系（HC / WC / CS）
+
+#### HC（坂路調教）
+
+公式レイアウト:
+
+- 現行 JV-Data 4.9.0.1 / SDK 5.0.0 の 60 バイト配置だけを受け付けます。
+- 美浦の測定距離は 2004-11-30 に 600m から 800m へ変わりましたが、物理 record
+  長と 4 項目 identity は変わりません。
+
+identity（主キー）:
+
+- `TresenKubun`, `ChokyoDate`, `ChokyoTime`, `KettoNum` の 4 項目です。
+
+保存先:
+
+- native `NL_HC` と標準名 `HANRO` は同じ ordered primary key、必須
+  header/key/body、公式 field capacity を使用します。
+- HC は蓄積系のみで `RT_HC` は作成しません。
+
+DataKubun:
+
+- `DataKubun=0` は 4 項目 key だけを使う exact erase です。非 key 本文を decode
+  しないのは削除指示を失わせないための project policy であり、provider 仕様が
+  任意 binary 本文を規定するという意味ではありません。
+
+値の扱い:
+
+- 7 つの走破・lap time を 0.1 秒単位の provider 整数から秒へ正規化します。
+  公式の測定不能値 `0000`/`000` は 0.0 秒として欠損と混同せず保持します。
+
+既存 DB からの移行手順:
+
+- 既存の nullable、keyless、wrong-key、wrong-type、追加列または追加
+  UNIQUE/FK/CHECK を持つ `NL_HC` / `HANRO` は自動修復せず、mutation 前に
+  停止します。
+- バックアップ後に現行 schema で再作成し、`SLOP` を再取込してください。
+
+#### WC（ウッドチップ調教）
+
+公式レイアウト:
+
+- JV-Data 4.9.0.1 と SDK 5.0.0 の 105 バイト配置を使用し、10 ハロンから
+  1 ハロンまでの合計・ラップを保存します。
+- 4.7.0.1 で追記されたのは美浦・栗東の提供開始時期と計測距離の説明であり、
+  別の物理レイアウトではありません。
+
+identity（主キー）:
+
+- 公式キーはトレセン区分・調教年月日・調教時刻・血統登録番号の 4 項目です。
+  `Course`（コース）や馬場周りは公式キーではありません。4 項目キーは
+  [JRA-VAN ソフトサポートの回答](https://developer.jra-van.jp/t/topic/99)とも
+  一致します。
+
+保存先:
+
+- native `NL_WC`、標準名モード `WOOD`。`WOOD` はデータ種別名と SDK 構造に
+  対応させた jrvltsql の標準名モード上の canonical table 名であり、提供元が
+  SQL DDL やテーブル名を規定しているという意味ではありません。
+
+DataKubun:
+
+- `0` は同じキーの削除です。
+
+値の扱い:
+
+- タイムが全桁 9 のデータは規定内として配信されるため、欠損へ置換せず数値
+  sentinel として保存します
+  （[スタッフ回答](https://developer.jra-van.jp/t/topic/367)）。
+
+既存 DB からの移行手順:
+
+- 旧版 jrvltsql が作成した `Course` 入り・トレセン区分なしの主キーは自動修復
+  せず、取込前に拒否します。
+
+#### CS（コース情報）
+
+公式レイアウト:
+
+- JV-Data 4.8.0.2 / 4.9.0.1 と SDK 5.0.0 で同一の 6,829 バイト配置です。
+  6,800 バイトの `CourseEx` を native `NL_CS` と標準名モード `COURSE` の両方へ
+  保存します。
+- 2009 年の導入直後に仕様書の誤記訂正履歴はありますが、根拠のない旧 binary
+  layout は受け付けません。また、2023 年には異常長の CS データが配信され、
+  [公式サポートが不備を認めて再提供した事例](https://developer.jra-van.jp/t/topic/237)が
+  あるため、6,829 バイト以外を推測補正せず拒否します。
+
+identity（主キー）:
+
+- 公式キーは競馬場コード・距離・トラックコード・コース改修年月日（改修後に
+  最初に開催された日）の 4 項目です。
+
+保存先:
+
+- native `NL_CS`、標準名モード `COURSE`。
+
+DataKubun:
+
+- `DataKubun=2` は行だけでなく別途取得したコース図も更新される場合があるため、
+  `JVCourseFile`/`JVCourseFile2` の結果を独自保存する利用者は図も更新して
+  ください。
+
+値の扱い:
+
+- 競馬場コードとトラックコードは公式コード表 2001/2009 の有効値に限定し、
+  未定義・未使用コードや物理幅を超える本文は取込前に拒否します。
+
+既存 DB からの移行手順:
+
+- 旧 jrvltsql の 3 項目主キー `NL_CS`、主キーなしの `COURSE`、本文列がないまま
+  既存行を持つ `COURSE`、追加の一意制約を持つ表は、別改修日の履歴消失・本文
+  欠損・再取込重複を避けるため取込前に拒否します。
+- 正しい 4 項目主キーを持つ空の `COURSE` だけは、欠けている列が `CourseEx`
+  だけなら安全に追加します。
+- それ以外は既存表をバックアップし、現行 DDL で再作成して `COMM` を
+  再取込してください。
+
+### 出走時点情報・マイニング系（CK / DM / TM）
+
+#### CK（出走時点情報）
+
+公式レイアウト:
+
+- 現行公式 6,870 バイトの 1,729 scalar leaf を扱います。旧 6,864 バイトは
+  現行 offset と混同せず拒否します。
+
+identity（主キー）:
+
+- 7 列の公式キーです。
+
+保存先:
+
+- PostgreSQL の 1 テーブル列数上限を超えないよう、native 名モードでは互換親
+  `NL_CK` と `NL_CK_CHAKU` 278 行、`NL_CK_RUIKEI` 8 行を 1 物理レコード単位の
+  transaction で更新します。
+- CK の JRA-VAN 標準名モードはまだ実装しておらず、`CHOKYO_DETAIL` へ誤って
+  部分保存せず明示的に停止します。
+
+DataKubun:
+
+- `DataKubun=0` は 7 列の公式キーで親子を削除します。
+- base domain は [公式 DataKubun の検証](#datakubun) の表を参照してください。
+
+既存 DB からの移行手順:
+
+- 既存 `NL_CK` には完全展開していない行があるため、追加される
+  `CKStorageVersion` が `NULL` の行を完全格納済みと扱ってはいけません。
+- 現行 `SNPN` を再取得して `CKStorageVersion=1`、子行数 278/8 をキーごとに
+  確認してください。
+
+#### DM（タイム型データマイニング予想）
+
+公式レイアウト:
+
+- 公式 303 バイトの 18 頭配列を扱います。
+
+保存先:
+
+- native 名モードでは `NL_DM` / `RT_DM` へ馬ごとの行として保存し、JRA-VAN
+  標準名モードでは `MINING` へ 1 レース 1 行の wide 形式で保存します。
+
+値の扱い:
+
+- `DMTime` は公式 SDK と同じ 5 桁文字列（9分99秒99）を保持します。
+
+既存 DB からの移行手順:
+
+- 旧 48 バイト復元データ、旧標準名 `DATA_MASTER`、主キーのない `MINING`、
+  数値型の `DMTime1`〜`DMTime18` は安全に自動変換できないため、取り込みを
+  停止して再構築を求めます。
+
+速報 snapshot の扱いは [DM / TM 共通](#dm-tm-snapshot-transaction) を参照してください。
+
+#### TM（対戦型データマイニング予想）
+
+公式レイアウト:
+
+- 公式 141 バイトの 18 頭配列を扱います。
+
+保存先:
+
+- native 名モードでは `NL_TM` / `RT_TM` へ馬ごとの行として保存し、JRA-VAN
+  標準名モードでは `TAISENGATA_MINING` へ 1 レース 1 行の wide 形式で
+  保存します。
+
+値の扱い:
+
+- `TMScore` は公式 SDK と同じ 4 桁文字列を保持し、右端 1 桁が小数第一位です。
+
+既存 DB からの移行手順:
+
+- 旧 39 バイト復元データ、旧標準名 `TIME_MASTER`、主キーのない
+  `TAISENGATA_MINING`、`TMScore` が整数型の旧 native テーブルは安全に自動
+  変換できないため、取り込みを停止して再構築を求めます。
+
+速報 snapshot の扱いは [DM / TM 共通](#dm-tm-snapshot-transaction) を参照してください。
+
+#### DM / TM 共通（速報 snapshot と transaction）
+
+DataKubun:
+
+- base domain（`0`, `1`, `2`, `3`, `7`）と速報での `7` 拒否は
+  [公式 DataKubun の検証](#datakubun) を参照してください。
+
+速報 snapshot の受け付け:
+
+- 速報の非削除 DM/TM は、1 物理レコードから展開された同一種別・同一
+  `DataKubun` の 1〜18 頭を完全な list として渡す必要があります。
+- 共通 metadata、展開 index、馬番（`01`〜`18`、重複なし）、metadata 内と展開後の
+  正規化済み各行内容が完全一致しない list、または 19 頭以上は DB へ到達する
+  前に拒否します。
+- `process_parsed_record` へ渡す list は 1 物理スナップショットだけを表し、
+  他種別との混在を拒否します。非削除の 1 行 dict を完全 snapshot とは
+  扱いません。
+- `DataKubun=0` だけは metadata を持たない単一の削除レコードとして
+  受け付けます。
+- `process_parsed_records_batch` は、先頭行の展開 index と metadata 件数で
+  複数の DM/TM 物理スナップショットを分割し、間にある削除や他種別レコードも
+  提供順の 1 transaction で処理します。
+
+transaction:
+
+- 途中の不完全な展開、metadata の無い非削除行、または 1 操作でも DB 書込に
+  失敗した batch は、先行操作も含めて全て rollback し、`inserted=0` を
+  返します。成功時の `inserted` は最終行数ではなく、提供順に正常適用した
+  展開行と隣接レコードの操作数です。
+- DM/TM の native 速報スナップショット置換は、既存レース行の削除後に書込が
+  失敗した場合、caller 所有を含む active transaction 全体を rollback します。
+  rollback 不能時は接続を無効化し、それも失敗した場合は batch・optimized・
+  single・速報の全入口から `TransactionRecoveryError` を送出し、通常の失敗
+  結果へ変換しません。

--- a/docs/record_contracts.md
+++ b/docs/record_contracts.md
@@ -9,18 +9,19 @@ jrvltsql が各レコード種別をどの公式レイアウトで受け付け�
 - 「共通規則」には、複数のレコード種別に共通する検証・transaction・
   保存形式・移行手順を 1 回だけ書きます。
 - 「レコード別の契約」は、レコード種別ごとに次の小見出しで揃えます。
-  レコード固有の値の扱いがある場合は「値の扱い」を追加します。
     - 公式レイアウト
     - identity（主キー）
     - 保存先
     - DataKubun
     - 既存 DB からの移行手順
-- 移行手順の共通の流れは「既存 DB からの移行の共通手順」に書き、
-  各節にはそのレコードの停止条件と再取込元だけを書きます。
+- レコード固有の項目がある場合は「値の扱い」「transaction」を追加します。
+  記載事項のない小見出しは省略します。
+- 移行手順の共通の流れは「既存 DB からの移行の共通手順」に書きます。各節には、
+  そのレコードの停止条件、対象テーブル、再取込元（記載がある場合）、固有の
+  注意を書きます。
 - 用語: 本ページで「native」は `NL_*` / `RT_*` テーブル、「標準名」は
   JRA-VAN 標準名モードのテーブル（`HANSYOKU`, `HARAI` など。一部は
-  project canonical 名。各節参照）を指します。「蓄積系」は `JVOpen`、
-  「速報」は `JVRTOpen` で取得するデータです。
+  project canonical 名。各節参照）を指します。
 
 実装上の正本は以下です。
 
@@ -67,7 +68,7 @@ availability 表ではありません。速報では、この base domain から
 | `O1`〜`O6` | `0`, `1`, `2`, `3`, `4`, `5`, `9` |
 | `RA`, `SE` | `0`, `1`, `2`, `3`, `4`, `5`, `6`, `7`, `9`, `A`, `B` |
 
-速報での差分:
+**速報での差分:**
 
 - 速報では、公式に蓄積系限定とされる `7` を `DM`, `TM`, `WF` で
   受け付けません。したがって速報の `DM`/`TM` は `0`, `1`, `2`, `3`、
@@ -75,14 +76,17 @@ availability 表ではありません。速報では、この base domain から
 - それ以外の形式では、公式資料に明記されない速報独自の制限を推測で
   追加していません。
 
-旧データ（`MakeDate` 境界）:
+**旧データ（`MakeDate` 境界）:**
 
 - 同じ物理長の旧データも、公式変更日の前であることを `MakeDate` から
   確認できる場合に限り扱います。
-- `RC=2` は 2005-09-29 より前、`WH`/`WE`/`AV`/`JC=0` は 2003-07-11 より
-  前だけです。
-- `UM=9` は 2003-04-22 より前のデータでは拒否します。
 - 日付が無い、読めない、または境界日以後なら現行仕様として検証します。
+
+| レコード / 区分 | `MakeDate` 境界 | 扱い |
+| --- | --- | --- |
+| `RC=2` | 2005-09-29 | より前だけ扱います |
+| `WH`/`WE`/`AV`/`JC=0` | 2003-07-11 | より前だけ扱います |
+| `UM=9` | 2003-04-22 | より前のデータでは拒否します |
 
 ### 通常インポートの transaction / rollback 規約
 
@@ -103,7 +107,7 @@ availability 表ではありません。速報では、この base domain から
   分類できないため `TransactionRecoveryError` を送出し、既存の統計も
   成功・失敗のどちらへも推測更新しません。
 
-レコード別の差分は各節に書きます（[HS](#hs) の `auto_commit` 別の
+レコード別の補足は各節に書きます（[HS](#hs) の `auto_commit` 別の
 扱い、[WF](#wf-win5) の batch 全体 rollback、[DM / TM](#dm-tm-snapshot-transaction) の
 速報 snapshot 置換と `TransactionRecoveryError`）。
 
@@ -143,6 +147,7 @@ availability 表ではありません。速報では、この base domain から
 - 移行手順: DB をバックアップし、対象テーブルだけを退避または削除して
   現行の標準名スキーマ（`VARCHAR(8)`）で再作成した後、JRA-VAN の保持期間内の
   データを再取得してください。既存値を時刻部分だけで移植しないでください。
+  （流れは [既存 DB からの移行の共通手順](#db) と同じです。）
 
 ### 0B14 の日単位 snapshot 置換と 0B16
 
@@ -150,23 +155,24 @@ availability 表ではありません。速報では、この base domain から
   同一 transaction 内で当該日の `RT_WE` / `RT_AV` / `RT_JC` / `RT_TC` /
   `RT_CC` を置換し、後続 snapshot から消えた変更を除去します。
 - `0B16` は指定イベントの更新であり、この日単位置換とは別です。
-- レコード別の補足は [WE](#we)、[AV](#av)、[JC](#jc)、[TC](#tc)、
-  [CC](#cc) の各節に書きます。
+- レコード別の補足は [WE](#we)、[AV](#av)、[JC](#jc)、[CC](#cc) の
+  各節に書きます。
 
 ### 既存 DB からの移行の共通手順
 
-各レコードの節に挙げた停止条件に当たる既存テーブルは、自動修復せず停止します
-（各節の記載を参照）。停止のタイミング（mutation 前 / 取込前 / 他表の
-additive migration 前）と停止条件はレコードごとに異なるため、各節に書きます。
+各レコードの節に挙げた停止条件に当たる既存テーブルは、自動修復せず停止（拒否）
+します（各節の記載を参照）。停止のタイミング（mutation 前 / 取込前 / 起動時 /
+他表の additive migration 前など）と停止条件はレコードごとに異なるため、各節に
+書きます。
 
 移行の共通の流れは次のとおりです。
 
 1. DB をバックアップします。
-2. 対象テーブルだけを現行 schema（DDL）で再作成します。
-3. 各節に書かれた source から、保持期間内のデータを再取込 / 再取得します。
+2. 対象テーブルを現行 schema（DDL）で再作成します。
+3. 各節に書かれた source と範囲で、データを再取込 / 再取得します。
 
-各節には、対象テーブル、再取込元、そのレコード固有の注意（旧行を移植しない、
-親を先に作成する、など）だけを書きます。
+各節には、対象テーブル、再取込元（記載がある場合）、そのレコード固有の注意
+（旧行を移植しない、親を先に作成する、など）を書きます。
 
 ### 旧仕様 dataspec 名（DIFF / BLOD / SNAP / HOSE / TCOV / RCOV）
 
@@ -193,35 +199,35 @@ cache の変更に入る前に、対応する現行種別名を示して停止�
 
 ## レコード別の契約
 
-### 速報開催情報系（WH / WE / AV / JC / TC / CC）
+### 速報馬体重・開催情報系（WH / WE / AV / JC / TC / CC）
 
 #### WH（速報馬体重）
 
-公式レイアウト:
+**公式レイアウト:**
 
 - 公式 format 101 の 847 バイト馬体重レコードです。1 レコード内に 18 頭の
   配列を持ちます。
 
-identity（主キー）:
+**identity（主キー）:**
 
 - native `NL_WH` / `RT_WH` は 18 頭配列を馬ごとの行へ展開し、レース識別子と
   馬番を主キーにします。
 - `HappyoTime` は訂正発表の時刻として保存しますが、同一レース・同一馬の
   新しい発表は最新値として置き換わります。
 
-保存先:
+**保存先:**
 
 - native `NL_WH` / 速報 `RT_WH`（馬ごとの行）。
 - JRA-VAN 標準名モードの `BATAIJYU` は展開せず、18 頭分を 1 行に保持する
   公式の横持ち表現です。1 つの公式 WH レコードにつき、レース主キーの 1 行を
   保存します。
 
-DataKubun:
+**DataKubun:**
 
 - 現行 `1`（[公式 DataKubun の検証](#datakubun) の表を参照）。旧区分 `0` の
   `MakeDate` 境界も同節を参照してください。
 
-既存 DB からの移行手順:
+**既存 DB からの移行手順:**
 
 - 旧 jrvltsql が作成した `NL_WH` / `RT_WH` は、誤って天候変更の 40 バイト
   相当の列と主キーを持っていました。この物理テーブルが存在する環境では、
@@ -239,11 +245,11 @@ DataKubun:
 
 #### WE（天候・馬場状態変更）
 
-公式レイアウト:
+**公式レイアウト:**
 
 - JV-Data 4.8.0.2 / 4.9.0.1 と SDK 5.0.0 で同一の 42 バイト配置です。
 
-identity（主キー）:
+**identity（主キー）:**
 
 - 公式キーは `Year`, `MonthDay`, `JyoCD`, `Kaiji`, `Nichiji`, `HappyoTime`,
   `HenkoID` の 7 項目です。
@@ -254,7 +260,7 @@ identity（主キー）:
   [事例](https://developer.jra-van.jp/t/topic/164)・
   [事例](https://developer.jra-van.jp/t/topic/141)とも一致します。
 
-保存先:
+**保存先:**
 
 - native `NL_WE` / `RT_WE` と標準名モードの `TENKO_BABA` は同じ順序の
   `NOT NULL` 主キーを使います。
@@ -262,14 +268,14 @@ identity（主キー）:
   lossless storage として許容します。通常行で必須の 6 つの本文コードは、
   既存表側の `NOT NULL` も安全です。
 
-DataKubun:
+**DataKubun:**
 
 - 現行のデータ区分は `1` です。
 - 2003-07-11 より前の `MakeDate` でだけ旧区分 `0` を受け付け、7 項目が完全
   一致する 1 発表を物理削除します。削除レコードの 6 つの天候・芝・ダート
   本文値は解釈しませんが、キーに含まれる `HenkoID` は必須です。
 
-値の扱い:
+**値の扱い:**
 
 - 通常行は変更識別 `1`〜`3`、天候 `0`〜`6`、芝・ダート `0`〜`4` を検証し、
   変更識別 `2` では馬場 4 項目、`3` では天候 2 項目が公式初期値 `0` である
@@ -277,7 +283,7 @@ DataKubun:
 - `0B14` の新しい応答が前回の日付 snapshot を置換する既存の一括更新契約は
   維持し、1 応答内では上記 7 項目キーで各発表を保持します。
 
-既存 DB からの移行手順:
+**既存 DB からの移行手順:**
 
 - 旧 6 項目キー、主キーなし、容量不足・数値化など lossless でないキー型、
   キーの NULL 許容、追加の `UNIQUE`/exclusion、PostgreSQL の遅延主キーがある
@@ -289,29 +295,29 @@ DataKubun:
 
 #### AV（出走取消・競走除外）
 
-公式レイアウト:
+**公式レイアウト:**
 
 - JV-Data 4.8.0.2 / 4.9.0.1 と SDK 5.0.0 で同一の 78 バイト配置です。
 
-identity（主キー）:
+**identity（主キー）:**
 
 - 公式キーは `Year`, `MonthDay`, `JyoCD`, `Kaiji`, `Nichiji`, `RaceNum`,
   `Umaban` の 7 項目です。`HappyoTime` は発表情報として保存しますがキーでは
   ありません。同一馬の後続発表は同じ行を更新します。
 
-保存先:
+**保存先:**
 
 - native `NL_AV` / `RT_AV` と標準名モードの `TORIKESI_JYOGAI` は同じ順序の
   `NOT NULL` 主キーを使います。
 
-DataKubun:
+**DataKubun:**
 
 - 現行のデータ区分は `1=出走取消` と `2=競走除外` です。
 - 2003-07-11 より前の `MakeDate` でだけ旧区分 `0` を受け付け、7 項目が完全に
   一致する行を物理削除します。旧削除レコードでは発表時刻・馬名・事由の
   本文を解釈しません。
 
-値の扱い:
+**値の扱い:**
 
 - 事由区分は blank と `000`〜`003` を受け付けます。2021-01-25 の仕様変更は
   初期値表記を `000` から space へ変えた同長変更であり、履歴データの
@@ -322,13 +328,13 @@ DataKubun:
   `0B16`/`JVWatchEvent` で受けられるという公式サポートの
   [説明](https://developer.jra-van.jp/t/topic/195)があります。
 
-既存 DB からの移行手順:
+**既存 DB からの移行手順:**
 
 - 旧 nullable key、主キーなし・誤順序、lossless でない型や容量、追加の
   `UNIQUE`/exclusion、PostgreSQL の遅延主キーを持つ既存表は mutation 前に
-  停止します。自動的な PK 変更は行いません。
-- DB をバックアップし、対象表だけを現行 DDL で再作成して保持範囲内を
-  再取込してください。
+  停止します。
+- 自動的な PK 変更は行わないため、DB をバックアップし、対象表だけを現行 DDL で
+  再作成して保持範囲内を再取込してください。
 - NULL または不完全な identity を持つ旧行は正しい 7 項目キーへ安全に
   backfill できないため、バックアップには残しても現行表へ再利用せず、
   公式 provider から再取得してください。
@@ -338,23 +344,23 @@ DataKubun:
 
 #### JC（騎手変更）
 
-公式レイアウト:
+**公式レイアウト:**
 
 - JV-Data 4.8.0.2 / 4.9.0.1 と SDK 5.0.0 で同一の 161 バイト配置です。
 
-identity（主キー）:
+**identity（主キー）:**
 
 - 公式キーは `Year`, `MonthDay`, `JyoCD`, `Kaiji`, `Nichiji`, `RaceNum`,
   `HappyoTime`, `Umaban` の 8 項目です。
 - 同一馬について「未定」の発表と確定後の発表など複数時刻が存在し得るため、
   発表月日時分を省いた最新 1 行への上書きは行いません。
 
-保存先:
+**保存先:**
 
 - native `NL_JC` / `RT_JC` と標準名モードの `KISYU_CHANGE` は、同じ順序の
   `NOT NULL` 主キーで再取込を冪等にします。
 
-DataKubun:
+**DataKubun:**
 
 - 現行のデータ区分は `1` です。
 - 2003-07-11 より前の `MakeDate` に限って旧区分 `0` を受け付け、8 項目が
@@ -366,13 +372,13 @@ DataKubun:
   [コミュニティで報告された実例](https://developer.jra-van.jp/t/topic/164)でも
   確認できます。
 
-値の扱い:
+**値の扱い:**
 
 - 負担重量は提供値が 0.1kg 単位なので、native / 速報の `REAL` 列では `550` を
   `55.0`kg へ正規化します。標準名モードの `VARCHAR(3)` は公式 3 バイト表現
   `550` をそのまま保持します。
 
-既存 DB からの移行手順:
+**既存 DB からの移行手順:**
 
 - 旧 7 項目キー、主キーなし、キーの NULL 許容、容量不足や誤型、追加の
   `UNIQUE`/exclusion、PostgreSQL の遅延主キーを持つ既存表は、取込または
@@ -384,32 +390,32 @@ DataKubun:
 
 #### TC（発走時刻変更）
 
-公式レイアウト:
+**公式レイアウト:**
 
 - 現行 JV-Data 4.9.0.1 / SDK 5.0.0 の 45 バイト配置だけを受け付けます。
 
-identity（主キー）:
+**identity（主キー）:**
 
 - `Year`, `MonthDay`, `JyoCD`, `Kaiji`, `Nichiji`, `RaceNum` の 6 項目です。
 
-保存先:
+**保存先:**
 
 - native `NL_TC`、速報 `RT_TC`、JRA-VAN 標準名 `HASSOU_JIKOKU_CHANGE` は同じ
   ordered primary key、必須 header/key/body、公式 field capacity を使います。
 
-DataKubun:
+**DataKubun:**
 
 - 現行の公式 `DataKubun` は `1` だけです。`0` を TC 単体の削除指示として
   扱いません。
 - `0B14` / `0B16` の扱いは [0B14 の日単位 snapshot 置換と 0B16](#0b14-snapshot-0b16)
   を参照してください。
 
-値の扱い:
+**値の扱い:**
 
 - `HappyoTime` は `MMDDhhmm`、変更後・変更前の時刻は各 `HHmm` として先頭ゼロを
   保ったまま保存します。公式の初期値 `00000000` / `0000` も欠損へ変換しません。
 
-既存 DB からの移行手順:
+**既存 DB からの移行手順:**
 
 - 既存の nullable、keyless、wrong-key、wrong-type、容量不足、generated /
   identity 列、追加列または追加 UNIQUE/FK/CHECK を持つ TC table は自動修復
@@ -420,34 +426,35 @@ DataKubun:
 
 #### CC（コース変更）
 
-公式レイアウト:
+**公式レイアウト:**
 
 - 現行 JV-Data 4.9.0.1 / SDK 5.0.0 の 50 バイト配置だけを受け付けます。
 
-identity（主キー）:
+**identity（主キー）:**
 
 - `Year`, `MonthDay`, `JyoCD`, `Kaiji`, `Nichiji`, `RaceNum` の 6 項目です。
 
-保存先:
+**保存先:**
 
 - native `NL_CC`、速報 `RT_CC`、JRA-VAN 標準名 `COURSE_CHANGE` は同じ ordered
   primary key と必須 15 列を使います。
 
-DataKubun:
+**DataKubun:**
 
 - 現行の公式 `DataKubun` は `1` だけで、CC 単体の status 0 delete はありません。
-- `0B14` の正常完了後だけ日単位 snapshot 置換を行い、後続 snapshot から消えた
-  CC を削除します。`0B16` はイベント指定更新なので日単位置換を行いません。
+- `0B14` の正常完了後だけ[日単位 snapshot 置換](#0b14-snapshot-0b16)を行い、
+  後続 snapshot から消えた CC を削除します。`0B16` はイベント指定更新なので
+  日単位置換を行いません。
 - 開催中止決定前に発表済みの CC は、公式仕様どおり中止後も提供対象です。
 
-値の扱い:
+**値の扱い:**
 
 - `HappyoTime` は `MMDDhhmm`、変更前後の距離は 4 桁、track code は公式コード表
   2009 の `00`, `10`〜`29`, `51`〜`59`、事由区分は初期値 `0` または `1`〜`4`
   です。
 - `00000000`、距離 `0000`、track `00`、事由 `0` は欠損へ変換しません。
 
-既存 DB からの移行手順:
+**既存 DB からの移行手順:**
 
 - 既存の nullable、keyless、wrong-key、wrong-type、容量不足、generated /
   identity 列、追加列または追加 UNIQUE/FK/CHECK を持つ CC table は、失われた
@@ -459,24 +466,24 @@ DataKubun:
 
 #### HR（払戻）
 
-公式レイアウト:
+**公式レイアウト:**
 
 - JV-Data 4.8.0.2 / 4.9.0.1 と SDK 5.0.0 の 719 バイト配置へ結び付けています。
 - 単勝 3、複勝 5、枠連 3、馬連 3、ワイド 7、予備 3、馬単 6、三連複 3、
   三連単 6 の全 repeat を保存します。
 
-identity（主キー）:
+**identity（主キー）:**
 
 - 公式キーは `Year`, `MonthDay`, `JyoCD`, `Kaiji`, `Nichiji`, `RaceNum` の
   6 項目です。
 
-保存先:
+**保存先:**
 
 - native 名は `NL_HR` / `RT_HR`、標準名モードは `HARAI` で、いずれも同じ順序の
   `NOT NULL` 主キーを使います。標準名モードでも払戻・人気・予備を NULL へ
   落としません。
 
-DataKubun:
+**DataKubun:**
 
 - 現行データ区分は `0`, `1`, `2`, `9` です。
 - `9` は中止状態として保持し、削除には使いません。公式仕様は `9` の本文値を
@@ -489,7 +496,7 @@ DataKubun:
   せずに扱います。header、6 項目キー、およびそれ以外の解釈対象範囲は
   引き続き strict CP932 検査を通します。
 
-値の扱い:
+**値の扱い:**
 
 - 予備 3 件は数値として意味付けせず、4/9/3 バイトの各区画を文字列で保持します。
 - 不成立・特払・返還の 3 つの券種 flag 配列は、6 件目が公式予備のため `0`
@@ -500,14 +507,15 @@ DataKubun:
   一致します。provider flag を理由に本文を間引かず、公式固定配置の各値を
   独立して保存します。
 - 公式変更履歴の 2004-03-02 の記録はレコード長を変えず、位置 604〜717 の
-  予備領域を三連単関連へ転用しています。別の公式特記事項が示す三連単発売
-  開始日 2004-08-14 より前の race では、この 114 バイトを三連単として解釈せず
-  `LegacyReserved604_717Hex` へ hex で lossless 保持し、canonical 三連単列は
-  NULL にします。境界は訂正・再提供日になり得る `MakeDate` ではなく
-  `Year`+`MonthDay` の race date で判定します。これにより旧予備値を推測せず、
-  変更前と変更後を同じ 719 バイト envelope で区別します。
+  予備領域を三連単関連へ転用しています。
+- 別の公式特記事項が示す三連単発売開始日 2004-08-14 より前の race では、この
+  114 バイトを三連単として解釈せず `LegacyReserved604_717Hex` へ hex で
+  lossless 保持し、canonical 三連単列は NULL にします。
+- 境界は訂正・再提供日になり得る `MakeDate` ではなく `Year`+`MonthDay` の
+  race date で判定します。これにより旧予備値を推測せず、変更前と変更後を同じ
+  719 バイト envelope で区別します。
 
-既存 DB からの移行手順:
+**既存 DB からの移行手順:**
 
 - 旧 nullable key、主キーなし、予備 2・3 件目の列欠落、予備列の数値型、
   型・容量不一致、追加の `UNIQUE`/exclusion、PostgreSQL の deferrable 主キーが
@@ -518,7 +526,7 @@ DataKubun:
 
 #### SE（馬毎レース情報）
 
-公式レイアウト:
+**公式レイアウト:**
 
 - JV-Data 4.8.0.2 / 4.9.0.1 と SDK 5.0.0 の現行 555 バイト配置だけを
   受け付けます。
@@ -526,23 +534,23 @@ DataKubun:
   分かっても旧レイアウト全体を復元できないため、推測で解釈せず明示的に
   拒否します。
 
-identity（主キー）:
+**identity（主キー）:**
 
 - 現行の公式キーは `Year`, `MonthDay`, `JyoCD`, `Kaiji`, `Nichiji`, `RaceNum`,
   `Umaban`, `KettoNum` の 8 項目です。
 
-保存先:
+**保存先:**
 
 - native の `NL_SE` / `RT_SE` と標準名モードの `UMA_RACE` はこの順序の
   `NOT NULL` 主キーを使います。
 - 標準名モードでは 4 つの予約領域も `reserved1`〜`reserved4` へ保持します。
 
-DataKubun:
+**DataKubun:**
 
 - `DataKubun=0` は 8 項目が完全に一致する 1 頭だけを削除します。
 - base domain は [公式 DataKubun の検証](#datakubun) の表を参照してください。
 
-値の扱い:
+**値の扱い:**
 
 - 馬体重と増減は kg の整数であり、native でも 508kg/+3kg を 508/3 として
   保存します。
@@ -552,7 +560,7 @@ DataKubun:
   合わせて availability 表が訂正された背景は、公式スタッフの
   [回答](https://developer.jra-van.jp/t/topic/61)を参照してください。
 
-既存 DB からの移行手順:
+**既存 DB からの移行手順:**
 
 - 旧 7 項目キーまたは主キーなしの表、キー型の不一致、追加の `UNIQUE`/
   exclusion、PostgreSQL の deferrable 主キーは取込や他表の additive migration
@@ -564,17 +572,17 @@ DataKubun:
 
 #### JG（競走馬除外情報）
 
-公式レイアウト:
+**公式レイアウト:**
 
 - 現行公式 80 バイト（Ver.4.1.0 で追加、Ver.4.1.1 は血統登録番号の初期値を
   追記したのみで layout 不変）を扱います。
 
-identity（主キー）:
+**identity（主キー）:**
 
 - 公式 8 列キー（開催キー 6 列＋`KettoNum`＋出馬投票受付順番）で更新するため、
   同一馬の再投票行は共存します。
 
-保存先:
+**保存先:**
 
 - native 名モードの保存先は `NL_JG`（互換名 `Num`、`SyussoKubun`、
   `JyogaiStateKubun`）です。
@@ -584,13 +592,13 @@ identity（主キー）:
 - 旧名 `WEIGHT_CHANGE` は読み取り側の名前解決互換として残しますが、新規
   import 先には使いません。
 
-DataKubun:
+**DataKubun:**
 
 - `DataKubun` は公式どおり 0/1 のみ、出走区分・除外状態区分は公式コードのみを
   受け付けます。
 - `DataKubun=0` では同じ 8 列キーの行だけを提供順に物理削除します。
 
-既存 DB からの移行手順:
+**既存 DB からの移行手順:**
 
 - `WEIGHT_CHANGE` しか存在しない標準名 DB は行を変更せず停止します。
 - 旧 7 列キー（受付順番を含まない）の `NL_JG` / `JOGAIBA` や列の欠けた
@@ -600,7 +608,7 @@ DataKubun:
 
 #### WF（重勝式 WIN5）
 
-公式レイアウト:
+**公式レイアウト:**
 
 - 現行公式 7,215 バイト（JV-Data 4.8.0.2 / 4.9.0.1、SDK 5.0.0 `JV_WF_INFO`）を
   1 物理レコードとして扱います。
@@ -611,11 +619,11 @@ DataKubun:
   物理レイアウトではありません。旧 jrvltsql の 169 バイト復元データは取得元
   レコードとして受け付けません。
 
-identity（主キー）:
+**identity（主キー）:**
 
 - 公式キーは開催年・開催月日の 2 列です。
 
-保存先:
+**保存先:**
 
 - native 名モードの保存先は `NL_WF` / `RT_WF`（1 レコード 1 行、払戻 243 枠は
   `PayoutsJson`）です。
@@ -628,7 +636,7 @@ identity（主キー）:
 - `WIN5` は読み取り側の名前解決互換用の alias であり、新規 import 先には
   使いません。
 
-DataKubun:
+**DataKubun:**
 
 - データ区分は蓄積系が 0/1/2/3/7/9、速報系（`0B51`）が 0/1/2/3/9 で、それ以外は
   取り込み前に拒否します。
@@ -641,13 +649,15 @@ DataKubun:
   残高・払戻が初期値、`2`/`9` はこれらの値が設定される場合とされない場合が
   混在し、`3`/`7` では必須として検証します。
 
-値の扱い:
+**値の扱い:**
 
 - 対象レースの競馬場は同版の公式コード表 2001 に掲載された値から初期値・
   未使用値を除いたコードを検証し、廃止済みの競馬場・国を含むため現在使用中の
-  会場一覧とは扱いません。初期値 `00`、使用しないと明記されたコード、
-  未掲載コード、小文字表記は受け付けません。公式コードが追加された場合は、
-  固定した仕様 manifest と検証集合を同じ変更で更新する必要があります。
+  会場一覧とは扱いません。
+- 初期値 `00`、使用しないと明記されたコード、未掲載コード、小文字表記は
+  受け付けません。
+- 公式コードが追加された場合は、固定した仕様 manifest と検証集合を同じ変更で
+  更新する必要があります。
 - 各フラグは未設定時の公式初期値も `0` なので、非削除レコードでは常に `0` か
   `1` です。予備領域も公式初期値 `00`/`000000` だけを受け付けます。
 - 払戻枠は空欄か組番・払戻金・的中票数の揃った組だけを受け付けます。
@@ -659,7 +669,7 @@ DataKubun:
   中止状態 `9` は上記の中止用払戻が優先されるため、この的中無規則を一律には
   適用しません。
 
-transaction:
+**transaction:**
 
 - native・標準名・速報の各 WF 書込は batch 途中の DB 例外で全体を rollback し、
   行単位 fallback による部分成功や、rollback された操作を成功件数へ残すことを
@@ -668,51 +678,52 @@ transaction:
 - 速報 grouped batch と時系列 CLI の境界は
   [共通規則](#grouped-batch-cli-transaction) を参照してください。
 
-既存 DB からの移行手順:
+**既存 DB からの移行手順:**
 
 - 主キーや `HatubaiHyosu` のない旧 `JYUSYOSIKI_HEAD`、`Num`・主キー・外部キーの
   ない旧 `JYUSYOSIKI`、親子の片方だけが存在する DB、`WIN5` しか存在しない
   標準名 DB は自動 `ALTER` せず、行や schema を変更する前に停止します。
 - DB をバックアップして両テーブルを現行 schema（親を先に作成）で再作成し、
   `RACE` で保持期間内の現行データを再取得してください。
-- WF 保存先は全列の型・文字容量と主キーを取込前に検証します。PostgreSQL の
-  主キーは `ON CONFLICT` で使用できる valid・ready・即時・非 deferrable で
-  なければならず、公式キー以外の追加 `UNIQUE`/排他制約も、置換時に別開催を
-  消し得るため拒否します。検索用の非一意 index は保持できます。
+- WF 保存先は全列の型・文字容量と主キーを取込前に検証します。
+- PostgreSQL の主キーは `ON CONFLICT` で使用できる valid・ready・即時・非
+  deferrable でなければならず、公式キー以外の追加 `UNIQUE`/排他制約も、置換時に
+  別開催を消し得るため拒否します。
+- 検索用の非一意 index は保持できます。
 
 ### マスタ系（HN / UM / BT / KS / CH / HS）
 
 #### HN（繁殖馬マスタ）
 
-公式レイアウト:
+**公式レイアウト:**
 
 - 現行 JV-Data 4.9.0.1 / SDK 5.0.0 の 251 バイト配置だけを受け付け、旧 245
   バイト配置は拒否します。
 
-identity（主キー）:
+**identity（主キー）:**
 
 - 公式 identity は 10 桁の `HansyokuNum` です。
 
-保存先:
+**保存先:**
 
 - native `NL_HN` と標準名 `HANSYOKU` は同じ ordered primary key、必須
   header/key/body、公式 field capacity を使い、status 1/2 を provider 順に
   同じ行へ反映します。
 - HN は蓄積系 master だけであり、`RT_HN` は作成しません。
 
-DataKubun:
+**DataKubun:**
 
 - `DataKubun=0` はこの key だけを使う物理 exact erase です。削除指示の非 key
   本文を decode しない扱いは erase を失わせないための project policy で、
   provider 仕様が任意 binary 本文を規定するという意味ではありません。
 
-値の扱い:
+**値の扱い:**
 
 - 公式に空欄になり得る `BameiKana`・`BameiEng`・`SanchiName` は、両 table とも
   `NULL` ではなく空文字で保持します（他の table の「空欄→`NULL`」規則の例外）。
 - 欠落した項目や `None` は検証で拒否され、`NULL` として保存されません。
 
-既存 DB からの移行手順:
+**既存 DB からの移行手順:**
 
 - 既存の nullable、keyless、wrong-key、wrong-type、容量不足、generated /
   identity 列、追加列または追加 UNIQUE/FK/CHECK を持つ `NL_HN` / `HANSYOKU`
@@ -722,30 +733,30 @@ DataKubun:
 
 #### UM（競走馬マスタ）
 
-公式レイアウト:
+**公式レイアウト:**
 
 - 公式 1609 バイトを扱い、血統登録番号 `KettoNum` を 10 文字のまま保存します。
 
-identity（主キー）:
+**identity（主キー）:**
 
 - native 名モードの `NL_UM` と JRA-VAN 標準名モードの `UMA` は、どちらも
   `KettoNum` の 1 列だけを主キーとして同じ登録馬の更新を置き換え、異なる
   登録馬を共存させます。
 - `KettoNum` は正確な 10 桁 ASCII 数字だけを受け付けます。
 
-保存先:
+**保存先:**
 
 - native `NL_UM`、標準名 `UMA`。
 - 現行の標準名 `UMA` では、公式レコード内の 27 組×6 着回数、4 脚質、登録
   レース数も個別列へ欠落なく展開し、抹消年月日の `00000000` は 8 文字のまま
   保持します。
 
-DataKubun:
+**DataKubun:**
 
 - base domain は [公式 DataKubun の検証](#datakubun) の表と `UM=9` の
   `MakeDate` 境界を参照してください。
 
-既存 DB からの移行手順:
+**既存 DB からの移行手順:**
 
 - 公式主キー以外の `UNIQUE`/exclusion 制約や、PostgreSQL で `ON CONFLICT` に
   使えない遅延主キーがある既存テーブルも、行を置換して消失させるおそれが
@@ -758,29 +769,29 @@ DataKubun:
 
 #### BT（系統情報）
 
-公式レイアウト:
+**公式レイアウト:**
 
 - 現行公式 6,889 バイトを扱い、10 文字の `HansyokuNum`、`KeitoId`、
   `KeitoName`、最大 6,800 バイトの `KeitoEx` を保存します。
 - 旧 6,887 バイト BT は 8 文字の繁殖登録番号を前提とするため、現行 layout
   として受け付けません。
 
-identity（主キー）:
+**identity（主キー）:**
 
 - `HansyokuNum` を主キーに更新します。
 
-保存先:
+**保存先:**
 
 - native 名モードの保存先は `NL_BT`、JRA-VAN 標準名モードの保存先は公式名
   `KEITO` です。
 - 旧名 `BLOOD` は読み取り側の名前解決互換として残しますが、新規 import 先には
   使いません。
 
-DataKubun:
+**DataKubun:**
 
 - `DataKubun=0` では同じキーの行を物理削除します。
 
-既存 DB からの移行手順:
+**既存 DB からの移行手順:**
 
 - 標準名モードの開始時は既存の標準名テーブルを変更前に一括検証するため、
   再構築が必要な旧 `KEITO` または legacy-only table が残る DB では、BT 以外の
@@ -793,38 +804,46 @@ DataKubun:
 
 #### KS（騎手マスタ）
 
-公式レイアウト:
+**公式レイアウト:**
 
 - 公式 4173 バイトを 1 物理レコードとして扱います。旧 772 バイトの復元データは
   取得元レコードとして受け付けません。
 
-保存先:
+**保存先:**
 
 - native では `NL_KS` と `NL_KS_SEISEKI`、JRA-VAN 標準名モードでは `KISYU` と
   `KISYU_SEISEKI` へ原子的に保存します。
 - `NL_KS` は基本情報・初騎乗/初勝利・最近重賞 3 件、`NL_KS_SEISEKI` は
   本年・前年・累計の 3 行を保持します。
 
-既存 DB からの移行手順:
+**DataKubun:**
+
+- base domain は [公式 DataKubun の検証](#datakubun) の表を参照してください。
+
+**既存 DB からの移行手順:**
 
 - 既存の標準名テーブルが主キー契約を満たさない場合は行を変更せず停止します。
 - 現行 schema で再作成した後、`DIFN` の option 3/4 で全件を再取得してください。
 
 #### CH（調教師マスタ）
 
-公式レイアウト:
+**公式レイアウト:**
 
 - 公式 3862 バイトを 1 物理レコードとして扱います。旧 592 バイトの復元データは
   取得元レコードとして受け付けません。
 
-保存先:
+**保存先:**
 
 - native では `NL_CH` と `NL_CH_SEISEKI`、JRA-VAN 標準名モードでは `CHOKYO` と
   `CHOKYO_SEISEKI` へ原子的に保存します。
 - `NL_CH` は header・最近重賞 3 件、`NL_CH_SEISEKI` は本年・前年・累計の 3 行を
   保持します。
 
-既存 DB からの移行手順:
+**DataKubun:**
+
+- base domain は [公式 DataKubun の検証](#datakubun) の表を参照してください。
+
+**既存 DB からの移行手順:**
 
 - 旧標準名テーブルは主キーと文字列日付の契約を満たさないため、自動変換せず
   停止します。
@@ -833,16 +852,16 @@ DataKubun:
 
 #### HS（競走馬市場取引価格）
 
-公式レイアウト:
+**公式レイアウト:**
 
 - 現行 JV-Data 4.9.0.1 / SDK 5.0.0 の 200 バイト配置だけを受け付け、旧 196
   バイト配置は常に拒否します。
 
-identity（主キー）:
+**identity（主キー）:**
 
 - 公式の保存 identity は `KettoNum`, `SaleCode`, `FromDate` の 3 項目です。
 
-保存先:
+**保存先:**
 
 - native `NL_HS` と標準名 `SALE` は同じ ordered primary key、必須 header/key、
   公式 field capacity を使います。
@@ -851,13 +870,13 @@ identity（主キー）:
 - 現行 parser または同等の caller validation を通った行には
   `CurrentLayoutVersion=200` を保存します。
 
-DataKubun:
+**DataKubun:**
 
 - `DataKubun=0` はこの key だけを使う exact erase です。非 key 本文を decode
   しない扱いは exact erase を失わせないための project policy であり、
   provider 仕様が任意 binary 本文を規定しているという意味ではありません。
 
-値の扱い:
+**値の扱い:**
 
 - 現行 10 バイトの `HansyokuFNum` / `HansyokuMNum` 欄には 8 桁値＋space
   padding も正当に存在するため、strip 後の 8 文字は旧世代判定の根拠に
@@ -866,14 +885,16 @@ DataKubun:
   `MakeDate` から再解釈しません。一方、`SaleName` は provider が保持する当時
   表記をそのまま保存します。
 
-transaction:
+**transaction:**
 
 - `auto_commit=False` の同一呼出しで後続 HS が検証失敗した場合は、先行する
   未確定行とその統計を rollback します。
 - `auto_commit=True` では既に確定した provider operation を残す incremental
   semantics であり、失敗した後続 record を成功件数へ加えません。
+- 共通規則は [通常インポートの transaction / rollback 規約](#transaction-rollback)
+  を参照してください。
 
-既存 DB からの移行手順:
+**既存 DB からの移行手順:**
 
 - v2 以前の `NL_HS` / `SALE` は、空 table も含めて父母繁殖登録番号の値長などから
   世代を推測して自動移行しません。バックアップ後に table を再作成し、現行 200
@@ -886,34 +907,34 @@ transaction:
 
 #### HC（坂路調教）
 
-公式レイアウト:
+**公式レイアウト:**
 
 - 現行 JV-Data 4.9.0.1 / SDK 5.0.0 の 60 バイト配置だけを受け付けます。
 - 美浦の測定距離は 2004-11-30 に 600m から 800m へ変わりましたが、物理 record
   長と 4 項目 identity は変わりません。
 
-identity（主キー）:
+**identity（主キー）:**
 
 - `TresenKubun`, `ChokyoDate`, `ChokyoTime`, `KettoNum` の 4 項目です。
 
-保存先:
+**保存先:**
 
 - native `NL_HC` と標準名 `HANRO` は同じ ordered primary key、必須
   header/key/body、公式 field capacity を使用します。
 - HC は蓄積系のみで `RT_HC` は作成しません。
 
-DataKubun:
+**DataKubun:**
 
 - `DataKubun=0` は 4 項目 key だけを使う exact erase です。非 key 本文を decode
   しないのは削除指示を失わせないための project policy であり、provider 仕様が
   任意 binary 本文を規定するという意味ではありません。
 
-値の扱い:
+**値の扱い:**
 
 - 7 つの走破・lap time を 0.1 秒単位の provider 整数から秒へ正規化します。
   公式の測定不能値 `0000`/`000` は 0.0 秒として欠損と混同せず保持します。
 
-既存 DB からの移行手順:
+**既存 DB からの移行手順:**
 
 - 既存の nullable、keyless、wrong-key、wrong-type、追加列または追加
   UNIQUE/FK/CHECK を持つ `NL_HC` / `HANRO` は自動修復せず、mutation 前に
@@ -922,44 +943,44 @@ DataKubun:
 
 #### WC（ウッドチップ調教）
 
-公式レイアウト:
+**公式レイアウト:**
 
 - JV-Data 4.9.0.1 と SDK 5.0.0 の 105 バイト配置を使用し、10 ハロンから
   1 ハロンまでの合計・ラップを保存します。
 - 4.7.0.1 で追記されたのは美浦・栗東の提供開始時期と計測距離の説明であり、
   別の物理レイアウトではありません。
 
-identity（主キー）:
+**identity（主キー）:**
 
 - 公式キーはトレセン区分・調教年月日・調教時刻・血統登録番号の 4 項目です。
   `Course`（コース）や馬場周りは公式キーではありません。4 項目キーは
   [JRA-VAN ソフトサポートの回答](https://developer.jra-van.jp/t/topic/99)とも
   一致します。
 
-保存先:
+**保存先:**
 
 - native `NL_WC`、標準名モード `WOOD`。`WOOD` はデータ種別名と SDK 構造に
   対応させた jrvltsql の標準名モード上の canonical table 名であり、提供元が
   SQL DDL やテーブル名を規定しているという意味ではありません。
 
-DataKubun:
+**DataKubun:**
 
 - `0` は同じキーの削除です。
 
-値の扱い:
+**値の扱い:**
 
 - タイムが全桁 9 のデータは規定内として配信されるため、欠損へ置換せず数値
   sentinel として保存します
   （[スタッフ回答](https://developer.jra-van.jp/t/topic/367)）。
 
-既存 DB からの移行手順:
+**既存 DB からの移行手順:**
 
 - 旧版 jrvltsql が作成した `Course` 入り・トレセン区分なしの主キーは自動修復
   せず、取込前に拒否します。
 
 #### CS（コース情報）
 
-公式レイアウト:
+**公式レイアウト:**
 
 - JV-Data 4.8.0.2 / 4.9.0.1 と SDK 5.0.0 で同一の 6,829 バイト配置です。
   6,800 バイトの `CourseEx` を native `NL_CS` と標準名モード `COURSE` の両方へ
@@ -969,27 +990,27 @@ DataKubun:
   [公式サポートが不備を認めて再提供した事例](https://developer.jra-van.jp/t/topic/237)が
   あるため、6,829 バイト以外を推測補正せず拒否します。
 
-identity（主キー）:
+**identity（主キー）:**
 
 - 公式キーは競馬場コード・距離・トラックコード・コース改修年月日（改修後に
   最初に開催された日）の 4 項目です。
 
-保存先:
+**保存先:**
 
 - native `NL_CS`、標準名モード `COURSE`。
 
-DataKubun:
+**DataKubun:**
 
 - `DataKubun=2` は行だけでなく別途取得したコース図も更新される場合があるため、
   `JVCourseFile`/`JVCourseFile2` の結果を独自保存する利用者は図も更新して
   ください。
 
-値の扱い:
+**値の扱い:**
 
 - 競馬場コードとトラックコードは公式コード表 2001/2009 の有効値に限定し、
   未定義・未使用コードや物理幅を超える本文は取込前に拒否します。
 
-既存 DB からの移行手順:
+**既存 DB からの移行手順:**
 
 - 旧 jrvltsql の 3 項目主キー `NL_CS`、主キーなしの `COURSE`、本文列がないまま
   既存行を持つ `COURSE`、追加の一意制約を持つ表は、別改修日の履歴消失・本文
@@ -1003,16 +1024,16 @@ DataKubun:
 
 #### CK（出走時点情報）
 
-公式レイアウト:
+**公式レイアウト:**
 
 - 現行公式 6,870 バイトの 1,729 scalar leaf を扱います。旧 6,864 バイトは
   現行 offset と混同せず拒否します。
 
-identity（主キー）:
+**identity（主キー）:**
 
 - 7 列の公式キーです。
 
-保存先:
+**保存先:**
 
 - PostgreSQL の 1 テーブル列数上限を超えないよう、native 名モードでは互換親
   `NL_CK` と `NL_CK_CHAKU` 278 行、`NL_CK_RUIKEI` 8 行を 1 物理レコード単位の
@@ -1020,12 +1041,12 @@ identity（主キー）:
 - CK の JRA-VAN 標準名モードはまだ実装しておらず、`CHOKYO_DETAIL` へ誤って
   部分保存せず明示的に停止します。
 
-DataKubun:
+**DataKubun:**
 
 - `DataKubun=0` は 7 列の公式キーで親子を削除します。
 - base domain は [公式 DataKubun の検証](#datakubun) の表を参照してください。
 
-既存 DB からの移行手順:
+**既存 DB からの移行手順:**
 
 - 既存 `NL_CK` には完全展開していない行があるため、追加される
   `CKStorageVersion` が `NULL` の行を完全格納済みと扱ってはいけません。
@@ -1034,59 +1055,59 @@ DataKubun:
 
 #### DM（タイム型データマイニング予想）
 
-公式レイアウト:
+**公式レイアウト:**
 
 - 公式 303 バイトの 18 頭配列を扱います。
 
-保存先:
+**保存先:**
 
 - native 名モードでは `NL_DM` / `RT_DM` へ馬ごとの行として保存し、JRA-VAN
   標準名モードでは `MINING` へ 1 レース 1 行の wide 形式で保存します。
 
-値の扱い:
+**値の扱い:**
 
 - `DMTime` は公式 SDK と同じ 5 桁文字列（9分99秒99）を保持します。
 
-既存 DB からの移行手順:
+**既存 DB からの移行手順:**
 
 - 旧 48 バイト復元データ、旧標準名 `DATA_MASTER`、主キーのない `MINING`、
   数値型の `DMTime1`〜`DMTime18` は安全に自動変換できないため、取り込みを
   停止して再構築を求めます。
 
-速報 snapshot の扱いは [DM / TM 共通](#dm-tm-snapshot-transaction) を参照してください。
+DataKubun と速報 snapshot・transaction の扱いは [DM / TM 共通](#dm-tm-snapshot-transaction) を参照してください。
 
 #### TM（対戦型データマイニング予想）
 
-公式レイアウト:
+**公式レイアウト:**
 
 - 公式 141 バイトの 18 頭配列を扱います。
 
-保存先:
+**保存先:**
 
 - native 名モードでは `NL_TM` / `RT_TM` へ馬ごとの行として保存し、JRA-VAN
   標準名モードでは `TAISENGATA_MINING` へ 1 レース 1 行の wide 形式で
   保存します。
 
-値の扱い:
+**値の扱い:**
 
 - `TMScore` は公式 SDK と同じ 4 桁文字列を保持し、右端 1 桁が小数第一位です。
 
-既存 DB からの移行手順:
+**既存 DB からの移行手順:**
 
 - 旧 39 バイト復元データ、旧標準名 `TIME_MASTER`、主キーのない
   `TAISENGATA_MINING`、`TMScore` が整数型の旧 native テーブルは安全に自動
   変換できないため、取り込みを停止して再構築を求めます。
 
-速報 snapshot の扱いは [DM / TM 共通](#dm-tm-snapshot-transaction) を参照してください。
+DataKubun と速報 snapshot・transaction の扱いは [DM / TM 共通](#dm-tm-snapshot-transaction) を参照してください。
 
 #### DM / TM 共通（速報 snapshot と transaction）
 
-DataKubun:
+**DataKubun:**
 
 - base domain（`0`, `1`, `2`, `3`, `7`）と速報での `7` 拒否は
   [公式 DataKubun の検証](#datakubun) を参照してください。
 
-速報 snapshot の受け付け:
+**速報 snapshot の受け付け:**
 
 - 速報の非削除 DM/TM は、1 物理レコードから展開された同一種別・同一
   `DataKubun` の 1〜18 頭を完全な list として渡す必要があります。
@@ -1102,14 +1123,15 @@ DataKubun:
   複数の DM/TM 物理スナップショットを分割し、間にある削除や他種別レコードも
   提供順の 1 transaction で処理します。
 
-transaction:
+**transaction:**
 
 - 途中の不完全な展開、metadata の無い非削除行、または 1 操作でも DB 書込に
   失敗した batch は、先行操作も含めて全て rollback し、`inserted=0` を
-  返します。成功時の `inserted` は最終行数ではなく、提供順に正常適用した
-  展開行と隣接レコードの操作数です。
+  返します。
+- 成功時の `inserted` は最終行数ではなく、提供順に正常適用した展開行と隣接
+  レコードの操作数です。
 - DM/TM の native 速報スナップショット置換は、既存レース行の削除後に書込が
   失敗した場合、caller 所有を含む active transaction 全体を rollback します。
-  rollback 不能時は接続を無効化し、それも失敗した場合は batch・optimized・
+- rollback 不能時は接続を無効化し、それも失敗した場合は batch・optimized・
   single・速報の全入口から `TransactionRecoveryError` を送出し、通常の失敗
   結果へ変換しません。

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -25,6 +25,7 @@ nav:
   - 時系列オッズ: timeseries_odds.md
   - PostgreSQL: postgresql.md
   - 対応データ種別一覧: data_support.md
+  - レコード別の公式契約と移行手順: record_contracts.md
   - CLI: CLI.md
   - スクリプト一覧: scripts.md
   - アーキテクチャ: architecture.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -19,6 +19,10 @@ markdown_extensions:
   - toc:
       permalink: true
 
+validation:
+  links:
+    anchors: warn
+
 nav:
   - ホーム: index.md
   - はじめに: getting_started.md

--- a/specs/operations/20260818_data_support_readability_worklog.md
+++ b/specs/operations/20260818_data_support_readability_worklog.md
@@ -102,8 +102,10 @@
   backup → rebuild → reimport flow every record section already states
   (stop conditions stay per record), and the one-line digests, each a
   strict subset of its record section.
-- One independent reviewer additionally performed a clause-by-clause old vs
-  new comparison (see below).
+- A clause-by-clause old vs new comparison by an independent reviewer is
+  still outstanding at the time of writing; see the handoff note below.
+  This line was corrected after review comment 3804634673 pointed out that
+  the original wording claimed a review that had not been recorded.
 
 ## 要確認事項 (doc kept as-is; documented for a later decision)
 

--- a/specs/operations/20260818_data_support_readability_worklog.md
+++ b/specs/operations/20260818_data_support_readability_worklog.md
@@ -166,7 +166,7 @@
 
 - (filled in below)
 
-## Handoff note (Devin, 2026-08-18 22:55 JST)
+## Handoff note (Devin, 2026-08-18 22:39 JST)
 
 - The implementer session stopped at 22:31 JST on the Claude Code session
   limit (resets 03:00 JST) **after** the restructure commit

--- a/specs/operations/20260818_data_support_readability_worklog.md
+++ b/specs/operations/20260818_data_support_readability_worklog.md
@@ -166,27 +166,30 @@
 
 - (filled in below)
 
-## Handoff note (Devin, 2026-08-18 22:5x JST)
+## Handoff note (Devin, 2026-08-18 22:55 JST)
 
 - The implementer session stopped at 22:31 JST on the Claude Code session
   limit (resets 03:00 JST) **after** the restructure commit
-   and its gates, but **before the
+  `f558ec6409db7edb1f34ed03da2c00f21f640b38` and its gates, but **before the
   single batched independent review was recorded**. The 「Independent review
   and repair batch」 section above is therefore still empty; treat this PR as
   not yet independently reviewed.
-- Devin re-ran the docs gates on that commit read-only:
-   pass,  =>
-  ,  pass,  clean
-  (fatal flake8 reported only vendored  files, which CI excludes).
+- Devin re-ran the docs gates on that commit: `mkdocs build --strict` pass,
+  `python scripts/validate_test_gate.py` => `TEST GATE PASS`,
+  `uv lock --check` pass, `git diff --check` clean. Fatal flake8
+  (`E9,F63,F7,F82`) reported only vendored `.venv` files, which CI excludes.
 - Devin also ran an independent token-level fact check between
-   and the new pair
-  ( + ): every identifier,
-  table name, spec ID, byte count, DataKubun value and numeric literal in the
-  old page is still present in the new pages. The only old tokens absent are
-  the English words  and , which were unified into the
+  `origin/master:docs/data_support.md` and the new pair
+  (`docs/data_support.md` plus `docs/record_contracts.md`): every identifier,
+  table name, spec ID, byte count, DataKubun value and numeric literal present
+  in the old page is still present in the new pages. The only old tokens absent
+  are the English words `backup` and `reimport`, which were unified into the
   Japanese wording. The only new tokens are anchor slugs, the two file names,
-  , and list numbering, i.e. no new factual token.
-- Next: run the batched independent review at/after 03:00 JST, record it
+  and list numbering, i.e. no new factual token was introduced. This is a
+  necessary condition, not a sufficient one: it cannot detect a changed claim
+  that reuses the same tokens, which is why the batched independent review is
+  still required.
+- Next: run the batched independent review at or after 03:00 JST, record it
   here, then merge.
 
 ## Next safe command and STOP conditions

--- a/specs/operations/20260818_data_support_readability_worklog.md
+++ b/specs/operations/20260818_data_support_readability_worklog.md
@@ -102,10 +102,11 @@
   backup → rebuild → reimport flow every record section already states
   (stop conditions stay per record), and the one-line digests, each a
   strict subset of its record section.
-- A clause-by-clause old vs new comparison by an independent reviewer is
-  still outstanding at the time of writing; see the handoff note below.
-  This line was corrected after review comment 3804634673 pointed out that
-  the original wording claimed a review that had not been recorded.
+- A clause-by-clause old vs new comparison by an independent reviewer was
+  outstanding when this section was first written (see the handoff note
+  below; the earlier wording was corrected after review comment
+  3804634673). It has since been performed and is recorded in
+  「Independent review and repair batch」 below.
 
 ## 要確認事項 (doc kept as-is; documented for a later decision)
 
@@ -160,13 +161,111 @@
   `table_mappings.py:186-187`) exist but are not listed; not added because
   that would be a new fact.
 
-## Independent review and repair batch
+## Independent review and repair batch (Claude Code, 2026-08-19)
 
-- (filled in below after the single batched review)
+Continued in the same Claude Code session (`claude --model fable`,
+`claude-fable-5`, session id `b3c80966-f901-4d2e-8907-25c80ab2f654`) after
+the 03:00 JST limit reset. Reviewed head: `c33229dccd94b793f985700369ad2c17b9a9b8ed`
+(PR #218). Three read-only reviewers ran in parallel, one batch:
+
+- (a) fact-set diff — clause-by-clause old (`origin/master:docs/data_support.md`)
+  vs new (`docs/data_support.md`, `docs/record_contracts.md`), concentrating
+  on same-words-different-meaning, strength, and scope; plus a check of the
+  author's C001–C110 mapping. Result: **0 blocking, 0 omitted, 0 added
+  facts, 0 number/identifier changes**; the 9 external topic URLs match by
+  count. Findings: 2 should-fix (low), several nits — all "restore the old
+  wording" fixes.
+- (b) technical accuracy vs `src/` and `tests/` — checked the statements
+  moved into shared sections, every identifier in the digest tables, the
+  terminology note, and all anchors. Result: **0 blocking**; the shared
+  「速報 grouped batch と時系列 CLI の transaction 境界」 and 「0B14 の日単位
+  snapshot 置換と 0B16」 sections hold on the general realtime updater / CLI
+  paths (`src/realtime/updater.py:641-654, 694-720, 748-797, 820-849`,
+  `src/importer/importer.py:1689-1732`, `src/cli/main.py:1761-1790, 1871,
+  1884-1887`, `src/realtime/updater.py:129-152`,
+  `src/services/realtime_monitor.py:326-328`), not only for WF/TC. Findings:
+  1 should-fix (terminology note over-generalised 「速報」), nits.
+- (c) readability / structure / rendering — `mkdocs build --strict` pass,
+  all 40 fragments resolve in the built HTML, tables and nested lists render.
+  Findings: 6 should-fix (structure only), nits.
+
+Deduplicated repair batch (one commit, no fact added, dropped, or reworded
+in strength):
+
+1. Restored old wording where a digest or shared sentence had drifted:
+   - digest rows: 「成功時に caller 側 transaction を勝手に commit しない」;
+     HappyoTime row scoped to 旧版の速報開催情報標準名テーブル・`ODDS_*_HEAD`
+     の `HappyoTime` が `TIMESTAMP`; TC row 「`COMMENT` しかない構成を
+     `HASSOU_JIKOKU_CHANGE` へ自動転用しない」; HR row 「2004-08-14 より前の
+     通常 record」; KS/CH rows 「旧 772 / 592 バイト復元データは受け付けない」;
+   - shared migration flow: dropped the uniformly added 「保持期間内」 and
+     「対象テーブルだけ」 (old text says these only for some records), listed
+     「起動時」 among the stop timings, 「停止（拒否）」, 「再取込元（記載が
+     ある場合）」; digest row updated the same way;
+   - AV migration bullet restored the causal 「自動的な PK 変更は行わないため、
+     DB をバックアップし…」;
+   - removed the new terminology sentence 「蓄積系 = JVOpen / 速報 = JVRTOpen」
+     (over-general; the reviewer's proposed replacement would have added a
+     claim about 0B41/0B42 routing, so it was deleted instead of edited);
+   - 「レコード別の差分」→「レコード別の補足」; TC removed from the 0B14
+     補足 list (TC only links back).
+2. Structure / navigation (no text meaning changed): entry page order is now
+   読み方 → 先に結論 → 表の見方（凡例＋実装上の正本）→ 取得系統; the 3-layer
+   table names the actual sections and points to the digest; the sentence
+   under the JVRTOpen 速報 table became three link bullets; the digest is
+   split into the same five groups as the detail page with linked group
+   labels; detail-page sub-heading labels are bold; group heading renamed
+   「速報馬体重・開催情報系」; `MakeDate` boundaries are a 3-row table;
+   four long bullets split at sentence boundaries (HR, WF ×2, DM/TM); KS/CH
+   gained a `DataKubun` pointer to the shared base-domain table; DM/TM tail
+   lines point to DM/TM 共通 for DataKubun as well; HS transaction bullet
+   links back to the shared rule; HappyoTime migration bullet links to the
+   shared flow; CC links 日単位 snapshot 置換 to the shared section.
+3. Terminology: 「exact delete」→「exact erase」 (SLOP row; same page and HC
+   section already use erase); 0B20 row 「パーサー・スキーマのみ」 to match
+   the legend.
+4. `mkdocs.yml`: `validation: links: anchors: warn` so that `--strict` now
+   fails on a broken fragment (proved: a deliberately broken
+   `record_contracts.md#wh-broken` aborted the strict build with 1 warning;
+   restored). Reviewer (b) noted the previous pass was real but weak.
+
+Refuted or not applied (with reason):
+
+- CodeRabbit thread 3805258712 asked to add KS/CH key columns
+  (`KisyuCode`, `ChokyosiCode`), CK's seven key names, and native vs standard
+  DM/TM keys. Not applied: those facts are not in the old page and this PR
+  is a fact-preserving restructure; adding them needs its own evidence PR.
+  The DataKubun part is already covered by the shared table; pointers added.
+- (b) proposed wording for the terminology note added a routing claim →
+  sentence removed instead (see above).
+- (c) suggested merging the three near-identical 「project policy」 sentences
+  (HN/HS/HC) and compressing CC's 0B14 bullet → not merged (HN says 「物理」,
+  merging could strengthen HS/HC); CC kept, link added.
+- (c) suggested a gloss for 「mutation」 → not added (new definition).
+- (c) suggested nesting the nav and updating `RELEASE_NOTES.md` /
+  `CHANGELOG.md` pointers → not done (history files; entry page links to the
+  detail page). Mentioned in the PR body.
+- (a) noted `.tmp/claims_checklist.md` legend/line-range nits → fixed in the
+  local (git-ignored) checklist.
+
+Maintainer decisions received (Devin, 2026-08-18 23:50 JST) on 要確認事項,
+applied as "do not touch in this PR": item 4 confirmed correct by the
+official JV-Data change history (no edit needed); item 1 (quickstart
+standard/full) and item 2 (`0B51` key wording) are doc errors to be fixed in
+a separate PR; item 8 (UM replacement-key check missing on native `NL_UM`)
+is an implementation gap for a separate red-first iteration.
+
+Gates after the repair batch: `mkdocs build --strict` pass (with anchor
+validation, 0 warnings; 0 unresolved fragments by HTML-id check),
+`python scripts/validate_test_gate.py` → `TEST GATE PASS`, fatal flake8
+(`E9,F63,F7,F82`) → 0, `uv lock --check` pass, `git diff --check` clean,
+docs-adjacent tests 11 passed (Python 3.12).
 
 ## PR
 
-- (filled in below)
+- PR #218 `docs: split data_support into a reader entry page and per-record
+  contracts` (base `master`). Head after the repair batch is recorded in
+  the PR comment; merge is left to Devin.
 
 ## Handoff note (Devin, 2026-08-18 22:39 JST)
 
@@ -193,10 +292,15 @@
   still required.
 - Next: run the batched independent review at or after 03:00 JST, record it
   here, then merge.
+- Update (Claude Code, 2026-08-19): done — see 「Independent review and
+  repair batch」 above; the PR is now independently reviewed.
 
 ## Next safe command and STOP conditions
 
-- Next: address review threads on the PR with evidence; leave merge to Devin.
+- Next: keep PR #218 threads at zero unresolved with evidence; leave merge
+  to Devin. Separate follow-ups (not this PR): doc fixes for 要確認事項 1 and
+  2 (Devin), red-first fix for 要確認事項 8 (native `NL_UM` replacement-key
+  check).
 - STOP if a reviewer shows a fact was dropped/added/re-scoped and the fix
   would require choosing between doc and code wording that cannot be
   decided from the repository alone; in that case keep the old wording and

--- a/specs/operations/20260818_data_support_readability_worklog.md
+++ b/specs/operations/20260818_data_support_readability_worklog.md
@@ -1,0 +1,200 @@
+# data_support.md readability restructure worklog
+
+## Start state (2026-08-18)
+
+- Objective: make `docs/data_support.md` easier to read without changing
+  the set of facts it states (user request: 「わかりやすい形にしてほしい。
+  ただし嘘は絶対に入れないで」).
+- Scope: docs only. Split the 655-line page into a reader entry page
+  (`docs/data_support.md`) and a per-record contract page
+  (`docs/record_contracts.md`); add the new page to `mkdocs.yml` nav,
+  `docs/index.md`, and the README docs table. No parser/schema/CLI change.
+- Repository: `miyamamoto/jrvltsql`.
+- Worktree: `/home/keiba/scratch/20260818_jrvltsql_docs_readability`.
+- Branch: `docs/data-support-readability-20260818`.
+- Base and starting HEAD: `36800dcbba37d964653b6581cba7eba873fbdef2`
+  (`origin/master`, HN PR #217 squash merge). Worktree was clean.
+- Implementer: Claude Code, `claude --model fable` (`claude-fable-5`),
+  session id `b3c80966-f901-4d2e-8907-25c80ab2f654`.
+- Hard constraints followed: no fact added, dropped, weakened, or
+  strengthened; suspected doc/code disagreements are NOT edited in the doc
+  and are listed below as 要確認事項; every table / record type / spec ID /
+  CLI command / byte count / DataKubun value / primary-key column kept in
+  the doc was checked against `src/` and `tests/`.
+
+## Method
+
+1. Read `git show origin/master:docs/data_support.md` and enumerated its
+   claims as a numbered checklist (C001–C110, one row per sentence group,
+   keyed by old line numbers). Kept in the worktree-local
+   `.tmp/claims_checklist.md` (git-ignored); the same mapping is summarised
+   in the PR body.
+2. Ran four parallel read-only verification passes against the
+   implementation and tests, by category:
+   - dataspec IDs / options / retired names / realtime specs / CLI
+     subcommands and flags / batch files / retention comments
+     (`src/jvlink/constants.py`, `src/cli/main.py`, `scripts/*.py`, `*.bat`);
+   - table names (native `NL_*`, realtime `RT_*`, timeseries `TS_*`,
+     standard-name tables and read-side legacy aliases), column names,
+     primary keys, and fail-closed verifier functions
+     (`src/database/schema*.py`, `table_mappings.py`, `migration.py`,
+     `src/importer/importer.py`);
+   - record byte lengths, DataKubun base domains (38 types), historical
+     `MakeDate` gates, date boundaries and value rules
+     (`src/parser/*_parser.py`, `status_domain.py`, `code_domains.py`,
+     `tests/fixtures/official_layout/*`, `tests/test_*_official_contract.py`);
+   - transaction / rollback / `TransactionRecoveryError` / realtime grouped
+     batch / 0B14 snapshot / WF, CK, KS, CH coupling semantics
+     (`src/importer/`, `src/realtime/updater.py`,
+     `src/services/realtime_monitor.py`, `src/cli/main.py`).
+   Result: every identifier named in the doc exists; all 38 DataKubun rows,
+   all byte lengths, all primary-key lists, all CLI subcommands/flags, and
+   all realtime spec → record-type mappings match code. Items that could
+   not be confirmed or where wording differs from code are listed under
+   要確認事項 and were left unchanged in the doc.
+3. Restructured:
+   - `docs/data_support.md` (entry): 「このページの読み方」(3-layer guide +
+     表の見方 + 実装上の正本) → 先に結論 → 取得系統 → JVOpen 蓄積系データ →
+     JVRTOpen 速報レース・開催情報 → JVRTOpen オッズ・票数 →
+     パーサー・テーブル対応 → レコード別の契約・移行手順（要点、1 行 + link）
+     → 対象外. Tables kept verbatim; long contract prose moved out.
+   - `docs/record_contracts.md` (detail): 共通規則（公式 DataKubun の検証 /
+     通常インポートの transaction・rollback 規約 / 速報 grouped batch と時系列
+     CLI の transaction 境界 / HappyoTime（MMDDhhmm）/ 0B14 と 0B16 /
+     既存 DB からの移行の共通手順 / 旧仕様 dataspec 名）, then 22 record
+     sections (WH, WE, AV, JC, TC, CC / HR, SE, JG, WF / HN, UM, BT, KS, CH,
+     HS / HC, WC, CS / CK, DM, TM + DM/TM 共通) each with the same
+     sub-headings: 公式レイアウト / identity（主キー）/ 保存先 / DataKubun /
+     値の扱い（if any）/ 既存 DB からの移行手順.
+   - The task listed WH, TC, CC, HN, HC, HS, JG, WF, CK, DM, TM as the
+     detail-page targets; the remaining contract paragraphs (HR, SE, WE, AV,
+     JC, CS, WC, KS, CH, UM, BT) were moved as well, because leaving them in
+     the entry page would contradict the goal of a short entry page. Reason
+     is stated in the PR body.
+   - Scoping judgment: the old WF paragraph (old lines 586–597) contained
+     sentences whose subject is 「速報の通常 grouped batch」, psycopg SELECT
+     transactions, validation-only rejection, and 「時系列取得 CLI」. Their
+     wording is general and code confirms they are the general realtime
+     updater / CLI paths (`src/realtime/updater.py:641-654, 698-728,
+     822-849`; `src/importer/importer.py:1689-1732`;
+     `src/cli/main.py:1761-1792, 1871-1887`), so they were placed under
+     共通規則 with the WF section linking to them. WF-specific sentences
+     (batch-wide rollback of WF writes, `inserted` semantics) stayed in WF.
+4. Gates on the candidate commit: `mkdocs build --strict` pass (0 anchor
+   warnings; every `record_contracts.md#...` target verified in built HTML),
+   `python scripts/validate_test_gate.py` → `TEST GATE PASS`, fatal flake8
+   (`E9,F63,F7,F82`) → 0, `uv lock --check` pass, `git diff --check` clean.
+   Docs-adjacent tests (`tests/test_public_setup_contract.py`,
+   `tests/test_quickstart_cli.py -k docs/documentation/notes/contract`) →
+   11 passed under the repository-supported Python 3.12 environment.
+
+## Fact-set equality check (how it was done)
+
+- Old → new: each checklist row C001–C110 records the old line range and
+  the new file/heading where the statement now lives, and whether it is
+  同一 (same wording), 再構成 (bulletised/tabulated only), or 移動 (moved to
+  the detail page). All 110 rows have a target; none is dropped.
+- New → old: additions were limited to navigation text (「このページの読み方」
+  tables, group headings, sub-heading labels), a terminology note (native =
+  `NL_*`/`RT_*`; 標準名 = JRA-VAN 標準名モードのテーブル), a
+  旧名→現行名 table that repeats the JVOpen table's 旧仕様名 column, a
+  「既存 DB からの移行の共通手順」 paragraph that only generalises the
+  backup → rebuild → reimport flow every record section already states
+  (stop conditions stay per record), and the one-line digests, each a
+  strict subset of its record section.
+- One independent reviewer additionally performed a clause-by-clause old vs
+  new comparison (see below).
+
+## 要確認事項 (doc kept as-is; documented for a later decision)
+
+1. quickstart standard / full: the doc says `MING` and `COMM` are 「full
+   quickstart に含めています」 and `TOKU`/`SLOP`/`WOOD`/`HOYU` 「standard /
+   full quickstart に含めています」. `scripts/quickstart.py:1858-1888`
+   defines `STANDARD_SPECS` and `FULL_SPECS` as identical lists (both include
+   `MING` and `COMM`). Not edited.
+2. `0B51` key format 「`YYYYMMDD` または WIN5 開催キー」: only the date-keyed
+   form is evidenced (`src/jvlink/constants.py:129,137,163-168`,
+   `scripts/daily_update.py:48`). Not edited.
+3. `JVCourseFile` / `JVCourseFile2` (CS section) and `JVWatchEvent` (0B16 /
+   AV) are JV-Link API names; no implementation in `src/` (`JVWatchEvent`
+   appears only in comments, e.g. `src/jvlink/constants.py:135`). Kept as
+   provider-API references.
+4. 2023-08 JV-Data change widths 「繁殖登録番号 8→10 / 生産者コード 6→8 /
+   生産者名 70→72」: the repo records whole-record length changes effective
+   2023-08-08 (`tests/fixtures/official_layout/jvdata_layout_history.json`)
+   and 10-char `HansyokuNum` constants; the 6→8 and 70→72 field widths are
+   not stated anywhere in `src/`/`tests/`. Kept.
+5. CK 「1物理レコード単位のtransactionで更新」 and WF 「提供順にtransactionで
+   置き換え」: happy path uses one transaction per batch with per-record
+   parent+children grouping inside (`src/importer/importer.py:6344-6350`,
+   `:3341-3363`); per-record transactions only in the `DatabaseError`
+   retry (`:6360-6375`). Atomicity holds; granularity wording differs. Kept.
+6. `0B14` 「正常終了を確認した同一transaction内で…置換」:
+   `src/services/realtime_monitor.py:321-328` issues `replace_date_snapshot`
+   right after `JVRTOpen` returns ≥ 0, before the record stream is drained;
+   the whole cycle rolls back on any failure (`:280-281`). End state matches;
+   timing wording differs. Kept.
+7. KS/CH 「本年・前年・累計の3行」: exactly three rows are enforced
+   (`src/importer/importer.py:5422-5424`, `:5246-5248`); the labels are not
+   in code. Kept.
+8. UM UNIQUE/exclusion and deferrable-PK rejection is implemented for the
+   standard-name `UMA` via `_verify_replacement_key_constraints`
+   (`src/importer/importer.py:2945`, `:3425-3430`); no dedicated native
+   `NL_UM` verifier. Kept.
+9. DM 「`DMTime`は…5桁文字列」: bare `DMTime` exists in native
+   `NL_DM`/`RT_DM` (`src/database/schema.py:373,1663`); `MINING` has
+   `DMTime1`..`DMTime18` `VARCHAR(5)` (`schema_jravan.py:835-903`). Kept.
+10. `inserted` = provider-order operations: confirmed for realtime
+    WF/DM/TM (`src/realtime/updater.py:781,925,999`); importer statistics
+    count provider operations only for `_PROVIDER_OPERATION_COUNT_STORAGE_TABLES`
+    (`importer.py:692-700`). Kept (doc scopes it to realtime `inserted`).
+11. WH 「起動時の schema migration は主キー不一致を検出して停止」: no
+    dedicated WH verifier; the generic `verify_table_schema`
+    (`src/database/migration.py:421,507-522`) raises, while
+    `migrate_table_if_needed` logs and returns `False` without altering
+    (`:352-359`). Behaviour matches the doc. Kept.
+- Observations, no doc change: `RT_RC` (`src/database/schema.py:2375`) and
+  `TS_O3`–`TS_O6` (`schema.py:2548-2640`, retained for compatibility per
+  `table_mappings.py:186-187`) exist but are not listed; not added because
+  that would be a new fact.
+
+## Independent review and repair batch
+
+- (filled in below after the single batched review)
+
+## PR
+
+- (filled in below)
+
+## Handoff note (Devin, 2026-08-18 22:5x JST)
+
+- The implementer session stopped at 22:31 JST on the Claude Code session
+  limit (resets 03:00 JST) **after** the restructure commit
+   and its gates, but **before the
+  single batched independent review was recorded**. The 「Independent review
+  and repair batch」 section above is therefore still empty; treat this PR as
+  not yet independently reviewed.
+- Devin re-ran the docs gates on that commit read-only:
+   pass,  =>
+  ,  pass,  clean
+  (fatal flake8 reported only vendored  files, which CI excludes).
+- Devin also ran an independent token-level fact check between
+   and the new pair
+  ( + ): every identifier,
+  table name, spec ID, byte count, DataKubun value and numeric literal in the
+  old page is still present in the new pages. The only old tokens absent are
+  the English words  and , which were unified into the
+  Japanese wording. The only new tokens are anchor slugs, the two file names,
+  , and list numbering, i.e. no new factual token.
+- Next: run the batched independent review at/after 03:00 JST, record it
+  here, then merge.
+
+## Next safe command and STOP conditions
+
+- Next: address review threads on the PR with evidence; leave merge to Devin.
+- STOP if a reviewer shows a fact was dropped/added/re-scoped and the fix
+  would require choosing between doc and code wording that cannot be
+  decided from the repository alone; in that case keep the old wording and
+  extend 要確認事項.
+- No production DB (192.168.0.220), no provider fetch, no `kps_*`
+  container was touched. No credentials recorded.


### PR DESCRIPTION
## Summary

`docs/data_support.md`（655 行）を、事実の集合を変えずに読みやすく再構成しました。docs のみの変更です。

- `docs/data_support.md` は**利用者の入口**にしました: 「このページの読み方」（3 層構成の案内・表の見方・実装上の正本）→ 先に結論 → 取得系統 → JVOpen 蓄積系データ → JVRTOpen 速報レース・開催情報 → JVRTOpen オッズ・票数 → パーサー・テーブル対応 → レコード別の契約・移行手順（要点 1 行 + リンク）→ 対象外。
- 新規 `docs/record_contracts.md` に、レコード別の公式契約と移行手順を移しました。共通規則（公式 `DataKubun` の検証 / 通常インポートの transaction・rollback 規約 / 速報 grouped batch と時系列 CLI の transaction 境界 / `HappyoTime`（`MMDDhhmm`）/ `0B14` と `0B16` / 既存 DB からの移行の共通手順 / 旧仕様 dataspec 名）を 1 箇所に書き、22 のレコード節を同じ小見出し（公式レイアウト / identity（主キー）/ 保存先 / DataKubun / 値の扱い / 既存 DB からの移行手順）で揃えました。
- `mkdocs.yml` の nav（`対応データ種別一覧` の直後）、`docs/index.md`、README の詳細ドキュメント表に新ページを追加しました。

### 推奨構成からの変更点と理由

- 依頼で例示された対象（WH, TC, CC, HN, HC, HS, JG, WF, CK, DM, TM）に加えて、HR, SE, WE, AV, JC, CS, WC, KS, CH, UM, BT の契約段落も `record_contracts.md` へ移しました。入口ページに長文の契約段落を残すと「利用者の入口」という目的に反するためです。情報は 1 文も落としていません。
- 旧 WF 段落（旧 586–597 行）のうち、主語が「速報の通常 grouped batch」「時系列取得 CLI」「psycopg」である一般記述は、共通規則「速報 grouped batch と時系列 CLI の transaction 境界」に置きました。実装上も WF 固有ではなく速報 updater / CLI の一般経路です（`src/realtime/updater.py:641-654, 698-728, 822-849`、`src/importer/importer.py:1689-1732`、`src/cli/main.py:1761-1792, 1871-1887`）。WF 固有の文（WF 書込の batch 全体 rollback、`inserted` の意味）は WF 節に残しています。

## 事実集合の照合方法

1. `git show origin/master:docs/data_support.md` の全文を、旧行番号付きの主張チェックリスト C001–C110（文グループ単位）に列挙しました。
2. 各行について新ファイル内の見出し位置を 1:1 で記録し、「同一 / 再構成（箇条書き・表化のみ）/ 移動」を付けました。110 行すべてに対応先があり、削除はありません。
3. 新→旧の逆方向では、追加した文が「導線・見出し・用語注・旧名→現行名の対応表（JVOpen 表の旧仕様名列と同じ）・移行の共通手順（各節が個別に述べる backup → 再作成 → 再取込の流れをまとめたもの。停止条件は各節に残置）・要点 1 行（各節の部分集合）」に限られることを確認しました。
4. 独立レビュー（3 観点、1 バッチ）を実施し、指摘を 1 回の修正バッチ（`e6f6e81`）で反映しました。結果は下記「独立レビュー結果」と worklog の「Independent review and repair batch」節に記録しています。これに先立ち Devin が旧ページと新 2 ページの token 単位の照合を行い、識別子・テーブル名・spec ID・バイト数・`DataKubun` 値・数値リテラルがすべて新ページに存在することを確認しています（欠落は英単語 `backup` / `reimport` の日本語化のみ、追加は anchor slug とファイル名と箇条書き番号のみ）。

## 独立レビュー結果（reviewed head `c33229d` → 修正 `e6f6e81`）

- (a) 事実集合の逐条照合: **blocking 0 / 欠落 0 / 追加 0 / 数値・識別子の変化 0**。should-fix（低）2 件（共通移行手順に「保持期間内」「だけ」を一律付与していた点、グループ見出し「速報開催情報系」に WH を含めていた点）と、要点表の nit 4 件（速報 grouped batch 行の「成功時に」、HappyoTime 行の対象範囲、TC 行の `COMMENT` 文言、HR 行の「通常 record」、KS/CH 行の「復元データ」）、AV の因果「ため」の復元 → すべて旧文言へ戻す形で反映。
- (b) 実装との一致: **blocking 0**。共通規則へ移した「速報 grouped batch と時系列 CLI の transaction 境界」「0B14 の日単位 snapshot 置換と 0B16」は WF/TC 固有ではなく一般経路で成立することをコードで確認（`src/realtime/updater.py:641-654, 694-720, 748-797, 820-849`、`src/importer/importer.py:1689-1732`、`src/cli/main.py:1761-1790, 1871, 1884-1887`、`src/realtime/updater.py:129-152`、`src/services/realtime_monitor.py:326-328`）。should-fix 1 件: 新規に加えた用語注「蓄積系 = JVOpen / 速報 = JVRTOpen」が過剰一般化 → 追記案は 0B41/0B42 の経路に関する新事実になるため採らず、文を削除。アンカー検証が INFO レベルで `--strict` を落とさない点の指摘 → `mkdocs.yml` に `validation.links.anchors: warn` を追加（壊れた fragment で strict build が失敗することを実測）。
- (c) 読みやすさ・構成: should-fix 6 件（先に結論を読み方の直後へ、3 層表の節名一致、速報表下の長文を箇条書きへ、小見出しラベルの太字化、読み方の自己記述の修正、KS/CH の DataKubun ポインタ）と nit（`MakeDate` 境界の表化、長い箇条書きの文単位分割、要点表の 5 グループ分割、`exact delete`→`exact erase` の用語統一、0B20 行を凡例表記に合わせる）→ 反映。HN/HS/HC の同文統合・「mutation」の語義追加・nav の入れ子は事実追加や強度変化の恐れがあるため不採用。
- CodeRabbit の「KS/CH/CK/DM/TM の主キー列名を追記」要求は、旧ページに無い事実の追加になるため反証（別 PR の対象）。DataKubun は共通表へのポインタで対応。
- maintainer 判断（Devin, 2026-08-18 23:50 JST）: 要確認事項 4 は公式仕様で正しいと確認（修正不要）。1・2 はドキュメント側の誤りとして**別 PR**で修正、8 は実装の穴として**別イテレーション**で赤先行修正。この PR では触っていません。

## 識別子の実在確認

テーブル名（`NL_*` / `RT_*` / `TS_*` / 標準名 / 読み取り互換 alias）、レコード種別 38 形式、spec ID（JVOpen 14 種・JVRTOpen 18 種・旧名 6 種）、CLI サブコマンドとフラグ、batch ファイルとフラグ、バイト数、`DataKubun` domain（38 形式全行）、`MakeDate` 境界、主キー列を `src/` と `tests/` で確認しました。全て実在します。確認できなかった／表現がコードと異なる疑いのある項目は下記に挙げ、**本文は変更していません**。

## 要確認事項（本文は旧記述のまま）

1. quickstart の standard / full: 本文は `MING`, `COMM` を「full quickstart に含めています」、`TOKU`/`SLOP`/`WOOD`/`HOYU` を「standard / full quickstart に含めています」としていますが、`scripts/quickstart.py:1858-1888` の `STANDARD_SPECS` と `FULL_SPECS` は同一リスト（どちらも `MING`, `COMM` を含む）です。
2. `0B51` のキー形式「`YYYYMMDD` または WIN5 開催キー」: 日付キーだけが実装で確認できます（`src/jvlink/constants.py:129,137,163-168`、`scripts/daily_update.py:48`）。
3. `JVCourseFile` / `JVCourseFile2`（CS）、`JVWatchEvent`（0B16 / AV）: JV-Link API 名であり `src/` に実装はありません（`JVWatchEvent` はコメントのみ、例 `src/jvlink/constants.py:135`）。
4. 2023-08 仕様変更の桁数「繁殖登録番号 8→10 / 生産者コード 6→8 / 生産者名 70→72」: リポジトリにはレコード長の変更（`tests/fixtures/official_layout/jvdata_layout_history.json`、2023-08-08）と 10 桁 `HansyokuNum` の定数はありますが、6→8 / 70→72 の項目幅は記録がありません。
5. CK「1物理レコード単位のtransactionで更新」/ WF「提供順にtransactionで置き換え」: 正常系は batch 単位の 1 transaction 内で親子をレコード単位にまとめて書き（`src/importer/importer.py:6344-6350`, `:3341-3363`）、レコード単位 transaction は `DatabaseError` 後の再試行だけです（`:6360-6375`）。原子性は一致、粒度の表現が異なります。
6. `0B14`「正常終了を確認した同一transaction内で…置換」: `src/services/realtime_monitor.py:321-328` は `JVRTOpen` の戻り値確認直後（レコード読み出し前）に `replace_date_snapshot` を発行し、失敗時は cycle 全体を rollback します（`:280-281`）。最終状態は一致、タイミングの表現が異なります。
7. KS/CH「本年・前年・累計の3行」: 3 行であることは強制されています（`src/importer/importer.py:5422-5424`, `:5246-5248`）が、行のラベルはコードにありません。
8. UM の UNIQUE/exclusion・遅延主キー拒否: 標準名 `UMA` の `_verify_replacement_key_constraints`（`src/importer/importer.py:2945`, `:3425-3430`）で実装。native `NL_UM` 専用 verifier はありません。
9. DM「`DMTime` は…5 桁文字列」: 素の `DMTime` 列は native `NL_DM`/`RT_DM`（`src/database/schema.py:373,1663`）にあり、`MINING` は `DMTime1`〜`DMTime18` `VARCHAR(5)`（`schema_jravan.py:835-903`）です。
10. `inserted`「提供順に正常適用された操作数」: 速報 WF/DM/TM で確認（`src/realtime/updater.py:781,925,999`）。importer 統計で provider 操作数を数えるのは `_PROVIDER_OPERATION_COUNT_STORAGE_TABLES`（`importer.py:692-700`）の表だけです。
11. WH「起動時の schema migration は主キー不一致を検出して停止」: WH 専用 verifier はなく、汎用 `verify_table_schema`（`src/database/migration.py:421,507-522`）が停止させます。`migrate_table_if_needed` は変更せず警告して `False` を返します（`:352-359`）。挙動は本文と一致します。
- 観察（本文変更なし）: `RT_RC`（`schema.py:2375`）と `TS_O3`〜`TS_O6`（`schema.py:2548-2640`、`table_mappings.py:186-187` により互換維持）は実在しますが本文に無いため、事実追加を避けて記載していません。

## ゲート

- `mkdocs build --strict`: pass（`validation.links.anchors: warn` を有効化し、アンカー警告 0。`record_contracts.md#...` の全リンク先を生成 HTML の id で確認）
- `python scripts/validate_test_gate.py`: `TEST GATE PASS`
- fatal flake8（`E9,F63,F7,F82`）: 0
- `uv lock --check`: pass
- `git diff --check`: clean
- docs 隣接テスト（`tests/test_public_setup_contract.py`, `tests/test_quickstart_cli.py -k docs/documentation/notes/contract`）: 11 passed（Python 3.12）

## worklog

`specs/operations/20260818_data_support_readability_worklog.md`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive guidance on official record layouts, validation, storage, migration, rollback, and realtime snapshot handling.
  * Improved the data support guide with clearer summaries, supported formats, commands, storage locations, and record references.
  * Updated documentation navigation with a recommended reading order and the new record contracts guide.
  * Added link and anchor validation to improve documentation navigation.
  * Added a worklog documenting the documentation restructuring and verification process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
