### PR TITLE
fix(jvlink): let a deployment own the JVOpen response budget

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,9 @@ docker compose exec jltsql jltsql fetch --spec RACE --from 20260101 --to 2026041
 取得中に JV-Link が版更新の確認ダイアログを出すことがあります。既定では
 何も押さないので、noVNC 上で人が答えるまで `JVOpen` は戻りません（実測
 1,008 秒）。無人で流す場合だけ `JVLINK_AUTO_CLOSE_DIALOGS=1` を明示すると、
-既知のダイアログを Escape で拒否します（承諾する入力は送りません）。
+既知のダイアログを Escape で拒否します（承諾する入力は送りません）。人の応答待ちや
+setup 取得が 120 秒を超える環境では `JVLINK_OPEN_TIMEOUT_SECONDS`（1〜7200 秒）で
+`JVOpen` の応答待ちを延ばします。
 
 ## 詳細ドキュメント
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,10 @@ services:
       # prompts wait for a person on the noVNC desktop; set 1 to let the client
       # reject the known ones so an unattended fetch is not blocked.
       JVLINK_AUTO_CLOSE_DIALOGS: ${JVLINK_AUTO_CLOSE_DIALOGS:-0}
+      # JVOpen returns only after JV-Link has enumerated the range, and it also
+      # waits while a dialog is unanswered (measured 1,008s). Raise this when a
+      # setup fetch or a human answer needs longer than the 120s default.
+      JVLINK_OPEN_TIMEOUT_SECONDS: ${JVLINK_OPEN_TIMEOUT_SECONDS:-120}
       NOVNC_PUBLIC_PORT: 6080
       VNC_PUBLIC_PORT: 15900
       POSTGRES_HOST: ${POSTGRES_HOST:-postgres}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -44,7 +44,10 @@ JV-Link は `JVOpen` / `JVRTOpen` 中にお知らせや DataLab 更新確認を�
 `JVOpen` は戻りません（実測 1,008 秒）。無人運転する場合に限り
 `JVLINK_AUTO_CLOSE_DIALOGS=1` を明示すると、既知のダイアログだけを安全側へ
 拒否します（承諾する入力は送りません）。監視間隔は
-`JVLINK_DIALOG_WATCH_INTERVAL_SECONDS` で変更できます。未知のダイアログ、応答
+`JVLINK_DIALOG_WATCH_INTERVAL_SECONDS` で変更できます。`JVOpen` の応答待ち
+上限は既定 120 秒で、setup 取得や人の応答待ちが長い環境では
+`JVLINK_OPEN_TIMEOUT_SECONDS`（1〜7200 秒）で延ばします。読めない値は既定へ
+落とさず error にします。未知のダイアログ、応答
 timeout、読めない bridge 応答は成功扱いせず、timeout 時は状態不明の bridge
 process を終了します。
 

