### PR TITLE
docs(release): state the verified scope of the 2.0.0.dev0 development-test prerelease

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -9,8 +9,8 @@ What `2.0.0.dev0` is verified against:
 
 - the complete test gate on the frozen release SHA, with SQLite and a real
   PostgreSQL 16 backend
-- a wheel/sdist built from that same SHA, installed into an isolated virtual
-  environment, where `jltsql --version`, `jltsql init`, full schema creation
+- a wheel and an sdist built from that same SHA. The wheel (not the sdist) was
+  installed into an isolated virtual environment, where `jltsql --version`, `jltsql init`, full schema creation
   (80 tables), and an official fixed-width O2 import (complete-snapshot
   replacement plus `------` / `******` / `000000` markers) were exercised
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,8 +1,23 @@
 # jrvltsql v2.0.0 Release Notes (unreleased draft)
 
-This version is not released yet. The repository reports `2.0.0.dev0` until
-the official data-contract repairs, documentation audit, and real acquisition
-and database release gates are complete.
+`2.0.0` is not released yet. `2.0.0.dev0` is a **development-test prerelease**
+of the official data-contract work. It is **not** a production compatibility
+claim and **not** an acquisition-readiness claim: it is still gated on fresh
+real-provider (JV-Link) validation in a real development environment.
+
+What `2.0.0.dev0` is verified against:
+
+- the complete test gate on the frozen release SHA, with SQLite and a real
+  PostgreSQL 16 backend
+- a wheel/sdist built from that same SHA, installed into an isolated virtual
+  environment, where `jltsql --version`, `jltsql init`, full schema creation
+  (80 tables), and an official fixed-width O2 import (complete-snapshot
+  replacement plus `------` / `******` / `000000` markers) were exercised
+
+What it is **not** verified against:
+
+- real JV-Link acquisition, real provider ordering, or 64-bit SDK execution
+- migration of an existing 1.x database (rebuild and reimport are required)
 
 Current migration boundary:
 
@@ -47,6 +62,32 @@ Public API replacements:
   be backed up, rebuilt, and reimported. Current status 1 is the only accepted
   status; stale realtime rows are removed only after a successful 0B14
   full-date snapshot, while 0B16 remains event-oriented.
+- O1-O6 odds (オッズ1〜6) now bind the official fixed-width layouts
+  (962 / 2,042 / 2,654 / 4,031 / 12,293 / 83,285 bytes) and keep every official
+  provider value. The parser previously discarded rows whose odds were all `0`
+  or `-`/`*`, so `000000` (no bet), `------` (cancelled before sale) and
+  `******` (cancelled after sale) were lost; odds and favourite-order columns
+  were `REAL`/`INTEGER` in `NL_O1`-`NL_O6` and `RT_O1`-`RT_O6` and
+  `DECIMAL`/`SMALLINT` in the standard `ODDS_*` children, so cancellation
+  markers collapsed into `NULL` and could not be told apart from "not
+  registered" (blank). Those columns are now text and store the official value
+  verbatim.
+- one physical O1-O6 record is the complete odds snapshot of one race at one
+  point in time, so native, realtime and standard storage now replace the whole
+  race snapshot. A later snapshot with fewer combinations no longer leaves the
+  combinations it no longer offers, and a totals-only snapshot (no sale or a
+  cancelled race) replaces every earlier combination while keeping the official
+  vote totals as a single `Kumi=TOTAL` row. `DataKubun=0` erases the race
+  physically from every O1-O6 table, leaving no tombstone or totals sentinel.
+- O1-O6 race keys and combination numbers are now `NOT NULL`, and the official
+  body domain plus a strict schema preflight run on every storage path
+  (batch importer, optimized importer, single-record import, realtime, and
+  `DualDatabase`) before any DML. Missing official keys, nullable keys,
+  additional UNIQUE/partial/expression/exclusion indexes, deferrable primary
+  keys, columns too narrow or too numeric for the official markers, missing
+  owner/child tables, and unapproved CHECK/FOREIGN KEY constraints are
+  rejected. Existing O1-O6 tables are not migrated automatically: back up,
+  rebuild with the current schema, and reimport from `RACE`.
 - native and standard schemas now verify primary keys, types, capacities,
   child-table constraints, and cancellation/delete behavior before mutation;
   several record families gained complete child storage or corrected keys

