### PR TITLE
release: cut 2.0.0.dev3 for five-year setup recovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,13 +9,15 @@
 
 次回リリースは互換性を破る変更を含むため `2.0.0` とする。1.xとしては配布しない。
 
-### 次の開発検証用prerelease
+### 2.0.0.dev3 (開発検証用prerelease)
 
 - 公式 option 3/4 の historical setup tail は終了時刻で上限を切れないため、
   setup を年単位に再帰して後続tailを反復しない。要求開始日を包含する
   start-only `JVOpen` を1回だけ使い、`--to` はclient-side filterとして扱う
 - 複数年setupを有限に監視できるよう `JVLINK_OPEN_TIMEOUT_SECONDS` の許容範囲を
   1〜86,400秒へ拡張する（既定120秒は維持、非有限値と範囲外はfail closed）
+- setup開始境界の修正前に作られたNL cache schema-v2完了markerをschema v3で
+  失効する。`cache build/rebuild`も日付範囲をcache lookup/clearより先に検証する
 
 ### 2.0.0.dev2 (開発検証用prerelease)
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,11 +1,11 @@
 # jrvltsql v2.0.0 Release Notes (unreleased draft)
 
-`2.0.0` is not released yet. `2.0.0.dev2` is a **development-test prerelease**
+`2.0.0` is not released yet. `2.0.0.dev3` is a **development-test prerelease**
 of the official data-contract work. It is **not** a production compatibility
 claim: the 64-bit SDK path, 1.x database migration, and long-run collection are
 still unverified.
 
-Changes queued for the next development prerelease after `2.0.0.dev2`:
+What `2.0.0.dev3` adds over `2.0.0.dev2`:
 
 - option 3/4 setup uses one inclusive-start, start-only `JVOpen`. The official
   historical setup tail is all setup data after `fromtime`; an end timestamp
@@ -14,6 +14,10 @@ Changes queued for the next development prerelease after `2.0.0.dev2`:
 - the finite `JVLINK_OPEN_TIMEOUT_SECONDS` ceiling is raised to 86,400 seconds
   for monitored multi-hour setup recovery; the default remains 120 seconds
   and invalid, non-finite, or larger values fail closed
+- NL cache schema v3 invalidates completeness markers built with the old
+  setup start boundary while retaining their v2 raw bytes separately;
+  `cache build/rebuild` also rejects malformed or inverted ranges before
+  cache lookup or clearing
 
 What `2.0.0.dev2` adds over `2.0.0.dev1`:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "jltsql"
-version = "2.0.0.dev2"
+version = "2.0.0.dev3"
 description = "JRA-VAN DataLab の競馬データをSQLite・PostgreSQLにインポートするツール"
 readme = "README.md"
 license = "Apache-2.0"

