### PR TITLE
" ’ "の文字を含むレース名の取り込みでエラーとなる

### DIFF
--- a/specs/operations/20260826_pr245_com_buffer_recovery_worklog.md
+++ b/specs/operations/20260826_pr245_com_buffer_recovery_worklog.md
@@ -1,0 +1,63 @@
+# PR #245 COM buffer recovery worklog
+
+## Scope and identity
+
+- Purpose: repair and independently validate `miyamamoto/jrvltsql#245` without broadening into unrelated parser/importer changes.
+- Repository: `miyamamoto/jrvltsql`.
+- Worktree: `/home/keiba/scratch/20260826_jrvltsql_pr245_repair`.
+- Branch: `codex/pr245-buffer-recovery-20260826`.
+- Base `master`: `34a3297a376b56646ff166f9d1de903d92b010c9`.
+- Contributor candidate at start: `7bb78c846260ccfa46e0954c4fea8291c4523409`.
+- PR: <https://github.com/miyamamoto/jrvltsql/pull/245>.
+- Production/release line: `2.0.0.dev5`; no version change belongs to this repair iteration.
+
+## Contract and plan
+
+- Preserve exact JV-Data bytes for latin-1-like, CP1252, and CP932 pywin32 marshal shapes.
+- A trailing COM NUL must not alter encoding-candidate selection.
+- Reject ambiguous recovery rather than returning a same-length corrupted record.
+- Add the paired failing regression first, run it against the contributor candidate, then make the smallest production repair.
+- Run focused transport tests and the repository-required relevant suite at the final full SHA.
+
+## Initial state
+
+- The main `/home/keiba/jrvltsql` checkout was already dirty on an unrelated old branch and is intentionally untouched.
+- The dedicated worktree started clean at the contributor full SHA above.
+- GitHub reported the PR mergeable/clean and its existing test/lint checks successful.
+
+## Red-first evidence
+
+- Added one paired regression for CP1252 and CP932 marshal strings with trailing COM NUL padding.
+- On unchanged production code at `7bb78c846260ccfa46e0954c4fea8291c4523409`, both parameters failed: the recovered bytes differed from the original bytes at index 10.
+- Added the fail-closed oversized-prefix contract. With the ambiguity branch temporarily absent, the focused test failed with `DID NOT RAISE JVLinkError`.
+- These failures establish that the tests can say no; they are not success-only coverage.
+
+## Repair
+
+- Strip only trailing COM NUL padding before building encoding candidates. JV-Data fixed records end in CRLF, so this does not discard a valid record suffix.
+- Require all exact-length candidates to agree.
+- If only oversized candidates exist, compare their truncated prefixes and reject differing bytes as ambiguous instead of selecting by candidate order.
+
+## Validation
+
+- Python 3.13 focused transport module: `84 passed`.
+- Fresh isolated Python 3.12.11 focused transport module: `84 passed`.
+- Fresh isolated Python 3.12.11 repository suite (integration/e2e/slow excluded in the same shape as CI): `4735 passed, 503 skipped, 14 deselected, 21 subtests passed`.
+- The first full-suite collection attempt was unable to import the optional PostgreSQL drivers. After installing the locked `postgres` extra into the isolated environment, the same command passed as recorded above; this was an environment setup issue, not a product failure.
+- Workflow-equivalent fatal flake8 selection (`E9,F63,F7,F82`): pass with zero findings.
+- `python scripts/validate_test_gate.py`: `TEST GATE PASS`.
+- `uv lock --check`: pass.
+- `git diff --check`: pass.
+- A direct Ruff run reports pre-existing style debt in `wrapper.py`; none was introduced by this bounded repair and Ruff is not the workflow's fatal lint gate.
+
+## Remaining before merge
+
+- Commit and push this exact repair to the contributor PR branch, recording the resulting full SHA on the PR.
+- Confirm required GitHub checks, actionable review findings, and unresolved-thread count on that pushed SHA.
+- Merge only from a clean worktree after those gates are green.
+
+## STOP conditions
+
+- Stop if the dedicated worktree drifts outside the files listed in this worklog.
+- Stop rather than guessing if actual COM padding cannot be represented without corrupting one of the paired marshal paths.
+- Do not bump or tag a release from this branch.

--- a/specs/operations/20260826_pr245_com_buffer_recovery_worklog.md
+++ b/specs/operations/20260826_pr245_com_buffer_recovery_worklog.md
@@ -1,5 +1,7 @@
 # PR #245 COM buffer recovery worklog
 
