### PR TITLE
fix: count accepted provider operations consistently

### DIFF
--- a/specs/operations/20260827_postgresql_import_statistics_worklog.md
+++ b/specs/operations/20260827_postgresql_import_statistics_worklog.md
@@ -1,0 +1,91 @@
+# PostgreSQL provider-operation import statistics — 2026-08-27
+
+## Purpose and minimal scope
+
+The unpublished `2.0.0` final candidate completed a bounded real-provider DIFN
+option-4 setup with 253,944 parsed records, zero failed records, and 253,529
+reported imports. The durable PostgreSQL master state was correct, but 415
+accepted same-primary-key provider revisions were collapsed by the PostgreSQL
+multi-row upsert before the importer counted them. SQLite counts the accepted
+input operations. This iteration fixes only that statistics/backend-parity
+contract; it does not change parsing, validation, keys, final-row semantics,
+transactions, collector identity, or release metadata.
+
+## Repository and immutable starting state
+
+- Repository: `miyamamoto/jrvltsql`
+- Worktree: `/home/keiba/scratch/20260827_jrvltsql_import_stats`
+- Branch: `fix/postgresql-import-statistics-20260827`
+- Base and initial HEAD: `def93638466722e30a12f318baf7da5ec0da9ec2`
+- Base source: freshly fetched `origin/master`
+- Related draft release PR: `#249` (`2.0.0` final; publication held)
+- Current published prerelease: `v2.0.0.dev6`
+- Target release after this repair is merged and revalidated: `v2.0.0`
+- Initial worktree state: clean
+
+The shared checkout `/home/keiba/jrvltsql` contains unrelated changes and is
+out of scope. The KIR runtime checkout also contains unrelated local state and
+must not be edited by this iteration.
+
+## Observed evidence and cause
+
+- Real provider DIFN option-4 setup accepted 253,944 parsed records and reported
+  zero failures, but `records_imported=253529`.
+- The discrepancy is concentrated in one successful 10,000-record PostgreSQL
+  chunk: it reported 9,585 imports, exactly 415 fewer accepted operations.
+- `PostgreSQLDatabase.insert_many()` deliberately keeps the last row for each
+  repeated primary key so one `ON CONFLICT DO UPDATE` statement is valid.
+- Generic importer statistics use that deduplicated physical-operation count
+  except for a selective record-family allowlist. Therefore an unlisted DIFN
+  family undercounts accepted provider operations; SQLite does not.
+- Final durable data and transaction completion were correct. This is a
+  statistics/observability defect, not record loss.
+
+## Red-first contract
+
+Add one compact regression using an existing generic DIFN master family and
+two valid same-key provider revisions in one batch. It must prove:
+
+1. both regular and optimized importers report two accepted operations;
+2. durable storage contains one row with the last provider revision;
+3. `records_failed` remains zero;
+4. SQLite and PostgreSQL agree;
+5. the test fails against the base behavior before implementation.
+
+Do not create a broad record-family matrix. Reuse an existing official-contract
+fixture and its PostgreSQL integration fixture where possible.
+
+## Implementation boundary under review
+
+On a successful generic batch, every converted input row was accepted; batch
+failure already enters the existing per-record fallback (or propagates for a
+caller-owned transaction) and counts individual successes/failures. The likely
+minimal fix is therefore to count `len(converted_batch)` / `len(batch)` after a
+successful generic batch rather than maintain a selective allowlist. Before
+changing it, verify there is no success path where `insert_many` intentionally
+returns fewer accepted input operations for a reason other than same-key
+deduplication.
+
+## Verification and merge gates
+
+- Red proof against base, with the observed assertion recorded here and in the
+  PR.
+- Focused official-contract test on SQLite and disposable PostgreSQL 16.
+- Existing importer/database focused tests affected by the shared path.
+- Formatting/lint/compile and `git diff --check` proportional to the delta.
+- Candidate full SHA recorded after push; unresolved review threads zero;
+  clean worktree; PR merged before rebuilding draft release PR `#249`.
+
+## STOP conditions
+
+- Any durable-row or transaction semantic change beyond statistics.
+- Any mismatch between the reproduced failure and the real DIFN evidence.
+- Any unexpected shared-worktree drift in this dedicated worktree.
+- Any PostgreSQL result that indicates actual record failure or loss rather
+  than same-key compaction.
+
+## Next safe action
+
+Extend one existing DIFN official-contract test with a two-revision same-key
+batch, run it unchanged against this base to capture the red result, then make
+the smallest shared statistics correction in both importer implementations.

