### PR TITLE
release: cut 2.0.0.dev5 for H6 provider cancellation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@
 
 次回リリースは互換性を破る変更を含むため `2.0.0` とする。1.xとしては配布しない。
 
+### 2.0.0.dev5 (開発検証用prerelease)
+
+- 実登録済みproviderの5年setupで後から確認できたH6レース中止形に対応する。
+  `DataKubun=9`で既知の3連単組番を保持し、票数欄だけを公式の11バイト空白で
+  返す場合に限り、parserでは`SanrentanHyo=""`、native数値票数列ではSQL
+  `NULL`として保存する。`DataKubun=2/4/5`の空値、tabを混ぜた物理値、
+  callerの`None`や空白値はmutation前に拒否する。速報のraw・parsed-record・
+  batch入口にも同じ検証を適用する。既存のexpanded caller契約ではstatus 9の
+  `SanrentanHyo=""`も受理するため、caller-created mappingへraw provenanceを
+  主張しない
+- H6 `DataKubun=0`はkey-onlyの物理eraseであり、非key本文が非canonicalまたは
+  decode不能でもrace key・固定長・CRLFが正しければ本文検証で削除を抑止しない。
+  live statusは引き続き本文全体をstrictに検証する
+
 ### 2.0.0.dev4 (開発検証用prerelease)
 
 - 実登録済みproviderの5年setupで確認したH1レース中止形に対応する。

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,9 +1,26 @@
 # jrvltsql v2.0.0 Release Notes (unreleased draft)
 
-`2.0.0` is not released yet. `2.0.0.dev4` is a **development-test prerelease**
+`2.0.0` is not released yet. `2.0.0.dev5` is a **development-test prerelease**
 of the official data-contract work. It is **not** a production compatibility
 claim: the 64-bit SDK path, 1.x database migration, and long-run collection are
 still unverified.
+
+What `2.0.0.dev5` adds over `2.0.0.dev4`:
+
+- accepts the exact H6 race-cancellation shape subsequently observed during
+  the registered five-year provider setup: `DataKubun=9` may retain a known
+  trifecta combination while its physical vote field is exactly eleven
+  spaces. The parser exposes `SanrentanHyo=""` and native numeric vote storage
+  uses SQL `NULL`; blank values on live statuses 2/4/5, mixed tab/digit bytes,
+  caller `None`, and caller space-only values remain rejected before mutation.
+  Realtime raw, parsed-record, and batch inputs use the same validation.
+  Existing expanded caller rows with status 9 and `SanrentanHyo=""` remain
+  accepted as SQL `NULL`, so this release does not claim raw-record provenance
+  for caller-created mappings
+- preserves H6 `DataKubun=0` as a key-only physical erase. A noncanonical or
+  undecodable non-key body cannot suppress an exact erase when the type,
+  status, MakeDate, six-field race key, fixed length, and CRLF remain valid;
+  live statuses continue to validate the complete body
 
 What `2.0.0.dev4` adds over `2.0.0.dev3`:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "jltsql"
-version = "2.0.0.dev4"
+version = "2.0.0.dev5"
 description = "JRA-VAN DataLab の競馬データをSQLite・PostgreSQLにインポートするツール"
 readme = "README.md"
 license = "Apache-2.0"

--- a/specs/operations/20260822_release_2_0_0_dev5_worklog.md
+++ b/specs/operations/20260822_release_2_0_0_dev5_worklog.md
@@ -104,3 +104,42 @@ surface before freezing the candidate.
 Next safe action: commit and push the grouped release metadata, freeze its
 full SHA, run the Python 3.12 workflow/release-artifact gates, and append only
 the resulting evidence before the one native review.