+All dates in this worklog use the repository operator timezone, Asia/Tokyo.
+
 ## Scope and identity
 
 - Purpose: repair and independently validate `miyamamoto/jrvltsql#245` without broadening into unrelated parser/importer changes.
@@ -50,11 +52,13 @@
 - `git diff --check`: pass.
 - A direct Ruff run reports pre-existing style debt in `wrapper.py`; none was introduced by this bounded repair and Ruff is not the workflow's fatal lint gate.
 
-## Remaining before merge
+## Immutable candidate and remaining merge gate
 
-- Commit and push this exact repair to the contributor PR branch, recording the resulting full SHA on the PR.
-- Confirm required GitHub checks, actionable review findings, and unresolved-thread count on that pushed SHA.
-- Merge only from a clean worktree after those gates are green.
+- The production/test/worklog repair was committed and pushed as full SHA `eb6e1ec32f5ea553a1fbc12d4c59d12c08c8f186` to the contributor PR branch.
+- The Python 3.12 full suite, focused Python 3.12/3.13 tests, fatal lint, lock, test-gate and diff checks recorded above are bound to that full SHA.
+- GitHub test, lint, Windows batch syntax, and CodeRabbit checks all completed successfully on that SHA; performance is the workflow's intentional pull-request skip.
+- This evidence-only worklog update does not change production or tests. Its resulting full SHA is recorded in the PR rather than creating a prohibited self-referential worklog commit loop.
+- Merge only after replying to and resolving the current worklog review threads, confirming unresolved-thread count zero, and cleaning generated ignored artifacts from the dedicated worktree.
 
 ## STOP conditions
 

--- a/src/jvlink/wrapper.py
+++ b/src/jvlink/wrapper.py
@@ -54,6 +54,30 @@ CP1252_TO_BYTE = {
 }
 
 