--- a/specs/operations/20260822_release_2_0_0_dev3_worklog.md
+++ b/specs/operations/20260822_release_2_0_0_dev3_worklog.md
@@ -1,0 +1,62 @@
+# jrvltsql 2.0.0.dev3 release worklog — 2026-08-22
+
+## Start state and objective
+
+- Objective: publish the merged official start-only JVOpen setup repair as the
+  next development-test prerelease so the registered development collector can
+  run the five-year recovery from an immutable released artifact.
+- Minimum scope: version parity, release-facing changelog/notes, lock update,
+  exact-SHA tests, fresh wheel/sdist gates, PR review/merge, signed evidence by
+  artifact digest, tag and GitHub prerelease. No live provider call, runtime
+  pin, database/cache mutation, Wine registration change, or production
+  `2.0.0` claim belongs to this release-code iteration.
+- Repository: `miyamamoto/jrvltsql`.
+- Worktree: `/home/keiba/scratch/20260822_jrvltsql_release_dev3`.
+- Branch: `release/2.0.0.dev3-20260822`.
+- Base/start HEAD: `9d5c6b1aa0b27769134161623e1dcdeada251884`,
+  exact fetched `origin/master` and squash merge of PR #238.
+- Previous prerelease: tag/release `v2.0.0.dev2` at
+  `3c4650dfceb96df89808291ef29191de506ef85f`; published wheel digest
+  `7c4e2cec80bddbe34f6fc75874c48480e38e33fdde7a3274903bfa0098282376`.
+- Upstream repair evidence: PR #238 final head
+  `e7df4dea795a0fc72ab8a14befe33e39850b80aa`, merged at the base SHA above;
+  Python 3.12 full `4726 passed, 508 skipped, 22 subtests`, final review with
+  no finding, all GitHub checks successful, unresolved threads zero.
+- Operator/recovery evidence remains KIR draft PR #167. Its next live setup
+  operation is prohibited until this release is merged, published and pinned.
+- Implementation is by the primary Codex agent. No Claude session is used:
+  this iteration changes release metadata/version parity only and does not
+  implement a new gate, concurrency boundary, or multi-repository behavior.
+
+## Planned release contract
+
+1. Bump `pyproject.toml`, `src.__version__`, `uv.lock` and exact version tests
+   from `2.0.0.dev2` to `2.0.0.dev3`.
+2. Promote the already-merged “next development prerelease” setup/cache notes
+   to a named dev3 section without weakening the unreleased `2.0.0` warning.
+3. Prove version parity and the updater's PEP 440 prerelease behavior, then run
+   lock/test gate, the Python 3.12 workflow-equivalent suite, fatal lint and
+   clean git-archive wheel/sdist content plus isolated install/init/schema
+   smoke.
+4. Push one release candidate, use one GitHub-native review, aggregate any
+   concrete findings once, and merge only with exact-head checks successful,
+   unresolved threads zero and a clean tracked/ignored worktree.
+5. Rebuild artifacts from the merge SHA, validate content and installed version,
+   create annotated `v2.0.0.dev3`, publish a GitHub prerelease with both exact
+   artifacts, and verify release asset digests against the local build.
+
+## STOP conditions
+
+- Any version mismatch, stale `dev2` current-release statement, lock drift,
+  failed test/content/install smoke, unresolved finding, non-clean worktree,
+  or tag/release name collision stops publication.
+- Do not reuse candidate artifacts after the merge SHA changes; release
+  artifacts must be rebuilt from the exact merged tag target.
+- Do not call JV-Link, mutate the development runtime/database/cache, update a
+  KIR pin, or claim five-year recovery from this metadata-only iteration.
+- Do not publish final `2.0.0`; this is only the Devin-handoff development
+  prerelease requested by the user.
+
+Next safe action: commit/push this start record, open a Draft PR, then make the
+single version/release-note change and write the minimal parity regression
+before running the focused gate.

--- a/specs/operations/20260822_release_2_0_0_dev3_worklog.md
+++ b/specs/operations/20260822_release_2_0_0_dev3_worklog.md
@@ -60,3 +60,30 @@
 Next safe action: commit/push this start record, open a Draft PR, then make the
 single version/release-note change and write the minimal parity regression
 before running the focused gate.
+
+## Release candidate implementation
+
+- The start record was committed/pushed as
+  `8fd981e7da7b220bf92d00a4774d9fafc65b754d`; Draft PR #239 is the
+  authoritative review surface.
+- Version parity was changed from `2.0.0.dev2` to `2.0.0.dev3` in
+  `pyproject.toml`, `src/__init__.py`, the editable project entry in `uv.lock`,
+  and the two current-version updater assertions. `uv lock` reported only
+  `Updated jltsql v2.0.0.dev2 -> v2.0.0.dev3`.
+- The merged setup work is now named under the dev3 sections in CHANGELOG and
+  release notes: one official inclusive-start/start-only setup open, finite
+  timeout ceiling 86,400 seconds, NL cache schema-v3 invalidation, and
+  cache-command fail-before-lookup date validation. The final `2.0.0`
+  unreleased/compatibility warning remains unchanged.
+- No new checker was added in this release-only iteration. Existing version
+  parity coverage already compares source, CLI, project metadata and lock;
+  updater PEP 440 coverage compares final 2.0.0 against dev3.
+- Pre-commit focused evidence on Python 3.12.11:
+  - updater/public-version/distribution/installer selection: **95 passed**;
+  - `uv lock --check`: pass;
+  - `scripts/validate_test_gate.py`: `TEST GATE PASS`;
+  - `git diff --check`: pass.
+
+Next safe action: commit/push the one release candidate, run the full Python
+3.12 and git-archive distribution/install gates on that immutable SHA, record
+their evidence once, and mark PR #239 Ready for one exact-head review.

--- a/specs/operations/20260822_release_2_0_0_dev3_worklog.md
+++ b/specs/operations/20260822_release_2_0_0_dev3_worklog.md
@@ -84,6 +84,36 @@ before running the focused gate.
   - `scripts/validate_test_gate.py`: `TEST GATE PASS`;
   - `git diff --check`: pass.
 
