### PR TITLE
fix(cli): report the JV-Link transport that actually exists

### DIFF
--- a/src/cli/main.py
+++ b/src/cli/main.py
@@ -285,11 +285,13 @@ def status():
     console.print(f"Version: {__version__}")
     console.print()
     console.print("[bold]JRA-VAN DataLab:[/bold]")
-    try:
-        from src.jvlink import JVLinkWrapper
-        console.print("  状態: [green]利用可能[/green]")
-    except ImportError:
-        console.print("  状態: [red]利用不可[/red]")
+    from src.jvlink import is_jvlink_available
+
+    if is_jvlink_available():
+        console.print("  JV-Link transport: [green]利用可能[/green]")
+    else:
+        console.print("  JV-Link transport: [red]利用不可[/red]")
+    console.print("  利用登録状態: 未確認 (JVInit/JVOpen で判定)")
     console.print("Status: [green]Ready[/green]")
 
 
@@ -306,11 +308,16 @@ def version(check):
 
     console.print()
     console.print("[bold]対応データソース:[/bold]")
-    try:
-        from src.jvlink import JVLinkWrapper
-        console.print("  - JRA-VAN DataLab (JV-Link): [green]利用可能[/green]")
-    except ImportError:
-        console.print("  - JRA-VAN DataLab (JV-Link): [red]未インストール[/red]")
+    from src.jvlink import is_jvlink_available
+
+    if is_jvlink_available():
+        console.print(
+            "  - JRA-VAN DataLab (JV-Link transport): [green]利用可能[/green]"
+        )
+    else:
+        console.print(
+            "  - JRA-VAN DataLab (JV-Link transport): [red]未インストール[/red]"
+        )
 
     if check:
         console.print()

--- a/src/jvlink/__init__.py
+++ b/src/jvlink/__init__.py
@@ -1,0 +1,25 @@
+"""JV-Link API interface.
+
+Platform support:
+- Windows (32-bit Python): direct COM via pywin32 (`JVLinkWrapper`)
+- Windows (64-bit Python): `JVLinkBridge` subprocess
+- Linux/Docker: `JVLinkBridge` subprocess through an external Wine runner
+"""
+
+import sys
+
+
+def is_jvlink_available() -> bool:
+    """Report whether a JV-Link transport can be used on this platform.
+
+    Availability is transport-only: provider registration and subscription are
+    established by `JVInit` / `JVOpen`, not by the presence of a transport.
+    """
+    if sys.platform == "win32":
+        return True
+    try:
+        from src.jvlink.bridge import find_bridge_executable
+
+        return find_bridge_executable() is not None
+    except Exception:
+        return False

--- a/tests/unit/test_cli_transport_status.py
+++ b/tests/unit/test_cli_transport_status.py
@@ -1,0 +1,70 @@
+"""CLI availability reporting must follow the actual JV-Link transport.
+
+`from src.jvlink import JVLinkWrapper` always raised ImportError because the
+package never re-exported that name, so `status` / `version` reported JV-Link as
+unavailable on every platform, including a Windows host with a working COM
+install and a Wine host with a usable bridge executable.
+"""
+
+from unittest.mock import patch
+
+from click.testing import CliRunner
+
+from src.cli.main import cli
+
+
+def _invoke(command: str, available: bool):
+    with patch("src.jvlink.is_jvlink_available", return_value=available):
+        return CliRunner().invoke(cli, [command])
+
+
+def _strip_markup(text: str) -> str:
+    return " ".join(text.split())
+
+
+def test_status_reports_available_transport() -> None:
+    result = _invoke("status", True)
+    assert result.exit_code == 0
+    output = _strip_markup(result.output)
+    assert "JV-Link transport: 利用可能" in output
+    assert "利用不可" not in output
+    # A usable transport is not a registration or subscription claim.
+    assert "利用登録状態: 未確認" in output
+
+
+def test_status_reports_missing_transport() -> None:
+    result = _invoke("status", False)
+    assert result.exit_code == 0
+    assert "JV-Link transport: 利用不可" in _strip_markup(result.output)
+
+
+def test_version_reports_available_transport() -> None:
+    result = _invoke("version", True)
+    assert result.exit_code == 0
+    assert (
+        "JRA-VAN DataLab (JV-Link transport): 利用可能"
+        in _strip_markup(result.output)
+    )
+
+
+def test_version_reports_missing_transport() -> None:
+    result = _invoke("version", False)
+    assert result.exit_code == 0
+    assert (
+        "JRA-VAN DataLab (JV-Link transport): 未インストール"
+        in _strip_markup(result.output)
+    )
+
+
+def test_transport_availability_follows_bridge_discovery(monkeypatch) -> None:
+    import src.jvlink as jvlink
+
+    monkeypatch.setattr(jvlink.sys, "platform", "linux")
+    with patch(
+        "src.jvlink.bridge.find_bridge_executable", return_value=None
+    ):
+        assert jvlink.is_jvlink_available() is False
+    with patch(
+        "src.jvlink.bridge.find_bridge_executable", return_value="/bin/bridge"
+    ):
+        assert jvlink.is_jvlink_available() is True


### PR DESCRIPTION
## Summary

`status` and `version` never reported a usable JV-Link. Both asked for a name the package does not export:

```python
try:
    from src.jvlink import JVLinkWrapper   # src/jvlink/__init__.py was empty
    console.print("  状態: [green]利用可能[/green]")
except ImportError:
    console.print("  状態: [red]利用不可[/red]")   # always taken
```

So a 32-bit Windows host with a working COM install and a Wine host with a working bridge executable were both told 「利用不可」/「未インストール」. Availability is now decided by the transport that would actually be used:

```python
def is_jvlink_available() -> bool:
    if sys.platform == "win32":
        return True
    return find_bridge_executable() is not None   # exceptions -> False
```

The wording separates transport from registration, because a discoverable transport says nothing about whether the provider is registered or the feed is subscribed — that is what `JVInit` / `JVOpen` answer, and the real run measured both independently (`CoCreateInstance failed` on an unregistered prefix, `JVInit -> 0` on a registered one):

```text
  JV-Link transport: 利用可能
  利用登録状態: 未確認 (JVInit/JVOpen で判定)
```

Found while converting the deployment repository to depend on this package: the fix existed only in that repository's copy of `src/`, which is exactly the drift the dependency move removes.

Validation: red first (5 failed), then `4700 passed, 508 skipped, 20 subtests passed`; isolated fatal flake8 `0`; `git diff --check` clean.