+
+## Exact release-candidate validation
+
+- Release candidate commit:
+  `c18179e9efd2a2a11cda472195a8709c1ada3a36`, pushed to Draft PR #244.
+- Exact candidate GitHub Python 3.12 workflow suite:
+  **4,714 passed, 503 skipped, 14 deselected, 21 subtests passed**. The test
+  job also rebuilt both distributions, passed the content checker and passed
+  the isolated wheel init smoke. Lint and Windows batch syntax passed;
+  performance remained the workflow's intentional pull-request skip. Codecov
+  tokenless upload warnings were non-gating and the job concluded success.
+- The local Python 3.12.11 workflow selection executed the same 5,217 selected
+  nodes, produced coverage XML and left an empty `lastfailed` cache. Existing
+  gates on the same exact candidate also passed:
+  - updater/public-version/distribution/installer focused selection:
+    **95 passed**;
+  - H6 plus adjacent realtime selection: **232 passed, 13 skipped, 8 subtests
+    passed**;
+  - `uv lock --check` and `scripts/validate_test_gate.py`;
+  - fatal-only Flake8 selection over `src tests scripts tools`: **0**;
+  - `python -m compileall -q src tests scripts tools`;
+  - strict MkDocs build and `git diff --check`.
+- A fresh `git archive` of exact candidate `c18179e9...`, not the editable
+  worktree, was built with Python 3.12. Distribution content validation and
+  isolated wheel `init`/config/version/SQLite schema smoke passed. Wheel and
+  sdist metadata both report exactly `jltsql 2.0.0.dev5`:
+  - candidate wheel SHA-256
+    `65cb2aee23d8e80ce1336e122da39f0513973c11e9177f5216522e99ede5104d`;
+  - candidate sdist SHA-256
+    `740fcece73f2bc9de3d8d93880d8492e75098845b9a55135496a32cdefcb4d48`.
+- These artifacts are candidate evidence only. They must be removed and must
+  not be uploaded after squash merge; publication artifacts will be rebuilt
+  from the exact merge SHA.
+
+Next safe action: commit and push this evidence-only update, rerun the bounded
+focused/lock/lint/git-archive gates on that final PR head, remove generated
+candidate/worktree artifacts, mark PR #244 Ready and obtain one GitHub-native
+review. Merge only with exact-head CI success, concrete findings addressed,
+unresolved threads zero and tracked/ignored worktree clean.

--- a/specs/operations/20260822_release_2_0_0_dev5_worklog.md
+++ b/specs/operations/20260822_release_2_0_0_dev5_worklog.md
@@ -71,3 +71,36 @@
 Next safe action: commit and push this start record, open one Draft PR, then
 make the grouped version/release-note change and run the focused release
 surface before freezing the candidate.
+
+## Release candidate implementation
+
+- The start record was committed and pushed as
+  `a990c7d4cc14075657bd54466ee0ef8f4ff3328d`; Draft PR #244 is the
+  authoritative review surface.
+- Version parity changed from `2.0.0.dev4` to `2.0.0.dev5` in
+  `pyproject.toml`, `src/__init__.py`, the editable project entry in `uv.lock`,
+  and the two current-version updater assertions. A Python 3.12.11 locked
+  environment reports both source and installed editable metadata as exactly
+  `2.0.0.dev5`; `uv lock --check` passes.
+- CHANGELOG and release notes name dev5 and describe only merged PR #243: the
+  exact physical H6 status-9 eleven-space vote, SQL `NULL` representation,
+  retained strict live-status/caller/raw boundaries, realtime validation, and
+  the status-0 key-only opaque-body erase. The unreleased production `2.0.0`
+  warning remains unchanged.
+- No checker or validator is introduced by this metadata-only iteration, so
+  no new red-first test is required. The merged H6 repair already carries its
+  paired red/green evidence in
+  `specs/operations/20260822_h6_status9_vote_audit_worklog.md`; this release
+  updates existing version assertions rather than adding a duplicate test.
+- Pre-commit Python 3.12.11 evidence:
+  - updater/public-version/distribution/installer focused selection:
+    **95 passed**;
+  - H6 plus adjacent realtime selection: **232 passed, 13 skipped, 8 subtests
+    passed**;
+  - `scripts/validate_test_gate.py`: `TEST GATE PASS`;
+  - source and installed editable version: `2.0.0.dev5`;
+  - `uv lock --check` and `git diff --check`: pass.
+
+Next safe action: commit and push the grouped release metadata, freeze its
+full SHA, run the Python 3.12 workflow/release-artifact gates, and append only
+the resulting evidence before the one native review.