--- a/specs/operations/20260827_postgresql_import_statistics_worklog.md
+++ b/specs/operations/20260827_postgresql_import_statistics_worklog.md
@@ -148,3 +148,60 @@ the final test result in the PR evidence (avoiding a worklog self-reference
 commit loop). Resolve all actionable review threads before merge. After merge,
 refresh the draft `2.0.0` final branch from the new `master` and repeat only the
 provider/import statistics and package/runtime gates affected by this fix.
+
+## Aggregated review corrections
+
+The first candidate was `108ee0e2267f81dc5faa16845503f9fddc1804a0`.
+The non-slow local suite on that immutable candidate completed with:
+
+```text
+4796 passed, 507 skipped, 14 deselected, 21 subtests passed
+```
+
+Native review then identified one real adjacent failure boundary: the generic
+batch counters were updated before an auto-commit. If that commit failed, the
+existing per-record fallback retried the same provider operations and counted
+the fallback outcome on top of the failed batch. A minimal regression injects
+two commit failures so the batch commit fails, the first individual retry
+fails, and the second retry succeeds durably. Before the correction it produced
+the required red evidence:
+
+```text
+DataImporter:          records_imported=3, expected 1
+OptimizedDataImporter: records_imported=4, expected 1
+```
+
+The correction moves successful batch counters, and the optimized individual
+counter, after the applicable commit succeeds. The same regression is now
+green for both importers (`2 passed`), with one durable later revision,
+`records_imported=1`, `records_failed=1`, and `batches_processed=0`. This does
+not change caller-owned transaction behavior because those paths do not commit
+inside the importer.
+
+The PostgreSQL fixture cleanup was also made unconditional with `finally` so a
+schema cleanup failure cannot leak the test connection. A request to write the
+eventual candidate SHA into its own tracked commit is intentionally not
+followed: repository policy forbids self-reference commit loops. Exact final
+SHA and immutable test evidence are instead recorded on the PR and in GitHub
+check metadata.
+
+## Next safe action after review correction
+
+The complete BN contract and the bounded shared-path selection were run on
+SQLite plus a fresh disposable PostgreSQL 16 instance after the correction:
+
+```text
+tests/test_bn_official_contract.py
+tests/test_importer.py
+tests/test_importer_clean_record.py
+tests/test_dual_handler_transactions.py
+tests/test_postgresql.py
+tests/test_cc_official_contract.py: 176 passed
+```
+
+The disposable container was removed. `uv lock --check`, the repository test
+gate, fatal flake8 (`E9,F63,F7,F82`, count 0), compileall, and `git diff
+--check` also pass. Commit and push this one aggregated correction, run the
+non-slow suite on its immutable SHA, record that evidence on the PR, and
+resolve the review threads. Do not merge until required `lint` and `test`
+checks have executed successfully and the worktree is clean.

--- a/specs/operations/20260827_postgresql_import_statistics_worklog.md
+++ b/specs/operations/20260827_postgresql_import_statistics_worklog.md
@@ -89,3 +89,62 @@ deduplication.
 Extend one existing DIFN official-contract test with a two-revision same-key
 batch, run it unchanged against this base to capture the red result, then make
 the smallest shared statistics correction in both importer implementations.