-Next safe action: commit/push the one release candidate, run the full Python
-3.12 and git-archive distribution/install gates on that immutable SHA, record
-their evidence once, and mark PR #239 Ready for one exact-head review.
+## Exact release-candidate validation
+
+- Release candidate commit: `12e35b4ef788ea0fe3d76e56ccb2ab2f387997f4`.
+  It was pushed as Draft PR #239 before the following checks were run.
+- Exact candidate Python 3.12.11 full suite:
+  **4726 passed, 508 skipped, 22 subtests** in 109.59 seconds.
+- Existing release gates on the same candidate:
+  - updater/public-version/distribution/installer focused selection:
+    **95 passed**;
+  - `uv lock --check`: pass;
+  - `scripts/validate_test_gate.py`: `TEST GATE PASS`;
+  - workflow fatal flake8 selection over `src tests scripts tools`: **0**;
+  - `python -m compileall -q src tests scripts tools`: pass;
+  - `git diff --check`: pass.
+- A fresh `git archive` of the exact candidate was built with Python 3.12,
+  rather than from an editable checkout. Distribution content validation and
+  the isolated wheel smoke both passed. The smoke imported from the extracted
+  wheel, ran `init`, `config --show`, `version`, and SQLite `create-tables`,
+  verified actual tables, blocked optional PostgreSQL drivers, and detected no
+  installed-package mutation.
+- Both built metadata surfaces report exactly `jltsql 2.0.0.dev3`:
+  - wheel `jltsql-2.0.0.dev3-py3-none-any.whl` SHA-256
+    `dc142cc5edc61abaf7f58c7033195e0a7e6335a9bbdfbab309fb46dc7debf89a`;
+  - sdist `jltsql-2.0.0.dev3.tar.gz` SHA-256
+    `594c9bccba9250fce5678d15218049b76bbc4f56774c63375039ecc3c0b1deaf`.
+- These are candidate-gate artifacts only. They must not be uploaded after a
+  squash merge; publication artifacts will be rebuilt from the merge SHA and
+  recorded separately in the GitHub release evidence.
+
+Next safe action: commit/push this evidence-only worklog update, rerun the
+focused/fatal lint/git-archive gates on that final PR head, mark PR #239 Ready,
+request one GitHub-native exact-head review, and merge only with successful
+checks, unresolved threads zero, and a clean tracked/ignored worktree.

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,3 +1,3 @@
 """jrvltsql - JRA-VAN データ取得・管理ツール"""
 
-__version__ = "2.0.0.dev2"
+__version__ = "2.0.0.dev3"

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -46,7 +46,7 @@ class TestVersionComparison:
     def test_final_release_is_newer_than_its_development_prerelease(self):
         from src.utils.updater import _version_newer
 
-        assert _version_newer("2.0.0", "2.0.0.dev2") is True
+        assert _version_newer("2.0.0", "2.0.0.dev3") is True
 
 
 class TestGetCurrentVersion:
@@ -75,7 +75,7 @@ class TestGetCurrentVersion:
         version = get_current_version()
         # Source metadata is the candidate version; a stale release tag must
         # not make a development checkout report the previous release.
-        assert version == "2.0.0.dev2"
+        assert version == "2.0.0.dev3"
 
     @patch("subprocess.run")
     def test_fallback_to_installed_distribution_metadata(

--- a/uv.lock
+++ b/uv.lock
@@ -325,7 +325,7 @@ wheels = [
 
 [[package]]
 name = "jltsql"
-version = "2.0.0.dev2"
+version = "2.0.0.dev3"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Scope

Publish merged PR #238 as the next development-test prerelease required by the development recovery runtime.

- base: `9d5c6b1aa0b27769134161623e1dcdeada251884`
- final PR head: `331d12d36a3c1b52ae3eb97ba1d89897b58a320e`
- target version: `2.0.0.dev3`
- production `2.0.0`: explicitly out of scope
- live JV-Link/runtime/database/cache operations: not performed in this PR

## Exact-head evidence

- Python 3.12 full: **4726 passed, 508 skipped, 22 subtests**
- final-head focused release surface: **101 passed**
- workflow fatal flake8: **0**
- `uv lock --check`: pass
- test gate / compile / diff check: pass
- fresh git-archive wheel + sdist content gate: pass
- isolated wheel init/config/version/SQLite create-tables smoke: pass
- wheel and sdist metadata: exactly `2.0.0.dev3`
- final tracked and ignored worktree state: clean

Candidate artifact digests are recorded in the tracked worklog, but will not be reused after squash merge. Release artifacts will be rebuilt from the merge SHA and verified before the annotated tag and GitHub prerelease are published.

Tracked evidence: `specs/operations/20260822_release_2_0_0_dev3_worklog.md`.

Operational continuation after publication: [KIR #167](https://github.com/miyamamoto/kps-ingestion-runtime/pull/167).