### PR TITLE
Fix Click 8.5 CLI test isolation compatibility

### DIFF
--- a/specs/operations/20260827_click84_cli_test_isolation_worklog.md
+++ b/specs/operations/20260827_click84_cli_test_isolation_worklog.md
@@ -63,19 +63,27 @@ python -m pytest tests/test_cli.py tests/test_retired_data_specs.py -q --no-cov
   checks execute successfully; unresolved review threads are zero; worktree is
   clean before merge.
 
-## Uncommitted implementation verification
+## Implementation verification
 
 The minimal test-only compatibility runner was applied with no production
 source, dependency, warning-policy, or assertion changes. Python 3.12.11 with
-Click 8.5.0 now reports:
+Click 8.5.0 at implementation commit
+`e419fb2e342643df18c7f5c0bfed68bfed95908d` reports:
 
 ```text
 193 passed, 10 subtests passed
+4794 passed, 505 skipped, 14 deselected, 21 subtests passed
 ```
 
-The repository fail-closed test-gate validator and `compileall` also pass.
-The next candidate commit must still pass fatal flake8, `uv lock --check`, the
-non-slow full suite, and the required GitHub checks before merge.
+The second line is the complete non-slow local workflow selection. The
+repository fail-closed test-gate validator, fatal flake8, `compileall`,
+`uv lock --check`, and `git diff --check` also pass. The tree contained only
+the intended test helper, two test-module import changes, and this tracked
+worklog.
+
+The final worklog commit itself cannot record its own full SHA. Record that
+candidate SHA and its required GitHub-check results on the PR before merge, as
+required by the repository handoff policy.
 
 ## STOP conditions
 
@@ -86,6 +94,6 @@ non-slow full suite, and the required GitHub checks before merge.
 
 ## Next safe action
 
-Run the remaining local gates, commit the exact candidate, run the non-slow
-full suite against that SHA, then push one PR and complete its required checks
-and single native review before merging.
+Commit this verification evidence, rerun the focused selection on the resulting
+candidate, then push one PR and complete its required checks, single native
+review, unresolved-thread check, and clean-tree gate before merging.

--- a/specs/operations/20260827_click84_cli_test_isolation_worklog.md
+++ b/specs/operations/20260827_click84_cli_test_isolation_worklog.md
@@ -23,27 +23,59 @@ or release metadata changes are in scope.
 
 ## Red-first evidence to capture
 
-Use Python 3.12 with current allowed Click 8.4 and run
+Use Python 3.12 with a current allowed Click release (8.5.0 in the reproduced
+CI environment; the deprecation was introduced in 8.4) and run
 `tests/test_cli.py tests/test_retired_data_specs.py` unchanged. Record the
 warning-as-error failure count and exact warning. Do not suppress the warning
 and do not pin Click below 8.4.
 
+Captured red on unchanged production/tests at base
+`def93638466722e30a12f318baf7da5ec0da9ec2` using Python 3.12.11 and Click
+8.5.0:
+
+```text
+47 failed, 154 passed
+DeprecationWarning: 'isolated_filesystem' is deprecated and will be removed
+in Click 8.5. Use 'isolation' instead.
+```
+
+Command:
+
+```bash
+python -m pytest tests/test_cli.py tests/test_retired_data_specs.py -q --no-cov
+```
+
 ## Implementation boundary
 
-- Add a small test-only context manager based on
-  `tempfile.TemporaryDirectory()` and a guaranteed CWD restore in `finally`.
-- Replace only calls to Click's deprecated `isolated_filesystem()` in the two
-  affected modules.
+- Add a small test-only `CliRunner` compatibility subclass whose existing
+  isolation method is implemented with `tempfile.TemporaryDirectory()` and a
+  guaranteed CWD restore in `finally`.
+- Import that runner in only the two affected modules, retaining every existing
+  call site and assertion.
 - Retain `CliRunner` itself and all existing assertions.
 - Add no warning filters.
 
 ## Verification and merge gates
 
-- Same Python 3.12 / Click 8.4 selection turns green.
+- Same Python 3.12 / Click 8.5.0 selection turns green.
 - Existing test-gate validator, fatal flake8, compileall, and diff check pass.
 - Exact candidate full SHA recorded on the PR; required `test` and `lint`
   checks execute successfully; unresolved review threads are zero; worktree is
   clean before merge.
