### PR TITLE
fix: preserve official start-only JVOpen setup semantics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@
 
 次回リリースは互換性を破る変更を含むため `2.0.0` とする。1.xとしては配布しない。
 
+### 次の開発検証用prerelease
+
+- 公式 option 3/4 の historical setup tail は終了時刻で上限を切れないため、
+  setup を年単位に再帰して後続tailを反復しない。要求開始日を包含する
+  start-only `JVOpen` を1回だけ使い、`--to` はclient-side filterとして扱う
+- 複数年setupを有限に監視できるよう `JVLINK_OPEN_TIMEOUT_SECONDS` の許容範囲を
+  1〜86,400秒へ拡張する（既定120秒は維持、非有限値と範囲外はfail closed）
+
 ### 2.0.0.dev2 (開発検証用prerelease)
 
 実デプロイ設定を読み込んだ結果の修正。

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -257,7 +257,8 @@
 - HC/WC を日付なし master として扱わず、時系列の `ChokyoDate` で `--to` filter と
   cache 日付を判定。対応する event date を持たない master 行を検出した場合は完全
   cache marker を付けず、同一取得の部分 cache append も rollback する
-- 旧 cache の完全性 marker を schema v2 で失効させ、legacy raw と active raw を分離
+- setup開始境界の修正前に作成された schema v2 の完全性 marker を schema v3 で
+  失効させ、旧 raw と active raw を分離
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -161,8 +161,9 @@ docker compose exec jltsql jltsql fetch --spec RACE --from 20260101 --to 2026041
 何も押さないので、noVNC 上で人が答えるまで `JVOpen` は戻りません（実測
 1,008 秒）。無人で流す場合だけ `JVLINK_AUTO_CLOSE_DIALOGS=1` を明示すると、
 既知のダイアログを Escape で拒否します（承諾する入力は送りません）。人の応答待ちや
-setup 取得が 120 秒を超える環境では `JVLINK_OPEN_TIMEOUT_SECONDS`（1〜7200 秒）で
-`JVOpen` の応答待ちを延ばします。
+setup 取得が 120 秒を超える環境では `JVLINK_OPEN_TIMEOUT_SECONDS`（1〜86400 秒）で
+`JVOpen` の応答待ちを延ばします。前月までの official setup data は終了時刻で
+上限を切れず、複数年取得は数時間かかり得るため、配備側が監視可能な有限値を指定します。
 
 ## 詳細ドキュメント
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -330,8 +330,10 @@ Everything merged since v1.6.9: PR #149, #150, #151, #152, and #153.
   `ChokyoDate` for the `--to` filter and the cache date key. A master row with
   no corresponding event date suppresses the complete-cache marker and rolls
   back the partial cache appended by the same fetch.
-- Invalidates legacy cache completeness markers under schema v2, separating
-  legacy raw from active raw.
+- Invalidates pre-fix cache completeness markers under schema v3, separating
+  schema-v2 raw records from the active cache generation. A v2 marker cannot
+  prove that the corrected inclusive setup start retained a record stamped
+  exactly at midnight.
 - Corrects the `fetch --option 2` note and `--from` help to match the official
   JV-Link specification: `fromtime` manages continuity within the current race
   cycle rather than selecting an arbitrary retained week, and Sunday/Monday can

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -5,6 +5,16 @@ of the official data-contract work. It is **not** a production compatibility
 claim: the 64-bit SDK path, 1.x database migration, and long-run collection are
 still unverified.
 
+Changes queued for the next development prerelease after `2.0.0.dev2`:
+
+- option 3/4 setup uses one inclusive-start, start-only `JVOpen`. The official
+  historical setup tail is all setup data after `fromtime`; an end timestamp
+  only limits the current-month normal-data portion, so `--to` remains a
+  client-side record filter and calendar-year recursion is not used
+- the finite `JVLINK_OPEN_TIMEOUT_SECONDS` ceiling is raised to 86,400 seconds
+  for monitored multi-hour setup recovery; the default remains 120 seconds
+  and invalid, non-finite, or larger values fail closed
+
 What `2.0.0.dev2` adds over `2.0.0.dev1`:
 
 - `JVOpen` no longer imposes a fixed 120s response budget. A deployment sets

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -31,6 +31,13 @@ jltsql fetch --from 20260101 --to 20260417 --spec RACE --option 1
 `option 4` は長期間をまとめて取得するため、一定件数ごとにコミットします。途中で中断しても、
 そこまでに取り込んだぶんは残ります。
 
+`option 3/4` の過去setup dataは公式仕様上 `fromtime` より後の全件が対象です。
+終了時刻を付けても過去setup部分の上限にはならないため、`jltsql` は要求開始日の
+直前1秒を指定したstart-only `JVOpen`を1回だけ使います。`--to` は取得後の
+client-side filterであり、download量を指定範囲へ制限するオプションではありません。
+複数年setupは数時間かかり得るため、配備側では監視可能な有限の
+`JVLINK_OPEN_TIMEOUT_SECONDS`（1〜86,400秒、既定120秒）を指定できます。
+
 主な `spec`:
 
 | spec | 用途 |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -46,7 +46,9 @@ JV-Link は `JVOpen` / `JVRTOpen` 中にお知らせや DataLab 更新確認を�
 拒否します（承諾する入力は送りません）。監視間隔は
 `JVLINK_DIALOG_WATCH_INTERVAL_SECONDS` で変更できます。`JVOpen` の応答待ち
 上限は既定 120 秒で、setup 取得や人の応答待ちが長い環境では
-`JVLINK_OPEN_TIMEOUT_SECONDS`（1〜7200 秒）で延ばします。読めない値は既定へ
+`JVLINK_OPEN_TIMEOUT_SECONDS`（1〜86400 秒）で延ばします。前月までのsetup
+dataは終了時刻で上限を切れないため、複数年再構築では配備側が監視可能な有限値を
+指定します。読めない値は既定へ
 落とさず error にします。未知のダイアログ、応答
 timeout、読めない bridge 応答は成功扱いせず、timeout 時は状態不明の bridge
 process を終了します。

