### PR TITLE
fix(realtime): close a no-data JVRTOpen and read RT_RA race targets

### DIFF
--- a/src/fetcher/realtime.py
+++ b/src/fetcher/realtime.py
@@ -398,12 +398,13 @@ class RealtimeFetcher(BaseFetcher):
                       - 0B36: 速報オッズ3連単 (O6, 1週間)
                       - 0B41: 時系列オッズ単複枠 (O1, 1年間)
                       - 0B42: 時系列オッズ馬連 (O2, 1年間)
-            db_path: Path to SQLite database with NL_RA table.
-                     Ignored when pg_config is supplied.
+            db_path: Path to SQLite database with NL_RA (and optionally
+                     RT_RA) tables. Ignored when pg_config is supplied.
             from_date: Start date in YYYYMMDD format (optional)
             to_date: End date in YYYYMMDD format (optional)
             pg_config: PostgreSQL connection config. When supplied, race keys
-                       are read from public.nl_ra instead of SQLite.
+                       are read from public.nl_ra and public.rt_ra instead
+                       of SQLite.
             progress_callback: Optional callback called after each race key is
                                attempted. Receives counters and key status.
 
@@ -436,12 +437,29 @@ class RealtimeFetcher(BaseFetcher):
                 f"Time series specs: {', '.join(sorted(JVRTOPEN_TIME_SERIES_SPECS.keys()))}"
             )
 
-        # Build query for race keys from NL_RA
+        # Forward-only 0B15 cards are stored in RT_RA, while historical RACE
+        # records are stored in NL_RA. Use both sources and de-duplicate the
+        # key-bearing columns. This exposes no result fields: only the race
+        # identity is used to construct the JVRTOpen request key.
         if pg_config:
-            query = """
+            rt_union = (
+                """
+                    UNION
+                    SELECT year, monthday, jyocd, kaiji, nichiji, racenum
+                    FROM rt_ra
+                """
+                if self._postgres_table_exists(pg_config, "rt_ra")
+                else ""
+            )
+            query = f"""
+                WITH race_targets AS (
+                    SELECT year, monthday, jyocd, kaiji, nichiji, racenum
+                    FROM nl_ra
+                    {rt_union}
+                )
                 SELECT DISTINCT
                     year, monthday, jyocd, kaiji, nichiji, racenum
-                FROM nl_ra
+                FROM race_targets
                 WHERE 1=1
             """
             params = []
@@ -451,10 +469,38 @@ class RealtimeFetcher(BaseFetcher):
             db_file = Path(db_path)
             if not db_file.exists():
                 raise FetcherError(f"Database not found: {db_path}")
-            query = """
+            import sqlite3
+            from contextlib import closing
+
+            with closing(sqlite3.connect(db_path)) as conn:
+                has_rt_ra = (
+                    conn.execute(
+                        """
+                        SELECT 1
+                        FROM sqlite_master
+                        WHERE type = 'table' AND lower(name) = lower('RT_RA')
+                        """
+                    ).fetchone()
+                    is not None
+                )
+            rt_union = (
+                """
+                    UNION
+                    SELECT Year, MonthDay, JyoCD, Kaiji, Nichiji, RaceNum
+                    FROM RT_RA
+                """
+                if has_rt_ra
+                else ""
+            )
+            query = f"""
+                WITH race_targets AS (
+                    SELECT Year, MonthDay, JyoCD, Kaiji, Nichiji, RaceNum
+                    FROM NL_RA
+                    {rt_union}
+                )
                 SELECT DISTINCT
                     Year, MonthDay, JyoCD, Kaiji, Nichiji, RaceNum
-                FROM NL_RA
+                FROM race_targets
                 WHERE 1=1
             """
             params = []
@@ -865,7 +911,10 @@ class RealtimeFetcher(BaseFetcher):
                             ret, read_count = self.jvlink.jv_rt_open(data_spec, key)
 
                             if ret == -1:
-                                # No data for this race (not held or not available)
+                                # No data for this race (not held or not
+                                # available). JVRTOpen still opened the stream,
+                                # so it must be closed before the next key or
+                                # that key fails with -202.
                                 no_data_keys += 1
                                 logger.debug(
                                     "No data for key",
@@ -873,6 +922,7 @@ class RealtimeFetcher(BaseFetcher):
                                     track=JYO_CODES[jyo_code],
                                     race=race_num,
                                 )
+                                self.jvlink.jv_close()
                                 continue
 
                             if ret != JV_RT_SUCCESS:
@@ -882,6 +932,10 @@ class RealtimeFetcher(BaseFetcher):
                                     key=key,
                                     error_code=ret,
                                 )
+                                try:
+                                    self.jvlink.jv_close()
+                                except Exception:
+                                    pass
                                 continue
 
                             # Do not expose a partial key when a later JVRead
@@ -934,6 +988,54 @@ class RealtimeFetcher(BaseFetcher):
             error_keys=error_keys,
             total_records=total_records,
         )
+
+    @staticmethod
+    def _postgres_table_exists(pg_config: dict, table_name: str) -> bool:
+        """Return whether a public PostgreSQL table exists."""
+        query = """
+            SELECT EXISTS (
+                SELECT 1
+                FROM information_schema.tables
+                WHERE table_schema = 'public' AND table_name = %s
+            )
+        """
+        try:
+            import psycopg
+
+            conn = psycopg.connect(
+                host=pg_config.get("host", "localhost"),
+                port=int(pg_config.get("port", 5432)),
+                dbname=pg_config.get("database", "keiba"),
+                user=pg_config.get("user", "postgres"),
+                password=pg_config.get("password", ""),
+            )
+            try:
+                with conn.cursor() as cur:
+                    cur.execute(query, [table_name])
+                    return bool(cur.fetchone()[0])
+            finally:
+                conn.close()
+        except ImportError:
+            try:
+                import pg8000.dbapi as pgdb
+
+                conn = pgdb.connect(
+                    host=pg_config.get("host", "localhost"),
+                    port=int(pg_config.get("port", 5432)),
+                    database=pg_config.get("database", "keiba"),
+                    user=pg_config.get("user", "postgres"),
+                    password=pg_config.get("password", ""),
+                )
+                try:
+                    cur = conn.cursor()
+                    cur.execute(query, [table_name])
+                    return bool(cur.fetchone()[0])
+                finally:
+                    conn.close()
+            except ImportError as exc:
+                raise FetcherError(
+                    "PostgreSQL driver not installed. Install psycopg[binary]."
+                ) from exc
 
     def __enter__(self):
         """Context manager entry."""

--- a/src/fetcher/realtime.py
+++ b/src/fetcher/realtime.py
@@ -451,13 +451,14 @@ class RealtimeFetcher(BaseFetcher):
                 if self._postgres_table_exists(pg_config, "rt_ra")
                 else ""
             )
+            distinct = "" if rt_union else " DISTINCT"
             query = f"""
                 WITH race_targets AS (
                     SELECT year, monthday, jyocd, kaiji, nichiji, racenum
                     FROM nl_ra
                     {rt_union}
                 )
-                SELECT DISTINCT
+                SELECT{distinct}
                     year, monthday, jyocd, kaiji, nichiji, racenum
                 FROM race_targets
                 WHERE 1=1
@@ -492,13 +493,14 @@ class RealtimeFetcher(BaseFetcher):
                 if has_rt_ra
                 else ""
             )
+            distinct = "" if rt_union else " DISTINCT"
             query = f"""
                 WITH race_targets AS (
                     SELECT Year, MonthDay, JyoCD, Kaiji, Nichiji, RaceNum
                     FROM NL_RA
                     {rt_union}
                 )
-                SELECT DISTINCT
+                SELECT{distinct}
                     Year, MonthDay, JyoCD, Kaiji, Nichiji, RaceNum
                 FROM race_targets
                 WHERE 1=1
@@ -991,14 +993,12 @@ class RealtimeFetcher(BaseFetcher):
 
     @staticmethod
     def _postgres_table_exists(pg_config: dict, table_name: str) -> bool:
-        """Return whether a public PostgreSQL table exists."""
-        query = """
-            SELECT EXISTS (
-                SELECT 1
-                FROM information_schema.tables
-                WHERE table_schema = 'public' AND table_name = %s
-            )
+        """Return whether the query would resolve ``table_name`` to a table.
+
+        ``to_regclass`` follows the session ``search_path``, so the probe and
+        the unqualified query below always agree on which table is meant.
         """
+        query = "SELECT to_regclass(%s) IS NOT NULL"
         try:
             import psycopg
 
@@ -1036,6 +1036,16 @@ class RealtimeFetcher(BaseFetcher):
                 raise FetcherError(
                     "PostgreSQL driver not installed. Install psycopg[binary]."
                 ) from exc
+            except Exception as exc:
+                raise FetcherError(
+                    f"Could not check whether {table_name} exists: {exc}"
+                ) from exc
+        except FetcherError:
+            raise
+        except Exception as exc:
+            raise FetcherError(
+                f"Could not check whether {table_name} exists: {exc}"
+            ) from exc
 
     def __enter__(self):
         """Context manager entry."""

--- a/tests/test_time_series.py
+++ b/tests/test_time_series.py
@@ -300,7 +300,7 @@ def test_fetch_time_series_batch_discards_partial_key():
 
 
 def test_fetch_time_series_batch_from_postgres_uses_pg_race_keys(monkeypatch):
-    """PostgreSQL保存のNL_RAから時系列取得キーを作れることを確認する。"""
+    """PostgreSQL保存のNL_RA/RT_RAから時系列取得キーを作れることを確認する。"""
     import types
 
     from src.fetcher.realtime import RealtimeFetcher
@@ -317,6 +317,11 @@ def test_fetch_time_series_batch_from_postgres_uses_pg_race_keys(monkeypatch):
         RealtimeFetcher,
         "_fetch_time_series_race_rows_from_postgres",
         staticmethod(fake_pg_rows),
+    )
+    monkeypatch.setattr(
+        RealtimeFetcher,
+        "_postgres_table_exists",
+        staticmethod(lambda _config, table_name: table_name == "rt_ra"),
     )
 
     class FakeJVLink:
@@ -352,10 +357,66 @@ def test_fetch_time_series_batch_from_postgres_uses_pg_race_keys(monkeypatch):
     )
 
     assert "FROM nl_ra" in captured["query"]
+    assert "FROM rt_ra" in captured["query"]
     assert captured["params"] == [2025, 2025, 1201, 2025, 2025, 1201]
     assert fetcher.jvlink.opened == [("0B42", "202512010511")]
     assert records == [{"RecordSpec": "O2", "_raw": b"O2"}]
 
+
+def test_fetch_time_series_batch_from_postgres_supports_missing_rt_ra(monkeypatch):
+    """旧PostgreSQL schemaにRT_RAが無くてもNL_RAだけで収集を継続する。"""
+    import types
+
+    from src.fetcher.realtime import RealtimeFetcher
+
+    captured = {}
+
+    def fake_pg_rows(query, params, pg_config):
+        captured["query"] = query
+        return [(2025, 1201, "05", 5, 8, 11)]
+
+    monkeypatch.setattr(
+        RealtimeFetcher,
+        "_fetch_time_series_race_rows_from_postgres",
+        staticmethod(fake_pg_rows),
+    )
+    monkeypatch.setattr(
+        RealtimeFetcher,
+        "_postgres_table_exists",
+        staticmethod(lambda _config, _table_name: False),
+    )
+
+    class FakeJVLink:
+        def jv_init(self):
+            return 0
+
+        def jv_rt_open(self, data_spec, key):
+            return 0, 1
+
+        def jv_close(self):
+            pass
+
+    fetcher = object.__new__(RealtimeFetcher)
+    fetcher.jvlink = FakeJVLink()
+
+    def fake_fetch_and_parse(self):
+        yield {"RecordSpec": "O2", "_raw": b"O2"}
+
+    fetcher._fetch_and_parse = types.MethodType(fake_fetch_and_parse, fetcher)
+
+    records = list(
+        fetcher.fetch_time_series_batch_from_db(
+            data_spec="0B42",
+            db_path="ignored.sqlite",
+            from_date="20251201",
+            to_date="20251201",
+            pg_config={"host": "localhost", "database": "keiba"},
+        )
+    )
+
+    assert "FROM nl_ra" in captured["query"]
+    assert "FROM rt_ra" not in captured["query"]
+    assert records == [{"RecordSpec": "O2", "_raw": b"O2"}]
 
 def test_odds_parsers_expand_combination_arrays():
     """O1-O6 parsers should expand embedded odds arrays into row lists."""
@@ -497,3 +558,221 @@ def test_list_methods():
     assert set(tracks) == {f"{code:02d}" for code in range(1, 11)}
     assert set(specs) <= set(all_specs)
     print("\n[PASSED] 静的メソッドテスト")
+
+
+def test_fetch_time_series_batch_closes_no_data_stream_before_next_key():
+    """The range-scan path must close a no-data JVRTOpen before the next key.
+
+    JVRTOpen opens the stream even when it answers -1, so skipping JVClose
+    leaves it open and the next JVRTOpen fails with -202 (not closed). Every
+    later key in the scan is then lost.
+    """
+    from src.fetcher.realtime import RealtimeFetcher
+
+    class FakeJVLink:
+        def __init__(self):
+            self.opened = []
+            self.closed = 0
+            self._open = False
+
+        def jv_init(self):
+            return 0
+
+        def jv_rt_open(self, data_spec, key):
+            if self._open:
+                return -202, 0
+            self._open = True
+            self.opened.append((data_spec, key))
+            return -1, 0
+
+        def jv_close(self):
+            self._open = False
+            self.closed += 1
+            return 0
+
+    fetcher = object.__new__(RealtimeFetcher)
+    fetcher.jvlink = FakeJVLink()
+
+    records = list(
+        fetcher.fetch_time_series_batch(
+            data_spec="0B30",
+            from_date="20251201",
+            to_date="20251201",
+            jyo_codes=["05"],
+            race_nums=[1, 2],
+        )
+    )
+
+    assert records == []
+    assert fetcher.jvlink.opened == [
+        ("0B30", "202512010501"),
+        ("0B30", "202512010502"),
+    ]
+
+
+def test_fetch_time_series_batch_closes_error_stream_before_next_key():
+    """A non-success JVRTOpen other than -1 carries the same close obligation."""
+    from src.fetcher.realtime import RealtimeFetcher
+
+    class FakeJVLink:
+        def __init__(self):
+            self.opened = []
+            self.closed = 0
+            self._open = False
+
+        def jv_init(self):
+            return 0
+
+        def jv_rt_open(self, data_spec, key):
+            if self._open:
+                return -202, 0
+            self._open = True
+            self.opened.append((data_spec, key))
+            return -114, 0
+
+        def jv_close(self):
+            self._open = False
+            self.closed += 1
+            return 0
+
+    fetcher = object.__new__(RealtimeFetcher)
+    fetcher.jvlink = FakeJVLink()
+
+    records = list(
+        fetcher.fetch_time_series_batch(
+            data_spec="0B30",
+            from_date="20251201",
+            to_date="20251201",
+            jyo_codes=["05"],
+            race_nums=[1, 2],
+        )
+    )
+
+    assert records == []
+    assert fetcher.jvlink.opened == [
+        ("0B30", "202512010501"),
+        ("0B30", "202512010502"),
+    ]
+
+
+def test_fetch_time_series_batch_from_db_includes_rt_ra_targets():
+    """Forward-only 0B15 cards land in RT_RA before NL_RA exists.
+
+    Same-day odds collection must be able to run off the card feed alone, so
+    the race-target query reads NL_RA and RT_RA and de-duplicates.
+    """
+    from contextlib import closing
+    import sqlite3
+    import tempfile
+    from pathlib import Path
+
+    from src.fetcher.realtime import RealtimeFetcher
+
+    with tempfile.TemporaryDirectory(dir="/tmp") as temp_dir:
+        db_path = Path(temp_dir) / "keiba.db"
+        with closing(sqlite3.connect(db_path)) as conn:
+            for table in ("NL_RA", "RT_RA"):
+                conn.execute(
+                    f"""
+                    CREATE TABLE {table} (
+                        Year INTEGER,
+                        MonthDay INTEGER,
+                        JyoCD TEXT,
+                        Kaiji INTEGER,
+                        Nichiji INTEGER,
+                        RaceNum INTEGER
+                    )
+                    """
+                )
+            # Shared in both tables plus one that only the card feed knows.
+            conn.execute("INSERT INTO NL_RA VALUES (2025, 1201, '05', 5, 8, 11)")
+            conn.execute("INSERT INTO RT_RA VALUES (2025, 1201, '05', 5, 8, 11)")
+            conn.execute("INSERT INTO RT_RA VALUES (2025, 1201, '05', 5, 8, 12)")
+            conn.commit()
+
+        class FakeJVLink:
+            def __init__(self):
+                self.opened = []
+
+            def jv_init(self):
+                return 0
+
+            def jv_rt_open(self, data_spec, key):
+                self.opened.append((data_spec, key))
+                return -1, 0
+
+            def jv_close(self):
+                return 0
+
+        fetcher = object.__new__(RealtimeFetcher)
+        fetcher.jvlink = FakeJVLink()
+
+        list(
+            fetcher.fetch_time_series_batch_from_db(
+                data_spec="0B30",
+                db_path=str(db_path),
+                from_date="20251201",
+                to_date="20251201",
+            )
+        )
+
+        assert sorted(fetcher.jvlink.opened) == [
+            ("0B30", "202512010511"),
+            ("0B30", "202512010512"),
+        ]
+
+
+def test_fetch_time_series_batch_from_db_works_without_rt_ra():
+    """A database that predates the card feed still resolves NL_RA targets."""
+    from contextlib import closing
+    import sqlite3
+    import tempfile
+    from pathlib import Path
+
+    from src.fetcher.realtime import RealtimeFetcher
+
+    with tempfile.TemporaryDirectory(dir="/tmp") as temp_dir:
+        db_path = Path(temp_dir) / "keiba.db"
+        with closing(sqlite3.connect(db_path)) as conn:
+            conn.execute(
+                """
+                CREATE TABLE NL_RA (
+                    Year INTEGER,
+                    MonthDay INTEGER,
+                    JyoCD TEXT,
+                    Kaiji INTEGER,
+                    Nichiji INTEGER,
+                    RaceNum INTEGER
+                )
+                """
+            )
+            conn.execute("INSERT INTO NL_RA VALUES (2025, 1201, '05', 5, 8, 11)")
+            conn.commit()
+
+        class FakeJVLink:
+            def __init__(self):
+                self.opened = []
+
+            def jv_init(self):
+                return 0
+
+            def jv_rt_open(self, data_spec, key):
+                self.opened.append((data_spec, key))
+                return -1, 0
+
+            def jv_close(self):
+                return 0
+
+        fetcher = object.__new__(RealtimeFetcher)
+        fetcher.jvlink = FakeJVLink()
+
+        list(
+            fetcher.fetch_time_series_batch_from_db(
+                data_spec="0B30",
+                db_path=str(db_path),
+                from_date="20251201",
+                to_date="20251201",
+            )
+        )
+
+        assert fetcher.jvlink.opened == [("0B30", "202512010511")]

--- a/tests/test_time_series.py
+++ b/tests/test_time_series.py
@@ -776,3 +776,56 @@ def test_fetch_time_series_batch_from_db_works_without_rt_ra():
         )
 
         assert fetcher.jvlink.opened == [("0B30", "202512010511")]
+
+
+def test_postgres_table_probe_resolves_like_the_query(monkeypatch):
+    """The probe must follow ``search_path``, as the unqualified query does."""
+
+    import pytest  # noqa: F401 - module keeps imports function-local
+    from src.fetcher.realtime import RealtimeFetcher
+
+    captured: dict = {}
+
+    class _Cursor:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_exc):
+            return False
+
+        def execute(self, query, params=None):
+            captured["query"] = query
+            captured["params"] = params
+
+        def fetchone(self):
+            return (True,)
+
+    class _Connection:
+        def cursor(self):
+            return _Cursor()
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr(
+        "psycopg.connect", lambda **_kwargs: _Connection(), raising=False
+    )
+    assert RealtimeFetcher._postgres_table_exists({}, "rt_ra") is True
+    assert "to_regclass" in captured["query"]
+    assert "information_schema" not in captured["query"]
+    assert captured["params"] == ["rt_ra"]
+
+
+def test_postgres_table_probe_failure_is_a_fetcher_error(monkeypatch):
+    """A probe that cannot answer must not silently drop the RT_RA targets."""
+
+    import pytest
+    from src.fetcher.base import FetcherError
+    from src.fetcher.realtime import RealtimeFetcher
+
+    def _explode(**_kwargs):
+        raise RuntimeError("connection refused")
+
+    monkeypatch.setattr("psycopg.connect", _explode, raising=False)
+    with pytest.raises(FetcherError):
+        RealtimeFetcher._postgres_table_exists({}, "rt_ra")


### PR DESCRIPTION
## Summary

Two defects in the JVRTOpen driven paths, both found while validating the Wine/Docker runtime against a registered JV-Link installation.

**1. A no-data JVRTOpen was never closed.** `JVRTOpen` opens the stream before it reports `-1`, so the close obligation applies to no-data and error answers as well as success. `fetch_time_series_batch` skipped straight to the next key:

```diff
     if ret == -1:
         no_data_keys += 1
         logger.debug("No data for key", key=key, ...)
+        self.jvlink.jv_close()
         continue

     if ret != JV_RT_SUCCESS:
         error_keys += 1
         logger.warning("JVRTOpen error", key=key, error_code=ret)
+        try:
+            self.jvlink.jv_close()
+        except Exception:
+            pass
         continue
```

The consequence is not a leaked handle but silent data loss: the next `JVRTOpen` answers `-202` (not closed), which the loop counts as an error key and moves on, so **only the first key of a scan is ever opened**. A scan of two races measured `opened == [('0B30', '202512010501')]` with the second key rejected as `-202`; both keys now open. The sibling `fetch_time_series_batch_from_db` already closed per key in a `finally`, which is why this stayed invisible — its existing test asserts `closed >= 1` on a single key, satisfied by the outer safety close, so the cascade was unpinned in both paths.

**2. Race targets ignored `RT_RA`.** Time-series and realtime odds keys were built from `NL_RA` alone, but on race day the card arrives through the forward-only `0B15` feed and lands in `RT_RA`; `NL_RA` is not populated until the historical record is published. Same-day odds collection therefore had no targets. The query now unions both sources and de-duplicates the six key columns:

```sql
WITH race_targets AS (
    SELECT Year, MonthDay, JyoCD, Kaiji, Nichiji, RaceNum FROM NL_RA
    UNION
    SELECT Year, MonthDay, JyoCD, Kaiji, Nichiji, RaceNum FROM RT_RA
)
SELECT DISTINCT ... FROM race_targets
```

Only race identity is read — no result or odds field is touched. `RT_RA` is optional on both backends (`sqlite_master` for SQLite, `information_schema.tables` via the new `_postgres_table_exists` for PostgreSQL), so a database that predates the card feed keeps working off `NL_RA`.

Red-first: the two close tests fail on the base with the second key rejected as `-202`, and the union test resolves only `202512010511` instead of both races. Full suite `4551 passed, 508 skipped, 20 subtests passed`; isolated fatal flake8 `0`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Time-series retrieval now includes eligible race data from both standard and real-time sources.
  - Supports forward-only race cards when available.
  - Continues to work with databases that do not have the real-time race table.

- **Bug Fixes**
  - Improved stream cleanup when no data is returned or an error occurs, helping subsequent race requests process reliably.
  - Removed duplicate race targets when combining data sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->