--- a/specs/operations/20260822_release_2_0_0_dev5_worklog.md
+++ b/specs/operations/20260822_release_2_0_0_dev5_worklog.md
@@ -1,0 +1,73 @@
+# jrvltsql 2.0.0.dev5 release worklog — 2026-08-22
+
+## Start state and objective
+
+- Objective: publish the merged H6 provider-cancellation repair as the next
+  immutable development-test prerelease required before the registered
+  five-year JRA `RACE` setup can be retried. Stop at a `2.0.0.dev`
+  prerelease; do not declare or publish production `2.0.0`.
+- Minimum scope: version parity, release-facing changelog/notes, lock update,
+  exact-SHA tests, fresh wheel/sdist gates, PR review/merge, annotated tag and
+  GitHub prerelease with exact artifact digests. Live JV-Link calls, runtime
+  pinning, KIR pinning, database/cache mutation and provider retry belong to
+  dependent iterations after this release is published.
+- Repository: `miyamamoto/jrvltsql`.
+- Dedicated worktree:
+  `/home/keiba/scratch/20260822_jrvltsql_dev5_release`.
+- Branch: `release/2.0.0.dev5-20260822`.
+- Base/start HEAD: `2b5fbcf29b860b4d1ca24d1710fd068834b92de4`, exact
+  fetched `origin/master`, the squash merge of H6 repair PR #243.
+- Functional release delta: PR #243, squash merge
+  `2b5fbcf29b860b4d1ca24d1710fd068834b92de4`. It accepts only the exact
+  eleven-space provider vote in a combination-bearing H6 `DataKubun=9`
+  physical record, normalizes it to parser `SanrentanHyo=""` and SQL `NULL`,
+  keeps statuses `2/4/5` and non-space raw whitespace fail closed, applies the
+  same validator to realtime raw/parsed/batch routes, and preserves status-0
+  key-only erase even when its non-key body is undecodable or malformed.
+- Previous prerelease: tag/release `v2.0.0.dev4` at
+  `18ddb16f664750e35b31527ae85ba09e540ca0a5`; published wheel SHA-256
+  `2eb53ba8e054d6b453bb4e90e6144998a88bbc5a989b26586e604d491b46278b`
+  and sdist SHA-256
+  `9748697db59103260a760fe04e290bcf7dcd0bedc4199b49d6bd2304c2dba8d3`.
+- Dependent operational evidence remains Draft KIR PR #167. KPS feature-type
+  parity remains independent Draft PR #624. Neither may treat this unreleased
+  branch as an installed/runtime version.
+- Implementation is by the primary Codex agent. No Claude session is used:
+  this iteration changes release metadata and documentation only, and does not
+  implement a new gate, concurrency boundary or cross-repository behavior.
+
+## Planned release contract
+
+1. Bump `pyproject.toml`, `src.__version__`, `uv.lock` and exact
+   current-version tests from `2.0.0.dev4` to `2.0.0.dev5`.
+2. Add a named dev5 changelog/release-note section that describes the bounded
+   H6 status-9 physical shape, SQL representation, realtime validation and
+   status-0 opaque-body erase without changing the unreleased production
+   warning.
+3. Prove version parity and PEP 440 prerelease behavior, then run the
+   repository test gate, Python 3.12 workflow-equivalent suite, fatal lint,
+   lock check, and fresh git-archive wheel/sdist content plus isolated
+   install/init/schema smoke.
+4. Push one release candidate and use one GitHub-native review. Aggregate any
+   concrete findings once; merge only with exact-head checks successful,
+   unresolved threads zero and tracked/ignored worktree clean.
+5. Rebuild artifacts from the squash merge SHA, verify content and installed
+   version, create annotated `v2.0.0.dev5`, publish a GitHub prerelease, and
+   compare GitHub asset digests with the local immutable artifacts.
+
+## STOP conditions
+
+- Stop on any version mismatch, stale dev4 current-release statement, lock
+  drift, failed test/content/install smoke, unresolved finding, non-clean
+  worktree, or tag/release name collision.
+- Do not reuse candidate artifacts after squash merge. Publication artifacts
+  must be rebuilt from the exact merge/tag target.
+- Do not call JV-Link, mutate the development runtime/database/cache, update a
+  runtime or KIR pin, or claim five-year recovery in this release-code
+  iteration.
+- Do not publish final `2.0.0`. This is only the development prerelease the
+  user asked to reach before the eventual Devin handoff.
+
+Next safe action: commit and push this start record, open one Draft PR, then
+make the grouped version/release-note change and run the focused release
+surface before freezing the candidate.

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,3 +1,3 @@
 """jrvltsql - JRA-VAN データ取得・管理ツール"""
 