--- a/specs/operations/20260819_release_2_0_0_dev0_worklog.md
+++ b/specs/operations/20260819_release_2_0_0_dev0_worklog.md
@@ -1,0 +1,61 @@
+# 2.0.0.dev0 開発検証用 prerelease worklog（2026-08-19）
+
+## 対象
+
+- repository: `miyamamoto/jrvltsql`
+- worktree: `/home/keiba/scratch/20260819_jrvltsql_release_dev0`
+- branch: `agent/release-2.0.0.dev0-20260819`
+- frozen base / 検証対象 SHA: `f812ffea45aef2f448d744624c186bbece1685a8`
+  （O1-O6 無損失 storage PR #227 の merge commit、短縮 `f812ffe`）
+- package version: `pyproject.toml` の `version = "2.0.0.dev0"`（既存値、変更なし）
+
+直列順の最終段。前段までの公式契約イテレーション（HN #217 / docs #218 #219 /
+native `NL_UM` #220 / SK #221 / JG・RC・WC #222 / UM #223 / H1 #224 / H6 #225 /
+O1-O6 parser #226 / O1-O6 storage #227）はすべて merge 済み・CI green である。
+
+## STOP 条件
+
+- 検証対象 SHA と異なる commit を含めて成果物を作る必要が出たとき
+- ゲートが green にならない状態が3回の修正で解消しないとき
+- 実 provider（JV-Link）取得、本番 DB、frozen 研究 DB への操作が必要になったとき
+- prerelease tag / GitHub release の作成（release state の変更）にユーザー承認が
+  得られていないとき
+- `2.0.0` 本リリースの判断が必要になったとき（この段の範囲外）
+
+## 実施したこと
+
+1. `origin/master`（`f812ffe`）から専用 worktree を作成し、依存を `uv sync
+   --frozen --all-extras --dev` で凍結インストールした。
+2. 必須ゲートを再実行した。
+   - `uv lock --check`: pass（50 packages resolved）
+   - `scripts/validate_test_gate.py`: `TEST GATE PASS`
+   - `flake8 --isolated --select=E9,F63,F7,F82 src tests scripts tools`: pass
+   - `git diff --check`: pass
+3. フルスイートを SQLite と実 PostgreSQL 16（使い捨て container
+   `jltsql-sk-pg16-8215`）で実行: **5013 passed, 41 skipped, 23 subtests passed**。
+4. 同じ SHA から成果物を build した。
+   - `jltsql-2.0.0.dev0-py3-none-any.whl`
+   - `jltsql-2.0.0.dev0.tar.gz`
+5. 隔離した仮想環境に wheel だけを install して smoke を実施した。
+   - `jltsql --version` → `jltsql, version 2.0.0.dev0`
+   - `jltsql init` → 作業ディレクトリに `config/config.yaml`（SQLite-only）を作成
+   - `SchemaManager.create_all_tables()` → 80/80 テーブル作成
+   - 公式固定長 O2（2,042 バイト）を parse → import し、
+     `filled=3` の次に `filled=2` を取り込むと組合せが `0102`/`0103` だけになる
+     （完全 snapshot 置換）ことと、`------` / `******` / `000000` が
+     そのまま保存されることを確認した。
+
+## 事実として記録する制約
+
+- 実 provider（JV-Link）からの取得・provider 順序の検証は行っていない。
+- 64-bit SDK 実行経路は未検証のままである。
+- 1.x の既存 DB の移行は検証していない。列型と key が変わるため rebuild と
+  reimport が必要である。
+- したがって `2.0.0.dev0` は開発検証用 prerelease であり、本番互換性や
+  取得可用性の主張ではない。RELEASE_NOTES.md 冒頭にこの範囲を明記した。
+
+## 未実施（承認待ち）
+
+- prerelease tag `v2.0.0.dev0` の作成と GitHub prerelease の publish。
+  release state を変えるため、ユーザー承認を得てから実施する。
+- 実開発環境での install、実 JV-Link 取得・保存確認、`2.0.0` 本リリース判断。