--- a/docs/wine_docker.md
+++ b/docs/wine_docker.md
@@ -34,7 +34,7 @@ Windows では直接起動し、それ以外のホストでは `JVLINK_BRIDGE_RU
 | `JVLINK_BRIDGE_RUNNER` | `wine`（イメージ） | 非 Windows での外部ランナー |
 | `JVLINK_WINEPREFIX` | `/wineprefix` | JV-Link を含む Wine prefix |
 | `JVLINK_WINEARCH` | `win64` | prefix の種別（32-bit 側が必須） |
-| `JVLINK_OPEN_TIMEOUT_SECONDS` | `120` | `JVOpen`/`JVRead` の上限（1〜7200） |
+| `JVLINK_OPEN_TIMEOUT_SECONDS` | `120` | `JVOpen` 応答待ちの上限秒（1〜7200） |
 
 サービスキーを設定する環境変数は持たない。登録は noVNC 上で人が行う。
 

--- a/src/jvlink/bridge.py
+++ b/src/jvlink/bridge.py
@@ -128,8 +128,37 @@ _DISMISSIBLE_DIALOG_TITLE_PATTERNS = (
     r"^JRA-VAN DataLab\.$",
     r"^JRA-VANからのお知らせ$",
 )
+_DEFAULT_OPEN_TIMEOUT_SECONDS = 120.0
+_MAX_OPEN_TIMEOUT_SECONDS = 7200.0
 _ENABLED_VALUES = {"1", "true", "yes", "on"}
 _DISABLED_VALUES = {"0", "false", "no", "off"}
+
+
+def _open_timeout() -> float:
+    """Read the JVOpen response budget, which a deployment has to own.
+
+    JVOpen returns only after JV-Link has enumerated (and for setup options,
+    downloaded) the requested range, and it also blocks while a JV-Link dialog
+    waits for an answer: a real provider run measured 1,008s. A fixed budget
+    either cuts those runs off or hides a hung bridge, so the value is
+    configurable within a bound and an unusable setting fails closed instead of
+    silently falling back.
+    """
+    raw = os.environ.get("JVLINK_OPEN_TIMEOUT_SECONDS")
+    if raw is None or raw.strip() == "":
+        return _DEFAULT_OPEN_TIMEOUT_SECONDS
+    try:
+        timeout = float(raw)
+    except ValueError as error:
+        raise JVLinkBridgeError(
+            f"JVLINK_OPEN_TIMEOUT_SECONDS must be a number, got {raw!r}"
+        ) from error
+    if not math.isfinite(timeout) or not 1.0 <= timeout <= _MAX_OPEN_TIMEOUT_SECONDS:
+        raise JVLinkBridgeError(
+            "JVLINK_OPEN_TIMEOUT_SECONDS must be between 1 and "
+            f"{int(_MAX_OPEN_TIMEOUT_SECONDS)} seconds, got {raw!r}"
+        )
+    return timeout
 
 
 def _repo_root() -> Path:
@@ -615,7 +644,7 @@ class JVLinkBridge:
 
         response = self._send_command(
             {"cmd": "open", "dataspec": data_spec, "fromtime": fromtime, "option": option},
-            timeout=120.0,
+            timeout=_open_timeout(),
         )
 
         # A protocol-level success means the remote COM call has already

--- a/tests/unit/test_jvopen_timeout.py
+++ b/tests/unit/test_jvopen_timeout.py
@@ -1,0 +1,57 @@
+"""Tests for the configurable JVOpen response timeout."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from src.jvlink.bridge import JVLinkBridge, JVLinkBridgeError
+
+
+@pytest.fixture
+def bridge(tmp_path) -> JVLinkBridge:
+    exe = tmp_path / "JVLinkBridge.exe"
+    exe.touch()
+    return JVLinkBridge(sid="TEST", bridge_path=exe)
+
+
+def _open(bridge: JVLinkBridge) -> float:
+    recorded: dict[str, float | None] = {}
+
+    def fake_send(cmd: dict, timeout: float | None = None) -> dict:
+        recorded["timeout"] = timeout
+        return {"status": "ok", "code": 0, "readcount": 1, "downloadcount": 0, "lastfiletimestamp": "20260817133705"}
+
+    with patch.object(bridge, "_send_command", side_effect=fake_send):
+        bridge.jv_open("RACE", "20260810000000", 1)
+    assert recorded["timeout"] is not None
+    return recorded["timeout"]
+
+
+def test_open_timeout_defaults_to_two_minutes(monkeypatch, bridge) -> None:
+    monkeypatch.delenv("JVLINK_OPEN_TIMEOUT_SECONDS", raising=False)
+    assert _open(bridge) == 120.0
+
+
+def test_open_timeout_follows_the_environment(monkeypatch, bridge) -> None:
+    # A JVOpen that has to answer a JV-Link dialog was measured at 1,008s
+    # against a real provider, so a deployment must be able to wait longer
+    # than the default.
+    monkeypatch.setenv("JVLINK_OPEN_TIMEOUT_SECONDS", "7200")
+    assert _open(bridge) == 7200.0
+
+
+def test_open_timeout_treats_an_unset_compose_variable_as_default(monkeypatch, bridge) -> None:
+    # `JVLINK_OPEN_TIMEOUT_SECONDS: ${...:-}` renders as an empty string.
+    monkeypatch.setenv("JVLINK_OPEN_TIMEOUT_SECONDS", "")
+    assert _open(bridge) == 120.0
+
+
+@pytest.mark.parametrize("value", ["0", "-1", "7201", "later", "1e400", "nan"])
+def test_open_refuses_an_unusable_timeout(monkeypatch, bridge, value: str) -> None:
+    monkeypatch.setenv("JVLINK_OPEN_TIMEOUT_SECONDS", value)
+    with patch.object(bridge, "_send_command") as send:
+        with pytest.raises(JVLinkBridgeError, match="JVLINK_OPEN_TIMEOUT_SECONDS"):
+            bridge.jv_open("RACE", "20260810000000", 1)
+    send.assert_not_called()


### PR DESCRIPTION
## Summary

`jv_open` hard-coded its bridge response timeout at 120s, so any `JVOpen` that legitimately takes longer was reported as a bridge timeout and the open was abandoned. Real-provider measurement: a `JVOpen(RACE, 20260810000000, 1)` took **1,008s** because JV-Link raised its "新しいバージョン(5.0.0)…" prompt and waited for a human answer; setup options (`option=4`) enumerate/download for minutes as well. `docs/wine_docker.md` already documented `JVLINK_OPEN_TIMEOUT_SECONDS` (1–7200) and deployments already set it — the code never read it.

```diff
-    response = self._send_command({"cmd": "open", ...}, timeout=120.0)
+    response = self._send_command({"cmd": "open", ...}, timeout=_open_timeout())
```

`_open_timeout()` keeps `120.0` as the default (unset *or* empty, because `\${JVLINK_OPEN_TIMEOUT_SECONDS:-}` renders empty in compose), accepts `1.0 … 7200.0`, and raises `JVLinkBridgeError` for anything else — non-numeric, out of range, `nan`, `inf`. It does not silently fall back: a deployment that asked for a budget and typo'd it must not quietly run with a different one, and an unbounded value would turn a hung bridge into an unbounded hang.

Docs/compose now name the variable where the dialog behaviour is described, and `docs/wine_docker.md`'s claim that it also bounds `JVRead` is corrected (it does not).

## Verification

- red first: `tests/unit/test_jvopen_timeout.py` fails 7/9 against master's hard-coded timeout, passes 9/9 after the change
- `pytest tests`: 4709 passed, 508 skipped, 20 subtests passed
- fatal flake8 (E9,F63,F7,F82): 0


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added configurable `JVOpen` response timeouts through `JVLINK_OPEN_TIMEOUT_SECONDS`.
  - Supports values from 1 to 7,200 seconds, with a default of 120 seconds.
  - Documented behavior for unattended dialog handling and dialog monitoring.

- **Bug Fixes**
  - Invalid, non-finite, or out-of-range timeout values are now rejected clearly instead of being used.

- **Tests**
  - Added coverage for defaults, custom values, and invalid timeout settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->