### PR TITLE
fix(parser): accept the provider forms live JV-Link sends for 人気順 and 発表月日時分

### DIFF
--- a/src/parser/h1_parser.py
+++ b/src/parser/h1_parser.py
@@ -143,15 +143,16 @@ class H1Parser:
 
     @classmethod
     def _require_favourite(cls, value: object, width: int) -> None:
-        """人気順は数字のほか '--':発売前取消 '**':発売後取消 空白:登録なし を取る。"""
+        """人気順は数字のほか 全桁'-':発売前取消 全桁'*':発売後取消 空白:登録なし。"""
 
         if not isinstance(value, str):
             raise ValueError("H1 Ninki must be a provider value")
         if value == "":
             return
         text = value.strip()
-        if text in {"--", "**"}:
-            # 公式表記は2文字固定（'--':発売前取消 '**':発売後取消）。
+        if text in {"-" * width, "*" * width}:
+            # 取消マーカーは項目幅ぶんの繰り返しで届く（実データの3桁票数系は
+            # '***'）。幅の違うマーカーは桁落ちなので拒否する。
             return
         if len(text) == width and text.isascii() and text.isdigit():
             return

--- a/src/parser/odds_domain.py
+++ b/src/parser/odds_domain.py
@@ -65,11 +65,17 @@ def require_race_day(record_type: str, record: Mapping[str, object]) -> None:
 
 
 def require_announced_time(record_type: str, value: object) -> None:
-    """発表月日時分は中間オッズのみ設定される。空白は提供値として許す。"""
+    """発表月日時分は中間オッズのみ設定される。未設定値は提供値として許す。
+
+    公式の初期値は 0 で、実提供データは確定オッズの全レコードにゼロ詰めの
+    "00000000" を載せてくる。空白で届く経路もあるためどちらも保持する。
+    """
 
     if value in ("", None):
         return
     digits = require_ascii_digits(record_type, "HassoTime", value, ANNOUNCED_TIME_WIDTH)
+    if digits == "0" * ANNOUNCED_TIME_WIDTH:
+        return
     try:
         date(2000, int(digits[:2]), int(digits[2:4]))
     except ValueError as error:

--- a/tests/test_h1_official_contract.py
+++ b/tests/test_h1_official_contract.py
@@ -691,3 +691,82 @@ def test_h1_postgresql_standard_family_accepts_only_the_official_key_index(
     postgresql_db.commit()
     with pytest.raises(SchemaMigrationError):
         verify_h1_storage_schema(postgresql_db, "HYOSU")
+
+
+@pytest.mark.parametrize(
+    "bet_type,marker",
+    (
+        pytest.param("Tansyo", "--", id="tansyo-pre-sale-cancel"),
+        pytest.param("Tansyo", "**", id="tansyo-post-sale-cancel"),
+        pytest.param("Umaren", "---", id="umaren-pre-sale-cancel"),
+        pytest.param("Umaren", "***", id="umaren-post-sale-cancel"),
+        pytest.param("Wide", "***", id="wide-post-sale-cancel"),
+        pytest.param("Umatan", "***", id="umatan-post-sale-cancel"),
+        pytest.param("Sanrenpuku", "***", id="sanrenpuku-post-sale-cancel"),
+    ),
+)
+def test_h1_cancel_markers_fill_the_official_field_width(
+    bet_type: str, marker: str
+) -> None:
+    """A cancel marker occupies the whole 人気順 field, which is 2 or 3 wide.
+
+    Live JV-Link RACE data carries '***' for the three-character bet types, so
+    accepting only the two-character form rejects a real provider snapshot.
+    """
+
+    row = next(row for row in h1_rows() if row.get("BetType") == bet_type)
+    row["Ninki"] = marker
+    row["Hyo"] = "0" * len(row["Hyo"])
+    assert validate_h1_record(row, "NL_H1") is True
+
+
+@pytest.mark.parametrize(
+    "bet_type,malformed",
+    (
+        pytest.param("Tansyo", "---", id="tansyo-too-wide-marker"),
+        pytest.param("Umaren", "**", id="umaren-too-narrow-marker"),
+        pytest.param("Umaren", "-*-", id="umaren-mixed-marker"),
+        pytest.param("Umaren", "-1-", id="umaren-partial-digits"),
+    ),
+)
+def test_h1_rejects_favourite_markers_that_do_not_match_the_field(
+    bet_type: str, malformed: str
+) -> None:
+    row = next(row for row in h1_rows() if row.get("BetType") == bet_type)
+    row["Ninki"] = malformed
+    with pytest.raises(SchemaMigrationError):
+        validate_h1_record(row, "NL_H1")
+
+
+@pytest.mark.parametrize("marker", ("---", "***"))
+@pytest.mark.parametrize("use_standard", (False, True), ids=("native", "standard"))
+def test_h1_three_character_cancel_markers_survive_storage(
+    tmp_path: Path,
+    marker: str,
+    use_standard: bool,
+) -> None:
+    """The 馬連 人気順 field is three wide, so its marker is three characters."""
+
+    raw = bytearray(h1_raw())
+    umaren_offset, kumi, _hyo, ninki = _FIRST_ENTRIES[3]
+    start = umaren_offset + len(kumi) + 11
+    raw[start : start + len(ninki)] = marker.encode("ascii")
+    rows = [dict(row) for row in H1Parser().parse(bytes(raw))]
+    assert any(row.get("Ninki") == marker for row in rows)
+
+    tables = _tables(use_standard)
+    database = SQLiteDatabase({"path": str(tmp_path / f"wide-{use_standard}-{marker}.db")})
+    with database:
+        _create(database, tables)
+        stats = DataImporter(database, use_jravan_schema=use_standard).import_records(
+            iter(rows)
+        )
+        assert stats["records_failed"] == 0
+        if use_standard:
+            assert database.fetch_one(
+                "SELECT UmarenNinki FROM HYOSU_UMARENWIDE WHERE Kumi = '0102'"
+            ) == {"UmarenNinki": marker}
+        else:
+            assert database.fetch_one(
+                "SELECT Ninki FROM NL_H1 WHERE BetType = 'Umaren'"
+            ) == {"Ninki": marker}

--- a/tests/test_h1_official_contract.py
+++ b/tests/test_h1_official_contract.py
@@ -755,7 +755,11 @@ def test_h1_three_character_cancel_markers_survive_storage(
     assert any(row.get("Ninki") == marker for row in rows)
 
     tables = _tables(use_standard)
-    database = SQLiteDatabase({"path": str(tmp_path / f"wide-{use_standard}-{marker}.db")})
+    # '*' is not a portable filename character, so name the file by the marker.
+    marker_name = "pre-sale" if marker.startswith("-") else "post-sale"
+    database = SQLiteDatabase(
+        {"path": str(tmp_path / f"wide-{use_standard}-{marker_name}.db")}
+    )
     with database:
         _create(database, tables)
         stats = DataImporter(database, use_jravan_schema=use_standard).import_records(

--- a/tests/test_o1_o6_official_contract.py
+++ b/tests/test_o1_o6_official_contract.py
@@ -738,6 +738,7 @@ def test_realtime_keeps_every_official_no_vote_combination(
 
 
 @pytest.mark.parametrize("record_type", ALL_RECORD_TYPES)
+@pytest.mark.parametrize("data_kubun", OFFICIAL_DATA_KUBUN)
 @pytest.mark.parametrize(
     "announced",
     (
@@ -745,7 +746,9 @@ def test_realtime_keeps_every_official_no_vote_combination(
         pytest.param(b"        ", id="blank"),
     ),
 )
-def test_unset_announced_time_is_accepted(record_type: str, announced: bytes) -> None:
+def test_unset_announced_time_is_accepted(
+    record_type: str, data_kubun: str, announced: bytes
+) -> None:
     """発表月日時分 is set for 中間 odds only; final odds carry the initial value.
 
     Live JV-Link RACE data sends the zero-filled form for every final O1-O6
@@ -753,7 +756,7 @@ def test_unset_announced_time_is_accepted(record_type: str, announced: bytes) ->
     """
 
     layout = LAYOUTS[record_type]
-    raw = bytearray(layout.raw())
+    raw = bytearray(layout.raw(data_kubun=data_kubun))
     raw[27:35] = announced
     rows = layout.parser_class().parse(bytes(raw))
     assert rows

--- a/tests/test_o1_o6_official_contract.py
+++ b/tests/test_o1_o6_official_contract.py
@@ -735,3 +735,49 @@ def test_realtime_keeps_every_official_no_vote_combination(
         results = updater.process_record(raw)
         assert results and all(result["success"] for result in results)
         assert database.fetch_one(f"SELECT COUNT(*) AS cnt FROM {table_name}")["cnt"] == 3
+
+
+@pytest.mark.parametrize("record_type", ALL_RECORD_TYPES)
+@pytest.mark.parametrize(
+    "announced",
+    (
+        pytest.param(b"00000000", id="official-initial-zeros"),
+        pytest.param(b"        ", id="blank"),
+    ),
+)
+def test_unset_announced_time_is_accepted(record_type: str, announced: bytes) -> None:
+    """発表月日時分 is set for 中間 odds only; final odds carry the initial value.
+
+    Live JV-Link RACE data sends the zero-filled form for every final O1-O6
+    snapshot, so rejecting it rejects the whole feed.
+    """
+
+    layout = LAYOUTS[record_type]
+    raw = bytearray(layout.raw())
+    raw[27:35] = announced
+    rows = layout.parser_class().parse(bytes(raw))
+    assert rows
+    for row in rows:
+        layout.parser_class.validate_current_fields(row)
+
+
+@pytest.mark.parametrize("record_type", ALL_RECORD_TYPES)
+@pytest.mark.parametrize(
+    "announced",
+    (
+        pytest.param(b"01321200", id="impossible-day"),
+        pytest.param(b"01012500", id="impossible-hour"),
+        pytest.param(b"0101120x", id="non-digit"),
+    ),
+)
+def test_malformed_announced_time_is_still_rejected(
+    record_type: str, announced: bytes
+) -> None:
+    layout = LAYOUTS[record_type]
+    raw = bytearray(layout.raw())
+    raw[27:35] = announced
+    rows = layout.parser_class().parse(bytes(raw))
+    assert rows
+    with pytest.raises(ValueError):
+        for row in rows:
+            layout.parser_class.validate_current_fields(row)


### PR DESCRIPTION
## Summary

The first fetch against a real registered JV-Link installation (`JVOpen("RACE", "20260810000000", 1)`, 48 files) was rejected outright by our own domain validation. Two official provider forms were missing from the contract; with both accepted the same fetch stores **864,827 rows, 0 failed**, and both forms survive storage verbatim.

**1. A cancel marker fills its field, so it is not always two characters.** 人気順 is 2 wide for 単勝/複勝/枠連 and 3 wide for 馬連/ワイド/馬単/3連複, but the validator hard-coded the two-character forms:

```diff
-        if text in {"--", "**"}:
+        if text in {"-" * width, "*" * width}:
```

Live data carries `***` for the three-wide orders — 989 of the 144 H1 records in that fetch — so every H1 snapshot containing a post-sale cancellation was refused (`H1 Ninki must be 3 ASCII digits, a cancel marker, or blank`) and the import failed closed. The width is already passed in per bet type, so the fix also tightens the rule: `--` in a three-wide field is now a digit-loss rejection rather than an accepted marker. H6 was already correct (`----`/`****` for its 4-wide field), which is why this only ever showed up in H1.

**2. 発表月日時分 is unset for final odds, and the provider sends zeros, not blanks.** The specification marks the field 中間オッズのみ設定 with initial value `0`. The contract accepted only the blank form:

```diff
     digits = require_ascii_digits(record_type, "HassoTime", value, ANNOUNCED_TIME_WIDTH)
+    if digits == "0" * ANNOUNCED_TIME_WIDTH:
+        return
```

Measured: every O1-O6 record of that fetch (144 per record type, all six types) carries `'00000000'`. Without this the whole odds feed is unreachable (`O1 HassoTime must start with a real MMDD`). Malformed values are still rejected — the new tests pin `01321200`, `01012500` and `0101120x` as failures so this does not become "any 8 digits".

Both values are stored losslessly, not coerced to NULL: after the live import `NL_H1` holds `Sanrenpuku/***` ×609, `Umatan/***` ×190, `Umaren/***` ×95, `Wide/***` ×95, `Tansyo/**` ×7, and `NL_O1.HassoTime` is `'00000000'` for all 6,337 rows.

Red-first on both: the new H1 tests fail on the base for every three-wide bet type, and the O1-O6 test fails for all six record types. Full suite `4586 passed, 508 skipped, 20 subtests passed`; isolated fatal flake8 `0`.

Found while validating the Wine/Docker runtime against a live provider; no service key was read, written, or registered during the run.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Accepts correctly sized cancellation markers across supported H1 fields.
  * Recognizes zero-filled announced timestamps as unset values.
  * Continues rejecting malformed markers, invalid dates, times, and non-digit values.

* **Tests**
  * Added coverage for cancellation markers, storage compatibility, and unset timestamp formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->