--- a/specs/operations/20260819_release_2_0_0_dev0_worklog.md
+++ b/specs/operations/20260819_release_2_0_0_dev0_worklog.md
@@ -36,7 +36,8 @@ O1-O6 parser #226 / O1-O6 storage #227）はすべて merge 済み・CI green �
 4. 同じ SHA から成果物を build した。
    - `jltsql-2.0.0.dev0-py3-none-any.whl`
    - `jltsql-2.0.0.dev0.tar.gz`
-5. 隔離した仮想環境に wheel だけを install して smoke を実施した。
+5. 隔離した仮想環境に wheel だけを install して smoke を実施した（sdist は
+   build のみで、install 検証はしていない）。
    - `jltsql --version` → `jltsql, version 2.0.0.dev0`
    - `jltsql init` → 作業ディレクトリに `config/config.yaml`（SQLite-only）を作成
    - `SchemaManager.create_all_tables()` → 80/80 テーブル作成


### PR DESCRIPTION
## Summary

`2.0.0.dev0` の**開発検証用 prerelease** に向けたリリース段。コード挙動は変えず、
「何を検証したか／何を検証していないか」を release notes に事実として書き、検証証跡を
worklog に残す。

検証対象 SHA は `f812ffea45aef2f448d744624c186bbece1685a8`（O1-O6 無損失 storage
PR #227 の merge commit）。

RELEASE_NOTES.md の冒頭を、曖昧な「まだリリースされていない」から、範囲を明示する形へ
書き換えた。

```text
2.0.0.dev0 は development-test prerelease
  検証済み: 凍結SHAでの全ゲート（SQLite + 実PostgreSQL 16）
            同一SHAから build した wheel/sdist を隔離venvへinstallし、
            jltsql --version / jltsql init / 80表作成 /
            公式固定長O2の取込（完全snapshot置換 + ------ / ****** / 000000）
  未検証:   実JV-Link取得・provider順序・64-bit SDK実行
            1.x既存DBの移行（rebuild + reimport が必要）
```

あわせて、release notes に欠けていた **O1-O6 の変更**（#226 / #227）を追記した。公式値
`000000` / `------` / `******` が parser と列型の両方で失われていたこと、1物理レコードが
1レース1時点の完全 snapshot なので置換すること、`DataKubun=0` の物理消去、キーの
`NOT NULL` 化と全経路 preflight、既存表は自動移行せず rebuild/reimport が必要なこと。

## 証跡（この SHA で実測）

- `uv lock --check` / `scripts/validate_test_gate.py` / `flake8 --isolated
  --select=E9,F63,F7,F82` / `mkdocs build --strict` / `git diff --check`: すべて pass
- フルスイート（SQLite + 実 PostgreSQL 16）: **5013 passed, 41 skipped, 23 subtests
  passed**
- build: `jltsql-2.0.0.dev0-py3-none-any.whl` / `jltsql-2.0.0.dev0.tar.gz`
- 隔離 venv に wheel のみ install した smoke:

  ```text
  jltsql, version 2.0.0.dev0
  jltsql init      -> config/config.yaml（SQLite-only）
  create_all_tables-> 80/80
  filled=3 stored  -> ['0102', '0103', '0104']
  filled=2 stored  -> ['0102', '0103']
  marker ------    -> '------'
  marker ******    -> '******'
  marker 000000    -> '000000'
  ```

## 未実施

- prerelease tag `v2.0.0.dev0` の作成と GitHub prerelease の publish（release state を
  変えるため承認待ち）
- 実開発環境での install、実 JV-Link 取得・保存確認、`2.0.0` 本リリース判断

worklog: `specs/operations/20260819_release_2_0_0_dev0_worklog.md`
