### PR TITLE
docs: correct quickstart standard/full and the 0B51 request key

### DIFF
--- a/docs/data_support.md
+++ b/docs/data_support.md
@@ -63,16 +63,21 @@ jrvltsql は JRA / 中央競馬専用です。NAR / 地方競馬はこのリポ�
 | `RACE` | - | レース、出走馬、払戻、確定オッズ、票数、WIN5、除外情報 | `RA`, `SE`, `HR`, `H1`, `H6`, `O1`〜`O6`, `WF`, `JG` | `NL_RA`, `NL_SE`, `NL_HR`, `NL_H1`, `NL_H6`, `NL_O1`〜`NL_O6`, `NL_WF`, `NL_JG` | はい | はい | はい | 中核データです。`NL_O*` は確定オッズで、投資判断時点のオッズではありません。 |
 | `DIFN` | `DIFF` | 蓄積系マスタ差分 | `UM`, `KS`, `CH`, `BR`, `BN`, `RC` | `NL_UM`, `NL_KS`, `NL_KS_SEISEKI`, `NL_CH`, `NL_CH_SEISEKI`, `NL_BR`, `NL_BN`, `NL_RC` | はい | いいえ | はい | 旧名 `DIFF` は受け付けません（[旧仕様 dataspec 名](record_contracts.md#dataspec-diff-blod-snap-hose-tcov-rcov) 参照）。 |
 | `BLDN` | `BLOD` | 血統情報 | `HN`, `SK`, `BT` | `NL_HN`, `NL_SK`, `NL_BT` | はい | いいえ | はい | 旧名 `BLOD` は受け付けません（同上）。 |
-| `MING` | - | データマイニング予想 | `DM`, `TM` | `NL_DM`, `NL_TM` | はい | いいえ | はい | full quickstart に含めています。 |
+| `MING` | - | データマイニング予想 | `DM`, `TM` | `NL_DM`, `NL_TM` | はい | いいえ | はい | standard / full quickstart に含めています。 |
 | `SLOP` | - | 坂路調教関連 | `HC` | `NL_HC`（native）、`HANRO`（標準名モード） | はい | いいえ | はい | 現行`DataKubun=1`は60バイトの全項目を保存します。`DataKubun=0`は本文を保存せず、公式4項目キーでexact eraseします。standard / full quickstart に含めています。 |
 | `WOOD` | - | ウッドチップ調教関連 | `WC` | `NL_WC`（native）、`WOOD`（標準名モード） | はい | いいえ | はい | 現行105バイトを全項目保存します。公式キーはトレセン区分・調教年月日・調教時刻・血統登録番号の4項目で、`0` は同じキーの削除です。standard / full quickstart に含めています。 |
 | `YSCH` | - | 開催スケジュール | `YS` | `NL_YS` | はい | いいえ | はい | 開催カレンダー保守に使います。 |
 | `HOSN` | `HOSE` | 競走馬市場取引価格 | `HS` | `NL_HS` | はい | いいえ | はい | 旧名 `HOSE` は受け付けません（同上）。 |
 | `HOYU` | - | 馬名の意味由来 | `HY` | `NL_HY` | はい | いいえ | はい | standard / full quickstart に含めています。 |
-| `COMM` | - | 各種解説・コース情報 | `CS` | `NL_CS`（native）、`COURSE`（標準名モード） | はい | いいえ | はい | 現行6,829バイトと6,800バイトのコース説明を完全保存します。full quickstart に含めています。 |
+| `COMM` | - | 各種解説・コース情報 | `CS` | `NL_CS`（native）、`COURSE`（標準名モード） | はい | いいえ | はい | 現行6,829バイトと6,800バイトのコース説明を完全保存します。standard / full quickstart に含めています。 |
 | `SNPN` | `SNAP` | 出走時点情報 | `CK` | `NL_CK`、`NL_CK_CHAKU`、`NL_CK_RUIKEI` | はい | はい | はい | 現行6,870バイトをnative名モードで完全格納します。既定 quickstart では使っていません。旧名 `SNAP` は受け付けません（同上）。 |
 | `TCVN` | `TCOV` | 特別登録馬情報補填 | 複数のマスタ・レース系レコード | レコード種別に応じた既存 `NL_*` テーブル | いいえ | はい | いいえ | 今週データ更新で使います。旧名 `TCOV` は受け付けません（同上）。 |
 | `RCVN` | `RCOV` | レース情報補填 | 複数のマスタ・レース系レコード | レコード種別に応じた既存 `NL_*` テーブル | いいえ | はい | いいえ | 今週データ更新で使います。旧名 `RCOV` は受け付けません（同上）。 |
+
+`quickstart` の `standard` モードと `full` モードは、取得するデータ種別の一覧が
+同一です（`scripts/quickstart.py` の `STANDARD_SPECS` と `FULL_SPECS`）。
+確定オッズ（`O1`〜`O6`）は `RACE` に含まれるため、`full` でも追加のデータ種別は
+増えません。
 
 `O1`〜`O6` は `RACE` や速報系ストリームに含まれるレコード種別IDであり、
 単独の `JVOpen` データ種別IDではありません。確定オッズは `RACE` を取得して
@@ -95,7 +100,7 @@ jrvltsql は JRA / 中央競馬専用です。NAR / 地方競馬はこのリポ�
 | `0B15` | 出走馬名表以降の速報レース情報 | `RA`, `SE`, `HR` | `RT_RA`, `RT_SE`, `RT_HR` | `YYYYMMDD` | 対応済み |
 | `0B16` | 速報開催情報指定 | `WE`, `AV`, `JC`, `TC`, `CC` | `RT_WE`, `RT_AV`, `RT_JC`, `RT_TC`, `RT_CC` | `JVWatchEvent` が返すイベントキー | パーサー・保存対応。日付指定の日次同期には含めない |
 | `0B17` | 速報対戦型データマイニング予想 | `TM` | `RT_TM` | `YYYYMMDD` | 対応済み |
-| `0B51` | 速報重勝式 WIN5 | `WF` | `RT_WF` | `YYYYMMDD` または WIN5 開催キー | 公式7,215-byte形式（対象5レース・有効票数5件・払戻243件）に対応。速報系のデータ区分は0/1/2/3/9で、蓄積系のみの7は受け付けません |
+| `0B51` | 速報重勝式 WIN5 | `WF` | `RT_WF` | `YYYYMMDD` | 公式7,215-byte形式（対象5レース・有効票数5件・払戻243件）に対応。速報系のデータ区分は0/1/2/3/9で、蓄積系のみの7は受け付けません |
 
 この表に関わる共通規則は [レコード別の公式契約と移行手順](record_contracts.md)
 にあります。

--- a/specs/operations/20260819_data_support_fact_fix_worklog.md
+++ b/specs/operations/20260819_data_support_fact_fix_worklog.md
@@ -1,0 +1,73 @@
+# data_support fact fix (quickstart standard/full, 0B51 key) — 2026-08-19
+
+Base: `origin/master` = `008b97c0e559474eda8888db91f3356f016f3b7b`
+(PR #218, the fact-preserving restructure). This iteration changes facts, so it
+is a separate PR by design.
+
+## Scope
+
+Two of the 要確認事項 recorded in
+`specs/operations/20260818_data_support_readability_worklog.md` were adjudicated
+against the official specifications and are corrected here. The other items in
+that list are unchanged.
+
+## Sources used
+
+Official documents (primary, version 4.8 and later):
+
+- `JV-Data4901.pdf` (JV-Data 仕様書 4.9.0.1)
+- `JV-Data4802.pdf` (JV-Data 仕様書 4.8.0.2)
+- `JV-Link4901.pdf` (JV-Link 仕様書 4.9.0.1)
+
+Implementation (secondary): `scripts/quickstart.py`, `src/jvlink/constants.py`,
+`scripts/daily_update.py`.
+
+## Item 1 — quickstart `standard` / `full` (doc was wrong)
+
+`scripts/quickstart.py` defines `STANDARD_SPECS` and `FULL_SPECS` as identical
+lists: `TOKU, RACE, DIFN, BLDN, MING, SLOP, WOOD, YSCH, HOSN, HOYU, COMM`
+(all with the same option values). `MING` and `COMM` are in both. The two modes
+therefore request the same データ種別; the in-code note 「フルモード: 標準 +
+オッズ」 holds only because `O1`–`O6` are record types inside `RACE`, so `full`
+adds no データ種別.
+
+The page claimed `MING` and `COMM` are 「full quickstart に含めています」, i.e.
+that they are full-only. Corrected to 「standard / full quickstart に含めて
+います」 and one sentence added next to the JVOpen table stating that the two
+mode lists are identical and why `full` adds nothing.
+
+Maintainer decision (2026-08-19): accept that `standard` and `full` are
+equivalent; do not change the implementation to create a distinction. This PR
+is documentation only.
+
+## Item 2 — `0B51` request key (doc was misleading)
+
+JV-Link 4.9.0.1 defines `JVRTOpen` key formats for three units only:
+race (`YYYYMMDDJJKKHHRR` / `YYYYMMDDJJRR`), day (`YYYYMMDD`), and
+change-information (the values returned by the watch event). JV-Data 4.9.0.1
+lists `0B51` as 速報重勝式(WIN5) with 提供単位 「重勝式開催毎」, but no separate
+key syntax is defined for that unit anywhere in the inspected official material.
+The implementation issues the 8-digit date form (`src/jvlink/constants.py`,
+`scripts/daily_update.py`).
+
+The page's 「`YYYYMMDD` または WIN5 開催キー」 reads as if a second, distinct key
+syntax existed. Corrected to `YYYYMMDD`. The 提供単位 itself is unchanged
+elsewhere on the page.
+
+## Items kept unchanged
+
+- 2023-08 field widths (繁殖登録番号 8→10, 生産者コード 6→8, 生産者名(法人格無)
+  70→72, and the producer/breeding master equivalents): confirmed by the
+  2023-08-08 change history in the official JV-Data 仕様書. The page is correct;
+  no edit.
+- UM replacement-key verification missing on native `NL_UM`: an implementation
+  gap, not a documentation error. Handled in its own red-first iteration; the
+  documentation is not weakened here to match the current behaviour.
+
+## Gates
+
+- `mkdocs build --strict` — pass (anchor validation enabled, 0 warnings)
+- `scripts/validate_test_gate.py` — `TEST GATE PASS`
+- `tests/test_public_setup_contract.py tests/test_quickstart_cli.py` — 60 passed
+- `uv lock --check` — pass
+- `git diff --check` — clean


### PR DESCRIPTION
## Summary

PR #218 restructured `docs/data_support.md` without changing any fact, and listed 11 suspected doc/implementation mismatches as 要確認事項. This PR fixes the two of them that were adjudicated against the official specifications (JV-Data 4.8.0.2 / 4.9.0.1, JV-Link 4.9.0.1). Documentation only; no implementation change.

**1. quickstart `standard` / `full` are the same list.**

```python
# scripts/quickstart.py
STANDARD_SPECS = [TOKU, RACE, DIFN, BLDN, MING, SLOP, WOOD, YSCH, HOSN, HOYU, COMM]
FULL_SPECS     = [TOKU, RACE, DIFN, BLDN, MING, SLOP, WOOD, YSCH, HOSN, HOYU, COMM]  # identical
```

The page said `MING` and `COMM` are 「full quickstart に含めています」, i.e. full-only. They are in both. `full` adds no データ種別 because `O1`–`O6` are record types inside `RACE`. Rows corrected to 「standard / full」 and one sentence added next to the JVOpen table stating the two mode lists are identical and why.

Maintainer decision: accept the equivalence in the documentation rather than narrowing `standard` in code, so `scripts/quickstart.py` is untouched.

**2. `0B51` has no separate WIN5 key syntax.**

JV-Link 4.9.0.1 defines `JVRTOpen` key syntax for three units only — race (`YYYYMMDDJJKKHHRR` / `YYYYMMDDJJRR`), day (`YYYYMMDD`), and change-information (watch-event return values). JV-Data 4.9.0.1 lists `0B51` with 提供単位 「重勝式開催毎」, but specifies no key syntax for that unit, and the implementation issues the 8-digit date form (`src/jvlink/constants.py`, `scripts/daily_update.py`). 「`YYYYMMDD` または WIN5 開催キー」 implied a second syntax that does not exist, so the alternative is removed. The 提供単位 statement itself is unchanged.

**Not changed on purpose**

- 2023-08 field widths (繁殖登録番号 8→10, 生産者コード 6→8, 生産者名(法人格無) 70→72 and the producer/breeding-master equivalents) — the earlier note that the repo has no evidence for these was wrong: the official JV-Data change history for 2023-08-08 states them explicitly. The page was already correct.
- UM replacement-key verification missing on native `NL_UM` — that is an implementation gap (fail-open), so the documentation is deliberately *not* weakened to match current behaviour. It gets its own red-first iteration.

Evidence and the remaining 要確認事項 are recorded in `specs/operations/20260819_data_support_fact_fix_worklog.md`.

## Gates

`mkdocs build --strict` pass (anchor validation on, 0 warnings) · `scripts/validate_test_gate.py` → `TEST GATE PASS` · `tests/test_public_setup_contract.py tests/test_quickstart_cli.py` 60 passed · `uv lock --check` pass · `git diff --check` clean


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that standard and full quickstart modes include the same data set, including MING and COMM.
  * Documented shared quickstart data specifications and confirmed-odds behavior.
  * Updated the 0B51 WIN5 key format to use only `YYYYMMDD`.
  * Added a worklog recording specification corrections and validation results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->