### PR TITLE
release: cut 2.0.0.dev1 with the first real-provider evidence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,22 @@
 
 次回リリースは互換性を破る変更を含むため `2.0.0` とする。1.xとしては配布しない。
 
+### 2.0.0.dev1 (開発検証用prerelease)
+
+実登録済みJV-Linkでの実測を反映する。
+
+- 実provider取得→parse→保存を通した（`JVOpen(RACE, 20260810, option=1)`=0、
+  48ファイル、864,827件をSQLiteへ保存、失敗0件）
+- 実データが暴いた契約欠陥2件を修正。H1の人気順取消マーカーは項目幅ぶん埋まる
+  （3桁賭式は`***`）。O1〜O6の発表月日時分は中間オッズのみ設定され、確定オッズは
+  公式初期値の`00000000`。どちらも提供値のまま保存する
+- realtimeの`JVRTOpen`はno-data/error時にも`JVClose`する（次のkeyが`-202`で
+  失敗していた）。当日対象は`NL_RA`に加えて`RT_RA`も見る
+- Wine/Docker実行層（32-bit native bridge・image・entrypoint）と、noVNC上で人が
+  インストールと利用登録を行う手順書を同梱。承認を代行する経路は持たず、
+  JV-Linkのダイアログも既定では人に回す（`JVLINK_AUTO_CLOSE_DIALOGS=1`で明示的に
+  opt-inしたときだけ既知のものを拒否する）
+
 ### Removed
 
 - `JVLinkWrapper.jv_set_service_key` / `JVLinkBridge.jv_set_service_key` と、

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,11 +1,32 @@
 # jrvltsql v2.0.0 Release Notes (unreleased draft)
 
-`2.0.0` is not released yet. `2.0.0.dev0` is a **development-test prerelease**
+`2.0.0` is not released yet. `2.0.0.dev1` is a **development-test prerelease**
 of the official data-contract work. It is **not** a production compatibility
-claim and **not** an acquisition-readiness claim: it is still gated on fresh
-real-provider (JV-Link) validation in a real development environment.
+claim: the 64-bit SDK path, 1.x database migration, and long-run collection are
+still unverified.
 
-What `2.0.0.dev0` is verified against:
+What `2.0.0.dev1` adds over `2.0.0.dev0`, all of it measured against a real
+registered JV-Link on a Linux/Wine development host:
+
+- a first end-to-end acquisition through storage: `JVInit` `0`,
+  `JVOpen(RACE, 20260810, option=1)` `0` with 48 files, then
+  4,447 fetched / 864,827 parsed / 864,827 imported / 0 failed into SQLite
+  (`NL_H6` 319,548, `NL_O6` 319,548, `NL_H1` 112,257, `NL_RA` 144, `NL_SE` 1,934, …)
+- two contract defects that only real provider data exposes, both of which had
+  made whole record families unimportable: H1 cancellation markers fill the
+  field width, so three-character bet types send `***`, and O1-O6 announcement
+  time is set only for interim odds, so final odds carry the official
+  zero-filled `00000000`. Both values are now stored verbatim
+- a realtime `JVRTOpen` that closes on no-data and error, instead of leaving the
+  stream open so the next key fails with `-202`, plus `RT_RA` as a same-day
+  target source next to `NL_RA`
+- the Wine/Docker runtime layer (native 32-bit bridge, image, entrypoint) and
+  the manual noVNC registration runbook. Nothing in it performs an approval:
+  installing JV-Link, agreeing to the terms and entering the service key stay
+  with a person, and JV-Link's own dialogs are left for that person unless
+  `JVLINK_AUTO_CLOSE_DIALOGS=1` is set explicitly
+
+What `2.0.0.dev1` is verified against:
 
 - the complete test gate on the frozen release SHA, with SQLite and a real
   PostgreSQL 16 backend
@@ -16,8 +37,10 @@ What `2.0.0.dev0` is verified against:
 
 What it is **not** verified against:
 
-- real JV-Link acquisition, real provider ordering, or 64-bit SDK execution
+- 64-bit SDK execution, or ARM hosts (JV-Link and the bridge are 32-bit x86)
 - migration of an existing 1.x database (rebuild and reimport are required)
+- sustained multi-day collection, or realtime `JVRTOpen` against a live race day
+  (the measured `JVRTOpen` targets had no data on the days available)
 
 Current migration boundary:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "jltsql"
-version = "2.0.0.dev0"
+version = "2.0.0.dev1"
 description = "JRA-VAN DataLab の競馬データをSQLite・PostgreSQLにインポートするツール"
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,3 +1,3 @@
 """jrvltsql - JRA-VAN データ取得・管理ツール"""
 
-__version__ = "2.0.0.dev0"
+__version__ = "2.0.0.dev1"

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -46,7 +46,7 @@ class TestVersionComparison:
     def test_final_release_is_newer_than_its_development_prerelease(self):
         from src.utils.updater import _version_newer
 
-        assert _version_newer("2.0.0", "2.0.0.dev0") is True
+        assert _version_newer("2.0.0", "2.0.0.dev1") is True
 
 
 class TestGetCurrentVersion:
@@ -75,7 +75,7 @@ class TestGetCurrentVersion:
         version = get_current_version()
         # Source metadata is the candidate version; a stale release tag must
         # not make a development checkout report the previous release.
-        assert version == "2.0.0.dev0"
+        assert version == "2.0.0.dev1"
 
     @patch("subprocess.run")
     def test_fallback_to_installed_distribution_metadata(

--- a/uv.lock
+++ b/uv.lock
@@ -325,7 +325,7 @@ wheels = [
 
 [[package]]
 name = "jltsql"
-version = "2.0.0.dev0"
+version = "2.0.0.dev1"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

`2.0.0.dev0` was tagged before the first real JV-Link run, so it predates everything that run produced: the two contract defects live data exposed (#232), the realtime close obligation and `RT_RA` targets (#231), and the Wine/Docker runtime with its manual registration runbook (#233). A deployment that pins `dev0` still cannot import real H1 or odds data at all — both families fail closed on every record. This cuts `2.0.0.dev1` so the deployment repository has an artifact worth depending on.

Version, lock and the updater's expected source version move together; `tests/test_public_setup_contract.py::test_version_and_lock_metadata_are_consistent` already pins that.

```diff
-version = "2.0.0.dev0"     # pyproject.toml, src/__init__.py, uv.lock
+version = "2.0.0.dev1"
```

`RELEASE_NOTES.md` gains what only a real provider could establish, with the measured numbers:

```text
JVInit                                   -> 0
JVOpen(RACE, 20260810, option=1)         -> 0, 48 files
CLI fetch -> Fetched 4,447 / Parsed 864,827 / Imported 864,827 / Failed 0
stored: NL_H6 319,548  NL_O6 319,548  NL_H1 112,257  NL_RA 144  NL_SE 1,934 …
```

and it narrows the "not verified" list to what is still actually unproven: the 64-bit SDK, ARM hosts, 1.x migration, sustained collection, and `JVRTOpen` against a live race day (the days available had no realtime data, so `JVRTOpen` returned `-1`).

This is still a development prerelease. It is not the `2.0.0` production decision.

Validation: full suite `4695 passed, 508 skipped, 20 subtests passed`; isolated fatal flake8 `0`; `git diff --check` clean.
