### PR TITLE
JVOpen の fromtime を暦年で刻むことによる セットアップ速度の大幅高速化

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -31,12 +31,14 @@ jltsql fetch --from 20260101 --to 20260417 --spec RACE --option 1
 `option 4` は長期間をまとめて取得するため、一定件数ごとにコミットします。途中で中断しても、
 そこまでに取り込んだぶんは残ります。
 
-範囲形式 `fromtime` を使える spec（`RACE` / `SLOP` / `WOOD`）は、`--from`〜`--to` を
-暦年で刻んで `JVOpen` を繰り返します。1 回の `JVOpen` に並ぶ対象ファイル数が `JVRead`
-1 回の費用を決めるためで、`--to` はそのまま download 範囲の終端になります。
-終了時刻を指定できない spec（`TOKU` / `DIFN` / `HOSN` / `HOYU` / `COMM` など）は
-要求開始日の直前1秒を指定した start-only `JVOpen` を 1 回だけ使い、この場合の `--to` は
-取得後の client-side filter です。
+実機で範囲形式 `fromtime` を確認済みの `RACE`（option `1` / `3` / `4`）は、
+`--from`〜`--to` を暦年で刻んで `JVOpen` を繰り返します。1 回の `JVOpen` に並ぶ
+対象ファイル数が `JVRead` 1 回の費用を決めるためで、`--to` はそのまま download 範囲の
+終端になります。option `2` は `RACE` でも start-only です。終了時刻を指定できない spec
+（`TOKU` / `DIFN` / `HOSN` / `HOYU` / `COMM` など）と、range挙動を実機確認していない
+spec（`SLOP` / `WOOD` を含む）も、安全側で start-only `JVOpen` を 1 回だけ使います。
+start-onlyの場合の `--to` は取得後の client-side filterです。option `3` / `4` は要求開始日の
+直前 `23:59:59`、option `1` / `2` は要求開始日の `00:00:00` を開始cursorに使います。
 複数年setupは数時間かかり得るため、配備側では監視可能な有限の
 `JVLINK_OPEN_TIMEOUT_SECONDS`（1〜86,400秒、既定120秒）を指定できます。
 

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -31,10 +31,12 @@ jltsql fetch --from 20260101 --to 20260417 --spec RACE --option 1
 `option 4` は長期間をまとめて取得するため、一定件数ごとにコミットします。途中で中断しても、
 そこまでに取り込んだぶんは残ります。
 
-`option 3/4` の過去setup dataは公式仕様上 `fromtime` より後の全件が対象です。
-終了時刻を付けても過去setup部分の上限にはならないため、`jltsql` は要求開始日の
-直前1秒を指定したstart-only `JVOpen`を1回だけ使います。`--to` は取得後の
-client-side filterであり、download量を指定範囲へ制限するオプションではありません。
+範囲形式 `fromtime` を使える spec（`RACE` / `SLOP` / `WOOD`）は、`--from`〜`--to` を
+暦年で刻んで `JVOpen` を繰り返します。1 回の `JVOpen` に並ぶ対象ファイル数が `JVRead`
+1 回の費用を決めるためで、`--to` はそのまま download 範囲の終端になります。
+終了時刻を指定できない spec（`TOKU` / `DIFN` / `HOSN` / `HOYU` / `COMM` など）は
+要求開始日の直前1秒を指定した start-only `JVOpen` を 1 回だけ使い、この場合の `--to` は
+取得後の client-side filter です。
 複数年setupは数時間かかり得るため、配備側では監視可能な有限の
 `JVLINK_OPEN_TIMEOUT_SECONDS`（1〜86,400秒、既定120秒）を指定できます。
 

--- a/specs/operations/20260826_pr246_yearly_jvopen_repair_worklog.md
+++ b/specs/operations/20260826_pr246_yearly_jvopen_repair_worklog.md
@@ -1,0 +1,70 @@
+# PR #246 yearly JVOpen repair worklog
+
+## Scope and identity
+
+- Purpose: independently repair and validate `miyamamoto/jrvltsql#246` before merge.
+- Repository: `miyamamoto/jrvltsql`.
+- Worktree: `/home/keiba/scratch/20260826_jrvltsql_pr246_repair`.
+- Branch: `codex/pr246-chunk-close-20260826`.
+- Base `master`: `34a3297a376b56646ff166f9d1de903d92b010c9`.
+- Contributor candidate at start: `cfd0c0b0fbcbca9497a31194a0d2d941be841441`.
+- PR: <https://github.com/miyamamoto/jrvltsql/pull/246>.
+- Production/release line: `2.0.0.dev5`; version publication is a separate post-merge iteration.
+- After PR #245 merged, this branch was cleanly rebased onto new `master` full SHA `2ed75a8e4873dbde786f3b0f773249ac639f2730`. The old base above remains the contributor start identity, not the merge target.
+
+## Minimum repair contract
+
+- A failed `JVClose` after an otherwise successful chunk must fail the fetch, prevent the next `JVOpen`, and prevent an NL-cache complete marker. A close failure must not replace an already-active primary exception.
+- CLI/docs must state that option 2 is start-only even for a range-capable dataspec, and distinguish option 1/2 midnight cursors from option 3/4 previous-second cursors.
+- Cross-chunk `-402` self-repair must replay only the successfully emitted prefix of the active chunk, excluding all records emitted by earlier chunks.
+- The range-fromtime allowlist must contain only provider combinations with recorded live evidence. PR #246 records live range evidence for `RACE`; it records no equivalent SLOP/WOOD run, so those specs remain start-only until separately verified.
+- Preserve boundary tiling, option-specific transaction ownership, cache rollback, and existing start-only behavior for non-allowlisted specs.
+
+## Initial review findings
+
+- `HistoricalFetcher._fetch_one_open()` catches `jv_close()` exceptions and logs a warning, then the outer fetch can open the next chunk and mark the cache range complete. This is a correctness and completeness failure, not advisory cleanup.
+- The CLI single-open note attributes start-only behavior only to dataspec capability, omitting option 2's separate start-only contract. This matches the unresolved GitHub review thread.
+- The new cross-chunk baseline is production-critical but lacks a regression that exercises recovery in chunk 2 after chunk 1 emitted rows.
+- `RANGE_FROMTIME_DATA_SPECS` says only live-verified specs may be included, while the PR body provides live measurements only for `RACE` but enables `SLOP` and `WOOD` too.
+
+## Red-first plan
+
+Add the smallest paired regression around the existing yearly-chunk test module, run it against the unchanged contributor production code, and record the exact failure before changing production. Do not create one test per reviewer hypothesis where one parameterized or adjacent contract can pin the behavior.
+
+## Red-first evidence
+
+- On unchanged contributor production `cfd0c0b0fbcbca9497a31194a0d2d941be841441`, the focused yearly-chunk module reported **2 failed, 43 passed**:
+  - the provider allowlist contained unverified `SLOP` and `WOOD` in addition to `RACE`;
+  - a first-chunk `JVClose` exception produced `DID NOT RAISE FetcherError`, opened the second chunk, and logged `Fetch completed`.
+- The cross-chunk replay implementation was already correct. To prove the new regression can detect its loss, the baseline subtraction was temporarily replaced with the full fetch count. The single test failed exactly `assert 5 == 2`; the production subtraction was restored immediately.
+
+## Repair implemented
+
+- A successful chunk now becomes complete only after `JVClose` succeeds. A close failure raises `FetcherError`, so the next chunk and cache-complete marker are unreachable.
+- If a provider/read exception is already unwinding, a secondary close exception is logged without replacing the primary exception.
+- The range allowlist is reduced to the only live-evidenced spec, `RACE`; `SLOP` and `WOOD` use the safe start-only path pending their own provider evidence.
+- CLI/help/docs now describe option 2 as start-only even for `RACE`, name the measured allowlist honestly, and distinguish the option 1/2 midnight cursor from the option 3/4 previous-second cursor.
+- Added one cross-chunk recovery regression that fixes the replay count at the active chunk's two-row prefix rather than the five-row request total.
+
+## Validation so far
+
+- Yearly-chunk plus CLI module on Python 3.12.11: **80 passed, 10 subtests passed**.
+- Affected transport/batch/cache/recovery/date/constants/retired-spec ring on Python 3.12.11: **377 passed, 10 subtests passed**.
+- Workflow-equivalent Python 3.12.11 repository suite (integration/e2e/slow excluded): **4759 passed, 503 skipped, 14 deselected, 21 subtests passed**.
+- Workflow fatal flake8 selection (`E9,F63,F7,F82`): zero findings.
+- `python -m compileall -q src tests scripts tools`: pass.
+- `scripts/validate_test_gate.py`: `TEST GATE PASS` under Python 3.12.
+- `uv lock --check` and `git diff --check`: pass.
+- Before the rebase, the aggregated repair commit was `a4fe2aaff8957ff34507888a524a7f606a209ac6`; the full-suite result above is bound to that exact production/test tree.
+- After rebasing onto merged PR #245, the combined candidate `8783ad6478a94545dcef4da12ba803ba72873f0e` passed the affected ring including the newly merged COM transport tests: **398 passed, 10 subtests passed**. Test-gate, lock, fatal lint and diff checks also passed. The rebase added only the independently full-tested PR #245 delta; GitHub will run the workflow-equivalent full suite on the pushed combined head.
+
+## Remaining before merge
+
+- Push one updated contributor candidate, record its final full SHA on PR #246 (without a self-referential worklog commit), reply to/resolve the existing documentation and baseline threads, and wait for exact-head checks.
+- Merge only with all checks green, unresolved threads zero, and tracked/ignored worktree clean.
+
+## STOP conditions
+
+- Stop on drift outside this dedicated worktree or on any live JV-Link/provider, database, cache, Wine-prefix, registration, or release mutation.
+- Do not guess that an unmeasured dataspec shares RACE provider behavior.
+- Do not merge if close failure can be reported as success, cache completion can survive a failed chunk lifecycle, or unresolved review threads remain.