+
+## Uncommitted implementation verification
+
+The minimal test-only compatibility runner was applied with no production
+source, dependency, warning-policy, or assertion changes. Python 3.12.11 with
+Click 8.5.0 now reports:
+
+```text
+193 passed, 10 subtests passed
+```
+
+The repository fail-closed test-gate validator and `compileall` also pass.
+The next candidate commit must still pass fatal flake8, `uv lock --check`, the
+non-slow full suite, and the required GitHub checks before merge.
 
 ## STOP conditions
 
@@ -54,6 +86,6 @@ and do not pin Click below 8.4.
 
 ## Next safe action
 
-Create a disposable Python 3.12 environment with current project dependencies,
-run the two unchanged test modules to capture red, then implement the minimal
-test-only helper replacement.
+Run the remaining local gates, commit the exact candidate, run the non-slow
+full suite against that SHA, then push one PR and complete its required checks
+and single native review before merging.

--- a/specs/operations/20260827_click84_cli_test_isolation_worklog.md
+++ b/specs/operations/20260827_click84_cli_test_isolation_worklog.md
@@ -1,0 +1,59 @@
+# Click 8.4 CLI test isolation compatibility — 2026-08-27
+
+## Purpose and minimal scope
+
+The required GitHub Actions `test` job on PostgreSQL statistics PR `#251`
+executed after an Actions outage and failed 47 tests/subtests. Every failure is
+the same `DeprecationWarning`: Click 8.4 deprecates
+`CliRunner.isolated_filesystem()`, while this repository intentionally treats
+all warnings as errors. This iteration replaces only that deprecated test
+helper usage with an equivalent standard-library temporary working directory.
+No CLI production behavior, dependency range, importer, database, collector,
+or release metadata changes are in scope.
+
+## Repository and immutable starting state
+
+- Repository: `miyamamoto/jrvltsql`
+- Worktree: `/home/keiba/scratch/20260827_jrvltsql_click84_ci`
+- Branch: `fix/click84-test-isolation-20260827`
+- Base and initial HEAD: `def93638466722e30a12f318baf7da5ec0da9ec2`
+- Base source: freshly fetched `origin/master`
+- Dependent repair PR after this iteration: `#251`
+- Initial worktree state: clean
+
+## Red-first evidence to capture
+
+Use Python 3.12 with current allowed Click 8.4 and run
+`tests/test_cli.py tests/test_retired_data_specs.py` unchanged. Record the
+warning-as-error failure count and exact warning. Do not suppress the warning
+and do not pin Click below 8.4.
+
+## Implementation boundary
+
+- Add a small test-only context manager based on
+  `tempfile.TemporaryDirectory()` and a guaranteed CWD restore in `finally`.
+- Replace only calls to Click's deprecated `isolated_filesystem()` in the two
+  affected modules.
+- Retain `CliRunner` itself and all existing assertions.
+- Add no warning filters.
+
+## Verification and merge gates
+
+- Same Python 3.12 / Click 8.4 selection turns green.
+- Existing test-gate validator, fatal flake8, compileall, and diff check pass.
+- Exact candidate full SHA recorded on the PR; required `test` and `lint`
+  checks execute successfully; unresolved review threads are zero; worktree is
+  clean before merge.
+
+## STOP conditions
+
+- Any production source change.
+- Any warning suppression or dependency downgrade.
+- Any test assertion or CLI behavior change beyond filesystem isolation.
+- Any worktree drift outside this dedicated worktree.
+
+## Next safe action
+
+Create a disposable Python 3.12 environment with current project dependencies,
+run the two unchanged test modules to capture red, then implement the minimal
+test-only helper replacement.

--- a/specs/operations/20260827_click85_cli_test_isolation_worklog.md
+++ b/specs/operations/20260827_click85_cli_test_isolation_worklog.md
@@ -1,10 +1,10 @@
-# Click 8.4 CLI test isolation compatibility — 2026-08-27
+# Click 8.5 CLI test isolation compatibility — 2026-08-27
 
 ## Purpose and minimal scope
 
 The required GitHub Actions `test` job on PostgreSQL statistics PR `#251`
 executed after an Actions outage and failed 47 tests/subtests. Every failure is
-the same `DeprecationWarning`: Click 8.4 deprecates
+the same `DeprecationWarning`: Click 8.5 deprecates
 `CliRunner.isolated_filesystem()`, while this repository intentionally treats
 all warnings as errors. This iteration replaces only that deprecated test
 helper usage with an equivalent standard-library temporary working directory.