+
+## Red proof on the base implementation
+
+The compact BN regression was added without changing production code and run
+against a fresh disposable PostgreSQL 16 instance plus SQLite:
+
+```text
+tests/test_bn_official_contract.py: 2 failed, 48 passed
+PostgreSQL DataImporter:          assert 1 == 2
+PostgreSQL OptimizedDataImporter: assert 1 == 2
+SQLite regular/optimized controls: passed
+```
+
+Both PostgreSQL failures stored exactly one final row with the later body and
+reported zero failures. This matches the real DIFN setup evidence: data and
+provider order are correct, while accepted-operation statistics are
+under-counted after same-key batch compaction.
+
+## Implementation and focused green evidence
+
+- Removed the record-family allowlist from the two generic batch writers.
+- After a successful generic batch, `DataImporter` now counts
+  `len(converted_batch)` and `OptimizedDataImporter` counts `len(batch)`.
+- No error, fallback, commit, rollback, conversion, validation, or physical
+  upsert branch changed. A failed auto-commit batch still retries and counts
+  each individual result; a failed caller-owned batch still propagates.
+- The regression uses two independently parsed, official-length 477-byte BN
+  records with one key and distinct owner names. It verifies the later body is
+  durable as one row while both accepted provider operations are counted.
+
+Fresh disposable PostgreSQL 16 plus SQLite:
+
+```text
+tests/test_bn_official_contract.py: 50 passed
+tests/test_importer.py
+tests/test_importer_clean_record.py
+tests/test_dual_handler_transactions.py
+tests/test_postgresql.py
+tests/test_cc_official_contract.py: 124 passed
+```
+
+The second selection retains the previously reviewed same-key CC PostgreSQL
+contract and the generic batch-error/transaction coverage. No record failure,
+row divergence, or pending transaction was observed.
+
+Local workflow-equivalent static gates also pass: `uv lock --check`,
+`scripts/validate_test_gate.py`, fatal flake8 (`E9,F63,F7,F82`, count 0),
+Python 3.13 compileall, and `git diff --check`. The repository's advisory
+Black/Ruff debt predates this delta and is not a workflow merge gate; no
+unrelated formatting rewrite is included.
+
+## Handoff / next safe action
+
+Commit and push this bounded four-file delta, run the non-slow local suite on
+that exact candidate SHA, open one PR, and record the candidate full SHA plus
+the final test result in the PR evidence (avoiding a worklog self-reference
+commit loop). Resolve all actionable review threads before merge. After merge,
+refresh the draft `2.0.0` final branch from the new `master` and repeat only the
+provider/import statistics and package/runtime gates affected by this fix.

--- a/src/importer/importer.py
+++ b/src/importer/importer.py
@@ -987,17 +987,6 @@ _UM_LOSSLESS_TEXT_WIDTHS = {
     "NL_UM": _UM_NATIVE_LOSSLESS_TEXT_WIDTHS,
     "UMA": _UM_STANDARD_LOSSLESS_TEXT_WIDTHS,
 }