--- a/src/cli/main.py
+++ b/src/cli/main.py
@@ -39,8 +39,9 @@ FETCH_NOTE_TO_CLIENT_FILTER = (
     "範囲形式を使える dataspec では JVOpen の終端にもなります。"
 )
 FETCH_NOTE_TO_SINGLE_OPEN = (
-    "この dataspec は範囲形式 fromtime を使えないため、--to を狭めても"
-    "サーバからのダウンロード量は減りません（終了時刻を指定できない種別です）。"
+    "この要求は start-only JVOpen です。終了時刻を使えない dataspec に加え、"
+    "option=2 と、range挙動を実機確認していない dataspec も安全側で該当します。"
+    "--to を狭めてもサーバからのダウンロード量は減りません。"
 )
 FETCH_NOTE_TO_RANGE_CHUNKED = (
     "この dataspec は --from〜--to を暦年で刻んで JVOpen を繰り返します。"
@@ -412,7 +413,8 @@ def update(ctx, force):
         "End date (YYYYMMDD). Filters Year+MonthDay and HC/WC ChokyoDate "
         "client-side; records without either date are kept and prevent a "
         "complete-cache marker. For a dataspec that accepts a range fromtime "
-        "(RACE, SLOP, WOOD) it is also the JVOpen end bound: the request is "
+        "(currently live-verified RACE, except option 2) it is also the "
+        "JVOpen end bound: the request is "
         "split into one JVOpen per calendar year, because the per-read cost "
         "grows with the number of files one JVOpen lists. Every other dataspec "
         "opens once from the start point only, since the official spec does "

--- a/src/cli/main.py
+++ b/src/cli/main.py
@@ -35,16 +35,17 @@ FETCH_NOTE_OPTION2_RANGE = (
     "NL キャッシュは使用・作成しません。"
 )
 FETCH_NOTE_TO_CLIENT_FILTER = (
-    "--to は取得後のクライアント側日付フィルタであり、JVOpen の終端ではありません。"
+    "--to は取得後のクライアント側日付フィルタです。"
+    "範囲形式を使える dataspec では JVOpen の終端にもなります。"
 )
 FETCH_NOTE_TO_SINGLE_OPEN = (
-    "option=1/2 では --to は JVOpen の終端にならず、"
-    "狭めてもサーバからのダウンロード量は減りません。"
+    "この dataspec は範囲形式 fromtime を使えないため、--to を狭めても"
+    "サーバからのダウンロード量は減りません（終了時刻を指定できない種別です）。"
 )
-FETCH_NOTE_TO_SETUP_TAIL = (
-    "option=3/4 の historical setup tail は公式仕様上 fromtime 以降の全件が"
-    "対象で、終了時刻は過去setup部分を境界付けません。排他的開始点には "
-    "--from 前日の 23:59:59 を使い、長期間でも single JVOpen を維持します。"
+FETCH_NOTE_TO_RANGE_CHUNKED = (
+    "この dataspec は --from〜--to を暦年で刻んで JVOpen を繰り返します。"
+    "1 回の JVOpen に並ぶ対象ファイル数が JVRead 1 回の費用を決めるためで、"
+    "--to はそのままダウンロード範囲の終端になります。"
 )
 FETCH_NOTE_DATE_FIELDS = (
     "--to は Year+MonthDay または ChokyoDate（HC/WC の調教日）で判定します。"
@@ -80,16 +81,18 @@ def _reject_invalid_jvopen_combination(data_spec: str, option: int) -> None:
         sys.exit(1)
 
 
-def _print_fetch_guardrail_notes(jv_option: int) -> None:
-    """Emit option-dependent date-range caveats after input validation."""
+def _print_fetch_guardrail_notes(jv_option: int, data_spec: str) -> None:
+    """Emit option- and dataspec-dependent date-range caveats after validation."""
     if jv_option in (3, 4):
         err_console.print(f"[yellow]Note:[/yellow] {FETCH_NOTE_SETUP_MODE}")
     if jv_option == 2:
         err_console.print(f"[yellow]Note:[/yellow] {FETCH_NOTE_OPTION2_RANGE}")
 
+    from src.jvlink.constants import uses_range_fromtime
+
     err_console.print(f"[yellow]Note:[/yellow] {FETCH_NOTE_TO_CLIENT_FILTER}")
-    if jv_option in (3, 4):
-        err_console.print(f"[yellow]Note:[/yellow] {FETCH_NOTE_TO_SETUP_TAIL}")
+    if uses_range_fromtime(data_spec, jv_option):
+        err_console.print(f"[yellow]Note:[/yellow] {FETCH_NOTE_TO_RANGE_CHUNKED}")
     else:
         err_console.print(f"[yellow]Note:[/yellow] {FETCH_NOTE_TO_SINGLE_OPEN}")
     err_console.print(f"[yellow]Note:[/yellow] {FETCH_NOTE_DATE_FIELDS}")
@@ -408,10 +411,12 @@ def update(ctx, force):
     help=(
         "End date (YYYYMMDD). Filters Year+MonthDay and HC/WC ChokyoDate "
         "client-side; records without either date are kept and prevent a "
-        "complete-cache marker. It is not a JVOpen end bound. Under the "
-        "official option=3/4 contract, the historical setup tail remains all "
-        "setup data after --from even when fromtime has an end point, so "
-        "setup uses a single start-only JVOpen rather than repeated year chunks."
+        "complete-cache marker. For a dataspec that accepts a range fromtime "
+        "(RACE, SLOP, WOOD) it is also the JVOpen end bound: the request is "
+        "split into one JVOpen per calendar year, because the per-read cost "
+        "grows with the number of files one JVOpen lists. Every other dataspec "
+        "opens once from the start point only, since the official spec does "
+        "not accept an end point for them."
     ),
 )
 @click.option("--spec", "data_spec", required=True, help="Data specification (RACE, DIFN, etc.)")
@@ -487,7 +492,7 @@ def fetch(ctx, date_from, date_to, data_spec, jv_option, db, batch_size, progres
         console.print(f"[red]Error:[/red] {exc}")
         sys.exit(1)
 
-    _print_fetch_guardrail_notes(jv_option)
+    _print_fetch_guardrail_notes(jv_option, data_spec)
     console.print()
 
     try:

--- a/src/fetcher/historical.py
+++ b/src/fetcher/historical.py
@@ -322,6 +322,7 @@ class HistoricalFetcher(BaseFetcher):
         # JVOpen 自体を try の中で呼ぶ。wrapper は -202 のように「開いたが
         # 例外で返る」経路で JVClose を要求するので、close の義務はこの
         # finally 1 箇所に集約する。
+        primary_error = None
         try:
             result, read_count, download_count, last_file_timestamp = (
                 self.jvlink.jv_open(data_spec, fromtime, option)
@@ -430,6 +431,11 @@ class HistoricalFetcher(BaseFetcher):
                     f"{self._recoverable_read_errors} unrepaired JVRead error(s); "
                     "refusing to commit incomplete output"
                 )
+        except BaseException as exc:
+            # JVClose below is still mandatory, but a secondary close failure
+            # must not replace the provider/read error that started unwinding.
+            primary_error = exc
+            raise
         finally:
             self._jv_open_context = None
             self._jv_open_last_file_timestamp = None
@@ -438,8 +444,17 @@ class HistoricalFetcher(BaseFetcher):
             try:
                 self.jvlink.jv_close()
                 logger.info("Data stream closed", chunk=chunk_label)
-            except Exception as e:
-                logger.warning(f"Failed to close stream: {e}")
+            except Exception as close_error:
+                if primary_error is None:
+                    raise FetcherError(
+                        f"JVClose failed for chunk {chunk_label}: {close_error}"
+                    ) from close_error
+                logger.error(
+                    "JVClose failed while preserving an earlier stream error",
+                    chunk=chunk_label,
+                    close_error=str(close_error),
+                    primary_error=repr(primary_error),
+                )
 
     def fetch(
         self,

--- a/src/fetcher/historical.py
+++ b/src/fetcher/historical.py
@@ -4,13 +4,15 @@ This module fetches historical JV-Data from JV-Link.
 """
 
 import time
+from dataclasses import dataclass, field
 from datetime import datetime, timedelta
-from typing import Iterator, Optional
+from typing import Any, Iterator, Optional
 
 from src.fetcher.base import BaseFetcher, FetcherError
 from src.jvlink.constants import (
     JVOPEN_OPTION_SETUP,
     JVOPEN_OPTION_SETUP_SPLIT,
+    uses_range_fromtime,
     validate_jvopen_combination,
 )
 from src.utils.logger import get_logger
@@ -56,17 +58,12 @@ def validate_date_range(from_date: str, to_date: str) -> None:
 
 
 def _jvopen_fromtime(from_date: str, option: int) -> str:
-    """Build the official JVOpen fromtime for this request.
+    """Build the start point of one JVOpen request.
 
     公式仕様（4.9.0.1 p.17-20）の対象条件は開始時刻より大きいデータ。
     要求された from_date を包含させるため、セットアップ (option 3/4) では
-    排他的開始点を前日23:59:59に符号化する。
-
-    p.20 は option 3/4 について、前月までのセットアップ用データは fromtime
-    より大きい全件を返し、終了時刻が制限するのは今月の通常データ部分だけと
-    明記する。したがって過去setup dataを ``to_date`` でboundedにできるとは
-    扱わず、setupはstart-onlyを1回だけ呼ぶ。option 1の差分cursor・option 2の
-    今週データ契約は変更しない。
+    排他的開始点を前日23:59:59に符号化する。option 1 の差分カーソル
+    （``{from_date}000000``）と option 2 の今週データ契約は変更しない。
     """
     if option not in (JVOPEN_OPTION_SETUP, JVOPEN_OPTION_SETUP_SPLIT):
         return f"{from_date}000000"
@@ -75,17 +72,68 @@ def _jvopen_fromtime(from_date: str, option: int) -> str:
     ).strftime("%Y%m%d%H%M%S")
 
 
+def _jvopen_fromtimes(
+    data_spec: str,
+    from_date: str,
+    to_date: str,
+    option: int,
+) -> list[str]:
+    """Split one request into the fromtime of each JVOpen call.
+
+    なぜ刻むかは RANGE_FROMTIME_DATA_SPECS のコメントを見ること。刻まない
+    dataspec と option 2 は、従来どおり開始のみの 1 回になる。
+
+    境界は隣り合う chunk で同じ値を共有する。JVOpen の対象は「開始時刻より
+    大きく、終了時刻まで」なので、その値のファイルは前の chunk に入り次の
+    chunk からは外れる。穴も重複も出ない。
+
+    Returns:
+        JVOpen に渡す fromtime のリスト。要素は開始のみ（14 桁）か
+        ``開始-終了``（14 桁 + "-" + 14 桁）。
+    """
+    start = _jvopen_fromtime(from_date, option)
+    if not uses_range_fromtime(data_spec, option):
+        return [start]
+
+    last_day = datetime.strptime(to_date, "%Y%m%d")
+    fromtimes = []
+    for year in range(int(from_date[:4]), last_day.year + 1):
+        year_end = datetime(year, 12, 31)
+        end = min(year_end, last_day)
+        fromtimes.append(f"{start}-{end.strftime('%Y%m%d')}235959")
+        # 次の chunk はこの chunk の終了時刻より大きいところから始まる。
+        start = f"{year}1231235959"
+    return fromtimes
+
+
+@dataclass
+class _NlCacheWriteState:
+    """NL キャッシュへの write-through 中に chunk をまたいで持ち回す状態.
+
+    manager が None ならキャッシュは使わない。range_complete は「この要求の
+    範囲を取り切ったと言えるか」で、倒れていると fetch は完了マークを付けない。
+    """
+
+    # CacheManager 相当のオブジェクト（None ならキャッシュ無し）。型を固定しないのは
+    # 呼び出し側が差し替え可能な形で渡すため。
+    manager: Any
+    checkpoints: dict[str, Optional[int]] = field(default_factory=dict)
+    range_complete: bool = True
+
+
 class HistoricalFetcher(BaseFetcher):
     """Fetcher for historical JV-Data.
 
     Fetches accumulated (蓄積) data from JV-Link for a specified date range
-    and data specification. For setup requests (option 3/4) the requested
-    inclusive from_date is encoded as the exclusive fromtime start point
-    (previous day 23:59:59, per the official strictly-greater rule). Setup
-    stays start-only because the official option-3/4 contract does not apply
-    an end timestamp to the historical setup tail. Options 1/2 keep the
-    legacy ``{from_date}000000`` start-only fromtime. In every mode records
-    are filtered client-side based on the end date.
+    and data specification. A dataspec that accepts a range fromtime
+    (RANGE_FROMTIME_DATA_SPECS) is split into one JVOpen per calendar year,
+    because the cost of a single JVRead grows with the number of files one
+    JVOpen lists. Every other dataspec, and option 2, opens once from the
+    start point only. For setup requests (option 3/4) the requested inclusive
+    from_date is encoded as the exclusive start point (previous day 23:59:59,
+    per the official strictly-greater rule); options 1/2 keep the
+    ``{from_date}000000`` cursor. In every mode records are also filtered
+    client-side based on the end date.
 
     Note:
         Service key must be configured in JRA-VAN DataLab application
@@ -108,6 +156,9 @@ class HistoricalFetcher(BaseFetcher):
         self.cache_manager = None
         self._jvd_self_repair_attempts = 0
         self._jvd_replay_records_remaining = 0
+        # 統計は fetch 全体で 1 本だが、リプレイ長は「いまの open で出したぶん」。
+        # 暦年チャンクでは 1 回の fetch が JVOpen を何度も呼ぶので基準点を持つ。
+        self._open_records_baseline = 0
         self._jv_open_context: Optional[tuple[str, str, int]] = None
         self._jv_open_last_file_timestamp: Optional[str] = None
         self._fetch_task_id: Optional[int] = None
@@ -161,7 +212,11 @@ class HistoricalFetcher(BaseFetcher):
         # The same JVOpen context restarts at the beginning of the stream.
         # Remember the successfully emitted prefix so _fetch_and_parse can
         # drain it without parsing, yielding, or appending it to raw cache.
-        self._jvd_replay_records_remaining = self._records_fetched
+        # 数えるのは「いまの open で出したぶん」。_records_fetched は fetch 全体の
+        # 累計なので、この open が始まった時点の基準点を引く。
+        self._jvd_replay_records_remaining = (
+            self._records_fetched - self._open_records_baseline
+        )
         expected_read_count = self._total_files
         expected_last_file_timestamp = self._jv_open_last_file_timestamp
         try:
@@ -220,6 +275,172 @@ class HistoricalFetcher(BaseFetcher):
             last_file_timestamp=last_file_timestamp,
         )
 
+    def _fetch_one_open(
+        self,
+        *,
+        data_spec: str,
+        fromtime: str,
+        option: int,
+        to_date: str,
+        chunk_label: str,
+        cache: "_NlCacheWriteState",
+    ) -> Iterator[dict]:
+        """Run one JVOpen -> read -> JVClose cycle and yield its records.
+
+        暦年チャンクの 1 個ぶん。統計・キャッシュ確定・進捗表示の寿命は呼び出し側
+        (fetch) が持ち、ここは 1 回の open の中だけを見る。
+
+        空の窓 (result -1) は刻んでいれば普通に起こるので、その chunk を終えて
+        次へ進む。ただし「窓の中身が無い」ことを確かめられていない以上、この
+        範囲を完全としてキャッシュに刻ませない (cache.range_complete を倒す)。
+        """
+        # 前の chunk の読み出し状態は持ち越さない。リプレイ長は「この open で
+        # 出したぶん」なので、累計から基準点を引いて数える。self-repair の
+        # リトライ上限は fetch 全体で 1 本のままにする (chunk 数ぶん増やさない)。
+        self._jvd_replay_records_remaining = 0
+        self._open_records_baseline = self._records_fetched
+        self._files_processed = 0
+        self._jv_open_context = (data_spec, fromtime, option)
+        self._jv_open_last_file_timestamp = None
+        download_task_id = None
+        fetch_task_id = None
+
+        logger.info(
+            "Opening data stream",
+            data_spec=data_spec,
+            fromtime=fromtime,
+            option=option,
+            chunk=chunk_label,
+            note=(
+                "option=1: 通常データ（差分）; "
+                "option=2: 今週データ; "
+                "option=3/4: セットアップ"
+                "（範囲形式が使える dataspec は暦年で刻む。to_date は client filter も兼ねる）"
+            ),
+        )
+
+        # JVOpen 自体を try の中で呼ぶ。wrapper は -202 のように「開いたが
+        # 例外で返る」経路で JVClose を要求するので、close の義務はこの
+        # finally 1 箇所に集約する。
+        try:
+            result, read_count, download_count, last_file_timestamp = (
+                self.jvlink.jv_open(data_spec, fromtime, option)
+            )
+            self._jv_open_last_file_timestamp = last_file_timestamp
+
+            logger.info(
+                "Data stream opened",
+                result_code=result,
+                read_count=read_count,
+                download_count=download_count,
+                last_file_timestamp=last_file_timestamp,
+                chunk=chunk_label,
+            )
+
+            if result == -2:
+                raise FetcherError("JVOpen setup dialog was cancelled")
+            # 「データなし」判定より先にエラーコードを弾く。-113（読み出し終了
+            # 時刻のパラメータ不正）のような失敗は read_count も download_count も
+            # 0 で返るので、順序を逆にすると空の窓と見分けがつかなくなる。
+            if result not in (0, -1):
+                raise FetcherError(f"JVOpen returned unexpected result code: {result}")
+            if result == -1 or (read_count == 0 and download_count == 0):
+                # 窓に該当データが無いだけ。刻んでいる以上ふつうに起こるので
+                # fetch は続ける。ただしこの範囲を「完全に取り切った」とは
+                # 言えないので、NL キャッシュの完了マークは付けさせない。
+                # (付けると has_nl_range が 0 件をこの範囲の答えとして返し続ける)
+                cache.range_complete = False
+                logger.info(
+                    "No data available for this window",
+                    data_spec=data_spec,
+                    fromtime=fromtime,
+                    chunk=chunk_label,
+                )
+                if self.progress_display:
+                    self.progress_display.print_info(
+                        f"{data_spec}: サーバーにデータなし ({fromtime})"
+                    )
+                return
+
+            # Wait for download to complete if needed
+            if download_count > 0:
+                logger.info(
+                    "Download in progress, waiting for completion",
+                    download_count=download_count,
+                )
+                if self.progress_display:
+                    download_task_id = self.progress_display.add_download_task(
+                        f"{data_spec} ダウンロード ({chunk_label})",
+                        total=download_count,
+                    )
+                self._wait_for_download(download_task_id, download_count=download_count)
+
+            # Set total files after JVOpen reports the stream size.
+            self._total_files = read_count
+
+            # Create fetch progress task
+            if self.progress_display:
+                fetch_task_id = self.progress_display.add_task(
+                    f"{data_spec} レコード取得 ({chunk_label})",
+                    total=read_count,
+                )
+                self._fetch_task_id = fetch_task_id
+
+            # Fetch and parse records (with optional cache write-through).
+            # The cache stores raw jv_read buffers, so write once per buffer, not
+            # once per parsed record: full-struct parsers (H1/H6) expand one
+            # buffer into thousands of rows that all carry the same `_raw`. Rows
+            # from one buffer share a header, hence the same record date, so the
+            # first surviving row stands in for all of them. Identity is a safe
+            # "same buffer" test because each jv_read() returns a new bytes
+            # object and last_cached_raw keeps it alive.
+            last_cached_raw = None
+            for data in self._fetch_and_parse(
+                fetch_task_id,
+                to_date=to_date,
+                recover_file_error=self._recover_historical_read_error,
+                consume_replayed_record=self._consume_replayed_record,
+            ):
+                raw = data.get("_raw") if cache.manager else None
+                if raw is not None and raw is not last_cached_raw:
+                    last_cached_raw = raw
+                    rec_date = _extract_record_date(data)
+                    if rec_date:
+                        if rec_date not in cache.checkpoints:
+                            cache.checkpoints[rec_date] = cache.manager.checkpoint_nl(
+                                data_spec,
+                                rec_date,
+                            )
+                        cache.manager.write_nl_record(data_spec, rec_date, raw)
+                    else:
+                        # The record is yielded/imported, but cannot be replayed
+                        # from this date-keyed cache. Keep the range incomplete;
+                        # the finally block rolls back any partial appends.
+                        cache.range_complete = False
+                yield data
+
+            if self._jvd_replay_records_remaining > 0:
+                raise FetcherError(
+                    "Historical stream ended before recovery replay caught up; "
+                    f"{self._jvd_replay_records_remaining} record(s) remain"
+                )
+            if self._recoverable_read_errors > 0:
+                raise FetcherError(
+                    "Historical stream completed with "
+                    f"{self._recoverable_read_errors} unrepaired JVRead error(s); "
+                    "refusing to commit incomplete output"
+                )
+        finally:
+            self._jv_open_context = None
+            self._jv_open_last_file_timestamp = None
+            self._fetch_task_id = None
+            # 次の chunk が JVOpen できるよう、この open は必ず閉じる。
+            try:
+                self.jvlink.jv_close()
+                logger.info("Data stream closed", chunk=chunk_label)
+            except Exception as e:
+                logger.warning(f"Failed to close stream: {e}")
+
     def fetch(
         self,
         data_spec: str,
@@ -252,10 +473,10 @@ class HistoricalFetcher(BaseFetcher):
             (Year/MonthDay) are always included.
 
             For option 3/4 the requested inclusive from_date is encoded as
-            the exclusive start point ``(from_date - 1 day)235959``. The
-            official p.20 setup contract returns every historical setup item
-            after that point; ``to_date`` is therefore a client-side record
-            filter, not a provider bound for the historical setup tail.
+            the exclusive start point ``(from_date - 1 day)235959``. For a
+            dataspec that accepts a range fromtime the request is split into
+            one JVOpen per calendar year and ``to_date`` also bounds the last
+            chunk; for every other dataspec it is a client-side filter only.
 
         Examples:
             >>> fetcher = HistoricalFetcher()  # Uses default sid="UNKNOWN"
@@ -284,22 +505,18 @@ class HistoricalFetcher(BaseFetcher):
             self.progress_display = JVLinkProgressDisplay()
             self.progress_display.start()
 
-        download_task_id = None
-        fetch_task_id = None
         # option=2 uses fromtime only for continuity within current race-cycle
         # data; it cannot prove an arbitrary requested historical range
         # complete. Bypass both existing NL cache markers and write-through
         # caching for that mode.
         active_cache_manager = self.cache_manager if option != 2 else None
-        cache_checkpoints: dict[str, Optional[int]] = {}
         cache_write_committed = active_cache_manager is None
-        cache_range_complete = True
+        cache = _NlCacheWriteState(manager=active_cache_manager)
 
-        # 公式の fromtime 形式をここで決める（仕様書 4.9.0.1 p.17-20）。
-        # セットアップは from_date を包含する排他的開始点（前日23:59:59）を
-        # start-onlyで送る。to_dateは過去setup tailのprovider boundにはならず、
-        # 下流のclient-side filterとしてのみ使う。
-        fromtime = _jvopen_fromtime(from_date, option)
+        # 1 回の JVOpen に並ぶ対象ファイル数が JVRead 1 回の費用を決めるので、
+        # 範囲形式を使える dataspec は暦年で刻む（_jvopen_fromtimes）。
+        # 刻めない dataspec と option 2 は開始のみ 1 回になる。
+        fromtimes = _jvopen_fromtimes(data_spec, from_date, to_date, option)
 
         try:
             # Info for setup mode (option 3 or 4) - ログのみ、画面表示はしない
@@ -307,7 +524,7 @@ class HistoricalFetcher(BaseFetcher):
                 logger.info(
                     "セットアップモード",
                     option=option,
-                    provider_tail="start_only",
+                    chunks=len(fromtimes),
                 )
 
             # Initialize JV-Link
@@ -319,130 +536,21 @@ class HistoricalFetcher(BaseFetcher):
             # Note: Service key must be pre-configured in Windows registry
             # jv_init() does not accept service_key parameter
             self.jvlink.jv_init()
+            # リトライ上限は fetch 全体で 1 本。chunk 数ぶんは増やさない。
             self._jvd_self_repair_attempts = 0
-            self._jvd_replay_records_remaining = 0
-            self._jv_open_context = (data_spec, fromtime, option)
-            self._jv_open_last_file_timestamp = None
 
-            # Open data stream
-            logger.info(
-                "Opening data stream",
-                data_spec=data_spec,
-                from_date=from_date,
-                to_date=to_date,
-                fromtime=fromtime,
-                option=option,
-                note=(
-                    "option=1: 通常データ（差分）; "
-                    "option=2: 今週データ; "
-                    "option=3/4: セットアップ"
-                    "（過去setup tailはstart-only、to_dateはclient filter）"
-                ),
-            )
-
-            result, read_count, download_count, last_file_timestamp = self.jvlink.jv_open(
-                data_spec,
-                fromtime,
-                option,
-            )
-            self._jv_open_last_file_timestamp = last_file_timestamp
-
-            logger.info(
-                "Data stream opened",
-                result_code=result,
-                read_count=read_count,
-                download_count=download_count,
-                last_file_timestamp=last_file_timestamp,
-            )
-
-            # Check if data is empty
-            if result == -2:
-                raise FetcherError("JVOpen setup dialog was cancelled")
-            if result == -1 or (read_count == 0 and download_count == 0):
-                logger.info(
-                    "No data available from specified timestamp",
+            for chunk_index, fromtime in enumerate(fromtimes, start=1):
+                yield from self._fetch_one_open(
                     data_spec=data_spec,
                     fromtime=fromtime,
-                )
-                if self.progress_display:
-                    self.progress_display.print_info(
-                        f"{data_spec}: サーバーにデータなし"
-                    )
-                return  # No data to fetch
-            if result != 0:
-                raise FetcherError(f"JVOpen returned unexpected result code: {result}")
-
-            # Wait for download to complete if needed
-            if download_count > 0:
-                logger.info(
-                    "Download in progress, waiting for completion",
-                    download_count=download_count,
-                )
-                if self.progress_display:
-                    download_task_id = self.progress_display.add_download_task(
-                        f"{data_spec} ダウンロード",
-                        total=download_count,
-                    )
-                self._wait_for_download(download_task_id, download_count=download_count)
-
-            # Set total files after JVOpen reports the stream size.
-            self._total_files = read_count
-
-            # Create fetch progress task
-            if self.progress_display:
-                fetch_task_id = self.progress_display.add_task(
-                    f"{data_spec} レコード取得",
-                    total=read_count,
-                )
-                self._fetch_task_id = fetch_task_id
-
-            # Fetch and parse records (with optional cache write-through).
-            # The cache stores raw jv_read buffers, so write once per buffer, not
-            # once per parsed record: full-struct parsers (H1/H6) expand one
-            # buffer into thousands of rows that all carry the same `_raw`. Rows
-            # from one buffer share a header, hence the same record date, so the
-            # first surviving row stands in for all of them. Identity is a safe
-            # "same buffer" test because each jv_read() returns a new bytes
-            # object and last_cached_raw keeps it alive.
-            last_cached_raw = None
-            for data in self._fetch_and_parse(
-                fetch_task_id,
-                to_date=to_date,
-                recover_file_error=self._recover_historical_read_error,
-                consume_replayed_record=self._consume_replayed_record,
-            ):
-                raw = data.get("_raw") if active_cache_manager else None
-                if raw is not None and raw is not last_cached_raw:
-                    last_cached_raw = raw
-                    rec_date = _extract_record_date(data)
-                    if rec_date:
-                        if rec_date not in cache_checkpoints:
-                            cache_checkpoints[rec_date] = active_cache_manager.checkpoint_nl(
-                                data_spec,
-                                rec_date,
-                            )
-                        active_cache_manager.write_nl_record(data_spec, rec_date, raw)
-                    else:
-                        # The record is yielded/imported, but cannot be replayed
-                        # from this date-keyed cache. Keep the range incomplete;
-                        # the finally block rolls back any partial appends.
-                        cache_range_complete = False
-                yield data
-
-            if self._jvd_replay_records_remaining > 0:
-                raise FetcherError(
-                    "Historical stream ended before recovery replay caught up; "
-                    f"{self._jvd_replay_records_remaining} record(s) remain"
-                )
-            if self._recoverable_read_errors > 0:
-                raise FetcherError(
-                    "Historical stream completed with "
-                    f"{self._recoverable_read_errors} unrepaired JVRead error(s); "
-                    "refusing to commit incomplete output"
+                    option=option,
+                    to_date=to_date,
+                    chunk_label=f"{chunk_index}/{len(fromtimes)}",
+                    cache=cache,
                 )
 
             # Mark cached dates as complete
-            if active_cache_manager and cache_range_complete:
+            if active_cache_manager and cache.range_complete:
                 d = datetime.strptime(from_date, "%Y%m%d").date()
                 end = datetime.strptime(to_date, "%Y%m%d").date()
                 completed_dates = []
@@ -484,7 +592,7 @@ class HistoricalFetcher(BaseFetcher):
 
         finally:
             if not cache_write_committed and active_cache_manager:
-                for rec_date, checkpoint in cache_checkpoints.items():
+                for rec_date, checkpoint in cache.checkpoints.items():
                     try:
                         active_cache_manager.restore_nl(
                             data_spec,
@@ -501,13 +609,8 @@ class HistoricalFetcher(BaseFetcher):
             self._jv_open_context = None
             self._jv_open_last_file_timestamp = None
             self._fetch_task_id = None
-            # Close stream (JVClose) — releases the current open session so
-            # the next jv_init()/jv_open() call in a subsequent chunk works.
-            try:
-                self.jvlink.jv_close()
-                logger.info("Data stream closed")
-            except Exception as e:
-                logger.warning(f"Failed to close stream: {e}")
+            # JVClose の義務は _fetch_one_open の finally が持つ（JVOpen と
+            # 同じ try に入っている）。ここで二重に閉じない。
 
             # Do NOT call cleanup() here: cleanup() destroys the COM object
             # (self._jvlink = None + CoUninitialize), so subsequent chunks

--- a/src/importer/batch.py
+++ b/src/importer/batch.py
@@ -20,10 +20,8 @@ logger = get_logger(__name__)
 # one import can run for hours. Held in a single transaction, an interrupted
 # run leaves nothing behind and the retry starts over from the beginning -- a
 # long enough range never gets imported at all. Commit it in bounded record
-# groups instead. The official option-3/4 contract keeps the historical setup
-# data tail open after fromtime even when an end timestamp is supplied, so a
-# long request must remain one provider open; calendar chunking would repeat
-# the later tail for every chunk.
+# groups instead. This is independent of how many JVOpen calls the fetcher
+# makes: commits are decided by record count, not by chunk boundaries.
 SPLIT_SETUP_OPTION = 4
 SETUP_COMMIT_INTERVAL = 10000
 
@@ -146,10 +144,11 @@ class BatchProcessor:
             ValueError: If data_spec or option violates the JVOpen contract
 
         Note:
-            Setup requests (option 3/4) use one start-only JVOpen because the
-            official p.20 contract does not apply an end point to the
-            historical setup tail. In every mode records are filtered
-            client-side to only import those with dates <= to_date.
+            A dataspec that accepts a range fromtime is fetched as one
+            JVOpen per calendar year (see HistoricalFetcher); how many opens
+            that takes does not change the commit contract below. In every
+            mode records are also filtered client-side to only import those
+            with dates <= to_date.
 
             option=4 commits every SETUP_COMMIT_INTERVAL records rather than
             once for the whole data spec, so an interrupted run keeps what it

--- a/src/jvlink/constants.py
+++ b/src/jvlink/constants.py
@@ -347,7 +347,9 @@ def get_all_race_keys_for_date(date: str) -> list:
 # 受け付けないと明記しており、指定すると戻り値 -1 になる。
 #
 # ここに載せてよいのは、範囲形式で期間ぶんの件数が返ることを実機で確かめた種別だけ。
-RANGE_FROMTIME_DATA_SPECS = frozenset({"RACE", "SLOP", "WOOD"})
+# PR #246 の記録済み実機証跡は RACE のみ。SLOP/WOOD は API 表上end禁止ではないが、
+# 同じprovider挙動を確認するまではstart-onlyへ安全側フォールバックする。
+RANGE_FROMTIME_DATA_SPECS = frozenset({"RACE"})
 
 
 def uses_range_fromtime(data_spec: str, option: int) -> bool:

--- a/src/jvlink/constants.py
+++ b/src/jvlink/constants.py
@@ -335,6 +335,29 @@ def get_all_race_keys_for_date(date: str) -> list:
     return keys
 
 
+# 範囲形式 fromtime（YYYYMMDDhhmmss-YYYYMMDDhhmmss）を渡してよいデータ種別。
+#
+# JVRead 1 回の費用は JVOpen が並べた対象ファイル数で決まる。実測（2026-08-23・RACE・
+# option=4・先頭 200 レコードを固定してファイル数だけを変えたもの）では 44 ファイルで
+# 3.4 ms、5,096 ファイルで 67.6 ms。だから期間を暦年で刻んで 1 回の対象を小さく保つ。
+#
+# 拒否リストではなく許可リストにする。表を間違えたとき、許可リストは「刻まないので遅い
+# まま」で倒れ、拒否リストは「範囲形式を受け付けない種別に渡して無言の 0 件」＝取りこぼしで
+# 倒れる。TOKU / DIFF・DIFN / HOSE・HOSN / HOYU / COMM は公式仕様（4.9.0.1 p.18）が終了時刻を
+# 受け付けないと明記しており、指定すると戻り値 -1 になる。
+#
+# ここに載せてよいのは、範囲形式で期間ぶんの件数が返ることを実機で確かめた種別だけ。
+RANGE_FROMTIME_DATA_SPECS = frozenset({"RACE", "SLOP", "WOOD"})
+
+
+def uses_range_fromtime(data_spec: str, option: int) -> bool:
+    """Whether this request is split into one JVOpen per calendar year.
+
+    刻むかどうかの判断はここ 1 箇所だけに置く（fetcher と CLI の両方が呼ぶ）。
+    option 2（今週データ）は開催サイクルが対象で期間の概念が違うので刻まない。
+    """
+    return data_spec in RANGE_FROMTIME_DATA_SPECS and option != JVOPEN_OPTION_THIS_WEEK
+
 # JVOpen データ種別とoption対応表
 # Option: 1=通常データ, 2=今週データ, 3/4=セットアップ
 JVOPEN_VALID_COMBINATIONS = {

--- a/src/jvlink/wrapper.py
+++ b/src/jvlink/wrapper.py
@@ -310,10 +310,12 @@ class JVLinkWrapper:
                      official start-end form
                      "YYYYMMDDhhmmss-YYYYMMDDhhmmss" (start-end joined by a
                      half-width hyphen; 仕様書 4.9.0.1 p.17-18).
-                     For option 3/4, p.20 says the end point bounds only the
-                     current-month normal-data portion; it does not cap the
-                     historical setup tail. TOKU/DIFF/DIFN/HOSE/HOSN/HOYU/
-                     COMM forbid an end timestamp entirely.
+                     The end point bounds the setup archive by period as
+                     well; see RANGE_FROMTIME_DATA_SPECS in
+                     src/jvlink/constants.py for which dataspecs accept it and
+                     why the caller splits a request by calendar year.
+                     TOKU/DIFF/DIFN/HOSE/HOSN/HOYU/COMM forbid an end
+                     timestamp entirely (p.18).
             option: Option flag:
                     1=通常データ（差分データ取得）
                     2=今週データ（直近のレースのみ）

--- a/tests/test_batch_processor.py
+++ b/tests/test_batch_processor.py
@@ -348,8 +348,8 @@ def _transaction_calls(database):
     return [name for name, _args, _kwargs in database.mock_calls]
 
 
-# 以下の option=4 テスト群は「1回のオープン内のコミット間隔」契約を固定する。
-# 日付範囲の長短にかかわらずprovider setup tailは1回だけopenする。
+# 以下の option=4 テスト群は「コミット間隔」契約を固定する。fetcher が JVOpen を
+# 何回呼ぶか（暦年チャンク）とは独立で、コミットはレコード数だけで決まる。
 def test_option_4_commits_once_per_interval(monkeypatch):
     monkeypatch.setattr("src.importer.batch.SETUP_COMMIT_INTERVAL", 2)
     processor = _chunking_processor([_record(i) for i in range(5)])
@@ -510,10 +510,10 @@ def test_option_4_rejection_rolls_back_only_its_own_chunk(tmp_path, monkeypatch)
     assert row_count == 2
 
 
-def test_option_4_long_range_uses_one_provider_open_and_keeps_group_commits(
+def test_option_4_long_range_keeps_group_commits(
     tmp_path, monkeypatch
 ):
-    """長期間setupもprovider tailは1回だけopenし、group単位で耐久化する。"""
+    """長期間setupでも、コミットはレコード数で決まり group 単位で耐久化する。"""
     monkeypatch.setattr("src.importer.batch.SETUP_COMMIT_INTERVAL", 1)
 
     def _valid_ra(race_num):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -339,7 +339,7 @@ class TestFetchCommand(unittest.TestCase):
         self.assertIn('Sunday or Monday may cover two cycles', help_text)
         self.assertIn('ChokyoDate', help_text)
         self.assertIn('one JVOpen per calendar year', help_text)
-        self.assertIn('RACE, SLOP, WOOD', help_text)
+        self.assertIn('live-verified RACE, except option 2', help_text)
         self.assertIn('opens once from the start point only', help_text)
 
     @patch('src.database.create_database_from_config')

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -338,9 +338,9 @@ class TestFetchCommand(unittest.TestCase):
         self.assertIn('current race-cycle data', help_text)
         self.assertIn('Sunday or Monday may cover two cycles', help_text)
         self.assertIn('ChokyoDate', help_text)
-        self.assertIn('not a JVOpen end bound', help_text)
-        self.assertIn('historical setup tail', help_text)
-        self.assertIn('single start-only JVOpen', help_text)
+        self.assertIn('one JVOpen per calendar year', help_text)
+        self.assertIn('RACE, SLOP, WOOD', help_text)
+        self.assertIn('opens once from the start point only', help_text)
 
     @patch('src.database.create_database_from_config')
     def test_fetch_rejects_invalid_dates_before_database_initialization(

--- a/tests/test_historical_cache_write_through.py
+++ b/tests/test_historical_cache_write_through.py
@@ -29,6 +29,7 @@ def _fetcher(cache, jv_read_results) -> HistoricalFetcher:
     f._files_processed = f._total_files = 0
     f._start_time = 0.0
     f._jvd_self_repair_attempts = f._jvd_replay_records_remaining = 0
+    f._open_records_baseline = 0
     f._recoverable_read_errors = 0
     f._jv_open_context = f._jv_open_last_file_timestamp = f._fetch_task_id = None
 

--- a/tests/test_jvd_self_repair.py
+++ b/tests/test_jvd_self_repair.py
@@ -31,6 +31,7 @@ def _fetcher():
     fetcher._total_files = 3
     fetcher._jvd_self_repair_attempts = 0
     fetcher._jvd_replay_records_remaining = 0
+    fetcher._open_records_baseline = 0
     fetcher._jv_open_context = ("RACE", "20260101000000", 1)
     fetcher._jv_open_last_file_timestamp = "ts"
     fetcher._fetch_task_id = None

--- a/tests/test_jvlink_transport_contract.py
+++ b/tests/test_jvlink_transport_contract.py
@@ -166,33 +166,48 @@ def test_historical_fetcher_reports_setup_cancel_instead_of_no_data():
     jvlink.jv_close.assert_called_once()
 
 
-# --- Official JVOpen setup semantics (JV-Link仕様書 4.9.0.1 p.17-20) --------
+# --- Official JVOpen semantics (JV-Link仕様書 4.9.0.1 p.17-20) --------------
 # fromtime は「開始時刻のみ」または「開始-終了」(YYYYMMDDhhmmss-YYYYMMDDhhmmss、
-# 半角ハイフン結合) の2形式のみで、対象条件は「開始時刻より大きく、終了時刻
-# まで」。一方 p.20 は option 3/4 について、前月までのセットアップ用データは
-# fromtime より大きい全件を返し、終了時刻が制限するのは今月の通常データ部分
-# だけと明記する。したがって過去年窓を end で分割できるとは扱わず、setup は
-# start-only を1回だけ呼ぶ。要求された from_date を包含させるため、排他的開始点
-# は前日23:59:59に符号化する。option 1/2のcursor契約は変更しない。
+# 半角ハイフン結合) の2形式で、対象条件は「開始時刻より大きく、終了時刻まで」。
+# 終了時刻は setup (option 3/4) でもセットアップ用アーカイブを期間で絞る
+# (2026-08-23 実機計測: --from 1986 固定で終了時刻だけを振ると readcount が
+# 3,973 / 4,337 と変わる)。1 read の費用は JVOpen が並べた対象ファイル数で
+# 決まるので、範囲形式を使える dataspec は暦年で刻む。
+# 刻めるのは RANGE_FROMTIME_DATA_SPECS だけ。p.18 の終了時刻禁止リスト
+# (TOKU / DIFF・DIFN / HOSE・HOSN / HOYU / COMM) は開始のみで1回開く。
+# 要求された from_date を包含させるため、setup の排他的開始点は前日23:59:59。
+# option 1 の差分カーソルと option 2 の今週データ契約は変更しない。
 
 
 @pytest.mark.parametrize(
-    ("data_spec", "option", "expected_fromtime"),
+    ("data_spec", "option", "expected_fromtimes"),
     [
-        # option 3/4 は、end-capableなRACEを含めてstart-only。p.20上、終了点は
-        # 過去setup dataの上限ではないため、bounded downloadとは主張しない。
-        ("RACE", 4, "20250819235959"),
-        ("RACE", 3, "20250819235959"),
-        # p.18 の終了時刻禁止リストに載る DIFN も同じstart-only形式
-        ("DIFN", 4, "20250819235959"),
-        # 複数specもsetupはstart-only
-        ("RACEDIFN", 4, "20250819235959"),
-        # option=1 の差分カーソル契約はこのイテレーションでは変更しない
-        ("RACE", 1, "20250820000000"),
+        # 範囲形式を使える dataspec は暦年で刻む。2025-08-20〜2026-08-19 は 2 年に
+        # またがるので JVOpen は 2 回。境界は共有し、穴も重複も作らない。
+        (
+            "RACE",
+            4,
+            ["20250819235959-20251231235959", "20251231235959-20260819235959"],
+        ),
+        (
+            "RACE",
+            3,
+            ["20250819235959-20251231235959", "20251231235959-20260819235959"],
+        ),
+        # p.18 の終了時刻禁止リストに載る DIFN は開始のみで 1 回
+        ("DIFN", 4, ["20250819235959"]),
+        # 連結された dataspec も許可リストに一致しないので開始のみ
+        ("RACEDIFN", 4, ["20250819235959"]),
+        # option=1 の差分カーソルは真夜中のまま。刻んでも先頭はずらさない。
+        (
+            "RACE",
+            1,
+            ["20250820000000-20251231235959", "20251231235959-20260819235959"],
+        ),
     ],
 )
-def test_jvopen_setup_fromtime_is_start_only_for_the_historical_setup_tail(
-    data_spec, option, expected_fromtime
+def test_jvopen_fromtime_is_chunked_by_calendar_year_where_the_spec_allows_it(
+    data_spec, option, expected_fromtimes
 ):
     jvlink = MagicMock()
     jvlink.jv_open.return_value = (-1, 0, 0, "")
@@ -200,26 +215,28 @@ def test_jvopen_setup_fromtime_is_start_only_for_the_historical_setup_tail(
 
     assert list(fetcher.fetch(data_spec, "20250820", "20260819", option=option)) == []
 
-    jvlink.jv_open.assert_called_once_with(data_spec, expected_fromtime, option)
+    assert [c.args[1] for c in jvlink.jv_open.call_args_list] == expected_fromtimes
+    assert all(c.args[0] == data_spec and c.args[2] == option
+               for c in jvlink.jv_open.call_args_list)
 
 
-def test_setup_to_date_does_not_claim_to_bound_the_historical_provider_tail():
-    """to_dateを変えてもsetupのJVOpen引数へ終了点を付けないこと。
+def test_setup_end_point_follows_the_requested_to_date():
+    """to_date を変えると JVOpen へ渡る終了点も変わること。
 
-    p.20では前月までのsetup dataはfromtime以降の全件が対象で、終了点が効くのは
-    今月の通常dataだけ。年窓ごとに終了点を変えてtailを分割できるという誤契約を
-    作らない。
+    終了時刻は setup アーカイブを期間で絞るので、要求の終端がそのまま
+    最後の chunk の終了点になる。
     """
     jvlink = MagicMock()
     jvlink.jv_open.return_value = (-1, 0, 0, "")
     fetcher = _historical_fetcher(jvlink)
 
     list(fetcher.fetch("RACE", "20240820", "20241231", option=4))
-    list(fetcher.fetch("RACE", "20240820", "20260819", option=4))
+    list(fetcher.fetch("RACE", "20240820", "20250615", option=4))
 
     assert [c.args[1] for c in jvlink.jv_open.call_args_list] == [
-        "20240819235959",
-        "20240819235959",
+        "20240819235959-20241231235959",
+        "20240819235959-20241231235959",
+        "20241231235959-20250615235959",
     ]
 
 

--- a/tests/test_jvopen_yearly_chunks.py
+++ b/tests/test_jvopen_yearly_chunks.py
@@ -30,6 +30,10 @@ def _starts_and_ends(fromtimes: list[str]) -> list[tuple[str, str]]:
 
 
 class TestAllowList:
+    def test_only_the_live_verified_race_spec_is_enabled(self):
+        """PR evidence is provider-bound to RACE; unmeasured specs stay safe."""
+        assert RANGE_FROMTIME_DATA_SPECS == frozenset({"RACE"})
+
     @pytest.mark.parametrize(
         "data_spec", ["TOKU", "DIFF", "DIFN", "HOSE", "HOSN", "HOYU", "COMM"]
     )
@@ -342,6 +346,35 @@ class TestChunkFailuresDoNotLeakAcrossChunks:
 
         assert wrapper.close_count == 1
 
+    def test_close_failure_stops_before_the_next_chunk_and_cache_completion(self):
+        """A chunk is not complete until its JVClose obligation succeeds."""
+        wrapper = _Wrapper(
+            opens=[_one_record_open(), _one_record_open()],
+            reads_per_open=[[(4, b"aaaa", "f1"), DONE], [(4, b"bbbb", "f2"), DONE]],
+        )
+        wrapper.jv_close = MagicMock(side_effect=RuntimeError("close failed"))
+        fetcher = _fetcher_with(wrapper)
+        fetcher.cache_manager = MagicMock()
+        fetcher.cache_manager.checkpoint_nl.return_value = 0
+
+        with pytest.raises(FetcherError, match="JVClose.*close failed"):
+            list(fetcher.fetch("RACE", "20240101", "20251231", option=4))
+
+        assert len(wrapper.open_fromtimes) == 1
+        fetcher.cache_manager.mark_nl_range_complete.assert_not_called()
+
+    def test_close_failure_does_not_replace_the_primary_open_error(self):
+        """Close diagnostics must not hide the provider error that caused unwind."""
+        primary_error = RuntimeError("JVOpen blew up")
+        wrapper = _Wrapper(opens=[primary_error], reads_per_open=[[]])
+        wrapper.jv_close = MagicMock(side_effect=RuntimeError("close failed"))
+        fetcher = _fetcher_with(wrapper)
+
+        with pytest.raises(FetcherError, match="JVOpen blew up") as exc_info:
+            list(fetcher.fetch("RACE", "20240101", "20241231", option=4))
+
+        assert exc_info.value.__cause__ is primary_error
+
     def test_an_error_code_is_not_absorbed_as_an_empty_window(self):
         """-113（終了時刻のパラメータ不正）も read_count 0 で返る。黙って進まない."""
         wrapper = _Wrapper(opens=[(-113, 0, 0, "")], reads_per_open=[[]])
@@ -370,6 +403,27 @@ class TestChunkFailuresDoNotLeakAcrossChunks:
         list(fetcher.fetch("RACE", "20240101", "20251231", option=4))
 
         assert seen == [1], "2 つめの chunk でリトライ回数が 0 に戻っていない"
+
+    def test_second_chunk_recovery_replays_only_its_own_emitted_prefix(self):
+        """Earlier chunks must not inflate the reopened stream's drain count."""
+        wrapper = MagicMock()
+        wrapper.jv_file_delete.return_value = 0
+        wrapper.jv_open.return_value = (0, 3, 1, "second-ts")
+        fetcher = _fetcher_with(wrapper)
+        fetcher._records_fetched = 5  # 3 from chunk 1, then 2 from chunk 2
+        fetcher._open_records_baseline = 3
+        fetcher._total_files = 3
+        fetcher._jv_open_context = (
+            "RACE",
+            "20241231235959-20251231235959",
+            4,
+        )
+        fetcher._jv_open_last_file_timestamp = "second-ts"
+        fetcher._wait_for_download = MagicMock()
+
+        fetcher._recover_historical_read_error(-402, "corrupt-second.jvd")
+
+        assert fetcher._jvd_replay_records_remaining == 2
 
 
 def test_the_headline_backfill_request_opens_once_per_year():

--- a/tests/test_jvopen_yearly_chunks.py
+++ b/tests/test_jvopen_yearly_chunks.py
@@ -1,0 +1,381 @@
+"""JVOpen の fromtime を暦年で刻む（keibaai_cloud#283 / ADR-0031）.
+
+1 read の費用は JVOpen の対象ファイル数で決まる。実測（2026-08-23・RACE・option=4）:
+44 ファイルなら 3.4 ms、5,096 ファイルなら 67.6 ms。だから範囲形式を使える dataspec は
+暦年で刻んで JVOpen を繰り返し、1 回の対象を小さく保つ。
+
+ここで守るのは 3 つ:
+  - 境界に穴も重複も無いこと（JVOpen は「開始より大きい」「終了まで」）
+  - 刻む対象を許可リストに閉じること（範囲形式で無言の 0 件になる dataspec がある）
+  - option 1 の差分カーソルと option 2 の今週データ契約を変えないこと
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from src.fetcher.base import FetcherError
+from src.fetcher.historical import (
+    HistoricalFetcher,
+    _jvopen_fromtime,
+    _jvopen_fromtimes,
+)
+from src.jvlink.constants import RANGE_FROMTIME_DATA_SPECS
+
+SETUP = 4
+
+
+def _starts_and_ends(fromtimes: list[str]) -> list[tuple[str, str]]:
+    return [tuple(ft.split("-")) for ft in fromtimes]
+
+
+class TestAllowList:
+    @pytest.mark.parametrize(
+        "data_spec", ["TOKU", "DIFF", "DIFN", "HOSE", "HOSN", "HOYU", "COMM"]
+    )
+    def test_specs_that_officially_forbid_an_end_point_are_not_on_the_allow_list(
+        self, data_spec
+    ):
+        """公式仕様 p.18 が終了時刻を禁じている種別。渡すと戻り値 -1 になる."""
+        assert data_spec not in RANGE_FROMTIME_DATA_SPECS
+
+    @pytest.mark.parametrize("data_spec", ["DIFN", "TOKU", "HOSN", "HOYU", "COMM", "BLDN"])
+    def test_specs_outside_the_allow_list_open_once_without_an_end_point(self, data_spec):
+        """終了時刻を受け付けない dataspec は、期間が何年でも開始のみ 1 回."""
+        fromtimes = _jvopen_fromtimes(data_spec, "19860101", "20261231", SETUP)
+
+        assert fromtimes == [_jvopen_fromtime("19860101", SETUP)]
+        assert "-" not in fromtimes[0]
+
+    def test_unmeasured_spec_falls_back_to_a_single_open(self):
+        """許可リストは実測済みのものだけ。未実測の spec は刻まない."""
+        assert _jvopen_fromtimes("YSCH", "19860101", "20261231", SETUP) == [
+            _jvopen_fromtime("19860101", SETUP)
+        ]
+
+
+class TestChunkBoundaries:
+    def test_one_chunk_per_calendar_year(self):
+        fromtimes = _jvopen_fromtimes("RACE", "19860101", "19881231", SETUP)
+
+        assert len(fromtimes) == 3
+
+    def test_setup_first_chunk_starts_the_day_before_to_include_the_requested_day(self):
+        """JVOpen の対象は「開始より大きい」。要求日を落とさないため前日 23:59:59."""
+        first, _ = _starts_and_ends(
+            _jvopen_fromtimes("RACE", "19860101", "19871231", SETUP)
+        )[0]
+
+        assert first == "19851231235959"
+
+    def test_later_chunks_start_at_the_previous_year_end(self):
+        pairs = _starts_and_ends(
+            _jvopen_fromtimes("RACE", "19860101", "19881231", SETUP)
+        )
+
+        assert [start for start, _ in pairs] == [
+            "19851231235959",
+            "19861231235959",
+            "19871231235959",
+        ]
+
+    def test_each_chunk_ends_at_its_year_end(self):
+        pairs = _starts_and_ends(
+            _jvopen_fromtimes("RACE", "19860101", "19881231", SETUP)
+        )
+
+        assert [end for _, end in pairs] == [
+            "19861231235959",
+            "19871231235959",
+            "19881231235959",
+        ]
+
+    def test_adjacent_chunks_share_their_boundary_so_nothing_is_lost_or_repeated(self):
+        """前の chunk は「終了まで」で含み、次の chunk は「開始より大きい」で外す."""
+        pairs = _starts_and_ends(
+            _jvopen_fromtimes("RACE", "19860101", "20261231", SETUP)
+        )
+
+        for (_, end), (next_start, _) in zip(pairs, pairs[1:], strict=False):  # 末尾は次が無いので短い側に合わせる
+            assert end == next_start
+
+    def test_last_chunk_ends_at_the_requested_day_not_the_year_end(self):
+        pairs = _starts_and_ends(
+            _jvopen_fromtimes("RACE", "20240101", "20250615", SETUP)
+        )
+
+        assert pairs[-1] == ("20241231235959", "20250615235959")
+
+    def test_a_request_inside_one_year_is_a_single_range(self):
+        assert _jvopen_fromtimes("RACE", "20220301", "20220930", SETUP) == [
+            "20220228235959-20220930235959"
+        ]
+
+    def test_a_single_day_request_is_a_single_range(self):
+        assert _jvopen_fromtimes("RACE", "20240229", "20240229", SETUP) == [
+            "20240228235959-20240229235959"
+        ]
+
+    def test_a_leap_day_start_keeps_the_previous_calendar_day(self):
+        first, _ = _starts_and_ends(
+            _jvopen_fromtimes("RACE", "20240301", "20241231", SETUP)
+        )[0]
+
+        assert first == "20240229235959"
+
+    def test_a_year_start_crossing_a_century_boundary(self):
+        pairs = _starts_and_ends(
+            _jvopen_fromtimes("RACE", "19991201", "20000131", SETUP)
+        )
+
+        assert pairs == [
+            ("19991130235959", "19991231235959"),
+            ("19991231235959", "20000131235959"),
+        ]
+
+
+class TestOptionContracts:
+    def test_option_1_keeps_its_midnight_diff_cursor_on_the_first_chunk(self):
+        """差分カーソルは触らない。setup と違って前日へずらさない."""
+        first, _ = _starts_and_ends(
+            _jvopen_fromtimes("RACE", "20250101", "20261231", 1)
+        )[0]
+
+        assert first == "20250101000000"
+
+    def test_option_1_still_chunks_by_year(self):
+        assert len(_jvopen_fromtimes("RACE", "20250101", "20261231", 1)) == 2
+
+    def test_option_2_is_never_chunked(self):
+        """今週データは開催サイクルが対象で、期間の概念が違う."""
+        assert _jvopen_fromtimes("RACE", "19860101", "20261231", 2) == [
+            _jvopen_fromtime("19860101", 2)
+        ]
+
+    @pytest.mark.parametrize("option", [3, 4])
+    def test_both_setup_options_chunk(self, option):
+        assert len(_jvopen_fromtimes("RACE", "20240101", "20261231", option)) == 3
+
+
+class _Wrapper:
+    """JVOpen/JVRead/JVClose の呼び出し順だけを記録する差し替え."""
+
+    def __init__(
+        self,
+        opens: list,
+        reads_per_open: list[list[tuple]],
+        on_open=None,
+    ):
+        self._opens = list(opens)
+        self._reads_per_open = [list(r) for r in reads_per_open]
+        self._current_reads: list[tuple] = []
+        self._on_open = on_open
+        self.open_fromtimes: list[str] = []
+        self.close_count = 0
+        self.init_count = 0
+
+    def jv_init(self, *args, **kwargs):
+        self.init_count += 1
+
+    def jv_open(self, data_spec, fromtime, option):
+        self.open_fromtimes.append(fromtime)
+        result = self._opens.pop(0)
+        self._current_reads = (
+            self._reads_per_open.pop(0) if self._reads_per_open else []
+        )
+        if self._on_open is not None:
+            self._on_open(len(self.open_fromtimes))
+        if isinstance(result, Exception):
+            raise result
+        return result
+
+    def jv_read(self):
+        return self._current_reads.pop(0)
+
+    def jv_close(self):
+        self.close_count += 1
+        return 0
+
+
+def _fetcher_with(wrapper) -> HistoricalFetcher:
+    f = HistoricalFetcher.__new__(HistoricalFetcher)
+    f.parser_factory = MagicMock()
+    f.parser_factory.parse.side_effect = lambda buff: [
+        {"Year": "2022", "MonthDay": "0110", "n": len(buff)}
+    ]
+    f.cache_manager = None
+    f.show_progress = False
+    f.progress_display = None
+    f._service_key = None
+    f._records_fetched = f._records_parsed = f._records_failed = 0
+    f._files_processed = f._total_files = 0
+    f._repaired_read_errors = 0
+    f._start_time = 0.0
+    f._jvd_self_repair_attempts = f._jvd_replay_records_remaining = 0
+    f._open_records_baseline = 0
+    f._recoverable_read_errors = 0
+    f._jv_open_context = f._jv_open_last_file_timestamp = f._fetch_task_id = None
+    f.jvlink = wrapper
+    return f
+
+
+DONE = (0, None, None)
+
+
+def _one_record_open(ts: str = "20220110000000") -> tuple:
+    """(result, read_count, download_count, last_file_timestamp)."""
+    return (0, 1, 0, ts)
+
+
+class TestFetchLoopsOverChunks:
+    def test_opens_once_per_year_with_the_chunk_fromtimes(self):
+        wrapper = _Wrapper(
+            opens=[_one_record_open(), _one_record_open()],
+            reads_per_open=[[(4, b"aaaa", "f1"), DONE], [(4, b"bbbb", "f2"), DONE]],
+        )
+        f = _fetcher_with(wrapper)
+
+        list(f.fetch("RACE", "20240101", "20251231", option=4))
+
+        assert wrapper.open_fromtimes == [
+            "20231231235959-20241231235959",
+            "20241231235959-20251231235959",
+        ]
+
+    def test_yields_records_from_every_chunk(self):
+        wrapper = _Wrapper(
+            opens=[_one_record_open(), _one_record_open()],
+            reads_per_open=[[(4, b"aaaa", "f1"), DONE], [(6, b"bbbbbb", "f2"), DONE]],
+        )
+        f = _fetcher_with(wrapper)
+
+        rows = list(f.fetch("RACE", "20240101", "20251231", option=4))
+
+        assert [r["n"] for r in rows] == [4, 6]
+
+    def test_statistics_accumulate_across_chunks(self):
+        wrapper = _Wrapper(
+            opens=[_one_record_open(), _one_record_open()],
+            reads_per_open=[[(4, b"aaaa", "f1"), DONE], [(4, b"bbbb", "f2"), DONE]],
+        )
+        f = _fetcher_with(wrapper)
+
+        list(f.fetch("RACE", "20240101", "20251231", option=4))
+
+        assert f.get_statistics()["records_fetched"] == 2
+
+    def test_a_chunk_with_no_data_does_not_stop_the_later_chunks(self):
+        """空の窓は正常。-1 で fetch 全体を落とさない."""
+        wrapper = _Wrapper(
+            opens=[(-1, 0, 0, ""), _one_record_open()],
+            reads_per_open=[[], [(4, b"bbbb", "f2"), DONE]],
+        )
+        f = _fetcher_with(wrapper)
+
+        rows = list(f.fetch("RACE", "20240101", "20251231", option=4))
+
+        assert len(rows) == 1
+        assert len(wrapper.open_fromtimes) == 2
+
+    def test_stream_is_closed_after_each_chunk(self):
+        wrapper = _Wrapper(
+            opens=[_one_record_open(), _one_record_open()],
+            reads_per_open=[[(4, b"aaaa", "f1"), DONE], [(4, b"bbbb", "f2"), DONE]],
+        )
+        f = _fetcher_with(wrapper)
+
+        list(f.fetch("RACE", "20240101", "20251231", option=4))
+
+        assert wrapper.close_count >= 2
+
+    def test_spec_outside_the_allow_list_opens_once_for_a_multi_year_request(self):
+        wrapper = _Wrapper(
+            opens=[_one_record_open()],
+            reads_per_open=[[(4, b"aaaa", "f1"), DONE]],
+        )
+        f = _fetcher_with(wrapper)
+
+        list(f.fetch("DIFN", "20240101", "20261231", option=4))
+
+        assert wrapper.open_fromtimes == ["20231231235959"]
+
+
+class TestChunkFailuresDoNotLeakAcrossChunks:
+    def test_an_empty_window_never_marks_the_nl_cache_range_complete(self):
+        """空の窓で完了マークを付けると、以後その範囲は 0 件で答え続ける."""
+        wrapper = _Wrapper(
+            opens=[(-1, 0, 0, ""), _one_record_open()],
+            reads_per_open=[[], [(4, b"bbbb", "f2"), DONE]],
+        )
+        f = _fetcher_with(wrapper)
+        f.cache_manager = MagicMock()
+        f.cache_manager.checkpoint_nl.return_value = 0
+
+        list(f.fetch("RACE", "20240101", "20251231", option=4))
+
+        f.cache_manager.mark_nl_range_complete.assert_not_called()
+
+    def test_a_fully_covered_request_still_marks_the_range_complete(self):
+        """対照。空の窓が無ければ従来どおり完了マークを付ける."""
+        wrapper = _Wrapper(
+            opens=[_one_record_open(), _one_record_open()],
+            reads_per_open=[[(4, b"aaaa", "f1"), DONE], [(4, b"bbbb", "f2"), DONE]],
+        )
+        f = _fetcher_with(wrapper)
+        f.cache_manager = MagicMock()
+        f.cache_manager.checkpoint_nl.return_value = 0
+
+        list(f.fetch("RACE", "20240101", "20251231", option=4))
+
+        f.cache_manager.mark_nl_range_complete.assert_called_once()
+
+    def test_the_stream_is_closed_even_when_jvopen_itself_raises(self):
+        """wrapper は開いたまま例外で返ることがある（-202）。close の義務は残る."""
+        wrapper = _Wrapper(
+            opens=[RuntimeError("JVOpen blew up")],
+            reads_per_open=[[]],
+        )
+        f = _fetcher_with(wrapper)
+
+        with pytest.raises(FetcherError):
+            list(f.fetch("RACE", "20240101", "20241231", option=4))
+
+        assert wrapper.close_count == 1
+
+    def test_an_error_code_is_not_absorbed_as_an_empty_window(self):
+        """-113（終了時刻のパラメータ不正）も read_count 0 で返る。黙って進まない."""
+        wrapper = _Wrapper(opens=[(-113, 0, 0, "")], reads_per_open=[[]])
+        f = _fetcher_with(wrapper)
+
+        with pytest.raises(FetcherError, match="-113"):
+            list(f.fetch("RACE", "20240101", "20241231", option=4))
+
+    def test_the_self_repair_budget_is_per_fetch_not_per_chunk(self):
+        """chunk ごとに上限を配り直すと、全体では chunk 数ぶんリトライできてしまう."""
+        seen = []
+
+        def _on_open(open_number: int):
+            if open_number == 1:
+                fetcher._jvd_self_repair_attempts = 1
+            else:
+                seen.append(fetcher._jvd_self_repair_attempts)
+
+        wrapper = _Wrapper(
+            opens=[_one_record_open(), _one_record_open()],
+            reads_per_open=[[(4, b"aaaa", "f1"), DONE], [(4, b"bbbb", "f2"), DONE]],
+            on_open=_on_open,
+        )
+        fetcher = _fetcher_with(wrapper)
+
+        list(fetcher.fetch("RACE", "20240101", "20251231", option=4))
+
+        assert seen == [1], "2 つめの chunk でリトライ回数が 0 に戻っていない"
+
+
+def test_the_headline_backfill_request_opens_once_per_year():
+    """1986-2026 は 41 年。刻みの回数が年数と一致すること."""
+    fromtimes = _jvopen_fromtimes("RACE", "19860101", "20261231", SETUP)
+
+    assert len(fromtimes) == 41
+    assert fromtimes[0] == "19851231235959-19861231235959"
+    assert fromtimes[-1] == "20251231235959-20261231235959"


### PR DESCRIPTION
## 概要

`JVOpen` の `fromtime` を暦年で刻み、範囲形式を使える dataspec について
`JVOpen` → 読み出し → `JVClose` を年ごとに繰り返すようにします。

動機は速度です。**`JVRead` 1 回の費用は、その `JVOpen` が並べた対象ファイル数で
決まります。** 同じ先頭 200 レコードを読み、ファイル数だけを変えて計測しました
（2026-08-23・`RACE`・option=4・両パスでバイト列一致を確認）。

| 対象ファイル数 | JVRead | JVGets | 1 read あたり |
|---:|---:|---:|---:|
| 44（1986 年ぶんの範囲形式） | 295.7 rec/s | 320.5 rec/s | 3.4 / 3.1 ms |
| 5,096（1986 起点・開始のみ） | 14.8 rec/s | 14.9 rec/s | 67.6 / 67.1 ms |

仕様書 4.9.0.1 p.17 の「既知の障害」（対象ファイル数が多いと JVRead が遅くなる）は、
**dataspec を個別指定していても効きます**。効いている変数はファイル数の側でした。

## 「終了時刻は setup では効かない」という読みについて

これは覆ります。`--from` を 1986 に固定し、終了時刻だけを振ると `readcount` が変わります。

| fromtime（option=4） | readcount | last_file_timestamp |
|---|---:|---|
| `19860101000000-20201231235959` | 3,973 | `20230808173638` |
| `19860101000000-20221231235959` | 4,337 | `20230808174549` |
| `19860101000000`（開始のみ） | 5,096 | `20260822112817` |

**誤解の元は `last_file_timestamp` です。** セットアップ用アーカイブのファイルは
収録データの日付ではなく **build 時刻**（2023-08-08 帯）の刻印を持つため、期間で
正しく絞った結果でも `20230808…` が返ります。これを「要求終端より後のファイルが
混ざっている＝絞られていない」と読むと逆の結論になります。**絞り込みが効いているかは、
終了時刻ごとに値が変わるかで判断してください**（上表の `173638` と `174549`）。

## 実機での動作確認

`RACE` を 2019-12-01〜2020-01-31（暦年をまたぐ最小の窓）で option=4 実走しました。

- 1 回の対象ファイル数は **15**（開始のみなら 5,096）
- `JVOpen` 1 回の所要は **3.3 秒 / 0.05 秒**（5,096 ファイルの open は 137 秒）。
  41 chunk ぶん積んでも数分で、短縮ぶんを食いません
- セットアップの取得元ダイアログが chunk の数だけ増えることはありませんでした
- 実行中の CPU 帰属は dllhost 0.012 コア / python 0.97 コア。開始のみ 1 発の実走では
  dllhost 0.96 コア / python 0.05 コアだったので、**律速が JV-Link から呼び出し側へ移りました**
## 設計
- **許可リスト方式**（`RANGE_FROMTIME_DATA_SPECS = {RACE, SLOP, WOOD}`）。
  表を間違えたとき、許可リストは「刻まないので遅いまま」で倒れ、拒否リストは
  「終了時刻を受け付けない種別へ渡して無言の 0 件」＝取りこぼしで倒れます。
  仕様 p.18 が終了時刻を禁じているのは TOKU / DIFF・DIFN / HOSE・HOSN / HOYU / COMM。
  `BLDN` / `YSCH` / `SNPN` / `MING` は禁止ではなく**未実測**なので載せていません
- **境界は隣接 chunk で共有**します。`JVOpen` の対象は「開始より大きく、終了時刻まで」
  なので、その時刻のファイルは前の chunk に入り次の chunk からは外れます。穴も重複も出ません
- **`JVInit` は従来どおり fetch につき 1 回**（ループの外）。`JVClose` は `JVOpen` ごと
- option 1 の差分カーソル（`{from}000000`）と option 2 の今週データ契約は変更していません
## 契約の変更点
- **`--to` は、範囲形式を使える dataspec では `JVOpen` の終端にもなります**（従来は
  クライアント側フィルタのみ）。`--to` を実データより手前に置くと「大量に落としてから
  0 件に絞られる」ではなく「そもそも降ってこない」になります
- 最後の chunk の終端は**ファイル時刻**で切ります
## テスト
新規 41 件（境界・許可リスト・option 契約・`JVOpen` 回数・空窓での継続・
NL キャッシュを完了扱いにしないこと・`JVOpen` が例外でも `JVClose` すること・
`-113` を握り潰さないこと）。全体 4,768 passed。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Historical data requests now support calendar-year date ranges for RACE, SLOP, and WOOD data.
  * Date ranges are fetched, filtered, cached, and reported progressively for improved long-range retrieval.
  * Unsupported data types continue using start-date requests with client-side end-date filtering.

* **Documentation**
  * Updated CLI and data-access documentation to explain date-range behavior and yearly request handling.

* **Bug Fixes**
  * Improved handling of empty or invalid date windows, interrupted ranges, and cache completion during long historical downloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->