@@ -24,10 +24,10 @@ or release metadata changes are in scope.
 ## Red-first evidence to capture
 
 Use Python 3.12 with a current allowed Click release (8.5.0 in the reproduced
-CI environment; the deprecation was introduced in 8.4) and run
+CI environment; the deprecation was introduced in 8.5) and run
 `tests/test_cli.py tests/test_retired_data_specs.py` unchanged. Record the
 warning-as-error failure count and exact warning. Do not suppress the warning
-and do not pin Click below 8.4.
+and do not pin Click below 8.5.
 
 Captured red on unchanged production/tests at base
 `def93638466722e30a12f318baf7da5ec0da9ec2` using Python 3.12.11 and Click
@@ -36,7 +36,8 @@ Captured red on unchanged production/tests at base
 ```text
 47 failed, 154 passed
 DeprecationWarning: 'isolated_filesystem' is deprecated and will be removed
-in Click 8.5. Use 'isolation' instead.
+in Click 9.0. Use 'tempfile.TemporaryDirectory' or pytest's 'tmp_path' fixture
+with absolute paths instead.
 ```
 
 Command:
@@ -52,7 +53,8 @@ python -m pytest tests/test_cli.py tests/test_retired_data_specs.py -q --no-cov
   guaranteed CWD restore in `finally`.
 - Import that runner in only the two affected modules, retaining every existing
   call site and assertion.
-- Retain `CliRunner` itself and all existing assertions.
+- Retain `CliRunner` itself and all existing assertions; add one focused
+  regression only if review exposes an untested compatibility contract.
 - Add no warning filters.
 
 ## Verification and merge gates
@@ -84,6 +86,32 @@ worklog.
 The final worklog commit itself cannot record its own full SHA. Record that
 candidate SHA and its required GitHub-check results on the PR before merge, as
 required by the repository handoff policy.
+
+## Initial native review and repair
+
+PR `#252` received one native Copilot review at candidate
+`852e85d9f50587ae2b7a05c798809175a7bc41ee`. It correctly found that the
+compatibility override dropped Click's optional `temp_dir` parameter and that
+the docstring described the deprecation too loosely. The worklog also called
+this a Click 8.4 deprecation; direct Click 8.5.0 source and a fresh base-archive
+red reproduction established that 8.5.0 introduced it and its warning names
+Click 9.0 removal.
+
+A minimal regression was added before the repair. It failed on the reviewed
+candidate with:
+
+```text
+TypeError: CliRunner.isolated_filesystem() takes 1 positional argument but 2
+were given
+```
+
+The repair preserves the upstream signature, creates the isolated directory
+under the optional parent, retains it on context exit when a parent is
+provided, restores CWD in all cases, and still cleans default temporary
+directories. The new regression then passed, and the complete focused
+selection reported `194 passed, 10 subtests passed`. No second external review
+is requested solely for these two already-bounded comments; required CI and
+unresolved-thread gates still apply to the final candidate.
 
 ## STOP conditions
 

--- a/tests/cli_test_support.py
+++ b/tests/cli_test_support.py
@@ -1,0 +1,22 @@
+"""Test-only Click runner compatibility helpers."""
+
+import os
+import tempfile
+from collections.abc import Iterator
+from contextlib import contextmanager
+
+from click.testing import CliRunner as ClickCliRunner
+
+
+class CliRunner(ClickCliRunner):
+    """Keep CLI tests isolated without Click's deprecated CWD helper."""
+
+    @contextmanager
+    def isolated_filesystem(self) -> Iterator[str]:
+        original_directory = os.getcwd()
+        with tempfile.TemporaryDirectory() as directory:
+            os.chdir(directory)
+            try:
+                yield directory
+            finally:
+                os.chdir(original_directory)

--- a/tests/cli_test_support.py
+++ b/tests/cli_test_support.py
@@ -3,18 +3,26 @@
 import os
 import tempfile
 from collections.abc import Iterator
-from contextlib import contextmanager
+from contextlib import contextmanager, nullcontext
 
 from click.testing import CliRunner as ClickCliRunner
 
 
 class CliRunner(ClickCliRunner):
-    """Keep CLI tests isolated without Click's deprecated CWD helper."""
+    """Keep CLI tests isolated without Click's deprecated helper."""
 
     @contextmanager