-_PROVIDER_OPERATION_COUNT_STORAGE_TABLES = (
-    _AV_STORAGE_TABLES
-    | _HR_STORAGE_TABLES
-    | _HS_STORAGE_TABLES
-    | _HC_STORAGE_TABLES
-    | _HN_STORAGE_TABLES
-    | _SK_STORAGE_TABLES
-    | _TC_STORAGE_TABLES
-    | _CC_STORAGE_TABLES
-    | _UM_ERASE_STORAGE_TABLES
-)
 _JC_STORAGE_TABLES = frozenset({"NL_JC", "RT_JC", "KISYU_CHANGE"})
 _JC_KEY_COLUMNS = (
     "Year",
@@ -8892,14 +8881,12 @@ class DataImporter:
                 return
 
             # Insert batch using INSERT OR REPLACE
-            affected_rows = self.database.insert_many(table_name, converted_batch, use_replace=True)
+            self.database.insert_many(table_name, converted_batch, use_replace=True)
             # PostgreSQL collapses same-key replacement operations before one upsert.
-            # Statistics count accepted provider operations, not final rows.
-            rows = (
-                len(converted_batch)
-                if table_name in _PROVIDER_OPERATION_COUNT_STORAGE_TABLES
-                else affected_rows
-            )
+            # A successful generic batch accepted every converted input row, so
+            # statistics count provider operations rather than deduplicated
+            # physical upserts. Batch failures take the per-record fallback below.
+            rows = len(converted_batch)
 
             self._records_imported += rows
             self._batches_processed += 1

--- a/src/importer/importer.py
+++ b/src/importer/importer.py
@@ -8888,11 +8888,11 @@ class DataImporter:
             # physical upserts. Batch failures take the per-record fallback below.
             rows = len(converted_batch)
 
-            self._records_imported += rows
-            self._batches_processed += 1
-
             if auto_commit:
                 self.database.commit()
+
+            self._records_imported += rows
+            self._batches_processed += 1
 
             logger.debug(
                 "Batch inserted",

--- a/src/importer/importer_optimized.py
+++ b/src/importer/importer_optimized.py
@@ -1104,12 +1104,12 @@ class OptimizedDataImporter:
             # Batch failures take the per-record fallback below.
             rows = len(batch)
 
-            self._records_imported += rows
-            self._batches_processed += 1
-
             # Only commit if not in a larger transaction
             if commit_batch:
                 self.database.commit()
+
+            self._records_imported += rows
+            self._batches_processed += 1
 
             logger.debug(
                 "Batch inserted",
@@ -1135,10 +1135,11 @@ class OptimizedDataImporter:
             for record in batch:
                 try:
                     self.database.insert(table_name, record)
-                    self._records_imported += 1
 
                     if commit_batch:
                         self.database.commit()
+
+                    self._records_imported += 1
 
                 except DatabaseError as e:
                     self._records_failed += 1

--- a/src/importer/importer_optimized.py
+++ b/src/importer/importer_optimized.py
@@ -17,7 +17,6 @@ from src.importer.importer import (
     _PREPARED_CH_SEISEKI_ROWS_KEY,
     _PREPARED_CK_ROWS_KEY,
     _PREPARED_KS_SEISEKI_ROWS_KEY,
-    _PROVIDER_OPERATION_COUNT_STORAGE_TABLES,
     _RC_STORAGE_TABLES,
     _STANDARD_ODDS_CONFIG_BY_OWNER,
     _STANDARD_VOTE_CONFIG_BY_OWNER,
@@ -1094,18 +1093,16 @@ class OptimizedDataImporter:
             # Use optimized insert if available
             if hasattr(self.database, "insert_many_optimized"):
                 # Optimized path
-                affected_rows = self.database.insert_many_optimized(table_name, batch)
+                self.database.insert_many_optimized(table_name, batch)
             else:
                 # Standard insert_many
-                affected_rows = self.database.insert_many(table_name, batch)
+                self.database.insert_many(table_name, batch)
 
             # PostgreSQL collapses same-key replacement operations before one upsert.
-            # Statistics count accepted provider operations, not final rows.
-            rows = (
-                len(batch)
-                if table_name in _PROVIDER_OPERATION_COUNT_STORAGE_TABLES
-                else affected_rows
-            )
+            # A successful generic batch accepted every input row, so statistics
+            # count provider operations rather than deduplicated physical upserts.
+            # Batch failures take the per-record fallback below.
+            rows = len(batch)
 
             self._records_imported += rows
             self._batches_processed += 1

--- a/tests/test_bn_official_contract.py
+++ b/tests/test_bn_official_contract.py
@@ -7,6 +7,7 @@ from uuid import uuid4
 
 import pytest
 
+from src.database.base import DatabaseError
 from src.database.migration import SchemaMigrationError, migrate_table_if_needed
 from src.database.schema import SCHEMAS
 from src.database.schema_jravan import JRAVAN_SCHEMAS
@@ -209,9 +210,21 @@ def bn_statistics_database(request, tmp_path):
             database.rollback()
         except Exception:
             pass
-        database.execute(f"DROP SCHEMA IF EXISTS {schema_name} CASCADE")
-        database.commit()
-        database.disconnect()
+        try:
+            database.execute(f"DROP SCHEMA IF EXISTS {schema_name} CASCADE")
+            database.commit()
+        finally:
+            database.disconnect()
+
+
+def _same_key_provider_revisions() -> tuple[dict, dict]:
+    first = BNParser().parse(build_record())
+    assert first is not None
+    second_raw = bytearray(build_record())
+    second_raw[81:145] = _pad("Updated Owner Sentinel", 64)
+    second = BNParser().parse(bytes(second_raw))
+    assert second is not None
+    return first, second
 
 
 @pytest.mark.parametrize("importer_class", (DataImporter, OptimizedDataImporter))
@@ -221,12 +234,7 @@ def test_bn_same_key_provider_revisions_count_as_two_operations(
     database = bn_statistics_database
     database.execute(SCHEMAS["NL_BN"])
     database.commit()
-    first = BNParser().parse(build_record())
-    assert first is not None
-    second_raw = bytearray(build_record())
-    second_raw[81:145] = _pad("Updated Owner Sentinel", 64)
-    second = BNParser().parse(bytes(second_raw))
-    assert second is not None
+    first, second = _same_key_provider_revisions()
 
     stats = importer_class(database).import_records(iter([first, second]), auto_commit=True)
     stored = database.fetch_all(
@@ -235,6 +243,41 @@ def test_bn_same_key_provider_revisions_count_as_two_operations(
 
     assert stats["records_imported"] == 2
     assert stats["records_failed"] == 0
+    assert stored == [
+        {"BanusiCode": EXPECTED["BanusiCode"], "BanusiName": "Updated Owner Sentinel"}
+    ]
+
+
+class _TwoCommitFailuresSQLite(SQLiteDatabase):
+    remaining_commit_failures = 0
+
+    def commit(self) -> None:
+        if self.remaining_commit_failures:
+            self.remaining_commit_failures -= 1
+            self.rollback()
+            raise DatabaseError("injected commit failure")
+        super().commit()
+
+
+@pytest.mark.parametrize("importer_class", (DataImporter, OptimizedDataImporter))
+def test_bn_commit_failures_count_only_durable_individual_retries(
+    tmp_path, importer_class
+) -> None:
+    database = _TwoCommitFailuresSQLite({"path": str(tmp_path / "bn-commit-failure.db")})
+    with database:
+        database.execute(SCHEMAS["NL_BN"])
+        database.commit()
+        database.remaining_commit_failures = 2
+        first, second = _same_key_provider_revisions()
+
+        stats = importer_class(database).import_records(iter([first, second]), auto_commit=True)
+        stored = database.fetch_all(
+            'SELECT BanusiCode AS "BanusiCode", BanusiName AS "BanusiName" FROM NL_BN'
+        )
+
+    assert stats["records_imported"] == 1
+    assert stats["records_failed"] == 1
+    assert stats["batches_processed"] == 0
     assert stored == [
         {"BanusiCode": EXPECTED["BanusiCode"], "BanusiName": "Updated Owner Sentinel"}
     ]

--- a/tests/test_bn_official_contract.py
+++ b/tests/test_bn_official_contract.py
@@ -1,7 +1,9 @@
 #!/usr/bin/env python
 """BN parser and storage contract for the official current 477-byte layout."""
 
+import os
 from itertools import pairwise
+from uuid import uuid4
 
 import pytest
 
@@ -178,6 +180,64 @@ def test_bn_round_trips_every_business_field(
     for field_name in BUSINESS_FIELDS - NUMERIC_FIELDS - {"MakeDate"}:
         assert row[field_name] == EXPECTED[field_name]
     assert str(row["MakeDate"]).replace("-", "") == EXPECTED["MakeDate"]
+
+
+@pytest.fixture(params=("sqlite", "postgresql"))
+def bn_statistics_database(request, tmp_path):
+    if request.param == "sqlite":
+        database = SQLiteDatabase({"path": str(tmp_path / "bn-statistics.db")})
+        with database:
+            yield database
+        return
+
+    if os.getenv("JLTSQL_RUN_POSTGRESQL_INTEGRATION") != "1":
+        pytest.skip("Set JLTSQL_RUN_POSTGRESQL_INTEGRATION=1 to run PostgreSQL tests")
+
+    from scripts.setup_pg_test_db import postgresql_test_config
+    from src.database.postgresql_handler import PostgreSQLDatabase
+
+    database = PostgreSQLDatabase(postgresql_test_config())
+    schema_name = f"jlt_bn_stats_{uuid4().hex[:12]}"
+    database.connect()
+    try:
+        database.execute(f"CREATE SCHEMA {schema_name}")
+        database.execute(f"SET search_path TO {schema_name}")
+        database.commit()
+        yield database
+    finally:
+        try:
+            database.rollback()
+        except Exception:
+            pass
+        database.execute(f"DROP SCHEMA IF EXISTS {schema_name} CASCADE")
+        database.commit()
+        database.disconnect()
+
+
+@pytest.mark.parametrize("importer_class", (DataImporter, OptimizedDataImporter))
+def test_bn_same_key_provider_revisions_count_as_two_operations(
+    bn_statistics_database, importer_class
+) -> None:
+    database = bn_statistics_database
+    database.execute(SCHEMAS["NL_BN"])
+    database.commit()
+    first = BNParser().parse(build_record())
+    assert first is not None
+    second_raw = bytearray(build_record())
+    second_raw[81:145] = _pad("Updated Owner Sentinel", 64)
+    second = BNParser().parse(bytes(second_raw))
+    assert second is not None
+
+    stats = importer_class(database).import_records(iter([first, second]), auto_commit=True)
+    stored = database.fetch_all(
+        'SELECT BanusiCode AS "BanusiCode", BanusiName AS "BanusiName" FROM NL_BN'
+    )
+
+    assert stats["records_imported"] == 2
+    assert stats["records_failed"] == 0
+    assert stored == [
+        {"BanusiCode": EXPECTED["BanusiCode"], "BanusiName": "Updated Owner Sentinel"}
+    ]
 
 
 OBSOLETE_STANDARD_SCHEMA = """


### PR DESCRIPTION
## Summary

A real DIFN option-4 setup accepted 253,944 parsed records with zero failures but reported 253,529 imports. PostgreSQL compacts repeated primary keys before one multi-row upsert, so generic import statistics counted deduplicated physical operations while SQLite counted accepted provider operations.

This change makes both generic importers count every converted input after a successful batch. Batch failure, individual retry, rollback, validation, keys, and durable upsert semantics are unchanged.

The final 2.0.0 release PR #249 remains Draft until this repair is merged and revalidated.

## Red-first proof

On base def93638466722e30a12f318baf7da5ec0da9ec2, the new official BN same-key regression produced:

- PostgreSQL DataImporter: assert 1 == 2
- PostgreSQL OptimizedDataImporter: assert 1 == 2
- SQLite regular and optimized controls: pass
- overall: 2 failed, 48 passed

Both failing PostgreSQL cases had the correct single durable later row and zero failed records.

## Candidate evidence

Candidate: 108ee0e2267f81dc5faa16845503f9fddc1804a0

- Fresh PostgreSQL 16 plus SQLite BN contract: 50 passed
- Importer, Dual, PostgreSQL, and existing CC same-key contract: 124 passed
- CI-equivalent non-slow suite: 4796 passed, 507 skipped, 14 deselected, 21 subtests passed
- uv lock --check: pass
- validate_test_gate.py: pass
- fatal flake8 E9,F63,F7,F82: 0
- compileall and git diff --check: pass

Tracked worklog: specs/operations/20260827_postgresql_import_statistics_worklog.md

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected import statistics for PostgreSQL and SQLite.
  * Same-key provider revisions are now counted as separate imported records while retaining the latest revision details.
  * Import totals are now consistent across supported importer modes.
  * Existing transaction and failure behavior remains unchanged.

* **Documentation**
  * Added release and validation notes covering the import-statistics correction.

* **Tests**
  * Added regression coverage for same-key provider revisions across PostgreSQL and SQLite.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->