-__version__ = "2.0.0.dev4"
+__version__ = "2.0.0.dev5"

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -46,7 +46,7 @@ class TestVersionComparison:
     def test_final_release_is_newer_than_its_development_prerelease(self):
         from src.utils.updater import _version_newer
 
-        assert _version_newer("2.0.0", "2.0.0.dev4") is True
+        assert _version_newer("2.0.0", "2.0.0.dev5") is True
 
 
 class TestGetCurrentVersion:
@@ -75,7 +75,7 @@ class TestGetCurrentVersion:
         version = get_current_version()
         # Source metadata is the candidate version; a stale release tag must
         # not make a development checkout report the previous release.
-        assert version == "2.0.0.dev4"
+        assert version == "2.0.0.dev5"
 
     @patch("subprocess.run")
     def test_fallback_to_installed_distribution_metadata(

--- a/uv.lock
+++ b/uv.lock
@@ -325,7 +325,7 @@ wheels = [
 
 [[package]]
 name = "jltsql"
-version = "2.0.0.dev4"
+version = "2.0.0.dev5"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Scope

Publish the merged H6 provider-cancellation repair as development prerelease 2.0.0.dev5 before retrying the registered five-year RACE setup. Production 2.0.0 remains explicitly out of scope.

- base: 2b5fbcf29b860b4d1ca24d1710fd068834b92de4
- final review head: 6b1679207708f99aedc5fc5114f1d9caa8dc4901
- target version: 2.0.0.dev5
- live provider/runtime/database/cache operations: not performed in this PR

## Exact-head evidence

- GitHub Python 3.12: 4,714 passed, 503 skipped, 14 deselected, 21 subtests
- GitHub test, lint, and Windows batch syntax: success; performance job intentionally skipped by workflow condition
- local H6 focused: 95 passed
- local H6 plus realtime: 232 passed, 13 skipped, 8 subtests
- version parity, uv lock, test gate, compileall, strict MkDocs, fatal flake8, diff-check: pass
- git-archive wheel sha256: 1f3d337d7c03b9e0b1e3917cdb738f8ed35143108664b1900f63b2fb8594500c
- git-archive sdist sha256: 7b42aed7fb3a74f5f16f62d956030677cb3b1194829e121506a2fd24b01ea8da
- distribution content gate and isolated wheel init/config/SQLite smoke: pass
- start/end worktree: clean

Tracked worklog: specs/operations/20260822_release_2_0_0_dev5_worklog.md.

After merge, release artifacts will be rebuilt from the merge SHA, revalidated, and published as prerelease v2.0.0.dev5. The runtime/database retry is a separate operational iteration.