-    def isolated_filesystem(self) -> Iterator[str]:
+    def isolated_filesystem(
+        self,
+        temp_dir: str | os.PathLike[str] | None = None,
+    ) -> Iterator[str]:
         original_directory = os.getcwd()
-        with tempfile.TemporaryDirectory() as directory:
+        directory_context = (
+            tempfile.TemporaryDirectory()
+            if temp_dir is None
+            else nullcontext(tempfile.mkdtemp(dir=temp_dir))
+        )
+        with directory_context as directory:
             os.chdir(directory)
             try:
                 yield directory

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -7,9 +7,8 @@ import unittest
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
-from click.testing import CliRunner
-
 from src.cli.main import cli
+from tests.cli_test_support import CliRunner
 
 
 class TestCLIBasic(unittest.TestCase):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -53,6 +53,20 @@ class TestCLIBasic(unittest.TestCase):
         self.assertEqual(fetch_result.exit_code, 1)
         self.assertIn('Configuration file not found', fetch_result.output)
 
+    def test_isolated_filesystem_preserves_click_temp_dir_contract(self):
+        """The compatibility runner retains Click's optional parent directory."""
+        original_directory = Path.cwd()
+        with tempfile.TemporaryDirectory() as parent_directory:
+            with self.runner.isolated_filesystem(parent_directory) as isolated:
+                Path("sentinel").write_text("present", encoding="utf-8")
+                self.assertEqual(Path.cwd(), Path(isolated))
+
+            self.assertEqual(Path.cwd(), original_directory)
+            self.assertEqual(
+                (Path(isolated) / "sentinel").read_text(encoding="utf-8"),
+                "present",
+            )
+
 
 class TestInitCommand(unittest.TestCase):
     """Test init command."""

--- a/tests/test_retired_data_specs.py
+++ b/tests/test_retired_data_specs.py
@@ -15,7 +15,6 @@ from pathlib import Path
 from unittest.mock import MagicMock
 
 import pytest
-from click.testing import CliRunner
 
 from src.cli.main import cli
 from src.fetcher.historical import HistoricalFetcher
@@ -34,6 +33,7 @@ from src.jvlink.constants import (
     validate_jvopen_combination,
 )
 from src.jvlink.wrapper import JVLinkWrapper
+from tests.cli_test_support import CliRunner
 
 RETIRED = ("DIFF", "BLOD", "SNAP", "HOSE", "TCOV", "RCOV")
 REPLACEMENTS = ("DIFN", "BLDN", "SNPN", "HOSN", "TCVN", "RCVN")


### PR DESCRIPTION
## Summary

- replace only the deprecated Click test isolation helper with a stdlib-backed test-only compatibility runner
- preserve Click's optional `temp_dir` signature and semantics, including CWD restoration and caller-owned parent retention
- retain all existing CLI assertions and call sites
- keep production code, dependency ranges, and warning policy unchanged
- record red-first, native-review, and verification evidence in the tracked worklog

## Red-first evidence

Base `def93638466722e30a12f318baf7da5ec0da9ec2`, Python 3.12.11, Click 8.5.0:

- `47 failed, 154 passed`
- every failure was the same warning-as-error: `CliRunner.isolated_filesystem()` is deprecated in Click 8.5.0 and scheduled for Click 9.0 removal

Native review found that the first compatibility override dropped `temp_dir`. The minimal regression was red before repair:

- `TypeError: CliRunner.isolated_filesystem() takes 1 positional argument but 2 were given`

## Exact candidate

`cf6e4611e20bcaa7b5a263039b56ba2e94d12096`

## Local verification

- focused Click 8.5 selection: `194 passed, 10 subtests passed`
- non-slow workflow selection: `4795 passed, 505 skipped, 14 deselected, 21 subtests passed`
- optional-parent regression: pass
- fail-closed test-gate validator: pass
- fatal flake8: pass
- compileall: pass
- `uv lock --check`: pass
- `git diff --check`: pass
- worktree: clean

## Review handling

The one native Copilot review on the initial candidate produced two bounded comments. Both are addressed in this candidate: the upstream signature/semantics are preserved, and the helper docstring plus worklog now name the Click 8.5 deprecation accurately. Per repository policy, no repeated external review is requested solely for this bounded repair; required CI and unresolved-thread gates remain mandatory.

## Scope

Test infrastructure only. No production behavior, CLI behavior, dependency pin, warning suppression, importer, database, collector, or release metadata change.

## Dependency

This PR must merge before PostgreSQL statistics PR #251 is rebased and rechecked.