--- a/docs/wine_docker.md
+++ b/docs/wine_docker.md
@@ -34,7 +34,7 @@ Windows では直接起動し、それ以外のホストでは `JVLINK_BRIDGE_RU
 | `JVLINK_BRIDGE_RUNNER` | `wine`（イメージ） | 非 Windows での外部ランナー |
 | `JVLINK_WINEPREFIX` | `/wineprefix` | JV-Link を含む Wine prefix |
 | `JVLINK_WINEARCH` | `win64` | prefix の種別（32-bit 側が必須） |
-| `JVLINK_OPEN_TIMEOUT_SECONDS` | `120` | `JVOpen` 応答待ちの上限秒（1〜7200） |
+| `JVLINK_OPEN_TIMEOUT_SECONDS` | `120` | `JVOpen` 応答待ちの上限秒（1〜86400） |
 
 サービスキーを設定する環境変数は持たない。登録は noVNC 上で人が行う。
 

--- a/specs/operations/20260822_jvopen_bounded_setup_worklog.md
+++ b/specs/operations/20260822_jvopen_bounded_setup_worklog.md
@@ -1,18 +1,22 @@
-# JVOpen bounded setup worklog — 2026-08-22
+# JVOpen setup recovery worklog — 2026-08-22
 
 ## Objective and minimum scope
 
-Repair the JRA RACE official-setup transport so a requested date range is
-bounded at JVOpen rather than fetched as one unbounded tail. The minimum
-iteration is:
+Repair the JRA RACE official-setup transport without claiming a provider-side
+upper bound that the official option-3/4 contract does not provide. The
+minimum iteration, corrected after reading p.20 in context, is:
 
-1. send the official start/end `fromtime` form for end-capable setup specs;
-2. preserve the official start-only form for specs that forbid an end point;
-3. make long option-4 setup partitioning truly bounded and resumable without
-   weakening transaction, cache-complete, parser-rejection, or failure
-   semantics; and
-4. correct CLI/docs claims so operators do not mistake a client-side filter
-   for a provider download bound.
+1. encode an inclusive requested start as the official exclusive start point
+   `(from_date midnight - 1 second)` and keep setup as one start-only JVOpen;
+2. remove calendar-year setup recursion, which repeats the same later setup
+   tail and grows approximately quadratically;
+3. keep option-4 progress durable in bounded record groups after JVOpen
+   returns, without weakening transaction, cache-complete, parser-rejection,
+   or failure semantics;
+4. keep `to_date` as a client-side record filter and state explicitly that it
+   is not a provider download bound; and
+5. permit a monitored, finite response budget large enough for the measured
+   multi-hour five-year setup, while rejecting non-finite/unbounded values.
 
 Do not change record parsers, schemas, service-key/registration handling,
 provider identity, realtime collection, production release `2.0.0`, or KPS
@@ -50,31 +54,35 @@ the development runtime.
   `JV-Linkインターフェース仕様書_4.9.0.1(Win).pdf`, SHA-256
   `3167d5c98d8db78321a983cd2d897e1b5a9f42f141490f9ba817ca0dcf9d2364`.
   Pages 17--20 define `fromtime` as either one start timestamp or start/end
-  timestamps joined by `-`. RACE is not in the explicit list that forbids an
-  end timestamp. The same section documents options 3/4 and setup
-  interruption/resume.
+  timestamps joined by `-`. The general rule is `> start` and `<= end`, but
+  p.20 narrows the option-3/4 meaning: previous-month setup data is all setup
+  data after `fromtime`; the end timestamp limits only the current-month
+  normal-data portion. RACE accepting an end timestamp therefore does **not**
+  make the historical setup tail bounded.
 - Exact `2.0.0.dev2` constructs only
   `fromtime = f"{from_date}000000"`; `to_date` is a client-side record filter.
   Its option-3 yearly recursion therefore repeats all later provider data, and
-  option 4 is deliberately left as one unbounded open to avoid that O(n^2)
-  repetition. The two-hour failure is consequently not evidence that a
-  bounded yearly setup was attempted.
+  option 4 is deliberately left as one start-only open to avoid that O(n^2)
+  repetition. The two-hour failure is consequently evidence that the finite
+  7,200-second response budget is too short for the requested setup, not that
+  a provider-bounded yearly setup was attempted.
 
 ## Red-first and implementation contract
 
 Before production changes, add the minimum regression coverage and run it on
-this exact base. It must prove at least:
+the then-current candidate. It must prove at least:
 
-- bounded RACE setup calls JVOpen with the inclusive-date encoding
-  `(from_date - 1 second at midnight)-to_date 23:59:59`, for example
-  `20250819235959-20260819235959` for 2025-08-20..2026-08-19 (base must fail
-  because it sends only `20250820000000`);
-- an end-forbidden setup spec such as DIFN remains start-only (paired green);
-- option-4 long ranges partition into exact, nonoverlapping bounded chunks and
-  do not repeat the open tail;
-- a failed later chunk is not recorded complete and cannot silently discard or
-  double-count an already durable earlier chunk; and
-- invalid/missing dates fail before JV-Link or database mutation.
+- RACE option 3/4 calls JVOpen once with the inclusive-date encoding
+  `(from_date midnight - 1 second)`, for example `20250819235959` for
+  2025-08-20, and never appends a historical upper bound;
+- changing `to_date` does not change that provider request (paired proof that
+  it is only a client-side filter);
+- long option-3/4 ranges do not recurse into year windows or repeat the open
+  setup tail;
+- option 3 remains one atomic transaction while option 4 keeps its explicit
+  bounded record-group durability; and
+- invalid/missing dates fail before JV-Link or database mutation, and a finite
+  43,200-second budget is accepted while values above 86,400 are rejected.
 
 Record the exact pre-fix failure in this worklog and in the commit/PR evidence.
 Do not add one test per reviewer hypothesis; extend the existing historical or
@@ -109,6 +117,102 @@ Require it to inspect the official evidence and current tests, run the red
 test against exact base, implement the smallest coherent repair, run focused
 tests, update this worklog, and stop before commit/push/PR so the primary
 agent can inspect the result.
+
+## Superseding oracle correction — 2026-08-22
+
+The first implementation (`b034b4bff1bc71a577999a6a8f7db526f262a6ea`,
+evidence update `03db892ab7c0874d750b71d23af52987c2570a88`) interpreted
+the general start/end rule without the option-3/4 qualifier on p.20. It added
+an end timestamp and calendar-year opens. That interpretation is rejected and
+those commits are **not mergeable**. They remain below as audit history only;
+none of their bounded-provider claims is release evidence.
+
+Draft PR #238 was returned to Draft immediately after this correction. Its
+remote head remains `03db892ab7c0874d750b71d23af52987c2570a88` until the
+corrected candidate is frozen and tested. The public blocker record is
+<https://github.com/miyamamoto/jrvltsql/pull/238#issuecomment-5377091537>.
+No provider, runtime, database, cache, release, or Wine-prefix state was
+changed while correcting the code.
+
+### Corrected official interpretation
+
+Independent `pdftotext` inspection of the pinned p.17--20 establishes both
+facts, which must not be collapsed into one:
+
+- the API accepts start-only and start/end `fromtime` forms, with the general
+  eligibility rule `> start` and `<= end`;
+- for option 3/4, previous-month setup data is nevertheless **all** setup data
+  after `fromtime`; the end timestamp limits only the current-month normal
+  data appended to that setup response.
+
+Therefore an end timestamp cannot partition the historical setup tail. Calling
+one year at a time would repeatedly download later years and recreate the
+pre-existing option-3 O(n^2) behavior. The safe contract is one start-only
+JVOpen, client-side `to_date` filtering, and finite monitored bridge time.
+
+### Corrected red-first evidence
+
+The minimum corrected tests were applied before the corrected production
+implementation and run against the unsafe `03db892` candidate:
+
+```text
+.venv/bin/python -m pytest \
+  tests/test_jvlink_transport_contract.py \
+  tests/test_batch_processor.py \
+  tests/unit/test_jvopen_timeout.py \
+  tests/test_cli.py --no-cov -q
+```
+
+Result: **9 failed, 129 passed, 8 subtests passed**. The failures proved that
+the then-candidate still sent a start/end RACE request, changed the provider
+request with `to_date`, split option 3/4 into three provider/cache calls,
+rejected a finite 43,200-second budget because of the 7,200-second ceiling,
+and advertised the false bounded-download contract in CLI help. This is the
+required `no` evidence; the test does not merely exercise green cases.
+
+### Corrected implementation contract
+
+- `HistoricalFetcher` sends option 3/4 exactly one start-only timestamp at
+  `(from_date midnight - 1 second)`; options 1/2 retain their old cursor form.
+- `BatchProcessor` has no year-splitting decision/helper/path. Option 3 keeps
+  one transaction. Option 4 alone commits each `SETUP_COMMIT_INTERVAL` record
+  group after the provider call returns and streaming begins.
+- `to_date` remains a record filter and cache-scope component. It is never
+  described as a historical provider bound.
+- `JVLINK_OPEN_TIMEOUT_SECONDS` remains 120 seconds by default, must be finite,
+  and accepts 1--86,400 seconds. The development runtime may choose a smaller
+  monitored finite value (for example 43,200); code does not become unbounded.
+- CLI/help/README/architecture/Wine docs state these limits and the setup-tail
+  behavior. Release metadata will be updated in the separate next-dev release
+  iteration after this repair merges.
+
+The first corrected focused run after these production changes was
+**135 passed, 8 subtests passed** with the same command. A wider focused gate,
+full suite, distributions, and independent review are still required on a
+committed immutable SHA; this interim result is not the merge gate.
+
+The wider pre-commit focused gate then covered transport, batch transaction
+ownership, cache write/failure paths, `-402` self-repair, date filtering,
+JVOpen constants, CLI/public setup wording, CLI transport status, and timeout
+validation:
+
+```text
+.venv/bin/python -m pytest \
+  tests/test_jvlink_transport_contract.py tests/test_batch_processor.py \
+  tests/test_historical_cache_failures.py \
+  tests/test_historical_cache_write_through.py tests/test_jvd_self_repair.py \
+  tests/test_date_filtering.py tests/test_jvlink_constants.py \
+  tests/test_cli.py tests/test_public_setup_contract.py \
+  tests/test_quickstart_cli.py tests/unit/test_cli_transport_status.py \
+  tests/unit/test_jvopen_timeout.py --no-cov -q
+```
+
+Result: **246 passed, 8 subtests passed**. `compileall` and the workflow's
+fatal flake8 selection (`E9,F63,F7,F82`) also passed. A broad opt-in Ruff run
+reported the repository's existing style/type-modernization debt; the one
+newly exposed unused import caused by deleting the private split helper was
+removed. The workflow-equivalent lint/full/package gates remain for the
+committed candidate.
 
 ## Implementation record — 2026-08-22, session `ecb0bbe6-e0b1-4923-b214-07698693c5a7`
 
@@ -337,7 +441,11 @@ update does not change production code or tests):
   repair batch if actionable, and unresolved threads must be zero before
   merge. No extra live-provider call is used as a substitute for review.
 
-### Remaining risks and explicitly blocked items
+### Historical risks recorded for rejected `b034b4b` candidate (superseded)
+
+Everything in this subsection through its old "Next safe action" describes
+the rejected start/end/year-chunk hypothesis. It is retained only to make the
+audit trail explain why `03db892` was not merged; it is not the current plan.
 
 - Live-provider behaviour of the bounded setup fromtime is UNVERIFIED here
   (live operations are a STOP condition). The first supervised run must
@@ -363,7 +471,7 @@ update does not change production code or tests):
 - Registry deviation observed, untouched: local option-1 list allows
   MING/COMM although p.20 lists them only under options 3/4.
 
-### Next safe action
+### Historical next action for rejected candidate (superseded)
 
 Primary agent: commit this worklog-only evidence update, rerun the focused
 transport tests and fatal lint on that final full SHA, push both local commits,
@@ -373,3 +481,17 @@ only from a clean exact-SHA gate. Only after merge, a new `2.0.0.dev*` wheel,
 and runtime pinning may a supervised bounded RACE option-4 setup for
 20240820..20260819 be attempted, watching for -112/-113 and the JVOpen
 response budget.
+
+## Current next safe action
+
+1. finish the corrected docs/worklog and run the wider focused transport,
+   cache, self-repair, transaction, date-filter, CLI, and timeout tests;
+2. commit the corrected implementation as a superseding commit, then run the
+   full/test/package gates on that immutable full SHA;
+3. push the corrected head, rewrite PR #238 title/body so no bounded-download
+   claim remains, request one independent review, aggregate findings once,
+   and merge only with unresolved threads zero and a clean worktree;
+4. create the next `2.0.0.dev*` release from merged `master`, pin that exact
+   artifact in the development runtime, and only then resume the monitored
+   single-open RACE setup. Never use the rejected `03db892` artifact or its
+   CI as evidence for the corrected candidate.

--- a/specs/operations/20260822_jvopen_bounded_setup_worklog.md
+++ b/specs/operations/20260822_jvopen_bounded_setup_worklog.md
@@ -1,0 +1,109 @@
+# JVOpen bounded setup worklog — 2026-08-22
+
+## Objective and minimum scope
+
+Repair the JRA RACE official-setup transport so a requested date range is
+bounded at JVOpen rather than fetched as one unbounded tail. The minimum
+iteration is:
+
+1. send the official start/end `fromtime` form for end-capable setup specs;
+2. preserve the official start-only form for specs that forbid an end point;
+3. make long option-4 setup partitioning truly bounded and resumable without
+   weakening transaction, cache-complete, parser-rejection, or failure
+   semantics; and
+4. correct CLI/docs claims so operators do not mistake a client-side filter
+   for a provider download bound.
+
+Do not change record parsers, schemas, service-key/registration handling,
+provider identity, realtime collection, production release `2.0.0`, or KPS
+model/feature work in this iteration. Do not run another live setup until the
+code is reviewed, merged, released as a new `2.0.0.dev*` wheel, and pinned by
+the development runtime.
+
+## Repository and immutable start state
+
+- Repository: `miyamamoto/jrvltsql`
+- Worktree: `/home/keiba/scratch/20260822_jrvltsql_bounded_setup`
+- Branch: `fix/jvopen-bounded-setup-20260822`
+- Base / initial HEAD / `origin/master`:
+  `3c4650dfceb96df89808291ef29191de506ef85f`
+- Related installed/release version: `2.0.0.dev2`
+- Upstream runtime image used for the reproducer:
+  `kps-jra-collector-dev:e97924fd32049d41f77bafb8634dd32aedc06d17`
+- KIR operational evidence PR: #167, current evidence head
+  `7495b6eee9fbef965ceb20af90f7a306e29f3884`
+- This worktree started clean. The separate checkout `/home/keiba/jrvltsql`
+  already contained unrelated uncommitted realtime changes and must not be
+  edited or cleaned by this iteration.
+
+## Observed failure and official oracle
+
+- A RACE option-4 setup for 2025-08-20..2026-08-19 completed in about
+  32 minutes 37 seconds with `Fetched=135354`, `Parsed=22555875`,
+  `Imported=22555874`, `Failed=0`.
+- The next RACE option-4 scope, 2024-08-20..2026-08-19, remained live for the
+  exact configured 7,200 seconds but returned no JVOpen response. It exited 1
+  with `Bridge response timeout (7200.0s)`, counters zero, empty cache
+  checkpoints, no cache commit, no success progress ledger, unchanged durable
+  DB rows, and unchanged provider-local Data Lab files.
+- Pinned official oracle:
+  `JV-Linkインターフェース仕様書_4.9.0.1(Win).pdf`, SHA-256
+  `3167d5c98d8db78321a983cd2d897e1b5a9f42f141490f9ba817ca0dcf9d2364`.
+  Pages 17--20 define `fromtime` as either one start timestamp or start/end
+  timestamps joined by `-`. RACE is not in the explicit list that forbids an
+  end timestamp. The same section documents options 3/4 and setup
+  interruption/resume.
+- Exact `2.0.0.dev2` constructs only
+  `fromtime = f"{from_date}000000"`; `to_date` is a client-side record filter.
+  Its option-3 yearly recursion therefore repeats all later provider data, and
+  option 4 is deliberately left as one unbounded open to avoid that O(n^2)
+  repetition. The two-hour failure is consequently not evidence that a
+  bounded yearly setup was attempted.
+
+## Red-first and implementation contract
+
+Before production changes, add the minimum regression coverage and run it on
+this exact base. It must prove at least:
+
+- bounded RACE setup calls JVOpen with
+  `YYYYMMDD000000-YYYYMMDD235959` (base must fail because it sends only the
+  start timestamp);
+- an end-forbidden setup spec such as DIFN remains start-only (paired green);
+- option-4 long ranges partition into exact, nonoverlapping bounded chunks and
+  do not repeat the open tail;
+- a failed later chunk is not recorded complete and cannot silently discard or
+  double-count an already durable earlier chunk; and
+- invalid/missing dates fail before JV-Link or database mutation.
+
+Record the exact pre-fix failure in this worklog and in the commit/PR evidence.
+Do not add one test per reviewer hypothesis; extend the existing historical or
+batch-processor contracts with the smallest table/parameterized coverage that
+actually turns red.
+
+## Coding-agent session
+
+- Claude Code version: record when started.
+- Model: `--model fable`, selected because this changes a fail-closed transport
+  gate plus range partition, transaction order, cache completion and resume
+  semantics.
+- Session ID: `ecb0bbe6-e0b1-4923-b214-07698693c5a7`
+- Continue this same session with `--resume` for review fixes in this
+  iteration. If context becomes too long, summarize here before starting a new
+  session.
+
+## STOP conditions
+
+- Stop on worktree drift not created by this iteration.
+- Stop before any live provider operation, runtime image/wheel publication,
+  release tag, production deployment, Wine-prefix reset, registration change,
+  service-key output, or KIR/KPS mutation.
+- A missing official answer, unbounded provider call, cache range falsely
+  complete after failure, lost previously committed chunk, or transaction
+  ownership ambiguity is a blocker, not a reason to loosen the gate.
+
+Next safe command: commit and push this initial worklog, then start Claude Code
+`2.1.233` with `--model fable --session-id
+ecb0bbe6-e0b1-4923-b214-07698693c5a7` in this worktree. Require it to inspect
+the official evidence and current tests, run the red test against exact base,
+implement the smallest coherent repair, run focused tests, update this worklog,
+and stop before commit/push/PR so the primary agent can inspect the result.

--- a/specs/operations/20260822_jvopen_bounded_setup_worklog.md
+++ b/specs/operations/20260822_jvopen_bounded_setup_worklog.md
@@ -484,14 +484,38 @@ response budget.
 
 ## Current next safe action
 
-1. finish the corrected docs/worklog and run the wider focused transport,
-   cache, self-repair, transaction, date-filter, CLI, and timeout tests;
-2. commit the corrected implementation as a superseding commit, then run the
-   full/test/package gates on that immutable full SHA;
-3. push the corrected head, rewrite PR #238 title/body so no bounded-download
+### Immutable corrected-candidate gate
+
+The corrected implementation plus the superseding worklog was committed as
+`0cd578e1adcd27c68334a3ddf0f7752d0760f83d`. It was not pushed or used by a
+provider/runtime/database operation before the following gates completed:
+
+- `uv lock --check`: pass;
+- `scripts/validate_test_gate.py`: `TEST GATE PASS`;
+- workflow-equivalent full test selection on Python 3.13.5:
+  **4709 passed, 502 skipped, 14 deselected, 20 subtests passed**;
+- the same full selection in a fresh external Python 3.12.11 environment:
+  **4709 passed, 502 skipped, 14 deselected, 20 subtests passed**;
+- a fresh `git archive 0cd578e...` PEP 517 build produced a wheel and sdist;
+  `check_distribution_contents.py` and `smoke_distribution_init.py` both
+  passed. SHA-256:
+  - wheel: `dedd9cd09a3c154a30e0b0d76f8ee0414ff6a11713afdf06d3ae2bbd24a594b6`;
+  - sdist: `9fdf1ef59571a523edbc3ca1fc666a791e32abb2b1a09ddbe0ebb14f0b28bcee`.
+
+The build directory is disposable and is not release output; the next-dev
+release will build again from merged `master`. The final PR candidate after
+this evidence-only worklog commit must still receive its own focused/fatal
+lint gate, exact-SHA review, GitHub checks, and clean-worktree confirmation.
+The worklog is excluded from distributions, but an old test result will not be
+silently relabelled as evidence for a different production tree.
+
+1. commit this evidence-only worklog update and rerun the focused/fatal lint
+   gate on the resulting final full SHA; because production/package content is
+   unchanged, confirm a fresh build is byte-identical or rerun its gates;
+2. push the corrected head, rewrite PR #238 title/body so no bounded-download
    claim remains, request one independent review, aggregate findings once,
    and merge only with unresolved threads zero and a clean worktree;
-4. create the next `2.0.0.dev*` release from merged `master`, pin that exact
+3. create the next `2.0.0.dev*` release from merged `master`, pin that exact
    artifact in the development runtime, and only then resume the monitored
    single-open RACE setup. Never use the rejected `03db892` artifact or its
    CI as evidence for the corrected candidate.

--- a/specs/operations/20260822_jvopen_bounded_setup_worklog.md
+++ b/specs/operations/20260822_jvopen_bounded_setup_worklog.md
@@ -599,3 +599,25 @@ fresh-archive distribution gates on that exact full SHA, push once, update the
 PR evidence, then reply to and resolve both current-head cache threads. Merge
 remains prohibited until checks are green, unresolved threads are zero, and
 the final worktree is clean.
+
+### Cache repair code-commit gate
+
+The aggregated production/test/docs repair was committed as
+`69142ab9a62ca2e9bc45a98f97dfb0ac64ba7e83`. Against that immutable full SHA:
+
+- `uv lock --check`: pass;
+- `scripts/validate_test_gate.py`: `TEST GATE PASS`;
+- Python 3.12.11 full suite: **4726 passed, 508 skipped, 22 subtests
+  passed** in 107.99 seconds;
+- a fresh `git archive` PEP 517 wheel and sdist both passed the distribution
+  content checker, and the wheel passed the isolated installed-init smoke;
+- disposable artifact SHA-256 values (not release artifacts):
+  - wheel: `7e263ce74abbf1398367df7e4ea41cf93ccf4e474528a8f4edbb3bd99dae092b`;
+  - sdist: `186b85b3463073fff2c55b18ef77efc0abce971bac5d7907423f12badc98f35c`.
+
+This evidence update changes only the tracked worklog and therefore does not
+modify the tested production/test tree. Per the no-self-reference rule, its
+resulting commit SHA will be recorded in PR #238 rather than by another
+worklog-only commit. That final PR head still receives one focused/fatal-lint
+and archive gate before push; the full-suite evidence remains explicitly
+bound to the production/test commit above rather than silently relabelled.

--- a/specs/operations/20260822_jvopen_bounded_setup_worklog.md
+++ b/specs/operations/20260822_jvopen_bounded_setup_worklog.md
@@ -551,3 +551,51 @@ batch rather than two iterative fixes.
    artifact in the development runtime, and only then resume the monitored
    single-open RACE setup. Never use the rejected `03db892` artifact or its
    CI as evidence for the corrected candidate.
+
+### Exact-head cache-completeness review repair
+
+The next GitHub review pass on exact pushed head
+`2c969926c0ec9a744f1d519f4c44c1d29b4bb40b` found two adjacent cache
+fail-open paths. They were aggregated before changing production code:
+
+- an NL cache marked complete under schema v2 could have been created with
+  the old setup start boundary (`YYYYMMDD000000`). Such a marker cannot prove
+  that a provider record timestamped exactly at midnight was included, but
+  the corrected fetch path still trusted it and skipped JVOpen;
+- `cache build` called `has_nl_range` before the shared date validator. For an
+  inverted interval the cache loop examined zero dates, returned true, and
+  the command exited successfully as `[CACHED]`. The same order also affected
+  `cache rebuild`, which printed `Cleared 0` before the false cache success.
+
+One compact regression was added for each contract and overlaid on an
+immutable detached worktree at the exact old head. The measured red was:
+
+```text
+assert cm.has_nl_range("RACE", "20260401", "20260401") is False
+E AssertionError: assert True is False
+SUBFAILED(command='build'): 0 != 1; [CACHED] ... already in cache
+SUBFAILED(command='rebuild'): 0 != 1; Cleared 0 ... [CACHED]
+3 failed, 1 passed
+```
+
+The repair bumps only the NL raw-cache generation from v2 to v3. Existing v2
+bytes are retained but are neither read nor accepted as completion evidence;
+the first corrected fetch writes a separate v3 file and marker. Both cache
+commands now call the shared calendar/order validator before constructing a
+`CacheManager`, looking up completion, or clearing a file. Malformed input is
+reported as a controlled Click error with nonzero status.
+
+Green evidence in the working tree before its final commit:
+
+- exact two-test regression: **2 passed, 2 subtests passed**;
+- adjacent cache/CLI/transport/batch/failure/retired-spec/public-doc ring:
+  **379 passed, 10 subtests passed**;
+- `git diff --check`: pass.
+
+No provider, runtime, database, release, or actual cache state was touched.
+The temporary detached red-check worktree was removed. Next safe action is to
+commit this single aggregated review repair, run the Python 3.12 full and
+fresh-archive distribution gates on that exact full SHA, push once, update the
+PR evidence, then reply to and resolve both current-head cache threads. Merge
+remains prohibited until checks are green, unresolved threads are zero, and
+the final worktree is clean.

--- a/specs/operations/20260822_jvopen_bounded_setup_worklog.md
+++ b/specs/operations/20260822_jvopen_bounded_setup_worklog.md
@@ -127,9 +127,9 @@ an end timestamp and calendar-year opens. That interpretation is rejected and
 those commits are **not mergeable**. They remain below as audit history only;
 none of their bounded-provider claims is release evidence.
 
-Draft PR #238 was returned to Draft immediately after this correction. Its
-remote head remains `03db892ab7c0874d750b71d23af52987c2570a88` until the
-corrected candidate is frozen and tested. The public blocker record is
+At this correction point, PR #238 was returned to Draft and its remote head
+was still `03db892ab7c0874d750b71d23af52987c2570a88`; this is historical state,
+not the current PR head. The public blocker record is
 <https://github.com/miyamamoto/jrvltsql/pull/238#issuecomment-5377091537>.
 No provider, runtime, database, cache, release, or Wine-prefix state was
 changed while correcting the code.
@@ -509,12 +509,44 @@ lint gate, exact-SHA review, GitHub checks, and clean-worktree confirmation.
 The worklog is excluded from distributions, but an old test result will not be
 silently relabelled as evidence for a different production tree.
 
-1. commit this evidence-only worklog update and rerun the focused/fatal lint
-   gate on the resulting final full SHA; because production/package content is
-   unchanged, confirm a fresh build is byte-identical or rerun its gates;
-2. push the corrected head, rewrite PR #238 title/body so no bounded-download
-   claim remains, request one independent review, aggregate findings once,
-   and merge only with unresolved threads zero and a clean worktree;
+### Exact-head GitHub review repair
+
+After `9e5ec2c274f66927c15f31bbfd3ad2bda23da1f7` was pushed and PR #238 was
+marked Ready, exact-head GitHub review found one actionable code root and one
+documentation-state issue:
+
+- both the Codex connector and CodeRabbit independently observed that the CLI
+  called `create_database_from_config` and `create_all_tables` before
+  `BatchProcessor.process_date_range` could validate dates. This contradicted
+  the fail-before-schema contract even though direct processor tests passed;
+- CodeRabbit also observed that the historical correction paragraph still
+  read like current Draft/head state after the corrected SHA had been pushed.
+
+The CLI regression was written and run before the repair. It failed because
+an inverted range produced a `SchemaMigrationError` from `create_all_tables`
+instead of the date error, and the database factory had already been called:
+
+```text
+FAILED tests/test_cli.py::TestFetchCommand::
+  test_fetch_rejects_invalid_dates_before_database_initialization
+AssertionError: 'from_date must not be after to_date' not found
+```
+
+The repair invokes the shared `validate_date_range` after spec/option
+validation but before guardrail output, database construction, or schema work,
+and renders a controlled CLI error. The new test then passed, and the complete
+corrected focused ring was **247 passed, 8 subtests passed**; workflow fatal
+Flake8 remained zero and `git diff --check` passed. The historical paragraph
+above now explicitly labels the Draft/old-head statement as point-in-time
+history. Both code reviewers identified the same root, so they are one repair
+batch rather than two iterative fixes.
+
+1. commit this aggregated review repair, run the focused/full/package gates on
+   its final full SHA, and push it without another review-per-finding loop;
+2. update PR #238 evidence/current state, reply to and resolve the duplicate
+   date-validation root plus the obsolete `03db892` threads, and merge only
+   after current-head checks pass, independent review is green, unresolved
+   threads are zero, and the worktree is clean;
 3. create the next `2.0.0.dev*` release from merged `master`, pin that exact
    artifact in the development runtime, and only then resume the monitored
    single-open RACE setup. Never use the rejected `03db892` artifact or its

--- a/specs/operations/20260822_jvopen_bounded_setup_worklog.md
+++ b/specs/operations/20260822_jvopen_bounded_setup_worklog.md
@@ -114,8 +114,10 @@ agent can inspect the result.
 
 Model `claude-fable-5` (Fable 5) on Claude Code `2.1.233`, working only in
 this worktree on top of the immutable base (`d7a1523` = worklog only, code
-identical to `3c4650d`). No commit/push/PR/release/provider/database action
-was performed; the diff is left uncommitted for primary-agent review.
+identical to `3c4650d`). The implementation was subsequently inspected and
+committed locally by the primary agent as
+`b034b4bff1bc71a577999a6a8f7db526f262a6ea`. It was not yet pushed,
+released, deployed, or exercised against the live provider at that point.
 
 ### Official oracle verification
 
@@ -197,7 +199,7 @@ exclusive start point equals the previous chunk's inclusive bounded end
 (`…-20241231235959` then `20241231235959-…`), pinned by
 `test_adjacent_setup_chunk_opens_tile_exactly_at_the_boundary_second`.
 
-### Implementation summary (uncommitted)
+### Implementation summary (local commit `b034b4bff1bc71a577999a6a8f7db526f262a6ea`)
 
 - `src/jvlink/constants.py`: `JVOPEN_END_TIME_FORBIDDEN_SPECS` transcribed
   verbatim from p.18 (all seven IDs; DIFF/HOSE additionally remain blocked
@@ -296,6 +298,45 @@ exclusive start point equals the previous chunk's inclusive bounded end
   not treated as gates because the current baseline has unrelated advisory
   style debt and the actual workflow runs fatal Flake8 only.
 
+### Full-suite and distribution evidence for the local code commit
+
+Evidence below is bound to the production/test commit
+`b034b4bff1bc71a577999a6a8f7db526f262a6ea` (this subsequent worklog-only
+update does not change production code or tests):
+
+- Full locked-environment suite:
+  `.venv/bin/python -m pytest --no-cov -q`
+  -> **4732 passed, 508 skipped, 20 subtests passed** in 102.41 seconds.
+- Fatal workflow lint, `compileall`, and `git diff --check` all returned 0.
+- A fresh PEP 517 wheel and sdist were built from the immutable git code,
+  passed `scripts/check_distribution_contents.py`, and the extracted wheel
+  passed the isolated init smoke. The version remains `2.0.0.dev2` here;
+  cutting the next dev release is intentionally a separate post-merge
+  iteration.
+- Build artifact hashes (temporary local artifacts, removed after recording):
+  - wheel `jltsql-2.0.0.dev2-py3-none-any.whl`:
+    `e2191424baacf129feb13ce2e866c830614495d3b124754e3d76797686f6ca07`
+  - sdist `jltsql-2.0.0.dev2.tar.gz`:
+    `c1a16503425a3d2b7506c297f4fcf30d9d65c66c280b17bd07f20148a4f7b501`
+
+### Independent review availability and fallback
+
+- Two complementary read-only Claude Fable review sessions were started on
+  a detached, clean worktree fixed at exact
+  `b034b4bff1bc71a577999a6a8f7db526f262a6ea`:
+  - official transport/oracle: session
+    `59f05180-91c4-48b4-98f2-e81ce0718fe1`;
+  - transaction/cache/rollback: session
+    `23185388-20db-4b58-a04e-3b0594295c28`.
+- Both sessions ended at the external Claude account's session limit before
+  producing a verdict or actionable finding. Their retained JSONL transcripts
+  end with the explicit session-limit message; neither is counted as an
+  independent review pass.
+- Per repository policy, the fallback is one GitHub-native review against the
+  pushed final full SHA. Findings will be aggregated once, addressed in one
+  repair batch if actionable, and unresolved threads must be zero before
+  merge. No extra live-provider call is used as a substitute for review.
+
 ### Remaining risks and explicitly blocked items
 
 - Live-provider behaviour of the bounded setup fromtime is UNVERIFIED here
@@ -324,8 +365,11 @@ exclusive start point equals the previous chunk's inclusive bounded end
 
 ### Next safe action
 
-Primary agent: review this uncommitted diff (10 files), then commit/push and
-update draft PR #238 for this branch per the iteration protocol. Only after review,
-merge, a new `2.0.0.dev*` wheel, and runtime pinning may a supervised
-bounded RACE option-4 setup for 20240820..20260819 be attempted, watching
-for -112/-113 and the JVOpen response budget.
+Primary agent: commit this worklog-only evidence update, rerun the focused
+transport tests and fatal lint on that final full SHA, push both local commits,
+and update draft PR #238 with the red/green/full/package evidence. Request one
+GitHub-native review, aggregate and close every actionable thread, and merge
+only from a clean exact-SHA gate. Only after merge, a new `2.0.0.dev*` wheel,
+and runtime pinning may a supervised bounded RACE option-4 setup for
+20240820..20260819 be attempted, watching for -112/-113 and the JVOpen
+response budget.

--- a/specs/operations/20260822_jvopen_bounded_setup_worklog.md
+++ b/specs/operations/20260822_jvopen_bounded_setup_worklog.md
@@ -65,9 +65,10 @@ the development runtime.
 Before production changes, add the minimum regression coverage and run it on
 this exact base. It must prove at least:
 
-- bounded RACE setup calls JVOpen with
-  `YYYYMMDD000000-YYYYMMDD235959` (base must fail because it sends only the
-  start timestamp);
+- bounded RACE setup calls JVOpen with the inclusive-date encoding
+  `(from_date - 1 second at midnight)-to_date 23:59:59`, for example
+  `20250819235959-20260819235959` for 2025-08-20..2026-08-19 (base must fail
+  because it sends only `20250820000000`);
 - an end-forbidden setup spec such as DIFN remains start-only (paired green);
 - option-4 long ranges partition into exact, nonoverlapping bounded chunks and
   do not repeat the open tail;
@@ -82,7 +83,7 @@ actually turns red.
 
 ## Coding-agent session
 
-- Claude Code version: record when started.
+- Claude Code version: `2.1.233` (verified in-session via `claude --version`).
 - Model: `--model fable`, selected because this changes a fail-closed transport
   gate plus range partition, transaction order, cache completion and resume
   semantics.
@@ -101,9 +102,230 @@ actually turns red.
   complete after failure, lost previously committed chunk, or transaction
   ownership ambiguity is a blocker, not a reason to loosen the gate.
 
-Next safe command: commit and push this initial worklog, then start Claude Code
-`2.1.233` with `--model fable --session-id
-ecb0bbe6-e0b1-4923-b214-07698693c5a7` in this worktree. Require it to inspect
-the official evidence and current tests, run the red test against exact base,
-implement the smallest coherent repair, run focused tests, update this worklog,
-and stop before commit/push/PR so the primary agent can inspect the result.
+Next safe command (superseded — see "Next safe action" at the end): commit and
+push this initial worklog, then start Claude Code `2.1.233` with `--model
+fable --session-id ecb0bbe6-e0b1-4923-b214-07698693c5a7` in this worktree.
+Require it to inspect the official evidence and current tests, run the red
+test against exact base, implement the smallest coherent repair, run focused
+tests, update this worklog, and stop before commit/push/PR so the primary
+agent can inspect the result.
+
+## Implementation record — 2026-08-22, session `ecb0bbe6-e0b1-4923-b214-07698693c5a7`
+
+Model `claude-fable-5` (Fable 5) on Claude Code `2.1.233`, working only in
+this worktree on top of the immutable base (`d7a1523` = worklog only, code
+identical to `3c4650d`). No commit/push/PR/release/provider/database action
+was performed; the diff is left uncommitted for primary-agent review.
+
+### Official oracle verification
+
+- `/home/keibadb/work/keibadb/jra-van/docs/JV-Link4901.pdf` has SHA-256
+  `3167d5c98d8db78321a983cd2d897e1b5a9f42f141490f9ba817ca0dcf9d2364`, byte
+  identical to the pinned
+  `JV-Linkインターフェース仕様書_4.9.0.1(Win).pdf` inside the SDK directory.
+- Pages 17-20, read in-session: `fromtime` has exactly two forms — one start
+  point, or start-end joined by a half-width hyphen; eligibility is
+  "strictly greater than the start point, up to and including the end
+  point". The end point is forbidden for TOKU, DIFF, DIFN, HOSE, HOSN,
+  HOYU, COMM ("全データを取得するため"; specifying one returns -1, which is
+  indistinguishable from a legitimate no-data response). RACE is not in the
+  list. p.19 documents setup interruption/resume as "reopen with identical
+  parameters, then JVSkip to the saved file"; the existing -402 self-repair
+  already reopens with the identical stored fromtime, so the bounded form
+  composes with it. p.20's option table lists MING/COMM under options 3/4
+  only, while the local `JVOPEN_VALID_COMBINATIONS` also allows them under
+  option 1 — observed deviation, deliberately not touched this iteration.
+
+### Red-first evidence (all runs on base production code)
+
+Environment note: system Python is 3.10 (`StrEnum` import fails), so every
+run used `uv run --extra dev --extra postgres pytest ... --no-cov` inside
+this worktree, serially. `.venv/`, `.pytest-tmp/` are gitignored artifacts.
+
+1. Round 1 (three extended test files, first bounded-form expectations):
+   `uv run --extra dev --extra postgres pytest
+   tests/test_jvlink_transport_contract.py tests/test_batch_processor.py
+   tests/test_historical_cache_write_through.py --no-cov -q`
+   → **20 failed, 79 passed**. Representative exact failures:
+   - `AssertionError: expected call not found.` with
+     `Expected: jv_open('RACE', '20250820000000-20260819235959', 4)` vs
+     `Actual: jv_open('RACE', '20250820000000', 4)` (same for option 3) —
+     base sends only the start timestamp;
+   - `TypeError: BatchProcessor._should_split_setup_range() takes 3
+     positional arguments but 4 were given` — no dataspec dimension in the
+     split decision;
+   - option-4 long-range partition/durability and per-chunk cache-routing
+     tests failed (single unbounded open instead of chunks);
+   - all invalid/inverted-date cases failed (`DID NOT RAISE`), i.e. bad
+     dates reached JVOpen/schema on base.
+   The two long-range batch tests were then re-scoped to the actually
+   failed production range 20240820..20260819 (the first draft used a
+   364-day range below the 370-day split threshold) and re-proven red on
+   stashed base: `Failed: DID NOT RAISE SchemaMigrationError` and a
+   full-window single call `('RACE', '20240820', '20260819', 4)` where the
+   first bounded chunk `('RACE', '20240820', '20241231', 4)` was expected.
+2. Independent primary-agent verification on base production (transport
+   contract additions, pre-correction expectations): **8 failed, 2
+   passed** — bounded RACE expected but actual jv_open used start-only, and
+   invalid dates reached JV-Link; the two greens were the paired DIFN
+   start-only and option-1 cases.
+3. Post-correction expectations (see next section) re-proven on stashed
+   base with the same command restricted to the three transport tests:
+   **10 failed, 1 passed** (only `RACE option=1 → 20250820000000` green).
+   The captured base log also shows the inverted-range case reaching the
+   provider call path as `fromtime=20260819000000`.
+
+### Correction adopted before green: inclusive-from encoding
+
+The official eligibility rule is strictly greater than the start point and
+up to and including the end point. Therefore `"{from_date}000000"` silently
+drops a provider file stamped exactly at `from_date 00:00:00`, and adjacent
+year chunks (previous ends Dec31 23:59:59 inclusive, next starts Jan1
+00:00:00 exclusive) would drop a boundary-midnight file from both windows.
+For a five-year rebuild this is a completeness defect, not an acceptable
+residual, and it must not be deferred to option=1 differentials. Fix: for
+setup options 3/4 the requested inclusive `from_date` is encoded as the
+exclusive start point one second earlier (normally previous day 23:59:59):
+
+- RACE setup 20250820..20260819 sends
+  `20250819235959-20260819235959`;
+- DIFN setup (end-forbidden) sends start-only `20250819235959`;
+- option 1/2 keep the legacy `{from_date}000000` unchanged this iteration.
+
+Adjacent date chunks are then exact by construction: each next chunk's
+exclusive start point equals the previous chunk's inclusive bounded end
+(`…-20241231235959` then `20241231235959-…`), pinned by
+`test_adjacent_setup_chunk_opens_tile_exactly_at_the_boundary_second`.
+
+### Implementation summary (uncommitted)
+
+- `src/jvlink/constants.py`: `JVOPEN_END_TIME_FORBIDDEN_SPECS` transcribed
+  verbatim from p.18 (all seven IDs; DIFF/HOSE additionally remain blocked
+  by the retired-spec gate) and `jvopen_supports_end_timestamp()` (True iff
+  every four-character component is outside the list; malformed input is
+  False and is rejected earlier by `validate_jvopen_combination`).
+- `src/fetcher/historical.py`: `validate_date_range()` (8-digit, real
+  calendar date, from <= to) called in `fetch()` and `fetch_with_cache()`
+  before any JV-Link, cache, or schema side effect (also closes a silent
+  empty-success path for inverted ranges in `has_nl_range`);
+  `_jvopen_fromtime()` implements the setup forms above; docstrings and
+  stream logs updated to the actual contract.
+- `src/importer/batch.py`: `validate_date_range` before `create_all_tables`;
+  `_should_split_setup_range(data_spec, from_date, to_date, option)` now
+  splits >370-day ranges for options 3 and 4 but only for end-capable
+  specs (end-forbidden specs never split — splitting them would repeat the
+  open tail per chunk, the O(n^2) behaviour; they stay a single open);
+  `_process_split_setup_range` gained an option-4 branch in which each
+  chunk's inner `process_date_range` owns its transaction boundaries
+  (per-`SETUP_COMMIT_INTERVAL` commits when `auto_commit`, no outer
+  transaction, committed earlier chunks survive a later chunk's failure;
+  with `auto_commit=False` the caller stays the only commit boundary).
+  Option 3 keeps the existing single transaction across chunks unchanged.
+  `SINGLE_OPEN_SETUP_OPTION` renamed to `SPLIT_SETUP_OPTION` (internal).
+- `src/cli/main.py` + `src/jvlink/wrapper.py`: `--from`/`--to` help,
+  fetch guardrail notes (now option- and spec-dependent via
+  `_print_fetch_guardrail_notes(jv_option, data_spec)`), and the `jv_open`
+  fromtime docstring now state the real transport contract, including the
+  exclusive-start encoding and the end-forbidden list.
+- Tests: `tests/test_jvlink_transport_contract.py` (fromtime form table
+  RACE-3/4 bounded + DIFN start-only + option-1 unchanged; adjacent-chunk
+  boundary identity; invalid dates before any jvlink call),
+  `tests/test_batch_processor.py` (split-decision table over
+  spec x option; option-4 bounded partition + committed-chunk durability
+  on the real failed scope 20240820..20260819; per-chunk cache routing —
+  the resume mechanism; invalid dates before schema/transaction/fetch),
+  `tests/test_historical_cache_write_through.py` (failed stream restores
+  cache appends and never marks complete — STOP-condition pin),
+  `tests/test_cli.py` (new help claims). Existing option-4
+  commit-interval tests were re-dated 19860101→20220101 to stay on the
+  single-open path their intent pins; all option-3 split-transaction tests
+  are untouched and still pass.
+
+### Verification (after implementation)
+
+- Focused: `uv run --extra dev --extra postgres pytest
+  tests/test_jvlink_transport_contract.py tests/test_batch_processor.py
+  tests/test_historical_cache_write_through.py
+  tests/test_historical_cache_failures.py tests/test_jvd_self_repair.py
+  tests/test_date_filtering.py tests/test_jvlink_constants.py
+  tests/test_cli.py tests/test_public_setup_contract.py --no-cov -q`
+  → **188 passed, 8 subtests passed**.
+- Second ring: `tests/test_quickstart_cli.py tests/test_updater.py
+  tests/test_daily_update.py tests/test_cache_manager.py
+  tests/test_importer.py tests/test_retired_data_specs.py
+  tests/test_jvlink_wrapper.py` → **309 passed, 22 skipped** (Windows-only
+  skips).
+- `git diff --check` → clean.
+
+### Primary-agent independent audit
+
+- Draft PR #238 was created against `master` while the remote head still
+  contained only the initial worklog commit `d7a1523`; no implementation was
+  represented as complete before the red/green gate.
+- The primary agent independently stashed only the five production changes,
+  leaving the new tests on the base code, and ran the transport regression.
+  Result: **8 failed, 2 passed**. The exact bounded failure was
+  `Expected: jv_open('RACE', '20250820000000-20260819235959', 4)` versus
+  `Actual: jv_open('RACE', '20250820000000', 4)`; malformed, missing and
+  inverted dates reached the JV-Link path instead of raising. The production
+  stash was then restored without conflict.
+- Review against the pinned PDF found that the initial test expectation still
+  excluded a provider file stamped at the requested date's midnight. The same
+  Fable session was resumed and changed setup start encoding to the previous
+  second, added the exact adjacent-boundary equality test, and removed the
+  proposed midnight-gap residual. This is why the final RACE expectation is
+  `20250819235959-20260819235959`, not the first red draft above.
+- The primary agent corrected one CLI-help ambiguity: options 1/2 retain their
+  exclusive cursor contract and must not be described as having an inclusive
+  start date. The full seven-ID official end-forbidden list is now shown in
+  the public help/docstring. Cache rollback now asserts the exact
+  `FetcherError` type, and the transport table includes a mixed `RACEDIFN`
+  dataspec so one forbidden component keeps the whole open start-only.
+- A cache-bypass negative was added to the existing transport contract:
+  inverted dates raise before `has_nl_range`, cache reads, JVInit or JVOpen.
+- Independent focused rerun after those adjustments:
+  `.venv/bin/python -m pytest tests/test_jvlink_transport_contract.py
+  tests/test_batch_processor.py tests/test_historical_cache_write_through.py
+  tests/test_historical_cache_failures.py tests/test_jvd_self_repair.py
+  tests/test_date_filtering.py tests/test_jvlink_constants.py tests/test_cli.py
+  tests/test_public_setup_contract.py --no-cov -q`
+  → **190 passed, 8 subtests passed**.
+- Independent second ring remained **309 passed, 22 skipped**. Workflow fatal
+  lint (`flake8 ... --isolated --select=E9,F63,F7,F82`) returned **0**;
+  `compileall` and `git diff --check` passed. Repository-wide Ruff/Black were
+  not treated as gates because the current baseline has unrelated advisory
+  style debt and the actual workflow runs fatal Flake8 only.
+
+### Remaining risks and explicitly blocked items
+
+- Live-provider behaviour of the bounded setup fromtime is UNVERIFIED here
+  (live operations are a STOP condition). The first supervised run must
+  watch for -112/-113 (fromtime rejections) and confirm the provider
+  honours the end point for the setup-data portion; p.20 attaches the end
+  clause wording to the current-month normal-data part of the option-3/4
+  sentence, so the effective server-side bound for archived setup files is
+  an empirical question this iteration cannot answer.
+- Resume contract, stated honestly: with the cache enabled, a completed
+  chunk marks its exact window complete, so re-running the identical
+  command re-derives the identical partition and replays completed chunks
+  from local cache without provider calls; the first incomplete chunk
+  refetches bounded. Without the cache, a retry re-downloads each bounded
+  chunk and re-imports idempotently (upsert) — durable, not download-free.
+  A chunk whose stream contained a buffer without a supported event date
+  never marks complete and is refetched on retry. A durable chunk ledger
+  independent of the NL cache (true download-free resume without cache)
+  remains out of scope and is NOT claimed.
+- option 1/2 keep `{from_date}000000`: an option-1 backfill still excludes
+  a file stamped exactly at from_date midnight (pre-existing contract;
+  cursor-based syncs pass `lastfiletimestamp` and are unaffected).
+  Deferred explicitly, not silently.
+- Registry deviation observed, untouched: local option-1 list allows
+  MING/COMM although p.20 lists them only under options 3/4.
+
+### Next safe action
+
+Primary agent: review this uncommitted diff (10 files), then commit/push and
+update draft PR #238 for this branch per the iteration protocol. Only after review,
+merge, a new `2.0.0.dev*` wheel, and runtime pinning may a supervised
+bounded RACE option-4 setup for 20240820..20260819 be attempted, watching
+for -112/-113 and the JVOpen response budget.

--- a/src/cache/manager.py
+++ b/src/cache/manager.py
@@ -19,14 +19,18 @@ class CacheManager:
     Thread-safe for concurrent RT_ writes.
 
     Directory structure:
-        cache_dir/nl/{SPEC}/{YYYYMMDD}.v2.bin  -- 蓄積系
+        cache_dir/nl/{SPEC}/{YYYYMMDD}.v3.bin  -- 蓄積系
         cache_dir/rt/{SPEC_CODE}/{YYYYMMDD}.bin  -- 速報系
 
     Binary format: [uint32-BE length][raw bytes] per record (length-prefixed)
     """
 
     HEADER = struct.Struct(">I")  # 4-byte big-endian uint32
-    NL_CACHE_SCHEMA_VERSION = 2
+    # v3 invalidates v2 completion markers created before setup requests used
+    # the official exclusive boundary immediately before the requested date.
+    # A v2 marker cannot prove that a provider record stamped at 00:00:00 was
+    # included, so neither its marker nor its raw file may satisfy a new fetch.
+    NL_CACHE_SCHEMA_VERSION = 3
 
     def __init__(self, cache_dir: Path):
         self.cache_dir = Path(cache_dir)

--- a/src/cli/main.py
+++ b/src/cli/main.py
@@ -35,28 +35,16 @@ FETCH_NOTE_OPTION2_RANGE = (
     "NL キャッシュは使用・作成しません。"
 )
 FETCH_NOTE_TO_CLIENT_FILTER = (
-    "--to は取得後のクライアント側日付フィルタとして常に適用されます。"
+    "--to は取得後のクライアント側日付フィルタであり、JVOpen の終端ではありません。"
 )
 FETCH_NOTE_TO_SINGLE_OPEN = (
     "option=1/2 では --to は JVOpen の終端にならず、"
     "狭めてもサーバからのダウンロード量は減りません。"
 )
-FETCH_NOTE_TO_SETUP_BOUNDED = (
-    "この spec のセットアップ (option=3/4) は JVOpen の公式 fromtime "
-    "開始-終了形式で要求され、サーバからのダウンロード自体が "
-    "--from/--to の範囲に制限されます（公式の対象条件「開始より大きく、"
-    "終了まで」に合わせ、排他的開始点は --from 前日の 23:59:59、"
-    "終了点は --to の 23:59:59）。"
-)
-FETCH_NOTE_TO_SETUP_END_FORBIDDEN = (
-    "この spec は公式仕様で終了ポイント時刻の指定が禁止されているため"
-    "（指定すると -1）、セットアップでも JVOpen は開始のみで呼ばれ、"
-    "--to はクライアント側フィルタに留まります。"
-)
-FETCH_NOTE_TO_SETUP_CHUNKS = (
-    "370日超の範囲は年単位の境界付き JVOpen チャンクに分割され、"
-    "各チャンクは自分の窓のデータのみをダウンロードします。"
-    "--to の延長はその分のダウンロード量増加を意味します。"
+FETCH_NOTE_TO_SETUP_TAIL = (
+    "option=3/4 の historical setup tail は公式仕様上 fromtime 以降の全件が"
+    "対象で、終了時刻は過去setup部分を境界付けません。排他的開始点には "
+    "--from 前日の 23:59:59 を使い、長期間でも single JVOpen を維持します。"
 )
 FETCH_NOTE_DATE_FIELDS = (
     "--to は Year+MonthDay または ChokyoDate（HC/WC の調教日）で判定します。"
@@ -92,10 +80,8 @@ def _reject_invalid_jvopen_combination(data_spec: str, option: int) -> None:
         sys.exit(1)
 
 
-def _print_fetch_guardrail_notes(jv_option: int, data_spec: str) -> None:
-    """Emit option/spec-dependent date-range caveats after input validation."""
-    from src.jvlink.constants import jvopen_supports_end_timestamp
-
+def _print_fetch_guardrail_notes(jv_option: int) -> None:
+    """Emit option-dependent date-range caveats after input validation."""
     if jv_option in (3, 4):
         err_console.print(f"[yellow]Note:[/yellow] {FETCH_NOTE_SETUP_MODE}")
     if jv_option == 2:
@@ -103,17 +89,7 @@ def _print_fetch_guardrail_notes(jv_option: int, data_spec: str) -> None:
 
     err_console.print(f"[yellow]Note:[/yellow] {FETCH_NOTE_TO_CLIENT_FILTER}")
     if jv_option in (3, 4):
-        if jvopen_supports_end_timestamp(data_spec):
-            err_console.print(
-                f"[yellow]Note:[/yellow] {FETCH_NOTE_TO_SETUP_BOUNDED}"
-            )
-            err_console.print(
-                f"[yellow]Note:[/yellow] {FETCH_NOTE_TO_SETUP_CHUNKS}"
-            )
-        else:
-            err_console.print(
-                f"[yellow]Note:[/yellow] {FETCH_NOTE_TO_SETUP_END_FORBIDDEN}"
-            )
+        err_console.print(f"[yellow]Note:[/yellow] {FETCH_NOTE_TO_SETUP_TAIL}")
     else:
         err_console.print(f"[yellow]Note:[/yellow] {FETCH_NOTE_TO_SINGLE_OPEN}")
     err_console.print(f"[yellow]Note:[/yellow] {FETCH_NOTE_DATE_FIELDS}")
@@ -430,16 +406,12 @@ def update(ctx, force):
     "date_to",
     required=True,
     help=(
-        "End date (YYYYMMDD). Always filters Year+MonthDay and HC/WC "
-        "ChokyoDate client-side; records without either date are kept and "
-        "prevent a complete-cache marker. With option=3/4 on a spec that "
-        "permits an official end timestamp (e.g. RACE), it also bounds the "
-        "JVOpen download itself via the fromtime start-end form; specs that "
-        "forbid an end timestamp "
-        "(TOKU/DIFF/DIFN/HOSE/HOSN/HOYU/COMM) remain start only. "
-        "Setup ranges over 370 days on end-capable specs are split into "
-        "bounded calendar-year chunks, so downloads scale with the range. "
-        "With option=1/2, --to is not a JVOpen end bound."
+        "End date (YYYYMMDD). Filters Year+MonthDay and HC/WC ChokyoDate "
+        "client-side; records without either date are kept and prevent a "
+        "complete-cache marker. It is not a JVOpen end bound. Under the "
+        "official option=3/4 contract, the historical setup tail remains all "
+        "setup data after --from even when fromtime has an end point, so "
+        "setup uses a single start-only JVOpen rather than repeated year chunks."
     ),
 )
 @click.option("--spec", "data_spec", required=True, help="Data specification (RACE, DIFN, etc.)")
@@ -504,7 +476,7 @@ def fetch(ctx, date_from, date_to, data_spec, jv_option, db, batch_size, progres
         console.print(f"       option={jv_option} で取得可能: {', '.join(valid_specs)}")
         sys.exit(1)
 
-    _print_fetch_guardrail_notes(jv_option, data_spec)
+    _print_fetch_guardrail_notes(jv_option)
     console.print()
 
     try:

--- a/src/cli/main.py
+++ b/src/cli/main.py
@@ -633,7 +633,7 @@ def cache_build(ctx, data_spec, date_from, date_to, jv_option, also_import, db, 
       jltsql cache build --spec DIFN --from 20260101 --to 20260328 --also-import
     """
     from src.cache import CacheManager
-    from src.fetcher.historical import HistoricalFetcher
+    from src.fetcher.historical import HistoricalFetcher, validate_date_range
 
     _reject_invalid_jvopen_combination(data_spec, jv_option)
 
@@ -644,6 +644,11 @@ def cache_build(ctx, data_spec, date_from, date_to, jv_option, also_import, db, 
             "an arbitrary historical range, so the requested date range "
             "cannot be marked complete safely"
         )
+
+    try:
+        validate_date_range(date_from, date_to)
+    except ValueError as exc:
+        raise click.ClickException(str(exc)) from exc
 
     config = ctx.obj.get("config", {}) if ctx.obj else {}
 
@@ -746,6 +751,13 @@ def cache_rebuild(ctx, data_spec, date_from, date_to, jv_option, cache_dir):
             "an arbitrary historical range, so the requested date range "
             "cannot be marked complete safely"
         )
+
+    from src.fetcher.historical import validate_date_range
+
+    try:
+        validate_date_range(date_from, date_to)
+    except ValueError as exc:
+        raise click.ClickException(str(exc)) from exc
 
     from src.cache import CacheManager
     mgr = CacheManager(Path(cache_dir))

--- a/src/cli/main.py
+++ b/src/cli/main.py
@@ -443,6 +443,7 @@ def fetch(ctx, date_from, date_to, data_spec, jv_option, db, batch_size, progres
     """
     from src.database import create_database_from_config, DatabaseError
     from src.database.schema import create_all_tables
+    from src.fetcher.historical import validate_date_range
     from src.importer.batch import BatchProcessor
 
     config = ctx.obj.get("config")
@@ -474,6 +475,16 @@ def fetch(ctx, date_from, date_to, data_spec, jv_option, db, batch_size, progres
         console.print(f"[red]Error:[/red] データ種別 '{data_spec}' は option={jv_option} では取得できません")
         valid_specs = JVOPEN_VALID_COMBINATIONS.get(jv_option, [])
         console.print(f"       option={jv_option} で取得可能: {', '.join(valid_specs)}")
+        sys.exit(1)
+
+    # The CLI prepares every table before BatchProcessor runs. Reject the
+    # range here as well so malformed input cannot initialize a database or
+    # apply an additive schema migration before it is diagnosed.
+    try:
+        validate_date_range(date_from, date_to)
+    except ValueError as exc:
+        console.print()
+        console.print(f"[red]Error:[/red] {exc}")
         sys.exit(1)
 
     _print_fetch_guardrail_notes(jv_option)

--- a/src/cli/main.py
+++ b/src/cli/main.py
@@ -35,14 +35,28 @@ FETCH_NOTE_OPTION2_RANGE = (
     "NL キャッシュは使用・作成しません。"
 )
 FETCH_NOTE_TO_CLIENT_FILTER = (
-    "--to は JVOpen の終端ではなく、取得後のクライアント側フィルタです。"
+    "--to は取得後のクライアント側日付フィルタとして常に適用されます。"
 )
 FETCH_NOTE_TO_SINGLE_OPEN = (
-    "option=1/2/4 では --to を狭めてもサーバからのダウンロード量は減りません。"
+    "option=1/2 では --to は JVOpen の終端にならず、"
+    "狭めてもサーバからのダウンロード量は減りません。"
+)
+FETCH_NOTE_TO_SETUP_BOUNDED = (
+    "この spec のセットアップ (option=3/4) は JVOpen の公式 fromtime "
+    "開始-終了形式で要求され、サーバからのダウンロード自体が "
+    "--from/--to の範囲に制限されます（公式の対象条件「開始より大きく、"
+    "終了まで」に合わせ、排他的開始点は --from 前日の 23:59:59、"
+    "終了点は --to の 23:59:59）。"
+)
+FETCH_NOTE_TO_SETUP_END_FORBIDDEN = (
+    "この spec は公式仕様で終了ポイント時刻の指定が禁止されているため"
+    "（指定すると -1）、セットアップでも JVOpen は開始のみで呼ばれ、"
+    "--to はクライアント側フィルタに留まります。"
 )
 FETCH_NOTE_TO_SETUP_CHUNKS = (
-    "option=3 の370日超の範囲は年単位の JVOpen に分割され、"
-    "--to の延長で年次チャンクが追加される場合に呼び出し回数とダウンロード量が増えます。"
+    "370日超の範囲は年単位の境界付き JVOpen チャンクに分割され、"
+    "各チャンクは自分の窓のデータのみをダウンロードします。"
+    "--to の延長はその分のダウンロード量増加を意味します。"
 )
 FETCH_NOTE_DATE_FIELDS = (
     "--to は Year+MonthDay または ChokyoDate（HC/WC の調教日）で判定します。"
@@ -78,16 +92,28 @@ def _reject_invalid_jvopen_combination(data_spec: str, option: int) -> None:
         sys.exit(1)
 
 
-def _print_fetch_guardrail_notes(jv_option: int) -> None:
-    """Emit option-dependent date-range caveats after input validation."""
+def _print_fetch_guardrail_notes(jv_option: int, data_spec: str) -> None:
+    """Emit option/spec-dependent date-range caveats after input validation."""
+    from src.jvlink.constants import jvopen_supports_end_timestamp
+
     if jv_option in (3, 4):
         err_console.print(f"[yellow]Note:[/yellow] {FETCH_NOTE_SETUP_MODE}")
     if jv_option == 2:
         err_console.print(f"[yellow]Note:[/yellow] {FETCH_NOTE_OPTION2_RANGE}")
 
     err_console.print(f"[yellow]Note:[/yellow] {FETCH_NOTE_TO_CLIENT_FILTER}")
-    if jv_option == 3:
-        err_console.print(f"[yellow]Note:[/yellow] {FETCH_NOTE_TO_SETUP_CHUNKS}")
+    if jv_option in (3, 4):
+        if jvopen_supports_end_timestamp(data_spec):
+            err_console.print(
+                f"[yellow]Note:[/yellow] {FETCH_NOTE_TO_SETUP_BOUNDED}"
+            )
+            err_console.print(
+                f"[yellow]Note:[/yellow] {FETCH_NOTE_TO_SETUP_CHUNKS}"
+            )
+        else:
+            err_console.print(
+                f"[yellow]Note:[/yellow] {FETCH_NOTE_TO_SETUP_END_FORBIDDEN}"
+            )
     else:
         err_console.print(f"[yellow]Note:[/yellow] {FETCH_NOTE_TO_SINGLE_OPEN}")
     err_console.print(f"[yellow]Note:[/yellow] {FETCH_NOTE_DATE_FIELDS}")
@@ -389,10 +415,14 @@ def update(ctx, force):
     "date_from",
     required=True,
     help=(
-        "Start date (YYYYMMDD), passed as JVOpen fromtime for all options. "
-        "With option=2 it manages continuity within the current race-cycle "
-        "data; it does not select an arbitrary historical week, and Sunday "
-        "or Monday may cover two cycles. NL cache is bypassed."
+        "Start date (YYYYMMDD). With option=3/4 it is inclusive: the "
+        "exclusive JVOpen start point is encoded as the previous day "
+        "23:59:59 under the official strictly-greater rule. With option=1/2 "
+        "the existing cursor contract is unchanged and this date is passed "
+        "directly as YYYYMMDD000000. With option=2 it manages continuity "
+        "within the current race-cycle data; it does not select an arbitrary "
+        "historical week, and Sunday or Monday may cover two cycles. NL "
+        "cache is bypassed."
     ),
 )
 @click.option(
@@ -400,11 +430,16 @@ def update(ctx, force):
     "date_to",
     required=True,
     help=(
-        "Client-side end date (YYYYMMDD), not a JVOpen end bound. Filters "
-        "Year+MonthDay and HC/WC ChokyoDate; records without either date are "
-        "kept and prevent a complete-cache marker. With option=3, ranges over "
-        "370 days are split into calendar-year chunks; extending --to increases "
-        "downloads only when it adds another chunk."
+        "End date (YYYYMMDD). Always filters Year+MonthDay and HC/WC "
+        "ChokyoDate client-side; records without either date are kept and "
+        "prevent a complete-cache marker. With option=3/4 on a spec that "
+        "permits an official end timestamp (e.g. RACE), it also bounds the "
+        "JVOpen download itself via the fromtime start-end form; specs that "
+        "forbid an end timestamp "
+        "(TOKU/DIFF/DIFN/HOSE/HOSN/HOYU/COMM) remain start only. "
+        "Setup ranges over 370 days on end-capable specs are split into "
+        "bounded calendar-year chunks, so downloads scale with the range. "
+        "With option=1/2, --to is not a JVOpen end bound."
     ),
 )
 @click.option("--spec", "data_spec", required=True, help="Data specification (RACE, DIFN, etc.)")
@@ -469,7 +504,7 @@ def fetch(ctx, date_from, date_to, data_spec, jv_option, db, batch_size, progres
         console.print(f"       option={jv_option} で取得可能: {', '.join(valid_specs)}")
         sys.exit(1)
 
-    _print_fetch_guardrail_notes(jv_option)
+    _print_fetch_guardrail_notes(jv_option, data_spec)
     console.print()
 
     try:

--- a/src/fetcher/historical.py
+++ b/src/fetcher/historical.py
@@ -4,11 +4,16 @@ This module fetches historical JV-Data from JV-Link.
 """
 
 import time
-from datetime import datetime
+from datetime import datetime, timedelta
 from typing import Iterator, Optional
 
 from src.fetcher.base import BaseFetcher, FetcherError
-from src.jvlink.constants import validate_jvopen_combination
+from src.jvlink.constants import (
+    JVOPEN_OPTION_SETUP,
+    JVOPEN_OPTION_SETUP_SPLIT,
+    jvopen_supports_end_timestamp,
+    validate_jvopen_combination,
+)
 from src.utils.logger import get_logger
 from src.utils.progress import JVLinkProgressDisplay
 
@@ -27,12 +32,67 @@ def _extract_record_date(record: dict) -> Optional[str]:
     return None
 
 
+def validate_date_range(from_date: str, to_date: str) -> None:
+    """Reject malformed, non-calendar, or inverted date ranges.
+
+    JVOpen・キャッシュ・スキーマ作成のいずれに触れるよりも前に呼ぶこと。
+    fromtime はここで検証済みの日付からしか組み立てない。
+    """
+    for label, value in (("from_date", from_date), ("to_date", to_date)):
+        if not isinstance(value, str) or len(value) != 8 or not value.isdigit():
+            raise ValueError(
+                f"{label} must be an 8-digit YYYYMMDD string, got {value!r}"
+            )
+        try:
+            datetime.strptime(value, "%Y%m%d")
+        except ValueError:
+            raise ValueError(
+                f"{label} must be a real calendar date in YYYYMMDD format, "
+                f"got {value!r}"
+            ) from None
+    if from_date > to_date:
+        raise ValueError(
+            f"from_date must not be after to_date: {from_date} > {to_date}"
+        )
+
+
+def _jvopen_fromtime(data_spec: str, from_date: str, to_date: str, option: int) -> str:
+    """Build the official JVOpen fromtime for this request.
+
+    公式仕様（4.9.0.1 p.17-18）の対象条件は「開始時刻より大きく、終了時刻
+    まで」。要求された from_date を包含させるため、セットアップ (option 3/4)
+    では排他的開始点を前日 23:59:59 に符号化する。これにより隣接する年
+    チャンクは「次チャンクの排他的開始点 = 直前チャンクの包含終了点」で
+    秒単位まで正確に接続し、深夜0時ちょうどに打刻されたファイルも落とさない。
+
+    終了ポイント時刻を許す dataspec はさらに ``-{to_date}235959`` で
+    ダウンロード自体を要求範囲で打ち切る。終了時刻指定が禁止された dataspec
+    (TOKU/DIFF/DIFN/HOSE/HOSN/HOYU/COMM, p.18) に終了を付けると -1 が返り
+    正当な「データなし」と区別できないため、開始のみ形式を保つ。
+    option 1 の差分カーソル・option 2 の今週データ契約は変更しない。
+    """
+    if option not in (JVOPEN_OPTION_SETUP, JVOPEN_OPTION_SETUP_SPLIT):
+        return f"{from_date}000000"
+    start_exclusive = (
+        datetime.strptime(from_date, "%Y%m%d") - timedelta(seconds=1)
+    ).strftime("%Y%m%d%H%M%S")
+    if jvopen_supports_end_timestamp(data_spec):
+        return f"{start_exclusive}-{to_date}235959"
+    return start_exclusive
+
+
 class HistoricalFetcher(BaseFetcher):
     """Fetcher for historical JV-Data.
 
     Fetches accumulated (蓄積) data from JV-Link for a specified date range
-    and data specification. The JV-Link API retrieves all data from the
-    start date onwards, then filters records client-side based on the end date.
+    and data specification. For setup requests (option 3/4) the requested
+    inclusive from_date is encoded as the exclusive fromtime start point
+    (previous day 23:59:59, per the official strictly-greater rule); specs
+    that permit an official end timestamp additionally bound JVOpen with
+    the start-end form, so the provider only serves the requested window,
+    while end-forbidden specs stay start-only. Options 1/2 keep the legacy
+    ``{from_date}000000`` start-only fromtime. In every mode records are
+    additionally filtered client-side based on the end date.
 
     Note:
         Service key must be configured in JRA-VAN DataLab application
@@ -198,6 +258,18 @@ class HistoricalFetcher(BaseFetcher):
             dates up to and including to_date. Records without date fields
             (Year/MonthDay) are always included.
 
+            For option 3/4 the official eligibility rule is "strictly
+            greater than the start point, up to and including the end
+            point", so the requested inclusive from_date is encoded as the
+            exclusive start point ``(from_date - 1 day)235959``. Specs that
+            permit an official end timestamp (e.g. RACE) additionally send
+            ``-{to_date}235959`` so the provider transfer itself is
+            bounded; data *provided* after ``to_date 23:59:59`` (e.g. late
+            corrections) is then not part of this stream and arrives via
+            subsequent option=1 differential updates. Specs on the official
+            end-forbidden list (TOKU/DIFF/DIFN/HOSE/HOSN/HOYU/COMM) remain
+            start-only because an end timestamp makes JVOpen return -1.
+
         Examples:
             >>> fetcher = HistoricalFetcher()  # Uses default sid="UNKNOWN"
             >>> # 通常データ取得（差分データ）
@@ -211,6 +283,9 @@ class HistoricalFetcher(BaseFetcher):
         """
         # Validate every four-character component before JV-Link/cache state.
         validate_jvopen_combination(data_spec, option)
+        # Reject malformed/inverted dates before JV-Link or cache mutation;
+        # fromtime below is built from these validated values.
+        validate_date_range(from_date, to_date)
 
         # Fetcher instances are reused across data specs and setup chunks.
         # Reset before JVOpen so no-data/error early exits cannot expose
@@ -233,12 +308,19 @@ class HistoricalFetcher(BaseFetcher):
         cache_write_committed = active_cache_manager is None
         cache_range_complete = True
 
+        # 公式の fromtime 形式をここで決める（仕様書 4.9.0.1 p.17-18）。
+        # セットアップは from_date を包含する排他的開始点（前日 23:59:59）を
+        # 送り、終了時刻を許す spec はさらに終了点で提供側を境界付ける。
+        # それ以外は従来どおり開始のみ + クライアント側 to_date フィルタ。
+        fromtime = _jvopen_fromtime(data_spec, from_date, to_date, option)
+
         try:
             # Info for setup mode (option 3 or 4) - ログのみ、画面表示はしない
             if option in (3, 4):
                 logger.info(
-                    "セットアップモード - 全データを取得します",
+                    "セットアップモード",
                     option=option,
+                    bounded="-" in fromtime,
                 )
 
             # Initialize JV-Link
@@ -250,12 +332,6 @@ class HistoricalFetcher(BaseFetcher):
             # Note: Service key must be pre-configured in Windows registry
             # jv_init() does not accept service_key parameter
             self.jvlink.jv_init()
-
-            # Convert dates to fromtime format
-            # fromtime format: "YYYYMMDDhhmmss" (single timestamp)
-            # JV-Link retrieves data from this timestamp onwards
-            # Option meanings: 1=通常データ, 2=今週データ, 3/4=セットアップ
-            fromtime = f"{from_date}000000"
             self._jvd_self_repair_attempts = 0
             self._jvd_replay_records_remaining = 0
             self._jv_open_context = (data_spec, fromtime, option)
@@ -272,7 +348,8 @@ class HistoricalFetcher(BaseFetcher):
                 note=(
                     "option=1: 通常データ（差分）; "
                     "option=2: 今週データ; "
-                    "option=3/4: セットアップ（全データ）"
+                    "option=3/4: セットアップ"
+                    "（fromtime が開始-終了形式なら要求範囲で境界付け）"
                 ),
             )
 
@@ -379,7 +456,6 @@ class HistoricalFetcher(BaseFetcher):
 
             # Mark cached dates as complete
             if active_cache_manager and cache_range_complete:
-                from datetime import timedelta
                 d = datetime.strptime(from_date, "%Y%m%d").date()
                 end = datetime.strptime(to_date, "%Y%m%d").date()
                 completed_dates = []
@@ -518,7 +594,10 @@ class HistoricalFetcher(BaseFetcher):
             ValueError: If data_spec or option violates the JVOpen contract
         """
         # A cache hit bypasses fetch(), so validate before reading cache state.
+        # 日付検証も同様: 逆転した範囲は has_nl_range が空の全日付走査で
+        # True を返し「静かな空成功」になるため、ここで拒否する。
         validate_jvopen_combination(data_spec, option)
+        validate_date_range(from_date, to_date)
 
         if option == 2:
             # Do not trust old false-complete markers created by earlier

--- a/src/fetcher/historical.py
+++ b/src/fetcher/historical.py
@@ -11,7 +11,6 @@ from src.fetcher.base import BaseFetcher, FetcherError
 from src.jvlink.constants import (
     JVOPEN_OPTION_SETUP,
     JVOPEN_OPTION_SETUP_SPLIT,
-    jvopen_supports_end_timestamp,
     validate_jvopen_combination,
 )
 from src.utils.logger import get_logger
@@ -56,29 +55,24 @@ def validate_date_range(from_date: str, to_date: str) -> None:
         )
 
 
-def _jvopen_fromtime(data_spec: str, from_date: str, to_date: str, option: int) -> str:
+def _jvopen_fromtime(from_date: str, option: int) -> str:
     """Build the official JVOpen fromtime for this request.
 
-    公式仕様（4.9.0.1 p.17-18）の対象条件は「開始時刻より大きく、終了時刻
-    まで」。要求された from_date を包含させるため、セットアップ (option 3/4)
-    では排他的開始点を前日 23:59:59 に符号化する。これにより隣接する年
-    チャンクは「次チャンクの排他的開始点 = 直前チャンクの包含終了点」で
-    秒単位まで正確に接続し、深夜0時ちょうどに打刻されたファイルも落とさない。
+    公式仕様（4.9.0.1 p.17-20）の対象条件は開始時刻より大きいデータ。
+    要求された from_date を包含させるため、セットアップ (option 3/4) では
+    排他的開始点を前日23:59:59に符号化する。
 
-    終了ポイント時刻を許す dataspec はさらに ``-{to_date}235959`` で
-    ダウンロード自体を要求範囲で打ち切る。終了時刻指定が禁止された dataspec
-    (TOKU/DIFF/DIFN/HOSE/HOSN/HOYU/COMM, p.18) に終了を付けると -1 が返り
-    正当な「データなし」と区別できないため、開始のみ形式を保つ。
-    option 1 の差分カーソル・option 2 の今週データ契約は変更しない。
+    p.20 は option 3/4 について、前月までのセットアップ用データは fromtime
+    より大きい全件を返し、終了時刻が制限するのは今月の通常データ部分だけと
+    明記する。したがって過去setup dataを ``to_date`` でboundedにできるとは
+    扱わず、setupはstart-onlyを1回だけ呼ぶ。option 1の差分cursor・option 2の
+    今週データ契約は変更しない。
     """
     if option not in (JVOPEN_OPTION_SETUP, JVOPEN_OPTION_SETUP_SPLIT):
         return f"{from_date}000000"
-    start_exclusive = (
+    return (
         datetime.strptime(from_date, "%Y%m%d") - timedelta(seconds=1)
     ).strftime("%Y%m%d%H%M%S")
-    if jvopen_supports_end_timestamp(data_spec):
-        return f"{start_exclusive}-{to_date}235959"
-    return start_exclusive
 
 
 class HistoricalFetcher(BaseFetcher):
@@ -87,12 +81,11 @@ class HistoricalFetcher(BaseFetcher):
     Fetches accumulated (蓄積) data from JV-Link for a specified date range
     and data specification. For setup requests (option 3/4) the requested
     inclusive from_date is encoded as the exclusive fromtime start point
-    (previous day 23:59:59, per the official strictly-greater rule); specs
-    that permit an official end timestamp additionally bound JVOpen with
-    the start-end form, so the provider only serves the requested window,
-    while end-forbidden specs stay start-only. Options 1/2 keep the legacy
-    ``{from_date}000000`` start-only fromtime. In every mode records are
-    additionally filtered client-side based on the end date.
+    (previous day 23:59:59, per the official strictly-greater rule). Setup
+    stays start-only because the official option-3/4 contract does not apply
+    an end timestamp to the historical setup tail. Options 1/2 keep the
+    legacy ``{from_date}000000`` start-only fromtime. In every mode records
+    are filtered client-side based on the end date.
 
     Note:
         Service key must be configured in JRA-VAN DataLab application
@@ -258,17 +251,11 @@ class HistoricalFetcher(BaseFetcher):
             dates up to and including to_date. Records without date fields
             (Year/MonthDay) are always included.
 
-            For option 3/4 the official eligibility rule is "strictly
-            greater than the start point, up to and including the end
-            point", so the requested inclusive from_date is encoded as the
-            exclusive start point ``(from_date - 1 day)235959``. Specs that
-            permit an official end timestamp (e.g. RACE) additionally send
-            ``-{to_date}235959`` so the provider transfer itself is
-            bounded; data *provided* after ``to_date 23:59:59`` (e.g. late
-            corrections) is then not part of this stream and arrives via
-            subsequent option=1 differential updates. Specs on the official
-            end-forbidden list (TOKU/DIFF/DIFN/HOSE/HOSN/HOYU/COMM) remain
-            start-only because an end timestamp makes JVOpen return -1.
+            For option 3/4 the requested inclusive from_date is encoded as
+            the exclusive start point ``(from_date - 1 day)235959``. The
+            official p.20 setup contract returns every historical setup item
+            after that point; ``to_date`` is therefore a client-side record
+            filter, not a provider bound for the historical setup tail.
 
         Examples:
             >>> fetcher = HistoricalFetcher()  # Uses default sid="UNKNOWN"
@@ -308,11 +295,11 @@ class HistoricalFetcher(BaseFetcher):
         cache_write_committed = active_cache_manager is None
         cache_range_complete = True
 
-        # 公式の fromtime 形式をここで決める（仕様書 4.9.0.1 p.17-18）。
-        # セットアップは from_date を包含する排他的開始点（前日 23:59:59）を
-        # 送り、終了時刻を許す spec はさらに終了点で提供側を境界付ける。
-        # それ以外は従来どおり開始のみ + クライアント側 to_date フィルタ。
-        fromtime = _jvopen_fromtime(data_spec, from_date, to_date, option)
+        # 公式の fromtime 形式をここで決める（仕様書 4.9.0.1 p.17-20）。
+        # セットアップは from_date を包含する排他的開始点（前日23:59:59）を
+        # start-onlyで送る。to_dateは過去setup tailのprovider boundにはならず、
+        # 下流のclient-side filterとしてのみ使う。
+        fromtime = _jvopen_fromtime(from_date, option)
 
         try:
             # Info for setup mode (option 3 or 4) - ログのみ、画面表示はしない
@@ -320,7 +307,7 @@ class HistoricalFetcher(BaseFetcher):
                 logger.info(
                     "セットアップモード",
                     option=option,
-                    bounded="-" in fromtime,
+                    provider_tail="start_only",
                 )
 
             # Initialize JV-Link
@@ -349,7 +336,7 @@ class HistoricalFetcher(BaseFetcher):
                     "option=1: 通常データ（差分）; "
                     "option=2: 今週データ; "
                     "option=3/4: セットアップ"
-                    "（fromtime が開始-終了形式なら要求範囲で境界付け）"
+                    "（過去setup tailはstart-only、to_dateはclient filter）"
                 ),
             )
 

--- a/src/importer/batch.py
+++ b/src/importer/batch.py
@@ -5,16 +5,13 @@ This module provides utilities for batch processing of JV-Data.
 
 from datetime import datetime, timedelta
 from itertools import islice
-from typing import Iterator, List, Optional, Tuple
+from typing import Iterator, List
 
 from src.database.base import BaseDatabase
 from src.database.schema import create_all_tables
 from src.fetcher.historical import HistoricalFetcher, validate_date_range
 from src.importer.importer import DataImporter, ImporterError
-from src.jvlink.constants import (
-    jvopen_supports_end_timestamp,
-    validate_jvopen_combination,
-)
+from src.jvlink.constants import validate_jvopen_combination
 from src.utils.logger import get_logger
 
 logger = get_logger(__name__)
@@ -23,8 +20,10 @@ logger = get_logger(__name__)
 # one import can run for hours. Held in a single transaction, an interrupted
 # run leaves nothing behind and the retry starts over from the beginning -- a
 # long enough range never gets imported at all. Commit it in bounded record
-# groups instead, and split ranges over a year into end-bounded chunk opens
-# (see _should_split_setup_range) so no single open carries an unbounded tail.
+# groups instead. The official option-3/4 contract keeps the historical setup
+# data tail open after fromtime even when an end timestamp is supplied, so a
+# long request must remain one provider open; calendar chunking would repeat
+# the later tail for every chunk.
 SPLIT_SETUP_OPTION = 4
 SETUP_COMMIT_INTERVAL = 10000
 
@@ -147,17 +146,15 @@ class BatchProcessor:
             ValueError: If data_spec or option violates the JVOpen contract
 
         Note:
-            For setup requests (option 3/4) on specs that permit an official
-            end timestamp, JVOpen is bounded to the requested range; other
-            requests fetch from from_date onwards. In every mode records are
-            filtered client-side to only import those with dates <= to_date.
+            Setup requests (option 3/4) use one start-only JVOpen because the
+            official p.20 contract does not apply an end point to the
+            historical setup tail. In every mode records are filtered
+            client-side to only import those with dates <= to_date.
 
             option=4 commits every SETUP_COMMIT_INTERVAL records rather than
             once for the whole data spec, so an interrupted run keeps what it
-            already imported. Ranges over 370 days on end-capable specs are
-            additionally split into bounded yearly JVOpen chunks; committed
-            chunks survive a later chunk's failure, and with the cache
-            enabled a retry replays completed chunks from local cache.
+            already imported after JVOpen has returned and streaming begins.
+            A failed JVOpen itself has no import progress to commit.
 
         Examples:
             >>> processor = BatchProcessor(database=db)
@@ -175,16 +172,6 @@ class BatchProcessor:
             to_date=to_date,
             option=option,
         )
-
-        if self._should_split_setup_range(data_spec, from_date, to_date, option):
-            return self._process_split_setup_range(
-                data_spec=data_spec,
-                from_date=from_date,
-                to_date=to_date,
-                option=option,
-                auto_commit=auto_commit,
-                ensure_tables=ensure_tables,
-            )
 
         # Ensure tables exist
         if ensure_tables:
@@ -276,138 +263,6 @@ class BatchProcessor:
         failed_records = int(stats.get("records_failed", 0) or 0)
         if failed_records:
             raise ImporterError(f"Import rejected {failed_records} record(s)")
-
-    @staticmethod
-    def _should_split_setup_range(
-        data_spec: str, from_date: str, to_date: str, option: int
-    ) -> bool:
-        # セットアップ (option 3/4) の長期間要求は、終了ポイント時刻を許す
-        # dataspec に限り年単位の境界付き JVOpen に分割する。fetch が公式の
-        # 開始-終了 fromtime を送るため、各チャンクは自分の窓だけを取得し
-        # テールを反復しない。終了時刻禁止 spec（DIFN 等、仕様書 p.18）は
-        # fromtime を閉じられず、分割すると各チャンクが fromtime 以降の
-        # 全データを返す O(n^2) の反復になるため、option を問わず単一
-        # オープンのままにする。
-        if option not in (3, 4):
-            return False
-        if not jvopen_supports_end_timestamp(data_spec):
-            return False
-        start = datetime.strptime(from_date, "%Y%m%d")
-        end = datetime.strptime(to_date, "%Y%m%d")
-        return (end - start).days > 370
-
-    def _iter_year_chunks(self, from_date: str, to_date: str) -> Iterator[Tuple[str, str]]:
-        start = datetime.strptime(from_date, "%Y%m%d")
-        end = datetime.strptime(to_date, "%Y%m%d")
-        year = start.year
-        while year <= end.year:
-            chunk_start = max(start, datetime(year, 1, 1))
-            chunk_end = min(end, datetime(year, 12, 31))
-            yield chunk_start.strftime("%Y%m%d"), chunk_end.strftime("%Y%m%d")
-            year += 1
-
-    def _process_split_setup_range(
-        self,
-        data_spec: str,
-        from_date: str,
-        to_date: str,
-        option: int,
-        auto_commit: bool,
-        ensure_tables: bool,
-    ) -> dict:
-        # 年チャンクは日付レベルで連続する (次チャンクの from = 前チャンクの
-        # to + 1日)。fetch はセットアップの排他的開始点を「チャンク from の
-        # 前日 23:59:59」に符号化するため、隣接チャンクは提供タイムスタンプ
-        # 空間で「次チャンクの排他的開始点 = 直前チャンクの包含終了点」と
-        # なり、秒単位まで正確に・隙間も重複もなく敷き詰められる
-        # （開始は「より大きい」、終了は「まで」）。
-        logger.info(
-            "Splitting setup range into bounded yearly chunks",
-            data_spec=data_spec,
-            from_date=from_date,
-            to_date=to_date,
-            option=option,
-        )
-        if ensure_tables:
-            create_all_tables(self.database)
-
-        if option == SPLIT_SETUP_OPTION:
-            # option=4: 各チャンクの内側の process_date_range がトランザク
-            # ション境界を所有する（auto_commit 時は SETUP_COMMIT_INTERVAL
-            # 毎にコミット、失敗したグループはチャンク内でロールバック）。
-            # 外側でトランザクションを張らないことで所有権の曖昧さを避け、
-            # コミット済みの先行チャンクは後続チャンクの失敗で失われない。
-            # auto_commit=False の場合は従来どおり呼び出し元だけが唯一の
-            # コミット境界を持つ（内側は begin のみ行いコミットしない）。
-            #
-            # 再実行の契約: キャッシュ有効時、完了したチャンクは fetch が
-            # そのチャンク窓の complete マーカーを付けるため、同じ引数での
-            # 再実行は同一分割を再導出し、完了済みチャンクをローカル
-            # キャッシュから再生する（プロバイダ再取得なし・インポートは
-            # 冪等upsert）。キャッシュ無効時は各チャンクの再ダウンロードに
-            # なるが、いずれも境界付きでテールは反復しない。
-            option4_stats: dict = {}
-            for idx, (chunk_from, chunk_to) in enumerate(
-                self._iter_year_chunks(from_date, to_date), start=1
-            ):
-                logger.info(
-                    "Processing bounded setup chunk",
-                    chunk_index=idx,
-                    chunk_from=chunk_from,
-                    chunk_to=chunk_to,
-                    data_spec=data_spec,
-                )
-                chunk_stats = self.process_date_range(
-                    data_spec=data_spec,
-                    from_date=chunk_from,
-                    to_date=chunk_to,
-                    option=option,
-                    auto_commit=auto_commit,
-                    ensure_tables=False,
-                )
-                _accumulate_stats(option4_stats, chunk_stats)
-            return option4_stats
-
-        # option=3: 従来どおり全チャンクを単一トランザクションで所有し、
-        # 全チャンク成功時のみ一括コミットする（部分的な耐久性を作らない）。
-        combined_stats: dict = {}
-        try:
-            begin_transaction = getattr(self.database, "begin_transaction", None)
-            if begin_transaction is not None:
-                begin_transaction()
-
-            for idx, (chunk_from, chunk_to) in enumerate(
-                self._iter_year_chunks(from_date, to_date), start=1
-            ):
-                logger.info(
-                    "Processing setup chunk",
-                    chunk_index=idx,
-                    chunk_from=chunk_from,
-                    chunk_to=chunk_to,
-                    data_spec=data_spec,
-                )
-                chunk_stats = self.process_date_range(
-                    data_spec=data_spec,
-                    from_date=chunk_from,
-                    to_date=chunk_to,
-                    option=option,
-                    auto_commit=False,
-                    ensure_tables=False,
-                )
-                _accumulate_stats(combined_stats, chunk_stats)
-
-            if auto_commit:
-                self.database.commit()
-            return combined_stats
-        except Exception:
-            try:
-                self.database.rollback()
-            except Exception as rollback_error:
-                logger.warning(
-                    "Split setup rollback failed",
-                    error=str(rollback_error),
-                )
-            raise
 
     def process_month(
         self,

--- a/src/importer/batch.py
+++ b/src/importer/batch.py
@@ -9,19 +9,23 @@ from typing import Iterator, List, Optional, Tuple
 
 from src.database.base import BaseDatabase
 from src.database.schema import create_all_tables
-from src.fetcher.historical import HistoricalFetcher
+from src.fetcher.historical import HistoricalFetcher, validate_date_range
 from src.importer.importer import DataImporter, ImporterError
-from src.jvlink.constants import validate_jvopen_combination
+from src.jvlink.constants import (
+    jvopen_supports_end_timestamp,
+    validate_jvopen_combination,
+)
 from src.utils.logger import get_logger
 
 logger = get_logger(__name__)
 
-# option=4 (分割セットアップ) streams an accumulated range through a single
-# JVOpen call, so one import can run for hours. Held in a single transaction,
-# an interrupted run leaves nothing behind and the retry starts over from the
-# beginning -- a long enough range never gets imported at all. Commit it in
-# bounded chunks instead.
-SINGLE_OPEN_SETUP_OPTION = 4
+# option=4 (分割セットアップ) streams an accumulated range through JVOpen, so
+# one import can run for hours. Held in a single transaction, an interrupted
+# run leaves nothing behind and the retry starts over from the beginning -- a
+# long enough range never gets imported at all. Commit it in bounded record
+# groups instead, and split ranges over a year into end-bounded chunk opens
+# (see _should_split_setup_range) so no single open carries an unbounded tail.
+SPLIT_SETUP_OPTION = 4
 SETUP_COMMIT_INTERVAL = 10000
 
 
@@ -143,12 +147,17 @@ class BatchProcessor:
             ValueError: If data_spec or option violates the JVOpen contract
 
         Note:
-            JV-Link fetches all data from from_date onwards, then filters
-            records client-side to only import those with dates <= to_date.
+            For setup requests (option 3/4) on specs that permit an official
+            end timestamp, JVOpen is bounded to the requested range; other
+            requests fetch from from_date onwards. In every mode records are
+            filtered client-side to only import those with dates <= to_date.
 
             option=4 commits every SETUP_COMMIT_INTERVAL records rather than
             once for the whole data spec, so an interrupted run keeps what it
-            already imported.
+            already imported. Ranges over 370 days on end-capable specs are
+            additionally split into bounded yearly JVOpen chunks; committed
+            chunks survive a later chunk's failure, and with the cache
+            enabled a retry replays completed chunks from local cache.
 
         Examples:
             >>> processor = BatchProcessor(database=db)
@@ -157,6 +166,7 @@ class BatchProcessor:
         """
         # Stop before schema creation or transaction state for invalid input.
         validate_jvopen_combination(data_spec, option)
+        validate_date_range(from_date, to_date)
 
         logger.info(
             "Starting batch processing",
@@ -166,7 +176,7 @@ class BatchProcessor:
             option=option,
         )
 
-        if self._should_split_setup_range(from_date, to_date, option):
+        if self._should_split_setup_range(data_spec, from_date, to_date, option):
             return self._process_split_setup_range(
                 data_spec=data_spec,
                 from_date=from_date,
@@ -192,7 +202,7 @@ class BatchProcessor:
             # Where the transaction breaks is decided here and nowhere else.
             # Committing inside DataImporter would make a later parser/import
             # rejection impossible to roll back.
-            commit_per_chunk = option == SINGLE_OPEN_SETUP_OPTION and auto_commit
+            commit_per_chunk = option == SPLIT_SETUP_OPTION and auto_commit
             groups = (
                 _chunks(records, SETUP_COMMIT_INTERVAL)
                 if commit_per_chunk
@@ -268,11 +278,19 @@ class BatchProcessor:
             raise ImporterError(f"Import rejected {failed_records} record(s)")
 
     @staticmethod
-    def _should_split_setup_range(from_date: str, to_date: str, option: int) -> bool:
-        # option=4 (分割セットアップ) は JVOpen を1回だけ呼び出して全期間を一括取得する。
-        # 年単位に分割すると各チャンクで JV-Link が fromtime 以降の全データを返すため
-        # O(n^2) の処理量になる。option=3 のみ従来の年分割を維持する。
-        if option != 3:
+    def _should_split_setup_range(
+        data_spec: str, from_date: str, to_date: str, option: int
+    ) -> bool:
+        # セットアップ (option 3/4) の長期間要求は、終了ポイント時刻を許す
+        # dataspec に限り年単位の境界付き JVOpen に分割する。fetch が公式の
+        # 開始-終了 fromtime を送るため、各チャンクは自分の窓だけを取得し
+        # テールを反復しない。終了時刻禁止 spec（DIFN 等、仕様書 p.18）は
+        # fromtime を閉じられず、分割すると各チャンクが fromtime 以降の
+        # 全データを返す O(n^2) の反復になるため、option を問わず単一
+        # オープンのままにする。
+        if option not in (3, 4):
+            return False
+        if not jvopen_supports_end_timestamp(data_spec):
             return False
         start = datetime.strptime(from_date, "%Y%m%d")
         end = datetime.strptime(to_date, "%Y%m%d")
@@ -297,8 +315,14 @@ class BatchProcessor:
         auto_commit: bool,
         ensure_tables: bool,
     ) -> dict:
+        # 年チャンクは日付レベルで連続する (次チャンクの from = 前チャンクの
+        # to + 1日)。fetch はセットアップの排他的開始点を「チャンク from の
+        # 前日 23:59:59」に符号化するため、隣接チャンクは提供タイムスタンプ
+        # 空間で「次チャンクの排他的開始点 = 直前チャンクの包含終了点」と
+        # なり、秒単位まで正確に・隙間も重複もなく敷き詰められる
+        # （開始は「より大きい」、終了は「まで」）。
         logger.info(
-            "Splitting setup range into yearly chunks to avoid JVOpen memory pressure",
+            "Splitting setup range into bounded yearly chunks",
             data_spec=data_spec,
             from_date=from_date,
             to_date=to_date,
@@ -307,6 +331,45 @@ class BatchProcessor:
         if ensure_tables:
             create_all_tables(self.database)
 
+        if option == SPLIT_SETUP_OPTION:
+            # option=4: 各チャンクの内側の process_date_range がトランザク
+            # ション境界を所有する（auto_commit 時は SETUP_COMMIT_INTERVAL
+            # 毎にコミット、失敗したグループはチャンク内でロールバック）。
+            # 外側でトランザクションを張らないことで所有権の曖昧さを避け、
+            # コミット済みの先行チャンクは後続チャンクの失敗で失われない。
+            # auto_commit=False の場合は従来どおり呼び出し元だけが唯一の
+            # コミット境界を持つ（内側は begin のみ行いコミットしない）。
+            #
+            # 再実行の契約: キャッシュ有効時、完了したチャンクは fetch が
+            # そのチャンク窓の complete マーカーを付けるため、同じ引数での
+            # 再実行は同一分割を再導出し、完了済みチャンクをローカル
+            # キャッシュから再生する（プロバイダ再取得なし・インポートは
+            # 冪等upsert）。キャッシュ無効時は各チャンクの再ダウンロードに
+            # なるが、いずれも境界付きでテールは反復しない。
+            option4_stats: dict = {}
+            for idx, (chunk_from, chunk_to) in enumerate(
+                self._iter_year_chunks(from_date, to_date), start=1
+            ):
+                logger.info(
+                    "Processing bounded setup chunk",
+                    chunk_index=idx,
+                    chunk_from=chunk_from,
+                    chunk_to=chunk_to,
+                    data_spec=data_spec,
+                )
+                chunk_stats = self.process_date_range(
+                    data_spec=data_spec,
+                    from_date=chunk_from,
+                    to_date=chunk_to,
+                    option=option,
+                    auto_commit=auto_commit,
+                    ensure_tables=False,
+                )
+                _accumulate_stats(option4_stats, chunk_stats)
+            return option4_stats
+
+        # option=3: 従来どおり全チャンクを単一トランザクションで所有し、
+        # 全チャンク成功時のみ一括コミットする（部分的な耐久性を作らない）。
         combined_stats: dict = {}
         try:
             begin_transaction = getattr(self.database, "begin_transaction", None)

--- a/src/jvlink/bridge.py
+++ b/src/jvlink/bridge.py
@@ -129,7 +129,11 @@ _DISMISSIBLE_DIALOG_TITLE_PATTERNS = (
     r"^JRA-VANからのお知らせ$",
 )
 _DEFAULT_OPEN_TIMEOUT_SECONDS = 120.0
-_MAX_OPEN_TIMEOUT_SECONDS = 7200.0
+# Official setup can legitimately spend hours inside the blocking JVOpen call
+# before readcount/downloadcount are observable.  Keep a hard one-day ceiling
+# so a deployment can own a five-year rebuild budget without making a stuck
+# bridge unbounded.
+_MAX_OPEN_TIMEOUT_SECONDS = 86400.0
 _ENABLED_VALUES = {"1", "true", "yes", "on"}
 _DISABLED_VALUES = {"0", "false", "no", "off"}
 

--- a/src/jvlink/constants.py
+++ b/src/jvlink/constants.py
@@ -119,6 +119,25 @@ RETIRED_DATA_SPECS = {
 # 仕様変更が行われた年月。拒否メッセージに含める。
 RETIRED_DATA_SPEC_CHANGED_AT = "2023-08"
 
+# JVOpen fromtime の終了ポイント時刻を指定できないデータ種別ID。
+# 出典: JV-Linkインターフェース仕様書 4.9.0.1(Win)（SHA-256
+# 3167d5c98d8db78321a983cd2d897e1b5a9f42f141490f9ba817ca0dcf9d2364）p.18。
+# fromtime は「開始時刻のみ」または「開始-終了」を半角ハイフンで結合した
+# 2形式のみで、以下の ID は「全データを取得するため」終了ポイント時刻を
+# 指定できず、指定すると「戻り値:-1（該当データなし）」が返る。-1 は正当な
+# 「データなし」と区別できないため、送信前にこの登録簿で遮断する。
+# DIFF/HOSE は RETIRED_DATA_SPECS でも入口拒否されるが、公式リストの転記は
+# 完全に保つ（推測で除外しない）。
+JVOPEN_END_TIME_FORBIDDEN_SPECS = frozenset({
+    "TOKU",  # 特別登録馬情報
+    "DIFF",  # 蓄積系ソフト用 蓄積情報（旧仕様）
+    "DIFN",  # 蓄積系ソフト用 蓄積情報
+    "HOSE",  # 競走馬市場取引価格情報（旧仕様）
+    "HOSN",  # 競走馬市場取引価格情報
+    "HOYU",  # 馬名の意味由来情報
+    "COMM",  # 各種解説情報
+})
+
 # リアルタイムデータ種別 (JVRTOpen用)
 # 速報系データ: レース確定情報（結果が確定したら更新）
 # オッズ系データ: レース単位キーで取得する速報オッズ/時系列オッズ
@@ -385,6 +404,26 @@ def _split_jvopen_data_specs(data_spec: str) -> tuple[str, ...]:
     if not isinstance(data_spec, str) or not data_spec or len(data_spec) % 4:
         return ()
     return tuple(data_spec[index:index + 4] for index in range(0, len(data_spec), 4))
+
+
+def jvopen_supports_end_timestamp(data_spec: str) -> bool:
+    """Return True iff every component may take the official start-end form.
+
+    公式仕様 p.17-18 のとおり、終了時刻禁止 ID をひとつでも含む dataspec に
+    終了ポイント時刻を付けると -1 が返り「該当データなし」と区別できない。
+    そのため全構成要素が許す場合に限り True。不正・空の dataspec は False
+    （開始のみ形式へ倒す）とし、そもそも validate_jvopen_combination が先に
+    拒否する。大文字小文字を区別しないのは is_retired_data_spec と同じ理由。
+    """
+    if not isinstance(data_spec, str):
+        return False
+    components = _split_jvopen_data_specs(data_spec.upper())
+    if not components:
+        return False
+    return all(
+        component not in JVOPEN_END_TIME_FORBIDDEN_SPECS
+        for component in components
+    )
 
 
 def _retired_jvopen_components(data_spec: str) -> tuple[tuple[str, str], ...]:

--- a/src/jvlink/constants.py
+++ b/src/jvlink/constants.py
@@ -119,25 +119,6 @@ RETIRED_DATA_SPECS = {
 # 仕様変更が行われた年月。拒否メッセージに含める。
 RETIRED_DATA_SPEC_CHANGED_AT = "2023-08"
 
-# JVOpen fromtime の終了ポイント時刻を指定できないデータ種別ID。
-# 出典: JV-Linkインターフェース仕様書 4.9.0.1(Win)（SHA-256
-# 3167d5c98d8db78321a983cd2d897e1b5a9f42f141490f9ba817ca0dcf9d2364）p.18。
-# fromtime は「開始時刻のみ」または「開始-終了」を半角ハイフンで結合した
-# 2形式のみで、以下の ID は「全データを取得するため」終了ポイント時刻を
-# 指定できず、指定すると「戻り値:-1（該当データなし）」が返る。-1 は正当な
-# 「データなし」と区別できないため、送信前にこの登録簿で遮断する。
-# DIFF/HOSE は RETIRED_DATA_SPECS でも入口拒否されるが、公式リストの転記は
-# 完全に保つ（推測で除外しない）。
-JVOPEN_END_TIME_FORBIDDEN_SPECS = frozenset({
-    "TOKU",  # 特別登録馬情報
-    "DIFF",  # 蓄積系ソフト用 蓄積情報（旧仕様）
-    "DIFN",  # 蓄積系ソフト用 蓄積情報
-    "HOSE",  # 競走馬市場取引価格情報（旧仕様）
-    "HOSN",  # 競走馬市場取引価格情報
-    "HOYU",  # 馬名の意味由来情報
-    "COMM",  # 各種解説情報
-})
-
 # リアルタイムデータ種別 (JVRTOpen用)
 # 速報系データ: レース確定情報（結果が確定したら更新）
 # オッズ系データ: レース単位キーで取得する速報オッズ/時系列オッズ
@@ -404,26 +385,6 @@ def _split_jvopen_data_specs(data_spec: str) -> tuple[str, ...]:
     if not isinstance(data_spec, str) or not data_spec or len(data_spec) % 4:
         return ()
     return tuple(data_spec[index:index + 4] for index in range(0, len(data_spec), 4))
-
-
-def jvopen_supports_end_timestamp(data_spec: str) -> bool:
-    """Return True iff every component may take the official start-end form.
-
-    公式仕様 p.17-18 のとおり、終了時刻禁止 ID をひとつでも含む dataspec に
-    終了ポイント時刻を付けると -1 が返り「該当データなし」と区別できない。
-    そのため全構成要素が許す場合に限り True。不正・空の dataspec は False
-    （開始のみ形式へ倒す）とし、そもそも validate_jvopen_combination が先に
-    拒否する。大文字小文字を区別しないのは is_retired_data_spec と同じ理由。
-    """
-    if not isinstance(data_spec, str):
-        return False
-    components = _split_jvopen_data_specs(data_spec.upper())
-    if not components:
-        return False
-    return all(
-        component not in JVOPEN_END_TIME_FORBIDDEN_SPECS
-        for component in components
-    )
 
 
 def _retired_jvopen_components(data_spec: str) -> tuple[tuple[str, str], ...]:

--- a/src/jvlink/wrapper.py
+++ b/src/jvlink/wrapper.py
@@ -235,9 +235,13 @@ class JVLinkWrapper:
 
         Args:
             data_spec: Data specification code (e.g., "RACE", "DIFN")
-            fromtime: Start time in YYYYMMDDhhmmss format (14 digits)
-                     Example: "20241103000000"
-                     Retrieves data from this timestamp onwards
+            fromtime: Read start point "YYYYMMDDhhmmss" (14 digits), or the
+                     official bounded form
+                     "YYYYMMDDhhmmss-YYYYMMDDhhmmss" (start-end joined by a
+                     half-width hyphen; 仕様書 4.9.0.1 p.17-18).
+                     Specs in JVOPEN_END_TIME_FORBIDDEN_SPECS (TOKU/DIFF/
+                     DIFN/HOSE/HOSN/HOYU/COMM) must use the start-only
+                     form; an end timestamp makes JVOpen return -1.
             option: Option flag:
                     1=通常データ（差分データ取得）
                     2=今週データ（直近のレースのみ）

--- a/src/jvlink/wrapper.py
+++ b/src/jvlink/wrapper.py
@@ -236,12 +236,13 @@ class JVLinkWrapper:
         Args:
             data_spec: Data specification code (e.g., "RACE", "DIFN")
             fromtime: Read start point "YYYYMMDDhhmmss" (14 digits), or the
-                     official bounded form
+                     official start-end form
                      "YYYYMMDDhhmmss-YYYYMMDDhhmmss" (start-end joined by a
                      half-width hyphen; 仕様書 4.9.0.1 p.17-18).
-                     Specs in JVOPEN_END_TIME_FORBIDDEN_SPECS (TOKU/DIFF/
-                     DIFN/HOSE/HOSN/HOYU/COMM) must use the start-only
-                     form; an end timestamp makes JVOpen return -1.
+                     For option 3/4, p.20 says the end point bounds only the
+                     current-month normal-data portion; it does not cap the
+                     historical setup tail. TOKU/DIFF/DIFN/HOSE/HOSN/HOYU/
+                     COMM forbid an end timestamp entirely.
             option: Option flag:
                     1=通常データ（差分データ取得）
                     2=今週データ（直近のレースのみ）

--- a/tests/test_batch_processor.py
+++ b/tests/test_batch_processor.py
@@ -1,6 +1,6 @@
-"""Tests for batch processor setup-range splitting decisions."""
+"""Tests for batch processor setup-range and transaction decisions."""
 
-from unittest.mock import MagicMock, call
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -10,34 +10,6 @@ from src.database.sqlite_handler import SQLiteDatabase
 from src.fetcher.historical import HistoricalFetcher
 from src.importer.batch import BatchProcessor
 from src.importer.importer import DataImporter, ImporterError
-
-
-@pytest.mark.parametrize(
-    ("data_spec", "option", "expected"),
-    [
-        # 終了時刻を許す RACE のセットアップは、option 3/4 とも境界付き
-        # チャンクへ分割できる
-        ("RACE", 3, True),
-        ("RACE", 4, True),
-        # 終了時刻の指定が禁止された spec (仕様書 p.18) は fromtime を閉じ
-        # られず、分割すると各チャンクが開いたテールを反復するため、
-        # option を問わず単一オープンのまま
-        ("DIFN", 3, False),
-        ("DIFN", 4, False),
-        # 差分/今週データは分割対象ではない
-        ("RACE", 1, False),
-        ("RACE", 2, False),
-    ],
-)
-def test_long_ranges_split_only_when_chunks_can_be_end_bounded(
-    data_spec, option, expected
-):
-    assert (
-        BatchProcessor._should_split_setup_range(
-            data_spec, "20200101", "20220101", option
-        )
-        is expected
-    )
 
 
 def test_historical_no_data_resets_statistics_from_previous_spec():
@@ -256,102 +228,34 @@ def test_multiple_specs_passes_auto_commit_without_overwriting_option():
     assert results["_summary"]["failed"] == 0
 
 
-def test_split_setup_commits_once_after_all_chunks_succeed():
-    processor = BatchProcessor.__new__(BatchProcessor)
-    processor.database = MagicMock()
-    processor._iter_year_chunks = MagicMock(
-        return_value=iter(
-            [("20200101", "20201231"), ("20210101", "20211231")]
-        )
-    )
-    processor.process_date_range = MagicMock(
-        side_effect=[
-            {"records_imported": 2, "records_failed": 0},
-            {"records_imported": 3, "records_failed": 0},
-        ]
-    )
-
-    stats = processor._process_split_setup_range(
-        "RACE", "20200101", "20211231", 3, True, False
-    )
-
-    assert stats["records_imported"] == 5
-    assert all(
-        call.kwargs["auto_commit"] is False
-        for call in processor.process_date_range.call_args_list
-    )
-    processor.database.commit.assert_called_once_with()
-
-
-@pytest.mark.parametrize("driver", ["pg8000", "psycopg"])
-def test_split_setup_rolls_back_postgresql_transaction_on_later_failure(
-    monkeypatch, driver
-):
-    import src.database.postgresql_handler as postgresql_handler
-
-    database = postgresql_handler.PostgreSQLDatabase({})
-    database._connection = MagicMock()
-    database._cursor = MagicMock()
-    monkeypatch.setattr(postgresql_handler, "DRIVER", driver)
-
-    processor = BatchProcessor.__new__(BatchProcessor)
-    processor.database = database
-    processor._iter_year_chunks = MagicMock(
-        return_value=iter(
-            [("20200101", "20201231"), ("20210101", "20211231")]
-        )
-    )
-    processor.process_date_range = MagicMock(
-        side_effect=[{"records_imported": 1}, RuntimeError("later chunk failed")]
-    )
-
-    with pytest.raises(RuntimeError, match="later chunk failed"):
-        processor._process_split_setup_range(
-            "RACE", "20200101", "20211231", 3, True, False
-        )
-
-    if driver == "pg8000":
-        assert database._connection.run.call_args_list == [
-            call("BEGIN"),
-            call("ROLLBACK"),
-        ]
-    else:
-        database._connection.rollback.assert_called_once_with()
-
-
-def test_split_setup_rolls_back_all_chunks_on_later_failure(tmp_path):
-    database = SQLiteDatabase({"path": str(tmp_path / "split-atomic.db")})
+def test_option_3_long_range_uses_one_open_and_remains_atomic(tmp_path):
+    """option=3は年次tailを反復せず、後段拒否時は単一transactionを戻す。"""
+    database = SQLiteDatabase({"path": str(tmp_path / "option3-single-open.db")})
     processor = BatchProcessor.__new__(BatchProcessor)
     processor.database = database
     processor.cache_manager = None
     processor.fetcher = MagicMock()
-    processor.fetcher.fetch.side_effect = [
-        iter(
-            [
-                {
-                    "RecordSpec": "RA",
-                    "DataKubun": "1",
-                    "MakeDate": "20250714",
-                    "Year": "2025",
-                    "MonthDay": "0714",
-                    "JyoCD": "05",
-                    "Kaiji": "01",
-                    "Nichiji": "01",
-                    "RaceNum": "01",
-                }
-            ]
-        ),
-        iter([{"RecordSpec": "RA", "DataKubun": "Z"}]),
-    ]
-    processor.fetcher.get_statistics.side_effect = [
-        {"records_fetched": 1, "records_parsed": 1, "records_failed": 0},
-        {"records_fetched": 1, "records_parsed": 1, "records_failed": 0},
-    ]
-    processor._iter_year_chunks = MagicMock(
-        return_value=iter(
-            [("20250101", "20251231"), ("20260101", "20261231")]
-        )
+    processor.fetcher.fetch.return_value = iter(
+        [
+            {
+                "RecordSpec": "RA",
+                "DataKubun": "1",
+                "MakeDate": "20250714",
+                "Year": "2025",
+                "MonthDay": "0714",
+                "JyoCD": "05",
+                "Kaiji": "01",
+                "Nichiji": "01",
+                "RaceNum": "01",
+            },
+            {"RecordSpec": "RA", "DataKubun": "Z"},
+        ]
     )
+    processor.fetcher.get_statistics.return_value = {
+        "records_fetched": 2,
+        "records_parsed": 2,
+        "records_failed": 0,
+    }
 
     with database:
         database.execute(SCHEMAS["NL_RA"])
@@ -359,12 +263,15 @@ def test_split_setup_rolls_back_all_chunks_on_later_failure(tmp_path):
         processor.importer = DataImporter(database, batch_size=1)
 
         with pytest.raises(SchemaMigrationError, match="DataKubun"):
-            processor._process_split_setup_range(
-                "RACE", "20250101", "20261231", 3, True, False
+            processor.process_date_range(
+                "RACE", "20200101", "20260819", option=3, ensure_tables=False
             )
 
         row_count = database.fetch_one("SELECT COUNT(*) AS count FROM NL_RA")["count"]
 
+    processor.fetcher.fetch.assert_called_once_with(
+        "RACE", "20200101", "20260819", 3
+    )
     assert row_count == 0
 
 
@@ -442,14 +349,13 @@ def _transaction_calls(database):
 
 
 # 以下の option=4 テスト群は「1回のオープン内のコミット間隔」契約を固定する。
-# 370日超の RACE option=4 は境界付き年チャンクへ分割されるようになったため、
-# 単一オープン経路に留まるよう日付範囲は 370 日以下 (20220101-20221231) にする。
+# 日付範囲の長短にかかわらずprovider setup tailは1回だけopenする。
 def test_option_4_commits_once_per_interval(monkeypatch):
     monkeypatch.setattr("src.importer.batch.SETUP_COMMIT_INTERVAL", 2)
     processor = _chunking_processor([_record(i) for i in range(5)])
 
     processor.process_date_range(
-        "RACE", "20220101", "20221231", option=4, ensure_tables=False
+        "RACE", "19860101", "20221231", option=4, ensure_tables=False
     )
 
     assert [len(batch) for batch in processor.importer.calls] == [2, 2, 1]
@@ -461,7 +367,7 @@ def test_option_4_shorter_than_the_interval_commits_once(monkeypatch):
     processor = _chunking_processor([_record(0)])
 
     processor.process_date_range(
-        "RACE", "20220101", "20221231", option=4, ensure_tables=False
+        "RACE", "19860101", "20221231", option=4, ensure_tables=False
     )
 
     assert [len(batch) for batch in processor.importer.calls] == [1]
@@ -473,7 +379,7 @@ def test_option_4_empty_stream_still_commits_once(monkeypatch):
     processor = _chunking_processor([])
 
     processor.process_date_range(
-        "RACE", "20220101", "20221231", option=4, ensure_tables=False
+        "RACE", "19860101", "20221231", option=4, ensure_tables=False
     )
 
     assert [len(batch) for batch in processor.importer.calls] == [0]
@@ -499,7 +405,7 @@ def test_option_4_caller_managed_transaction_keeps_a_single_commit_point(monkeyp
 
     processor.process_date_range(
         "RACE",
-        "20220101",
+        "19860101",
         "20221231",
         option=4,
         auto_commit=False,
@@ -515,7 +421,7 @@ def test_option_4_sums_statistics_across_chunks(monkeypatch):
     processor = _chunking_processor([_record(i) for i in range(5)])
 
     stats = processor.process_date_range(
-        "RACE", "20220101", "20221231", option=4, ensure_tables=False
+        "RACE", "19860101", "20221231", option=4, ensure_tables=False
     )
 
     assert stats["records_imported"] == 5
@@ -535,7 +441,7 @@ def test_option_4_fetch_failure_blocks_commit_of_the_consuming_chunk(monkeypatch
 
     with pytest.raises(ImporterError, match="rejected 1 record"):
         processor.process_date_range(
-            "RACE", "20220101", "20221231", option=4, ensure_tables=False
+            "RACE", "19860101", "20221231", option=4, ensure_tables=False
         )
 
     # The clean first chunk commits; the chunk consumed alongside the parse
@@ -594,7 +500,7 @@ def test_option_4_rejection_rolls_back_only_its_own_chunk(tmp_path, monkeypatch)
 
         with pytest.raises(SchemaMigrationError, match="DataKubun"):
             processor.process_date_range(
-                "RACE", "20220101", "20221231", option=4, ensure_tables=False
+                "RACE", "19860101", "20221231", option=4, ensure_tables=False
             )
 
         row_count = database.fetch_one("SELECT COUNT(*) AS count FROM NL_RA")["count"]
@@ -604,42 +510,34 @@ def test_option_4_rejection_rolls_back_only_its_own_chunk(tmp_path, monkeypatch)
     assert row_count == 2
 
 
-def _chunk_ra_record(year, monthday):
-    return {
-        "RecordSpec": "RA",
-        "DataKubun": "1",
-        "MakeDate": f"{year}{monthday}",
-        "Year": year,
-        "MonthDay": monthday,
-        "JyoCD": "05",
-        "Kaiji": "01",
-        "Nichiji": "01",
-        "RaceNum": "01",
-    }
-
-
-def test_option_4_long_range_partitions_into_bounded_chunks_and_keeps_committed_chunks(
-    tmp_path,
+def test_option_4_long_range_uses_one_provider_open_and_keeps_group_commits(
+    tmp_path, monkeypatch
 ):
-    """370日超の option=4 は正確で重複しない境界付きチャンクに分割される。
+    """長期間setupもprovider tailは1回だけopenし、group単位で耐久化する。"""
+    monkeypatch.setattr("src.importer.batch.SETUP_COMMIT_INTERVAL", 1)
 
-    範囲は実際に7200秒タイムアウトした本番スコープ 20240820-20260819。
-    後続チャンクの失敗は当該チャンク内でロールバックされ、コミット済みの
-    先行チャンクを黙って破棄したり二重計上したりしない。
-    """
-    database = SQLiteDatabase({"path": str(tmp_path / "option4-split.db")})
+    def _valid_ra(race_num):
+        return {
+            "RecordSpec": "RA",
+            "DataKubun": "1",
+            "MakeDate": "20260714",
+            "Year": "2026",
+            "MonthDay": "0714",
+            "JyoCD": "05",
+            "Kaiji": "01",
+            "Nichiji": "01",
+            "RaceNum": race_num,
+        }
+
+    database = SQLiteDatabase({"path": str(tmp_path / "option4-single-open.db")})
     processor = BatchProcessor.__new__(BatchProcessor)
     processor.database = database
     processor.cache_manager = None
     processor.fetcher = MagicMock()
-    processor.fetcher.fetch.side_effect = [
-        iter([_chunk_ra_record("2024", "1101")]),
-        iter([_chunk_ra_record("2025", "1101")]),
-        iter([{"RecordSpec": "RA", "DataKubun": "Z"}]),
-    ]
+    processor.fetcher.fetch.return_value = iter([_valid_ra("01"), _valid_ra("02")])
     processor.fetcher.get_statistics.return_value = {
-        "records_fetched": 1,
-        "records_parsed": 1,
+        "records_fetched": 2,
+        "records_parsed": 2,
         "records_failed": 0,
     }
 
@@ -647,37 +545,26 @@ def test_option_4_long_range_partitions_into_bounded_chunks_and_keeps_committed_
         database.execute(SCHEMAS["NL_RA"])
         database.commit()
         processor.importer = DataImporter(database, batch_size=1)
-
-        with pytest.raises(SchemaMigrationError, match="DataKubun"):
-            processor.process_date_range(
-                "RACE", "20240820", "20260819", option=4, ensure_tables=False
-            )
-
+        stats = processor.process_date_range(
+            "RACE", "20240820", "20260819", option=4, ensure_tables=False
+        )
         row_count = database.fetch_one("SELECT COUNT(*) AS count FROM NL_RA")["count"]
 
-    # 要求範囲を年境界で正確に・重複なく敷き詰め、開いたテールを残さない
-    assert [c.args for c in processor.fetcher.fetch.call_args_list] == [
-        ("RACE", "20240820", "20241231", 4),
-        ("RACE", "20250101", "20251231", 4),
-        ("RACE", "20260101", "20260819", 4),
-    ]
-    # コミット済みの先行2チャンクは最終チャンクの失敗で失われない
+    processor.fetcher.fetch.assert_called_once_with(
+        "RACE", "20240820", "20260819", 4
+    )
+    assert stats["records_imported"] == 2
     assert row_count == 2
 
 
-def test_option_4_long_range_routes_each_bounded_chunk_through_the_cache():
-    """各チャンクがキャッシュ経路を通ること。
-
-    成功済みチャンクはその範囲の complete マーカーで識別されるため、同じ
-    コマンドの再実行は同一のチャンク分割を再導出し、完了済みチャンクを
-    プロバイダ再取得なしにローカルキャッシュから再生できる。
-    """
+def test_option_4_long_range_uses_one_full_scope_cache_request():
+    """cache付きでも年窓へ分割せず、同一scopeのresume単位を維持する。"""
     processor = BatchProcessor.__new__(BatchProcessor)
     processor.database = MagicMock()
     cache = MagicMock()
     processor.cache_manager = cache
     processor.fetcher = MagicMock()
-    processor.fetcher.fetch_with_cache.side_effect = [iter([]), iter([]), iter([])]
+    processor.fetcher.fetch_with_cache.return_value = iter([])
     processor.fetcher.get_statistics.return_value = {
         "records_fetched": 0,
         "records_parsed": 0,
@@ -689,11 +576,9 @@ def test_option_4_long_range_routes_each_bounded_chunk_through_the_cache():
         "RACE", "20240820", "20260819", option=4, ensure_tables=False
     )
 
-    assert [c.args for c in processor.fetcher.fetch_with_cache.call_args_list] == [
-        (cache, "RACE", "20240820", "20241231", 4),
-        (cache, "RACE", "20250101", "20251231", 4),
-        (cache, "RACE", "20260101", "20260819", 4),
-    ]
+    processor.fetcher.fetch_with_cache.assert_called_once_with(
+        cache, "RACE", "20240820", "20260819", 4
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/test_batch_processor.py
+++ b/tests/test_batch_processor.py
@@ -12,17 +12,32 @@ from src.importer.batch import BatchProcessor
 from src.importer.importer import DataImporter, ImporterError
 
 
-def test_option_3_setup_range_splits_long_periods():
-    assert BatchProcessor._should_split_setup_range("20200101", "20220101", 3) is True
-
-
-def test_option_4_setup_range_does_not_split_long_periods():
-    assert BatchProcessor._should_split_setup_range("20200101", "20220101", 4) is False
-
-
-def test_diff_options_do_not_split_long_periods():
-    assert BatchProcessor._should_split_setup_range("20200101", "20220101", 1) is False
-    assert BatchProcessor._should_split_setup_range("20200101", "20220101", 2) is False
+@pytest.mark.parametrize(
+    ("data_spec", "option", "expected"),
+    [
+        # 終了時刻を許す RACE のセットアップは、option 3/4 とも境界付き
+        # チャンクへ分割できる
+        ("RACE", 3, True),
+        ("RACE", 4, True),
+        # 終了時刻の指定が禁止された spec (仕様書 p.18) は fromtime を閉じ
+        # られず、分割すると各チャンクが開いたテールを反復するため、
+        # option を問わず単一オープンのまま
+        ("DIFN", 3, False),
+        ("DIFN", 4, False),
+        # 差分/今週データは分割対象ではない
+        ("RACE", 1, False),
+        ("RACE", 2, False),
+    ],
+)
+def test_long_ranges_split_only_when_chunks_can_be_end_bounded(
+    data_spec, option, expected
+):
+    assert (
+        BatchProcessor._should_split_setup_range(
+            data_spec, "20200101", "20220101", option
+        )
+        is expected
+    )
 
 
 def test_historical_no_data_resets_statistics_from_previous_spec():
@@ -426,12 +441,15 @@ def _transaction_calls(database):
     return [name for name, _args, _kwargs in database.mock_calls]
 
 
+# 以下の option=4 テスト群は「1回のオープン内のコミット間隔」契約を固定する。
+# 370日超の RACE option=4 は境界付き年チャンクへ分割されるようになったため、
+# 単一オープン経路に留まるよう日付範囲は 370 日以下 (20220101-20221231) にする。
 def test_option_4_commits_once_per_interval(monkeypatch):
     monkeypatch.setattr("src.importer.batch.SETUP_COMMIT_INTERVAL", 2)
     processor = _chunking_processor([_record(i) for i in range(5)])
 
     processor.process_date_range(
-        "RACE", "19860101", "20221231", option=4, ensure_tables=False
+        "RACE", "20220101", "20221231", option=4, ensure_tables=False
     )
 
     assert [len(batch) for batch in processor.importer.calls] == [2, 2, 1]
@@ -443,7 +461,7 @@ def test_option_4_shorter_than_the_interval_commits_once(monkeypatch):
     processor = _chunking_processor([_record(0)])
 
     processor.process_date_range(
-        "RACE", "19860101", "20221231", option=4, ensure_tables=False
+        "RACE", "20220101", "20221231", option=4, ensure_tables=False
     )
 
     assert [len(batch) for batch in processor.importer.calls] == [1]
@@ -455,7 +473,7 @@ def test_option_4_empty_stream_still_commits_once(monkeypatch):
     processor = _chunking_processor([])
 
     processor.process_date_range(
-        "RACE", "19860101", "20221231", option=4, ensure_tables=False
+        "RACE", "20220101", "20221231", option=4, ensure_tables=False
     )
 
     assert [len(batch) for batch in processor.importer.calls] == [0]
@@ -481,7 +499,7 @@ def test_option_4_caller_managed_transaction_keeps_a_single_commit_point(monkeyp
 
     processor.process_date_range(
         "RACE",
-        "19860101",
+        "20220101",
         "20221231",
         option=4,
         auto_commit=False,
@@ -497,7 +515,7 @@ def test_option_4_sums_statistics_across_chunks(monkeypatch):
     processor = _chunking_processor([_record(i) for i in range(5)])
 
     stats = processor.process_date_range(
-        "RACE", "19860101", "20221231", option=4, ensure_tables=False
+        "RACE", "20220101", "20221231", option=4, ensure_tables=False
     )
 
     assert stats["records_imported"] == 5
@@ -517,7 +535,7 @@ def test_option_4_fetch_failure_blocks_commit_of_the_consuming_chunk(monkeypatch
 
     with pytest.raises(ImporterError, match="rejected 1 record"):
         processor.process_date_range(
-            "RACE", "19860101", "20221231", option=4, ensure_tables=False
+            "RACE", "20220101", "20221231", option=4, ensure_tables=False
         )
 
     # The clean first chunk commits; the chunk consumed alongside the parse
@@ -576,7 +594,7 @@ def test_option_4_rejection_rolls_back_only_its_own_chunk(tmp_path, monkeypatch)
 
         with pytest.raises(SchemaMigrationError, match="DataKubun"):
             processor.process_date_range(
-                "RACE", "19860101", "20221231", option=4, ensure_tables=False
+                "RACE", "20220101", "20221231", option=4, ensure_tables=False
             )
 
         row_count = database.fetch_one("SELECT COUNT(*) AS count FROM NL_RA")["count"]
@@ -584,3 +602,126 @@ def test_option_4_rejection_rolls_back_only_its_own_chunk(tmp_path, monkeypatch)
     # Chunk 1 (races 01, 02) stays committed; chunk 2 loses race 03 along
     # with the rejected record.
     assert row_count == 2
+
+
+def _chunk_ra_record(year, monthday):
+    return {
+        "RecordSpec": "RA",
+        "DataKubun": "1",
+        "MakeDate": f"{year}{monthday}",
+        "Year": year,
+        "MonthDay": monthday,
+        "JyoCD": "05",
+        "Kaiji": "01",
+        "Nichiji": "01",
+        "RaceNum": "01",
+    }
+
+
+def test_option_4_long_range_partitions_into_bounded_chunks_and_keeps_committed_chunks(
+    tmp_path,
+):
+    """370日超の option=4 は正確で重複しない境界付きチャンクに分割される。
+
+    範囲は実際に7200秒タイムアウトした本番スコープ 20240820-20260819。
+    後続チャンクの失敗は当該チャンク内でロールバックされ、コミット済みの
+    先行チャンクを黙って破棄したり二重計上したりしない。
+    """
+    database = SQLiteDatabase({"path": str(tmp_path / "option4-split.db")})
+    processor = BatchProcessor.__new__(BatchProcessor)
+    processor.database = database
+    processor.cache_manager = None
+    processor.fetcher = MagicMock()
+    processor.fetcher.fetch.side_effect = [
+        iter([_chunk_ra_record("2024", "1101")]),
+        iter([_chunk_ra_record("2025", "1101")]),
+        iter([{"RecordSpec": "RA", "DataKubun": "Z"}]),
+    ]
+    processor.fetcher.get_statistics.return_value = {
+        "records_fetched": 1,
+        "records_parsed": 1,
+        "records_failed": 0,
+    }
+
+    with database:
+        database.execute(SCHEMAS["NL_RA"])
+        database.commit()
+        processor.importer = DataImporter(database, batch_size=1)
+
+        with pytest.raises(SchemaMigrationError, match="DataKubun"):
+            processor.process_date_range(
+                "RACE", "20240820", "20260819", option=4, ensure_tables=False
+            )
+
+        row_count = database.fetch_one("SELECT COUNT(*) AS count FROM NL_RA")["count"]
+
+    # 要求範囲を年境界で正確に・重複なく敷き詰め、開いたテールを残さない
+    assert [c.args for c in processor.fetcher.fetch.call_args_list] == [
+        ("RACE", "20240820", "20241231", 4),
+        ("RACE", "20250101", "20251231", 4),
+        ("RACE", "20260101", "20260819", 4),
+    ]
+    # コミット済みの先行2チャンクは最終チャンクの失敗で失われない
+    assert row_count == 2
+
+
+def test_option_4_long_range_routes_each_bounded_chunk_through_the_cache():
+    """各チャンクがキャッシュ経路を通ること。
+
+    成功済みチャンクはその範囲の complete マーカーで識別されるため、同じ
+    コマンドの再実行は同一のチャンク分割を再導出し、完了済みチャンクを
+    プロバイダ再取得なしにローカルキャッシュから再生できる。
+    """
+    processor = BatchProcessor.__new__(BatchProcessor)
+    processor.database = MagicMock()
+    cache = MagicMock()
+    processor.cache_manager = cache
+    processor.fetcher = MagicMock()
+    processor.fetcher.fetch_with_cache.side_effect = [iter([]), iter([]), iter([])]
+    processor.fetcher.get_statistics.return_value = {
+        "records_fetched": 0,
+        "records_parsed": 0,
+        "records_failed": 0,
+    }
+    processor.importer = _RecordingImporter()
+
+    processor.process_date_range(
+        "RACE", "20240820", "20260819", option=4, ensure_tables=False
+    )
+
+    assert [c.args for c in processor.fetcher.fetch_with_cache.call_args_list] == [
+        (cache, "RACE", "20240820", "20241231", 4),
+        (cache, "RACE", "20250101", "20251231", 4),
+        (cache, "RACE", "20260101", "20260819", 4),
+    ]
+
+
+@pytest.mark.parametrize(
+    ("bad_from", "bad_to"),
+    [
+        ("2025-08-20", "20260819"),  # 区切り文字入り
+        ("20250820", "20260832"),    # 実在しない暦日
+        (None, "20260819"),          # 欠落
+        ("20260819", "20250820"),    # 逆転した範囲
+    ],
+)
+def test_invalid_dates_stop_before_schema_transaction_or_fetch(
+    monkeypatch, bad_from, bad_to
+):
+    processor = BatchProcessor.__new__(BatchProcessor)
+    processor.database = MagicMock()
+    processor.cache_manager = None
+    processor.fetcher = MagicMock()
+    processor.importer = MagicMock()
+    prepare_schema = MagicMock()
+    monkeypatch.setattr("src.importer.batch.create_all_tables", prepare_schema)
+
+    with pytest.raises(ValueError):
+        processor.process_date_range("RACE", bad_from, bad_to, option=4)
+
+    prepare_schema.assert_not_called()
+    processor.fetcher.fetch.assert_not_called()
+    processor.fetcher.fetch_with_cache.assert_not_called()
+    assert "begin_transaction" not in [
+        name for name, _args, _kwargs in processor.database.mock_calls
+    ]

--- a/tests/test_cache_manager.py
+++ b/tests/test_cache_manager.py
@@ -145,6 +145,35 @@ class TestNlIndex:
         ]
         assert legacy_path.exists()
 
+    def test_v2_complete_cache_is_invalidated_after_setup_boundary_change(
+        self, tmp_path
+    ):
+        """Pre-fix v2 completeness cannot prove the inclusive setup start."""
+        cm = _make_cache(tmp_path)
+        v2_path = cm._nl_dir("RACE") / "20260401.v2.bin"
+        v2_path.write_bytes(cm.HEADER.pack(6) + b"old-v2")
+        cm._save_index(
+            cm._index_path("RACE"),
+            {
+                "20260401": {
+                    "complete": True,
+                    "schema_version": 2,
+                    "count": 1,
+                }
+            },
+        )
+
+        assert cm.has_nl_range("RACE", "20260401", "20260401") is False
+        assert list(cm.read_nl("RACE", "20260401", "20260401")) == []
+
+        cm.write_nl_record("RACE", "20260401", _raw("fresh"))
+        cm.mark_nl_complete("RACE", "20260401")
+
+        assert list(cm.read_nl("RACE", "20260401", "20260401")) == [
+            _raw("fresh")
+        ]
+        assert v2_path.exists()
+
     def test_mark_nl_complete_empty_date(self, tmp_path):
         cm = _make_cache(tmp_path)
         cm.mark_nl_complete("RACE", "20260402")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -413,6 +413,47 @@ jvlink:
             self.assertIsNotNone(result)
 
 
+class TestCacheBuildCommand(unittest.TestCase):
+    """Test fail-before-cache contracts for ``cache build``."""
+
+    def setUp(self):
+        self.runner = CliRunner()
+
+    @patch('src.cache.CacheManager')
+    def test_commands_reject_invalid_dates_before_cache_lookup(
+        self, mock_cache_manager
+    ):
+        example_config = (
+            Path(__file__).resolve().parents[1] / 'config' / 'config.yaml.example'
+        )
+        with self.runner.isolated_filesystem():
+            config_path = Path('config.yaml')
+            config_path.write_text(
+                example_config.read_text(encoding='utf-8'),
+                encoding='utf-8',
+            )
+            for command in ('build', 'rebuild'):
+                with self.subTest(command=command):
+                    mock_cache_manager.reset_mock()
+                    result = self.runner.invoke(
+                        cli,
+                        [
+                            '--config', str(config_path),
+                            'cache', command,
+                            '--spec', 'RACE',
+                            '--from', '20260820',
+                            '--to', '20250820',
+                            '--option', '4',
+                        ],
+                    )
+
+                    self.assertEqual(result.exit_code, 1, result.output)
+                    self.assertIn(
+                        'from_date must not be after to_date', result.output
+                    )
+                    mock_cache_manager.assert_not_called()
+
+
 class TestMonitorCommand(unittest.TestCase):
     """Test monitor command."""
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -338,10 +338,9 @@ class TestFetchCommand(unittest.TestCase):
         self.assertIn('current race-cycle data', help_text)
         self.assertIn('Sunday or Monday may cover two cycles', help_text)
         self.assertIn('ChokyoDate', help_text)
-        # option=3/4 + 終了時刻可の spec では --to が JVOpen 自体を境界付ける
-        self.assertIn('bounds the JVOpen download', help_text)
-        self.assertIn('remain start only', help_text)
-        self.assertIn('bounded calendar-year chunks', help_text)
+        self.assertIn('not a JVOpen end bound', help_text)
+        self.assertIn('historical setup tail', help_text)
+        self.assertIn('single start-only JVOpen', help_text)
 
     @patch('src.importer.batch.BatchProcessor')
     def test_fetch_with_all_args(self, mock_batch_processor):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -342,6 +342,35 @@ class TestFetchCommand(unittest.TestCase):
         self.assertIn('historical setup tail', help_text)
         self.assertIn('single start-only JVOpen', help_text)
 
+    @patch('src.database.create_database_from_config')
+    def test_fetch_rejects_invalid_dates_before_database_initialization(
+        self, mock_create_database
+    ):
+        example_config = (
+            Path(__file__).resolve().parents[1] / 'config' / 'config.yaml.example'
+        )
+        with self.runner.isolated_filesystem():
+            config_path = Path('config.yaml')
+            config_path.write_text(
+                example_config.read_text(encoding='utf-8'),
+                encoding='utf-8',
+            )
+            result = self.runner.invoke(
+                cli,
+                [
+                    '--config', str(config_path),
+                    'fetch',
+                    '--from', '20260820',
+                    '--to', '20250820',
+                    '--spec', 'RACE',
+                    '--db', 'sqlite',
+                ],
+            )
+
+        self.assertEqual(result.exit_code, 1, result.output)
+        self.assertIn('from_date must not be after to_date', result.output)
+        mock_create_database.assert_not_called()
+
     @patch('src.importer.batch.BatchProcessor')
     def test_fetch_with_all_args(self, mock_batch_processor):
         """Test fetch command with all arguments."""

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -338,8 +338,10 @@ class TestFetchCommand(unittest.TestCase):
         self.assertIn('current race-cycle data', help_text)
         self.assertIn('Sunday or Monday may cover two cycles', help_text)
         self.assertIn('ChokyoDate', help_text)
-        self.assertIn('calendar-year chunks', help_text)
-        self.assertIn('adds another chunk', help_text)
+        # option=3/4 + 終了時刻可の spec では --to が JVOpen 自体を境界付ける
+        self.assertIn('bounds the JVOpen download', help_text)
+        self.assertIn('remain start only', help_text)
+        self.assertIn('bounded calendar-year chunks', help_text)
 
     @patch('src.importer.batch.BatchProcessor')
     def test_fetch_with_all_args(self, mock_batch_processor):

--- a/tests/test_historical_cache_write_through.py
+++ b/tests/test_historical_cache_write_through.py
@@ -7,6 +7,9 @@ blob が行数ぶん重複する。
 
 from unittest.mock import MagicMock
 
+import pytest
+
+from src.fetcher.base import FetcherError
 from src.fetcher.historical import HistoricalFetcher
 
 H1_BYTES, H1_ROWS = 28_955, 1_485
@@ -106,3 +109,23 @@ def test_rows_filtered_out_by_to_date_do_not_lose_the_buffer():
 
     assert len(_run(f)) == 2, "範囲外の 1 行だけが除外されること"
     assert _written(cache) == [buff], "先頭行が除外されてもバッファは残ること"
+
+
+def test_failed_stream_restores_cache_and_never_marks_complete():
+    """STOP条件のピン: 失敗後にキャッシュ範囲が complete と誤記録されないこと.
+
+    途中で JVRead が失敗したストリームは、追記済みキャッシュをチェック
+    ポイントまで巻き戻し、いかなる日付にも complete マーカーを付けない。
+    """
+    buff = b"R" * 500
+    cache = MagicMock()
+    cache.checkpoint_nl.return_value = None
+    f = _fetcher(cache, [(500, buff, "f1"), (-502, None, None)])
+    f.parser_factory.parse.return_value = _row(0)
+
+    with pytest.raises(FetcherError, match="-502"):
+        _run(f)
+
+    cache.mark_nl_range_complete.assert_not_called()
+    cache.mark_nl_complete.assert_not_called()
+    cache.restore_nl.assert_called_once_with("RACE", "20220110", None)

--- a/tests/test_jvlink_transport_contract.py
+++ b/tests/test_jvlink_transport_contract.py
@@ -166,33 +166,32 @@ def test_historical_fetcher_reports_setup_cancel_instead_of_no_data():
     jvlink.jv_close.assert_called_once()
 
 
-# --- Official JVOpen fromtime forms (JV-Link仕様書 4.9.0.1(Win) p.17-18) -----
+# --- Official JVOpen setup semantics (JV-Link仕様書 4.9.0.1 p.17-20) --------
 # fromtime は「開始時刻のみ」または「開始-終了」(YYYYMMDDhhmmss-YYYYMMDDhhmmss、
 # 半角ハイフン結合) の2形式のみで、対象条件は「開始時刻より大きく、終了時刻
-# まで」。要求された from_date を包含させるため、セットアップ (option 3/4) は
-# 排他的開始点を前日 23:59:59 に符号化する。終了ポイント時刻を許す dataspec は
-# さらに終了点で要求範囲そのものを提供側で打ち切る。p.18 で終了時刻の指定が
-# 禁止された dataspec (TOKU/DIFF/DIFN/HOSE/HOSN/HOYU/COMM、指定すると -1
-# 「該当データなし」) は開始のみ形式を保つ。
+# まで」。一方 p.20 は option 3/4 について、前月までのセットアップ用データは
+# fromtime より大きい全件を返し、終了時刻が制限するのは今月の通常データ部分
+# だけと明記する。したがって過去年窓を end で分割できるとは扱わず、setup は
+# start-only を1回だけ呼ぶ。要求された from_date を包含させるため、排他的開始点
+# は前日23:59:59に符号化する。option 1/2のcursor契約は変更しない。
 
 
 @pytest.mark.parametrize(
     ("data_spec", "option", "expected_fromtime"),
     [
-        # 終了時刻を許す RACE のセットアップは、from_date を包含する排他的
-        # 開始点 (前日 23:59:59) と終了点で境界付ける
-        ("RACE", 4, "20250819235959-20260819235959"),
-        ("RACE", 3, "20250819235959-20260819235959"),
-        # p.18 の終了時刻禁止リストに載る DIFN は開始のみ。ただし開始点の
-        # 包含符号化は同じ (対になる start-only green)
+        # option 3/4 は、end-capableなRACEを含めてstart-only。p.20上、終了点は
+        # 過去setup dataの上限ではないため、bounded downloadとは主張しない。
+        ("RACE", 4, "20250819235959"),
+        ("RACE", 3, "20250819235959"),
+        # p.18 の終了時刻禁止リストに載る DIFN も同じstart-only形式
         ("DIFN", 4, "20250819235959"),
-        # 複数specのうち1つでも終了時刻禁止なら、連結dataspec全体を開始のみにする
+        # 複数specもsetupはstart-only
         ("RACEDIFN", 4, "20250819235959"),
         # option=1 の差分カーソル契約はこのイテレーションでは変更しない
         ("RACE", 1, "20250820000000"),
     ],
 )
-def test_jvopen_fromtime_bounds_setup_only_for_end_capable_specs(
+def test_jvopen_setup_fromtime_is_start_only_for_the_historical_setup_tail(
     data_spec, option, expected_fromtime
 ):
     jvlink = MagicMock()
@@ -204,25 +203,24 @@ def test_jvopen_fromtime_bounds_setup_only_for_end_capable_specs(
     jvlink.jv_open.assert_called_once_with(data_spec, expected_fromtime, option)
 
 
-def test_adjacent_setup_chunk_opens_tile_exactly_at_the_boundary_second():
-    """隣接チャンクの排他的開始点は直前チャンクの包含終了点に一致すること。
+def test_setup_to_date_does_not_claim_to_bound_the_historical_provider_tail():
+    """to_dateを変えてもsetupのJVOpen引数へ終了点を付けないこと。
 
-    「開始より大きく、終了まで」の公式条件の下で、この一致が隙間ゼロ・
-    重複ゼロの厳密な敷き詰めを与える（深夜0時打刻のファイルも落ちない）。
-    窓は実際に7200秒タイムアウトした本番スコープ 20240820..20260819 の
-    先頭2つの年チャンク。
+    p.20では前月までのsetup dataはfromtime以降の全件が対象で、終了点が効くのは
+    今月の通常dataだけ。年窓ごとに終了点を変えてtailを分割できるという誤契約を
+    作らない。
     """
     jvlink = MagicMock()
     jvlink.jv_open.return_value = (-1, 0, 0, "")
     fetcher = _historical_fetcher(jvlink)
 
     list(fetcher.fetch("RACE", "20240820", "20241231", option=4))
-    list(fetcher.fetch("RACE", "20250101", "20251231", option=4))
+    list(fetcher.fetch("RACE", "20240820", "20260819", option=4))
 
-    first, second = [c.args[1] for c in jvlink.jv_open.call_args_list]
-    assert first == "20240819235959-20241231235959"
-    assert second == "20241231235959-20251231235959"
-    assert second.split("-")[0] == first.split("-")[1]
+    assert [c.args[1] for c in jvlink.jv_open.call_args_list] == [
+        "20240819235959",
+        "20240819235959",
+    ]
 
 
 @pytest.mark.parametrize(

--- a/tests/test_jvlink_transport_contract.py
+++ b/tests/test_jvlink_transport_contract.py
@@ -166,6 +166,102 @@ def test_historical_fetcher_reports_setup_cancel_instead_of_no_data():
     jvlink.jv_close.assert_called_once()
 
 
+# --- Official JVOpen fromtime forms (JV-Link仕様書 4.9.0.1(Win) p.17-18) -----
+# fromtime は「開始時刻のみ」または「開始-終了」(YYYYMMDDhhmmss-YYYYMMDDhhmmss、
+# 半角ハイフン結合) の2形式のみで、対象条件は「開始時刻より大きく、終了時刻
+# まで」。要求された from_date を包含させるため、セットアップ (option 3/4) は
+# 排他的開始点を前日 23:59:59 に符号化する。終了ポイント時刻を許す dataspec は
+# さらに終了点で要求範囲そのものを提供側で打ち切る。p.18 で終了時刻の指定が
+# 禁止された dataspec (TOKU/DIFF/DIFN/HOSE/HOSN/HOYU/COMM、指定すると -1
+# 「該当データなし」) は開始のみ形式を保つ。
+
+
+@pytest.mark.parametrize(
+    ("data_spec", "option", "expected_fromtime"),
+    [
+        # 終了時刻を許す RACE のセットアップは、from_date を包含する排他的
+        # 開始点 (前日 23:59:59) と終了点で境界付ける
+        ("RACE", 4, "20250819235959-20260819235959"),
+        ("RACE", 3, "20250819235959-20260819235959"),
+        # p.18 の終了時刻禁止リストに載る DIFN は開始のみ。ただし開始点の
+        # 包含符号化は同じ (対になる start-only green)
+        ("DIFN", 4, "20250819235959"),
+        # 複数specのうち1つでも終了時刻禁止なら、連結dataspec全体を開始のみにする
+        ("RACEDIFN", 4, "20250819235959"),
+        # option=1 の差分カーソル契約はこのイテレーションでは変更しない
+        ("RACE", 1, "20250820000000"),
+    ],
+)
+def test_jvopen_fromtime_bounds_setup_only_for_end_capable_specs(
+    data_spec, option, expected_fromtime
+):
+    jvlink = MagicMock()
+    jvlink.jv_open.return_value = (-1, 0, 0, "")
+    fetcher = _historical_fetcher(jvlink)
+
+    assert list(fetcher.fetch(data_spec, "20250820", "20260819", option=option)) == []
+
+    jvlink.jv_open.assert_called_once_with(data_spec, expected_fromtime, option)
+
+
+def test_adjacent_setup_chunk_opens_tile_exactly_at_the_boundary_second():
+    """隣接チャンクの排他的開始点は直前チャンクの包含終了点に一致すること。
+
+    「開始より大きく、終了まで」の公式条件の下で、この一致が隙間ゼロ・
+    重複ゼロの厳密な敷き詰めを与える（深夜0時打刻のファイルも落ちない）。
+    窓は実際に7200秒タイムアウトした本番スコープ 20240820..20260819 の
+    先頭2つの年チャンク。
+    """
+    jvlink = MagicMock()
+    jvlink.jv_open.return_value = (-1, 0, 0, "")
+    fetcher = _historical_fetcher(jvlink)
+
+    list(fetcher.fetch("RACE", "20240820", "20241231", option=4))
+    list(fetcher.fetch("RACE", "20250101", "20251231", option=4))
+
+    first, second = [c.args[1] for c in jvlink.jv_open.call_args_list]
+    assert first == "20240819235959-20241231235959"
+    assert second == "20241231235959-20251231235959"
+    assert second.split("-")[0] == first.split("-")[1]
+
+
+@pytest.mark.parametrize(
+    ("bad_from", "bad_to"),
+    [
+        ("2025-08-20", "20260819"),  # 区切り文字入り
+        ("20250820", "2026-08-19"),  # 区切り文字入り
+        ("20250820", "20260832"),    # 実在しない暦日
+        ("", "20260819"),            # 欠落
+        (None, "20260819"),          # 欠落
+        ("20260819", "20250820"),    # 逆転した範囲
+    ],
+)
+def test_invalid_or_inverted_dates_fail_before_any_jvlink_call(bad_from, bad_to):
+    jvlink = MagicMock()
+    jvlink.jv_open.return_value = (-1, 0, 0, "")
+    fetcher = _historical_fetcher(jvlink)
+
+    with pytest.raises(ValueError):
+        list(fetcher.fetch("RACE", bad_from, bad_to, option=4))
+
+    jvlink.jv_init.assert_not_called()
+    jvlink.jv_open.assert_not_called()
+
+
+def test_inverted_cache_range_fails_before_cache_lookup_or_jvlink_call():
+    cache = MagicMock()
+    jvlink = MagicMock()
+    fetcher = _historical_fetcher(jvlink)
+
+    with pytest.raises(ValueError):
+        list(fetcher.fetch_with_cache(cache, "RACE", "20260819", "20250820", 4))
+
+    cache.has_nl_range.assert_not_called()
+    cache.read_nl.assert_not_called()
+    jvlink.jv_init.assert_not_called()
+    jvlink.jv_open.assert_not_called()
+
+
 def test_native_jvgets_uses_byte_array_size_and_filename_arguments():
     com = ThreeArgumentGetsCom((4, memoryview(b"ABCD"), "RACE.jvd"))
     wrapper = _wrapper(com, is_open=True)

--- a/tests/unit/test_jvopen_timeout.py
+++ b/tests/unit/test_jvopen_timeout.py
@@ -35,11 +35,11 @@ def test_open_timeout_defaults_to_two_minutes(monkeypatch, bridge) -> None:
 
 
 def test_open_timeout_follows_the_environment(monkeypatch, bridge) -> None:
-    # A JVOpen that has to answer a JV-Link dialog was measured at 1,008s
-    # against a real provider, so a deployment must be able to wait longer
-    # than the default.
-    monkeypatch.setenv("JVLINK_OPEN_TIMEOUT_SECONDS", "7200")
-    assert _open(bridge) == 7200.0
+    # One year completed in ~1,957s while a two-year official setup remained
+    # legitimately live beyond 7,200s.  The deployment therefore needs a
+    # bounded but substantially larger budget for a five-year rebuild.
+    monkeypatch.setenv("JVLINK_OPEN_TIMEOUT_SECONDS", "43200")
+    assert _open(bridge) == 43200.0
 
 
 def test_open_timeout_treats_an_unset_compose_variable_as_default(monkeypatch, bridge) -> None:
@@ -48,7 +48,7 @@ def test_open_timeout_treats_an_unset_compose_variable_as_default(monkeypatch, b
     assert _open(bridge) == 120.0
 
 
-@pytest.mark.parametrize("value", ["0", "-1", "7201", "later", "1e400", "nan"])
+@pytest.mark.parametrize("value", ["0", "-1", "86401", "later", "1e400", "nan"])
 def test_open_refuses_an_unusable_timeout(monkeypatch, bridge, value: str) -> None:
     monkeypatch.setenv("JVLINK_OPEN_TIMEOUT_SECONDS", value)
     with patch.object(bridge, "_send_command") as send:


### PR DESCRIPTION
## 状態

JRAの複数年RACE setupが7,200秒でtimeoutした実測を、公式option 3/4の意味を変えずに復旧可能にする修正です。

- final PR head: `e7df4dea795a0fc72ab8a14befe33e39850b80aa`
- production/test repair: `69142ab9a62ca2e9bc45a98f97dfb0ac64ba7e83`
- live provider・release・runtime・DB・実cache操作: **未実施**

最初のcandidate `03db892...` は、一般的なstart/end規則をoption 3/4の過去setup tailにも適用して年分割する誤実装でした。公式p.20を再確認して却下し、現headで完全に置き換えています。経緯は[blocker comment](https://github.com/miyamamoto/jrvltsql/pull/238#issuecomment-5377091537)とtracked worklogに残しました。

## 公式契約と修正

固定した正本は `JV-Linkインターフェース仕様書 4.9.0.1 (Win)`（worklogにSHA-256記載）です。

- option 3/4の前月までのsetup dataは `fromtime` より後の全setup dataが対象。終了時刻はhistorical setup tailをboundしない
- setupは要求開始日の直前1秒を指定したstart-only JVOpenを1回だけ使う（例: `20250820` → `20250819235959`）
- option 1/2の既存cursor形式は変更しない
- `--to`はclient-side record filter/cache scopeで、provider download boundとは表示しない
- option 3は単一transaction、option 4はJVOpen応答後のstreamを10,000 recordsごとにcommit
- malformed/missing/inverted dateはJV-Link、cache、schema、transactionより前に拒否
- `JVLINK_OPEN_TIMEOUT_SECONDS`はfinite fail-closedを維持し、上限を86,400秒へ拡張
- 修正前の開始境界で作られたNL cache schema-v2完了マーカーをschema v3で失効。v2 rawは残すが新規取得の完了証拠には使わない
- `cache build/rebuild`も日付検証をlookup/clearより前に実施

## 赤先行証跡

却下candidate `03db892...` への公式契約回帰:

```text
9 failed, 129 passed, 8 subtests passed
```

exact old head `2c969926...` へのcache回帰:

```text
assert v2 completion is False -> actual True
cache build inverted range -> actual exit 0 [CACHED]
cache rebuild inverted range -> actual exit 0 after Cleared 0
3 failed, 1 passed
```

paired greenも維持しています。

## 最終検証

Production/test commit `69142ab9...`:

- `uv lock --check`: pass
- `scripts/validate_test_gate.py`: pass
- Python 3.12.11 full: **4726 passed, 508 skipped, 22 subtests passed**
- fresh git-archive PEP517 build/content gate/isolated wheel init smoke: pass

Final PR head `e7df4dea...`（差分はtracked worklogのみ）:

- corrected focused ring: **379 passed, 10 subtests passed**
- workflow fatal Flake8 (`E9,F63,F7,F82`): **0**
- `compileall` / `git diff --check`: pass
- fresh exact-head git-archive PEP517 build/content gate/isolated wheel init smoke: pass
- disposable wheel SHA-256: `55fe15e6abeb32457372d4b5ba312f6e3ab73987d0e201edaaca1d2868e801bd`
- disposable sdist SHA-256: `4a4dfee21f2ed58686c9b89003915520fe558fcc6911c710576eed9686528490`
- tracked/ignored worktree: clean at push

Detailed commands, official interpretation, rejected hypothesis, review findings, and STOP conditions:
`specs/operations/20260822_jvopen_bounded_setup_worklog.md`.

## Merge後のlive gate

このPR自体では長時間provider callを実行しません。merge後に次の`2.0.0.dev*`を作り、そのexact artifactを開発runtimeへpinしてから、`ingestctl`で単一openの5年RACE option-4 setupを監視実行します。provider応答、cache/progress、DB耐久性、5年coverage、特徴量dtype/NULL整合性、runtime healthを確認するまでproduction `2.0.0`とは扱いません。

KIR運用証跡/引継ぎ: [kps-ingestion-runtime #167](https://github.com/miyamamoto/kps-ingestion-runtime/pull/167)

## Rollback

release/runtime pin前はPR revert/branch abandonment。dev artifact pin後はprior exact `2.0.0.dev2` artifactと既存DB backup/rebuild planへ戻し、部分schema rollbackは行いません。