+def _decode_via_cp1252_table(value: str, method_name: str) -> bytes:
+    """CP1252 で marshaling されたバッファを 1 文字 1 バイトで戻す。
+
+    この経路は「1 文字 = 1 バイト」を前提にしているので、CP932 として渡ってきた
+    バッファに当ててはいけない。呼び出し側が expected_size で長さを検査する。
+    """
+    result = bytearray()
+    for char in value:
+        codepoint = ord(char)
+        if codepoint <= 0xFF:
+            result.append(codepoint)
+        elif codepoint in CP1252_TO_BYTE:
+            result.append(CP1252_TO_BYTE[codepoint])
+        else:
+            try:
+                result.extend(char.encode("cp932"))
+            except UnicodeEncodeError as exc:
+                raise JVLinkError(
+                    f"{method_name} buffer contains an unrecoverable "
+                    f"character U+{codepoint:04X}"
+                ) from exc
+    return bytes(result)
+
+
 def _recover_com_buffer(value, expected_size: int, method_name: str) -> bytes:
     """Recover the exact JV-Data bytes from a pywin32 out buffer.
 
@@ -70,35 +94,53 @@ def _recover_com_buffer(value, expected_size: int, method_name: str) -> bytes:
                 f"{method_name} buffer contains an irreversible Unicode replacement character"
             )
 
-        try:
-            recovered = value.encode("latin-1")
-        except UnicodeEncodeError:
-            if any(ord(char) in CP1252_TO_BYTE for char in value):
-                result = bytearray()
-                for char in value:
-                    codepoint = ord(char)
-                    if codepoint <= 0xFF:
-                        result.append(codepoint)
-                    elif codepoint in CP1252_TO_BYTE:
-                        result.append(CP1252_TO_BYTE[codepoint])
-                    else:
-                        try:
-                            result.extend(char.encode("cp932"))
-                        except UnicodeEncodeError as exc:
-                            raise JVLinkError(
-                                f"{method_name} buffer contains an unrecoverable "
-                                f"character U+{codepoint:04X}"
-                            ) from exc
-                recovered = bytes(result)
-            else:
-                try:
-                    recovered = value.encode("cp932")
-                except UnicodeEncodeError as exc:
-                    bad = exc.object[exc.start]
-                    raise JVLinkError(
-                        f"{method_name} buffer contains an unrecoverable "
-                        f"character U+{ord(bad):04X}"
-                    ) from exc
+        # どの符号化で戻すかは、marshaling 経路によって変わる。pywin32 は同じ
+        # バッファを latin-1 相当（1 バイト 1 符号位置）でも、CP1252 でも、
+        # CP932 のテキストとしても渡してくる。
+        #
+        # 「1 文字 = 1 バイト」を前提にした経路（latin-1 と CP1252 表）は、
+        # CP932 として渡ってきたバッファに当てると長さが縮む。CP932 では
+        # 2 バイトなのに 1 バイトに落ちる文字が 2 群ある:
+        #
+        #   符号位置 0xFF 以下      ´ ¨ ± × ÷ ° § ¶
+        #   CP1252 表に載っている   ‘ ’ “ ” † ‡ … ‰
+        #
+        # 実例: 1987 年の RA レコードの Hondai が「’８７ゴールデンスパーＴ…」で、
+        # 年を表す ’（U+2019・CP932 では 81 66）が CP1252 表で 0x92 の 1 バイトに
+        # なり、1272 バイトのレコードが 1271 バイトになって取り込みが止まった。
+        #
+        # expected_size は呼び出し側が JV-Link から受け取った正解なので、推測せず
+        # これで選ぶ。長さの合った候補だけを採る。
+        candidates: list[bytes] = []
+        failures: list[str] = []
+        for build in (
+            lambda: value.encode("latin-1"),
+            lambda: value.encode("cp932"),
+            lambda: _decode_via_cp1252_table(value, method_name),
+        ):
+            try:
+                candidates.append(build())
+            except UnicodeEncodeError as exc:
+                bad = exc.object[exc.start]
+                failures.append(f"U+{ord(bad):04X}")
+
+        # 長さがちょうど合うものを最優先する。「以上」だけで選ぶと、CP1252 で
+        # marshaling されたバッファに cp932 を当てた結果（1 文字 2 バイトに
+        # 膨らむ）を採ってしまう。
+        recovered = next((c for c in candidates if len(c) == expected_size), None)
+        if recovered is None:
+            recovered = next((c for c in candidates if len(c) > expected_size), None)
+
+        if recovered is None:
+            if failures:
+                raise JVLinkError(
+                    f"{method_name} buffer contains an unrecoverable "
+                    f"character {failures[0]}"
+                )
+            raise JVLinkError(
+                f"{method_name} buffer could not be recovered at its return byte "
+                f"count of {expected_size}"
+            )
     else:
         raise JVLinkError(
             f"{method_name} returned unsupported buffer type {type(value).__name__}"

--- a/src/jvlink/wrapper.py
+++ b/src/jvlink/wrapper.py
@@ -94,6 +94,13 @@ def _recover_com_buffer(value, expected_size: int, method_name: str) -> bytes:
                 f"{method_name} buffer contains an irreversible Unicode replacement character"
             )
 
+        # Some COM dispatch paths expose one or more terminator/padding NULs
+        # after the byte count returned by JVRead.  They are not JV-Data (a
+        # fixed record ends in CRLF), and including them in candidate lengths
+        # can make a CP1252 buffer look like CP932 or vice versa.  Remove only
+        # this unambiguous trailing padding before choosing an encoding.
+        value = value.rstrip("\x00")
+
         # どの符号化で戻すかは、marshaling 経路によって変わる。pywin32 は同じ
         # バッファを latin-1 相当（1 バイト 1 符号位置）でも、CP1252 でも、
         # CP932 のテキストとしても渡してくる。
@@ -127,9 +134,31 @@ def _recover_com_buffer(value, expected_size: int, method_name: str) -> bytes:
         # 長さがちょうど合うものを最優先する。「以上」だけで選ぶと、CP1252 で
         # marshaling されたバッファに cp932 を当てた結果（1 文字 2 バイトに
         # 膨らむ）を採ってしまう。
-        recovered = next((c for c in candidates if len(c) == expected_size), None)
+        exact_candidates = {
+            candidate for candidate in candidates if len(candidate) == expected_size
+        }
+        if len(exact_candidates) > 1:
+            raise JVLinkError(
+                f"{method_name} buffer recovery is ambiguous at its return byte "
+                f"count of {expected_size}"
+            )
+        recovered = next(iter(exact_candidates), None)
         if recovered is None:
-            recovered = next((c for c in candidates if len(c) > expected_size), None)
+            # Preserve compatibility with genuinely oversized COM buffers,
+            # but never select one encoding merely because it was tried first.
+            # If their returned prefixes disagree, guessing would silently
+            # corrupt a record while still satisfying the byte count.
+            oversized_prefixes = {
+                candidate[:expected_size]
+                for candidate in candidates
+                if len(candidate) > expected_size
+            }
+            if len(oversized_prefixes) > 1:
+                raise JVLinkError(
+                    f"{method_name} buffer recovery is ambiguous above its return "
+                    f"byte count of {expected_size}"
+                )
+            recovered = next(iter(oversized_prefixes), None)
 
         if recovered is None:
             if failures:

--- a/tests/test_jvlink_transport_contract.py
+++ b/tests/test_jvlink_transport_contract.py
@@ -782,3 +782,32 @@ def test_recover_com_buffer_still_handles_a_cp1252_marshaled_buffer():
     recovered = _recover_com_buffer(marshaled, len(raw), "JVRead")
 
     assert recovered == raw
+
+
+@pytest.mark.parametrize("marshal_encoding", ["cp1252", "cp932"])
+def test_recover_com_buffer_ignores_trailing_com_nul_before_choosing_encoding(
+    marshal_encoding,
+):
+    """COM末尾NULを候補長へ混ぜても、別encodingを誤選択してはいけない。"""
+    from src.jvlink.wrapper import _recover_com_buffer
+
+    raw = b"A" * 10 + b"\x91\x92\x93\x94" + b"B" * 10
+    trailing_nuls = 1
+    if marshal_encoding == "cp932":
+        raw = b"A" * 10 + "‘’“”".encode("cp932") + b"B" * 10
+        # Four collapsed two-byte symbols plus four padding NULs produce the
+        # same candidate length, so length equality alone picks wrong bytes.
+        trailing_nuls = 4
+    marshaled = raw.decode(marshal_encoding) + "\x00" * trailing_nuls
+
+    recovered = _recover_com_buffer(marshaled, len(raw), "JVRead")
+
+    assert recovered == raw
+
+
+def test_recover_com_buffer_rejects_disagreeing_oversized_prefixes():
+    """期待長を満たす複数候補のbytesが違うなら、推測で成功させない。"""
+    from src.jvlink.wrapper import _recover_com_buffer
+
+    with pytest.raises(JVLinkError, match="ambiguous"):
+        _recover_com_buffer("¢A", 1, "JVRead")

--- a/tests/test_jvlink_transport_contract.py
+++ b/tests/test_jvlink_transport_contract.py
@@ -706,3 +706,79 @@ def test_historical_wait_rejects_count_overshoot_and_status_error_immediately():
                 interval=0.01,
             )
         jvlink.jv_status.assert_called_once()
+
+
+# --- JVRead の往復変換でレコードが 1 バイト縮む回帰 ---
+#
+# pywin32 は同じバッファを latin-1 相当でも CP1252 でも CP932 のテキストとしても
+# 渡してくる。「1 文字 = 1 バイト」を前提にした戻し方を CP932 のバッファへ当てると
+# 長さが縮む。CP932 では 2 バイトなのに 1 バイトへ落ちる文字が 2 群ある。
+CP932_TWO_BYTE_BUT_LATIN1_CODEPOINT = [
+    b"\x81\x4c",  # U+00B4 ´
+    b"\x81\x4e",  # U+00A8 ¨
+    b"\x81\x7d",  # U+00B1 ±
+    b"\x81\x7e",  # U+00D7 ×
+    b"\x81\x80",  # U+00F7 ÷
+    b"\x81\x8b",  # U+00B0 °
+    b"\x81\x98",  # U+00A7 §
+    b"\x81\xf7",  # U+00B6 ¶
+]
+CP932_TWO_BYTE_BUT_IN_CP1252_TABLE = [
+    b"\x81\x65",  # U+2018 ‘
+    b"\x81\x66",  # U+2019 ’   実際に取り込みを止めた文字
+    b"\x81\x67",  # U+201C “
+    b"\x81\x68",  # U+201D ”
+    b"\x81\xf5",  # U+2020 †
+    b"\x81\xf6",  # U+2021 ‡
+    b"\x81\x63",  # U+2026 …
+    b"\x81\xf1",  # U+2030 ‰
+]
+
+
+@pytest.mark.parametrize(
+    "two_byte",
+    CP932_TWO_BYTE_BUT_LATIN1_CODEPOINT + CP932_TWO_BYTE_BUT_IN_CP1252_TABLE,
+)
+def test_recover_com_buffer_keeps_every_two_byte_cp932_character(two_byte):
+    """CP932 で 2 バイトの文字は、符号位置が何であれ 2 バイトのまま戻す。"""
+    from src.jvlink.wrapper import _recover_com_buffer
+
+    raw = b"A" * 635 + two_byte + b"B" * 635
+    assert len(raw) == 1272
+
+    recovered = _recover_com_buffer(raw.decode("cp932"), len(raw), "JVRead")
+
+    assert recovered == raw
+
+
+def test_recover_com_buffer_restores_the_ra_record_that_stopped_the_import():
+    """実際に取り込みを止めた RA レコードを戻せること。
+
+    1987-12-05 阪神 5 回 1 日目 9R。Hondai（競走名本題・data[32:92]）が
+    「’８７ゴールデンスパーＴ」で始まり、年を表す ’（U+2019・CP932 では 81 66）が
+    CP1252 表で 0x92 の 1 バイトになっていた。1272 -> 1271。
+    """
+    from src.jvlink.wrapper import _recover_com_buffer
+
+    header = b"RA720021220198712050905010910000"
+    hondai = "’８７ゴールデンスパーＴ".encode("cp932")
+    raw = header + hondai + b"\x81\x40" * ((1272 - len(header) - len(hondai)) // 2)
+    assert len(raw) == 1272
+    assert raw[32:34] == b"\x81\x66"  # Hondai の先頭が ’
+
+    recovered = _recover_com_buffer(raw.decode("cp932"), len(raw), "JVRead")
+
+    assert recovered == raw
+    assert recovered[32:34] == b"\x81\x66"
+
+
+def test_recover_com_buffer_still_handles_a_cp1252_marshaled_buffer():
+    """CP1252 で渡ってきたバッファは従来どおり 1 文字 1 バイトで戻す。"""
+    from src.jvlink.wrapper import _recover_com_buffer
+
+    raw = b"A" * 10 + b"\x91\x92\x93\x94" + b"B" * 10  # CP1252 の ‘ ’ “ ”
+    marshaled = raw.decode("cp1252")
+
+    recovered = _recover_com_buffer(marshaled, len(raw), "JVRead")
+
+    assert recovered == raw


### PR DESCRIPTION
JVRead の往復変換でレコードが 1 バイト短くなり、取り込みが止まっていた。

    JVLinkError: JVRead buffer is shorter than its return byte count: 1271 < 1272

実際に止まったレコード（多年 option=4 setup の実走・435,277 レコード目）:

    レコード  RA（レース詳細・1272 バイト）
    レース    1987-12-05 阪神(09) 5 回 1 日目 9R
    項目      Hondai（競走名本題）data[32:92]
    内容      ’８７ゴールデンスパーＴ…
    原因文字  ’ (U+2019)  CP932 = 81 66（2 バイト）

pywin32 は同じバッファを latin-1 相当（1 バイト 1 符号位置）でも CP1252 でも CP932 のテキストとしても渡してくる。_recover_com_buffer は「1 文字 = 1 バイト」を 前提にした 2 つの経路を先に試すため、CP932 として渡ってきたバッファに当たると
長さが縮む。CP932 では 2 バイトなのに 1 バイトへ落ちる文字が 2 群ある。

    符号位置 0xFF 以下     ´ ¨ ± × ÷ ° § ¶      latin-1 経路が 1 バイトにする
    CP1252 表に載っている  ‘ ’ “ ” † ‡ … ‰      CP1252 経路が 1 バイトにする

上の実例は後者。’ が CP1252 表で 0x92 の 1 バイトになっていた。

expected_size は呼び出し側が JV-Link から受け取った正解なので、推測で経路を選ばず これで選ぶ。3 通り（latin-1 / cp932 / CP1252 表）を作り、長さがちょうど合うものを 最優先で採る。「以上」だけで選ぶと、CP1252 で marshaling されたバッファに cp932 を 当てた結果（1 文字 2 バイトに膨らむ）を採ってしまうため、完全一致を先に見る。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recovery of imported text containing mixed character encodings.
  * Prevented Japanese characters from being expanded or truncated during data import.
  * Preserved accurate byte lengths and exact record contents, including data with trailing padding.
  * Added safer handling for ambiguous or conflicting encoded data.

* **Tests**
  * Added regression coverage for affected character combinations and records.
  * Verified compatibility with CP1252-marshaled data and exact byte preservation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->