### PR TITLE
複数Specを取得するセットアップ時にダイアログ表示を一回にする

### DIFF
--- a/src/cli/main.py
+++ b/src/cli/main.py
@@ -421,7 +421,16 @@ def update(ctx, force):
         "not accept an end point for them."
     ),
 )
-@click.option("--spec", "data_spec", required=True, help="Data specification (RACE, DIFN, etc.)")
+@click.option(
+    "--spec",
+    "data_specs",
+    required=True,
+    multiple=True,
+    help=(
+        "Data specification (RACE, DIFN, etc.). 複数指定可: 指定した順に、"
+        "1 プロセス（＝1 JV-Link セッション）の中で dataspec ごとに JVOpen する"
+    ),
+)
 @click.option(
     "--option",
     "jv_option",
@@ -434,7 +443,7 @@ def update(ctx, force):
 @click.option("--progress/--no-progress", default=True, help="Show progress display (default: enabled)")
 @click.option("--use-cache/--no-cache", default=True, show_default=True, help="Use local cache if available")
 @click.pass_context
-def fetch(ctx, date_from, date_to, data_spec, jv_option, db, batch_size, progress, use_cache):
+def fetch(ctx, date_from, date_to, data_specs, jv_option, db, batch_size, progress, use_cache):
     """Fetch historical data from JRA-VAN DataLab.
 
     JVOpen option meanings:
@@ -443,10 +452,19 @@ def fetch(ctx, date_from, date_to, data_spec, jv_option, db, batch_size, progres
       - option=3 (セットアップ): 全データ取得（ダイアログ表示あり）
       - option=4 (分割セットアップ): 全データ取得（初回のみダイアログ）
 
+    --spec は複数回指定でき、指定した順に処理する。並べ替えはしない。
+    dataspec を連結して 1 回の JVOpen にはまとめない: 公式仕様は複数指定を
+    「対象ファイル数が多いと JVRead が遅くなる」既知障害として挙げ、回避策に
+    個別指定を挙げている。JVOpen は dataspec ごと、JV-Link セッションだけが
+    実走を通して 1 本になる（option=3/4 の取得元ダイアログも 1 回で済む）。
+    途中の dataspec が失敗したら以降は実行せず、終了コードで分かる。
+
     \b
     Examples:
       jltsql fetch --from 20240101 --to 20241231 --spec RACE
       jltsql fetch --from 20240101 --to 20241231 --spec DIFN --option 3
+      jltsql fetch --from 19860101 --to 20261231 --option 4 \\
+                   --spec DIFN --spec WOOD --spec SLOP --spec BLDN --spec RACE
     """
     from src.database import create_database_from_config, DatabaseError
     from src.database.schema import create_all_tables
@@ -468,21 +486,24 @@ def fetch(ctx, date_from, date_to, data_spec, jv_option, db, batch_size, progres
     console.print(f"[bold cyan]Fetching historical data from JRA-VAN DataLab...[/bold cyan]\n")
     console.print(f"  Data source: JRA (中央競馬)")
     console.print(f"  Date range: {date_from} -- {date_to}")
-    console.print(f"  Data spec:  {data_spec}")
+    console.print(f"  Data spec:  {', '.join(data_specs)}")
     console.print(f"  Option:     {jv_option} ({option_names.get(jv_option, '不明')})")
     console.print(f"  Database:   {db_type}")
 
-    # Validate data_spec and option combination
+    # Validate every requested spec before the database is touched: one bad
+    # spec must not leave the run half-imported.
     # 非対応の旧仕様種別は「option では取得できません」より先に理由を返す。
-    _reject_retired_data_spec(data_spec)
+    for data_spec in data_specs:
+        _reject_retired_data_spec(data_spec)
 
     from src.jvlink.constants import is_valid_jvopen_combination, JVOPEN_VALID_COMBINATIONS
-    if not is_valid_jvopen_combination(data_spec, jv_option):
-        console.print()
-        console.print(f"[red]Error:[/red] データ種別 '{data_spec}' は option={jv_option} では取得できません")
-        valid_specs = JVOPEN_VALID_COMBINATIONS.get(jv_option, [])
-        console.print(f"       option={jv_option} で取得可能: {', '.join(valid_specs)}")
-        sys.exit(1)
+    for data_spec in data_specs:
+        if not is_valid_jvopen_combination(data_spec, jv_option):
+            console.print()
+            console.print(f"[red]Error:[/red] データ種別 '{data_spec}' は option={jv_option} では取得できません")
+            valid_specs = JVOPEN_VALID_COMBINATIONS.get(jv_option, [])
+            console.print(f"       option={jv_option} で取得可能: {', '.join(valid_specs)}")
+            sys.exit(1)
 
     # The CLI prepares every table before BatchProcessor runs. Reject the
     # range here as well so malformed input cannot initialize a database or
@@ -530,23 +551,36 @@ def fetch(ctx, date_from, date_to, data_spec, jv_option, db, batch_size, progres
             if not progress:
                 console.print("[bold]Processing data...[/bold]")
 
-            result = processor.process_date_range(
-                data_spec=data_spec,
-                from_date=date_from,
-                to_date=date_to,
-                option=jv_option
-            )
+            # One BatchProcessor for the whole run. It owns a single
+            # HistoricalFetcher, and that fetcher establishes the JV-Link
+            # session once (JVInit). Rebuilding it per spec would bring the
+            # option=3/4 source dialog back once per dataspec.
+            for data_spec in data_specs:
+                # 単一指定の出力は従来どおりにする。前置きの "Data spec" 行が
+                # そのまま dataspec の見出しなので、複数のときだけ繰り返す。
+                if len(data_specs) > 1:
+                    console.print()
+                    console.print(f"  Data spec:  {data_spec}")
 
-            # Show results
-            console.print()
-            console.print("[bold green][OK] Fetch complete![/bold green]")
-            console.print()
-            console.print("[bold]Statistics:[/bold]")
-            console.print(f"  Fetched:  {result['records_fetched']}")
-            console.print(f"  Parsed:   {result['records_parsed']}")
-            console.print(f"  Imported: {result['records_imported']}")
-            console.print(f"  Failed:   {result['records_failed']}")
-            console.print(f"  Batches:  {result.get('batches_processed', 0)}")
+                # An exception here leaves the remaining specs unprocessed and
+                # exits non-zero (ADR-0023: stop and show a human).
+                result = processor.process_date_range(
+                    data_spec=data_spec,
+                    from_date=date_from,
+                    to_date=date_to,
+                    option=jv_option
+                )
+
+                # Show results
+                console.print()
+                console.print("[bold green][OK] Fetch complete![/bold green]")
+                console.print()
+                console.print("[bold]Statistics:[/bold]")
+                console.print(f"  Fetched:  {result['records_fetched']}")
+                console.print(f"  Parsed:   {result['records_parsed']}")
+                console.print(f"  Imported: {result['records_imported']}")
+                console.print(f"  Failed:   {result['records_failed']}")
+                console.print(f"  Batches:  {result.get('batches_processed', 0)}")
 
     except KeyboardInterrupt:
         console.print("\n[yellow]Interrupted by user[/yellow]")

--- a/src/cli/main.py
+++ b/src/cli/main.py
@@ -82,8 +82,48 @@ def _reject_invalid_jvopen_combination(data_spec: str, option: int) -> None:
         sys.exit(1)
 
 
-def _print_fetch_guardrail_notes(jv_option: int, data_spec: str) -> None:
-    """Emit option- and dataspec-dependent date-range caveats after validation."""
+def _reject_data_specs(data_specs, jv_option: int) -> None:
+    """Reject every requested spec that JVOpen cannot serve, before any side effect.
+
+    fetch は dataspec を複数受け取るので、1 つでも通らないものがあれば DB を
+    触る前に落とす（途中まで取り込んだ状態を作らない）。廃止済み種別の理由を
+    option 組み合わせより先に返す順序は単一指定のときから変えない。
+    """
+    from src.jvlink.constants import is_valid_jvopen_combination, JVOPEN_VALID_COMBINATIONS
+
+    for data_spec in data_specs:
+        _reject_retired_data_spec(data_spec)
+
+    for data_spec in data_specs:
+        if is_valid_jvopen_combination(data_spec, jv_option):
+            continue
+        console.print()
+        console.print(f"[red]Error:[/red] データ種別 '{data_spec}' は option={jv_option} では取得できません")
+        valid_specs = JVOPEN_VALID_COMBINATIONS.get(jv_option, [])
+        console.print(f"       option={jv_option} で取得可能: {', '.join(valid_specs)}")
+        sys.exit(1)
+
+
+def _print_fetch_statistics(result: dict) -> None:
+    """Emit the per-dataspec completion block the backfill driver reads."""
+    console.print()
+    console.print("[bold green][OK] Fetch complete![/bold green]")
+    console.print()
+    console.print("[bold]Statistics:[/bold]")
+    console.print(f"  Fetched:  {result['records_fetched']}")
+    console.print(f"  Parsed:   {result['records_parsed']}")
+    console.print(f"  Imported: {result['records_imported']}")
+    console.print(f"  Failed:   {result['records_failed']}")
+    console.print(f"  Batches:  {result.get('batches_processed', 0)}")
+
+
+def _print_fetch_guardrail_notes(jv_option: int, data_specs) -> None:
+    """Emit option- and dataspec-dependent date-range caveats after validation.
+
+    注記は実走に 1 回で、要求された dataspec 全体を見る。刻める dataspec と
+    刻めない dataspec が混ざる要求では該当する注記が両方出る（同じ注記を
+    dataspec の数だけ繰り返さない）。単一指定の出力は従来と一字一句同じ。
+    """
     if jv_option in (3, 4):
         err_console.print(f"[yellow]Note:[/yellow] {FETCH_NOTE_SETUP_MODE}")
     if jv_option == 2:
@@ -92,9 +132,11 @@ def _print_fetch_guardrail_notes(jv_option: int, data_spec: str) -> None:
     from src.jvlink.constants import uses_range_fromtime
 
     err_console.print(f"[yellow]Note:[/yellow] {FETCH_NOTE_TO_CLIENT_FILTER}")
-    if uses_range_fromtime(data_spec, jv_option):
+    chunked = [spec for spec in data_specs if uses_range_fromtime(spec, jv_option)]
+    start_only = [spec for spec in data_specs if not uses_range_fromtime(spec, jv_option)]
+    if chunked:
         err_console.print(f"[yellow]Note:[/yellow] {FETCH_NOTE_TO_RANGE_CHUNKED}")
-    else:
+    if start_only:
         err_console.print(f"[yellow]Note:[/yellow] {FETCH_NOTE_TO_SINGLE_OPEN}")
     err_console.print(f"[yellow]Note:[/yellow] {FETCH_NOTE_DATE_FIELDS}")
 
@@ -486,24 +528,14 @@ def fetch(ctx, date_from, date_to, data_specs, jv_option, db, batch_size, progre
     console.print(f"[bold cyan]Fetching historical data from JRA-VAN DataLab...[/bold cyan]\n")
     console.print(f"  Data source: JRA (中央競馬)")
     console.print(f"  Date range: {date_from} -- {date_to}")
-    console.print(f"  Data spec:  {', '.join(data_specs)}")
+    # 単数形は「いま処理している dataspec」だけを指す。実走全体の一覧は複数形に
+    # して、driver が見出し行を spec 名として読まないようにする。
+    spec_label = "Data spec: " if len(data_specs) == 1 else "Data specs:"
+    console.print(f"  {spec_label} {', '.join(data_specs)}")
     console.print(f"  Option:     {jv_option} ({option_names.get(jv_option, '不明')})")
     console.print(f"  Database:   {db_type}")
 
-    # Validate every requested spec before the database is touched: one bad
-    # spec must not leave the run half-imported.
-    # 非対応の旧仕様種別は「option では取得できません」より先に理由を返す。
-    for data_spec in data_specs:
-        _reject_retired_data_spec(data_spec)
-
-    from src.jvlink.constants import is_valid_jvopen_combination, JVOPEN_VALID_COMBINATIONS
-    for data_spec in data_specs:
-        if not is_valid_jvopen_combination(data_spec, jv_option):
-            console.print()
-            console.print(f"[red]Error:[/red] データ種別 '{data_spec}' は option={jv_option} では取得できません")
-            valid_specs = JVOPEN_VALID_COMBINATIONS.get(jv_option, [])
-            console.print(f"       option={jv_option} で取得可能: {', '.join(valid_specs)}")
-            sys.exit(1)
+    _reject_data_specs(data_specs, jv_option)
 
     # The CLI prepares every table before BatchProcessor runs. Reject the
     # range here as well so malformed input cannot initialize a database or
@@ -515,7 +547,7 @@ def fetch(ctx, date_from, date_to, data_specs, jv_option, db, batch_size, progre
         console.print(f"[red]Error:[/red] {exc}")
         sys.exit(1)
 
-    _print_fetch_guardrail_notes(jv_option, data_spec)
+    _print_fetch_guardrail_notes(jv_option, data_specs)
     console.print()
 
     try:
@@ -556,9 +588,10 @@ def fetch(ctx, date_from, date_to, data_specs, jv_option, db, batch_size, progre
             # session once (JVInit). Rebuilding it per spec would bring the
             # option=3/4 source dialog back once per dataspec.
             for data_spec in data_specs:
-                # 単一指定の出力は従来どおりにする。前置きの "Data spec" 行が
-                # そのまま dataspec の見出しなので、複数のときだけ繰り返す。
-                if len(data_specs) > 1:
+                # 単一指定では前置きの "Data spec" 行がそのまま見出しなので足さない。
+                # progress 表示が有効なときは JVLinkProgressDisplay.print_spec_header
+                # がより詳しい見出しを dataspec ごとに出すので、そちらに任せる。
+                if len(data_specs) > 1 and not progress:
                     console.print()
                     console.print(f"  Data spec:  {data_spec}")
 
@@ -571,16 +604,7 @@ def fetch(ctx, date_from, date_to, data_specs, jv_option, db, batch_size, progre
                     option=jv_option
                 )
 
-                # Show results
-                console.print()
-                console.print("[bold green][OK] Fetch complete![/bold green]")
-                console.print()
-                console.print("[bold]Statistics:[/bold]")
-                console.print(f"  Fetched:  {result['records_fetched']}")
-                console.print(f"  Parsed:   {result['records_parsed']}")
-                console.print(f"  Imported: {result['records_imported']}")
-                console.print(f"  Failed:   {result['records_failed']}")
-                console.print(f"  Batches:  {result.get('batches_processed', 0)}")
+                _print_fetch_statistics(result)
 
     except KeyboardInterrupt:
         console.print("\n[yellow]Interrupted by user[/yellow]")

--- a/src/fetcher/base.py
+++ b/src/fetcher/base.py
@@ -66,8 +66,15 @@ class BaseFetcher(ABC):
         # JVInit is application initialization in the official JV-Link spec,
         # not per-JVOpen setup. Establishing the session here means fetch()
         # starts at JVOpen, and a process running many JVOpen/JVClose pairs
-        # still holds a single JV-Link session. Both transports raise on a
-        # failed JVInit, so there is no result code left to inspect here.
+        # still holds a single JV-Link session.
+        #
+        # That single session is what makes a multi-dataspec setup usable:
+        # under option=3/4 JV-Link shows its source-selection dialog once per
+        # session, so a run covering several dataspecs asks the operator to
+        # answer it once instead of once per dataspec.
+        #
+        # Both transports raise on a failed JVInit, so there is no result code
+        # left to inspect here.
         self.jvlink.jv_init()
 
         self.parser_factory = ParserFactory()

--- a/src/fetcher/base.py
+++ b/src/fetcher/base.py
@@ -63,6 +63,12 @@ class BaseFetcher(ABC):
         else:
             self.jvlink = JVLinkWrapper(sid)
 
+        # JVInit is application initialization in the official JV-Link spec,
+        # not per-JVOpen setup. Establishing the session here means fetch()
+        # starts at JVOpen, and a process running many JVOpen/JVClose pairs
+        # still holds a single JV-Link session.
+        self.jvlink.jv_init()
+
         self.parser_factory = ParserFactory()
         self._records_fetched = 0
         self._records_parsed = 0

--- a/src/fetcher/base.py
+++ b/src/fetcher/base.py
@@ -66,7 +66,8 @@ class BaseFetcher(ABC):
         # JVInit is application initialization in the official JV-Link spec,
         # not per-JVOpen setup. Establishing the session here means fetch()
         # starts at JVOpen, and a process running many JVOpen/JVClose pairs
-        # still holds a single JV-Link session.
+        # still holds a single JV-Link session. Both transports raise on a
+        # failed JVInit, so there is no result code left to inspect here.
         self.jvlink.jv_init()
 
         self.parser_factory = ParserFactory()

--- a/src/fetcher/historical.py
+++ b/src/fetcher/historical.py
@@ -542,15 +542,14 @@ class HistoricalFetcher(BaseFetcher):
                     chunks=len(fromtimes),
                 )
 
-            # Initialize JV-Link
-            logger.info("Initializing JV-Link")
             if self.progress_display:
                 # スペックヘッダーを表示（日付範囲付き）
                 self.progress_display.print_spec_header(data_spec, from_date, to_date)
 
-            # Note: Service key must be pre-configured in Windows registry
-            # jv_init() does not accept service_key parameter
-            self.jvlink.jv_init()
+            # JVInit is not re-issued here: the JV-Link session is established
+            # once when the fetcher is constructed (see BaseFetcher.__init__),
+            # so this method starts at JVOpen. A JVInit failure therefore
+            # aborts before any fetch can attempt JVOpen.
             # リトライ上限は fetch 全体で 1 本。chunk 数ぶんは増やさない。
             self._jvd_self_repair_attempts = 0
 
@@ -625,7 +624,8 @@ class HistoricalFetcher(BaseFetcher):
             self._jv_open_last_file_timestamp = None
             self._fetch_task_id = None
             # JVClose の義務は _fetch_one_open の finally が持つ（JVOpen と
-            # 同じ try に入っている）。ここで二重に閉じない。
+            # 同じ try に入っている）。ここで二重に閉じない。JVInit はここでも
+            # 張り直さない。セッションは JVClose より長く生きる。
 
             # Do NOT call cleanup() here: cleanup() destroys the COM object
             # (self._jvlink = None + CoUninitialize), so subsequent chunks

--- a/src/fetcher/historical.py
+++ b/src/fetcher/historical.py
@@ -547,7 +547,9 @@ class HistoricalFetcher(BaseFetcher):
                 self.progress_display.print_spec_header(data_spec, from_date, to_date)
 
             # The session was established in BaseFetcher.__init__, so this
-            # method starts at JVOpen and never re-issues JVInit.
+            # method starts at JVOpen and never re-issues JVInit. Re-issuing it
+            # would put the option=3/4 source dialog in front of the operator
+            # again for every dataspec of a multi-spec setup run.
             # リトライ上限は fetch 全体で 1 本。chunk 数ぶんは増やさない。
             self._jvd_self_repair_attempts = 0
 

--- a/src/fetcher/historical.py
+++ b/src/fetcher/historical.py
@@ -546,10 +546,8 @@ class HistoricalFetcher(BaseFetcher):
                 # スペックヘッダーを表示（日付範囲付き）
                 self.progress_display.print_spec_header(data_spec, from_date, to_date)
 
-            # JVInit is not re-issued here: the JV-Link session is established
-            # once when the fetcher is constructed (see BaseFetcher.__init__),
-            # so this method starts at JVOpen. A JVInit failure therefore
-            # aborts before any fetch can attempt JVOpen.
+            # The session was established in BaseFetcher.__init__, so this
+            # method starts at JVOpen and never re-issues JVInit.
             # リトライ上限は fetch 全体で 1 本。chunk 数ぶんは増やさない。
             self._jvd_self_repair_attempts = 0
 

--- a/src/fetcher/realtime.py
+++ b/src/fetcher/realtime.py
@@ -143,9 +143,8 @@ class RealtimeFetcher(BaseFetcher):
             logger.debug("Using today's date as key", key=key)
 
         try:
-            # JVInit already ran once when this fetcher was constructed
-            # (BaseFetcher.__init__); the session spans every JVRTOpen here.
-
+            # The session was established in BaseFetcher.__init__ and spans
+            # every JVRTOpen below.
             logger.info(
                 "Starting realtime data fetch",
                 data_spec=data_spec,
@@ -578,9 +577,6 @@ class RealtimeFetcher(BaseFetcher):
 
         logger.info(f"Found {len(race_rows)} races in database")
 
-        # JVInit already ran once when this fetcher was constructed
-        # (BaseFetcher.__init__); it is not re-issued per batch.
-
         # Statistics
         total_keys = len(race_rows)
         success_keys = 0
@@ -876,9 +872,6 @@ class RealtimeFetcher(BaseFetcher):
             tracks=len(jyo_codes),
             races=len(race_nums),
         )
-
-        # JVInit already ran once when this fetcher was constructed
-        # (BaseFetcher.__init__); it is not re-issued per batch.
 
         # Statistics
         total_keys = 0

--- a/src/fetcher/realtime.py
+++ b/src/fetcher/realtime.py
@@ -143,11 +143,8 @@ class RealtimeFetcher(BaseFetcher):
             logger.debug("Using today's date as key", key=key)
 
         try:
-            # Initialize JV-Link
-            logger.info("Initializing JV-Link")
-            ret = self.jvlink.jv_init()
-            if ret != JV_RT_SUCCESS:
-                raise FetcherError(f"JV-Link initialization failed: {ret}")
+            # JVInit already ran once when this fetcher was constructed
+            # (BaseFetcher.__init__); the session spans every JVRTOpen here.
 
             logger.info(
                 "Starting realtime data fetch",
@@ -581,10 +578,8 @@ class RealtimeFetcher(BaseFetcher):
 
         logger.info(f"Found {len(race_rows)} races in database")
 
-        # Initialize JV-Link
-        ret = self.jvlink.jv_init()
-        if ret != JV_RT_SUCCESS:
-            raise FetcherError(f"JV-Link initialization failed: {ret}")
+        # JVInit already ran once when this fetcher was constructed
+        # (BaseFetcher.__init__); it is not re-issued per batch.
 
         # Statistics
         total_keys = len(race_rows)
@@ -882,10 +877,8 @@ class RealtimeFetcher(BaseFetcher):
             races=len(race_nums),
         )
 
-        # Initialize JV-Link once for the entire batch
-        ret = self.jvlink.jv_init()
-        if ret != JV_RT_SUCCESS:
-            raise FetcherError(f"JV-Link initialization failed: {ret}")
+        # JVInit already ran once when this fetcher was constructed
+        # (BaseFetcher.__init__); it is not re-issued per batch.
 
         # Statistics
         total_keys = 0

--- a/src/jvlink/bridge.py
+++ b/src/jvlink/bridge.py
@@ -486,7 +486,6 @@ class JVLinkBridge:
                     pass
         self._is_open = False
         self._needs_close = False
-        self._initialized = False
         self._download_count = None
         self._stop_dialog_watcher()
         self._close_stderr_file()
@@ -627,6 +626,28 @@ class JVLinkBridge:
     # JV-Link API Methods
     # =========================================================================
 
+    def _process_alive(self) -> bool:
+        process = getattr(self, "_process", None)
+        return process is not None and process.poll() is None
+
+    def _ensure_session(self) -> None:
+        """Bring the JV-Link session back if the bridge process died mid-run.
+
+        JVInit is issued once per bridge process, so a process aborted by a
+        response timeout or a broken pipe takes the session with it. Without
+        this repair every later JVOpen in the run would fail on a dead pipe;
+        the pre-hoist code got the same recovery for free from its per-fetch
+        JVInit. ``cleanup()`` clears the flag, so an explicitly closed bridge
+        is never resurrected.
+        """
+        if not getattr(self, "_initialized", False) or self._process_alive():
+            return
+
+        logger.warning(
+            "Bridge process is gone; re-establishing the JV-Link session"
+        )
+        self.jv_init()
+
     def jv_init(self) -> int:
         """Initialize the JV-Link session once for this bridge process.
 
@@ -635,9 +656,7 @@ class JVLinkBridge:
         Anything that ends the bridge process (``cleanup()``, ``_abort_process()``)
         drops the session, and the next call initializes again.
         """
-        if getattr(self, "_initialized", False) and (
-            self._process is not None and self._process.poll() is None
-        ):
+        if getattr(self, "_initialized", False) and self._process_alive():
             logger.debug("JV-Link already initialized via bridge; reusing session")
             return 0
 
@@ -663,6 +682,8 @@ class JVLinkBridge:
         # JVRTOpen realtime IDs are a separate namespace; this guard applies
         # the official four-character JVOpen contract before transmission.
         validate_jvopen_combination(data_spec, option)
+
+        self._ensure_session()
 
         response = self._send_command(
             {"cmd": "open", "dataspec": data_spec, "fromtime": fromtime, "option": option},
@@ -703,6 +724,8 @@ class JVLinkBridge:
         return code, read_count, download_count, last_ts
 
     def jv_rt_open(self, data_spec: str, key: str = "") -> Tuple[int, int]:
+        self._ensure_session()
+
         response = self._send_command(
             {"cmd": "rtopen", "dataspec": data_spec, "key": key},
             timeout=30.0,

--- a/src/jvlink/bridge.py
+++ b/src/jvlink/bridge.py
@@ -244,6 +244,9 @@ class JVLinkBridge:
         self._process: Optional[subprocess.Popen] = None
         self._is_open = False
         self._needs_close = False
+        # JVInit establishes the JV-Link session for the whole bridge process,
+        # not for a single JVOpen.
+        self._initialized = False
         self._download_count: Optional[int] = None
         self._use_external_runner = sys.platform != "win32"
         self._runner = _external_runner()
@@ -483,6 +486,7 @@ class JVLinkBridge:
                     pass
         self._is_open = False
         self._needs_close = False
+        self._initialized = False
         self._download_count = None
         self._stop_dialog_watcher()
         self._close_stderr_file()
@@ -624,6 +628,19 @@ class JVLinkBridge:
     # =========================================================================
 
     def jv_init(self) -> int:
+        """Initialize the JV-Link session once for this bridge process.
+
+        JVInit is application initialization in the official spec, so repeated
+        calls reuse the established session instead of re-issuing the command.
+        Anything that ends the bridge process (``cleanup()``, ``_abort_process()``)
+        drops the session, and the next call initializes again.
+        """
+        if getattr(self, "_initialized", False) and (
+            self._process is not None and self._process.poll() is None
+        ):
+            logger.debug("JV-Link already initialized via bridge; reusing session")
+            return 0
+
         self._start_process()
         response = self._send_command({"cmd": "init", "type": "jra", "key": self.sid})
 
@@ -633,6 +650,7 @@ class JVLinkBridge:
                 response.get("error", "JVInit failed"), error_code=code
             )
 
+        self._initialized = True
         logger.info("JV-Link initialized via bridge", code=code)
         return code
 
@@ -896,6 +914,7 @@ class JVLinkBridge:
         self._process = None
         self._is_open = False
         self._needs_close = False
+        self._initialized = False
         self._download_count = None
         self._close_stderr_file()
         self._stop_dialog_watcher()

--- a/src/jvlink/wrapper.py
+++ b/src/jvlink/wrapper.py
@@ -240,6 +240,9 @@ class JVLinkWrapper:
         self._is_open = False
         self._needs_close = False
         self._com_initialized = False
+        # JVInit is application-level initialization, not per-JVOpen setup.
+        # Keep the established session so repeated fetches reuse it.
+        self._initialized = False
 
         try:
             import sys
@@ -263,9 +266,16 @@ class JVLinkWrapper:
             raise JVLinkError(f"Failed to create JV-Link COM object: {e}")
 
     def jv_init(self) -> int:
-        """Initialize JV-Link.
+        """Initialize JV-Link once for this JV-Link session.
 
         Must be called before any other JV-Link operations.
+
+        The official spec treats JVInit as application initialization: it is
+        not re-issued per JVOpen. Repeated calls therefore reuse the session
+        established by the first successful JVInit instead of re-entering COM,
+        so one process holds one JV-Link session no matter how many JVOpen /
+        JVClose pairs run inside it. ``cleanup()`` and ``reinitialize_com()``
+        drop the session, and the next call initializes again.
 
         Note:
             Service key must be configured in JRA-VAN DataLab application
@@ -283,9 +293,14 @@ class JVLinkWrapper:
             >>> result = wrapper.jv_init()
             >>> assert result == 0
         """
+        if getattr(self, "_initialized", False):
+            logger.debug("JV-Link already initialized; reusing session", sid=self.sid)
+            return JV_RT_SUCCESS
+
         try:
             result = self._jvlink.JVInit(self.sid)
             if result == JV_RT_SUCCESS:
+                self._initialized = True
                 logger.info("JV-Link initialized successfully", sid=self.sid)
             else:
                 logger.error("JV-Link initialization failed", error_code=result, sid=self.sid)
@@ -937,6 +952,8 @@ class JVLinkWrapper:
 
             self._is_open = False
             self._needs_close = False
+            # The recreated COM object carries no JV-Link session.
+            self._initialized = False
 
             logger.info("COM component reinitialized successfully", sid=self.sid)
 
@@ -978,6 +995,10 @@ class JVLinkWrapper:
                 self.jv_close()
             except Exception:
                 pass
+
+        # Dropping the COM object ends the JV-Link session, so a later
+        # jv_init() must reach JVInit again instead of reusing the flag.
+        self._initialized = False
 
         # Release COM object reference BEFORE CoUninitialize
         # This prevents "Win32 exception occurred releasing IUnknown" warnings

--- a/tests/test_error_scenarios.py
+++ b/tests/test_error_scenarios.py
@@ -337,17 +337,17 @@ class TestFetcherErrors(unittest.TestCase):
 
     @patch('src.fetcher.base.JVLinkWrapper')
     def test_jvlink_init_failure(self, mock_jvlink_class):
-        """Test handling of JV-Link initialization failure."""
+        """A failing JVInit aborts the fetcher before any JVOpen is possible."""
         mock_jvlink = MagicMock()
         mock_jvlink_class.return_value = mock_jvlink
 
         # Mock JV_Init failure (raises exception)
         mock_jvlink.jv_init.side_effect = Exception("JV_Init failed")
 
-        fetcher = HistoricalFetcher(sid="TEST")
-
         with self.assertRaises(Exception):
-            list(fetcher.fetch("RACE", "20240101", "20240101"))
+            HistoricalFetcher(sid="TEST")
+
+        mock_jvlink.jv_open.assert_not_called()
 
     @patch('src.fetcher.base.JVLinkWrapper')
     def test_jvopen_failure(self, mock_jvlink_class):

--- a/tests/test_error_scenarios.py
+++ b/tests/test_error_scenarios.py
@@ -24,6 +24,7 @@ from src.database.schema import SchemaManager
 from src.database.sqlite_handler import SQLiteDatabase
 from src.fetcher.historical import FetcherError, HistoricalFetcher
 from src.importer.importer import DataImporter
+from src.jvlink.wrapper import JVLinkError
 from src.parser.factory import ParserFactory
 
 
@@ -341,10 +342,12 @@ class TestFetcherErrors(unittest.TestCase):
         mock_jvlink = MagicMock()
         mock_jvlink_class.return_value = mock_jvlink
 
-        # Mock JV_Init failure (raises exception)
-        mock_jvlink.jv_init.side_effect = Exception("JV_Init failed")
+        # -101 は JVInit の sid 書式エラー（公式コード表）
+        mock_jvlink.jv_init.side_effect = JVLinkError(
+            "JV-Link initialization failed", error_code=-101
+        )
 
-        with self.assertRaises(Exception):
+        with self.assertRaises(JVLinkError):
             HistoricalFetcher(sid="TEST")
 
         mock_jvlink.jv_open.assert_not_called()

--- a/tests/test_fetch_multiple_dataspecs.py
+++ b/tests/test_fetch_multiple_dataspecs.py
@@ -7,12 +7,18 @@
 """
 
 from pathlib import Path
+from typing import NamedTuple
 from unittest.mock import MagicMock, patch
 
 import pytest
 from click.testing import CliRunner
 
-from src.cli.main import cli
+from src.cli.main import (
+    FETCH_NOTE_DATE_FIELDS,
+    FETCH_NOTE_TO_CLIENT_FILTER,
+    FETCH_NOTE_TO_SINGLE_OPEN,
+    cli,
+)
 from src.fetcher.base import FetcherError
 
 EXAMPLE_CONFIG = (
@@ -27,9 +33,20 @@ STATS = {
     "batches_processed": 2,
 }
 
+# option=1 のガードレール注記そのものは #290 の対象外なので、文言は定数から組む。
+# ここで転記すると、注記を直しただけでこのテストが無関係な差分で落ちる。
+_OPTION1_NOTES = "\n".join(
+    f"Note: {note}"
+    for note in (
+        FETCH_NOTE_TO_CLIENT_FILTER,
+        FETCH_NOTE_TO_SINGLE_OPEN,
+        FETCH_NOTE_DATE_FIELDS,
+    )
+)
+
 # 単一 --spec の出力は #290 の前後で一字一句変わってはいけない。rich の折り返しを
 # 固定するため COLUMNS を固定した上で丸ごと突き合わせる。
-SINGLE_SPEC_GOLDEN = """\
+SINGLE_SPEC_GOLDEN = f"""\
 Fetching historical data from JRA-VAN DataLab...
 
   Data source: JRA (中央競馬)
@@ -37,9 +54,7 @@ Fetching historical data from JRA-VAN DataLab...
   Data spec:  RACE
   Option:     1 (通常データ)
   Database:   sqlite
-Note: --to は取得後のクライアント側日付フィルタであり、JVOpen の終端ではありません。
-Note: option=1/2 では --to は JVOpen の終端にならず、狭めてもサーバからのダウンロード量は減りません。
-Note: --to は Year+MonthDay または ChokyoDate（HC/WC の調教日）で判定します。対応する日付を持たないレコードは JV-Link 取得時に除外されず、その取得範囲は完全キャッシュとして記録されません。
+{_OPTION1_NOTES}
 
 Processing data...
 
@@ -59,8 +74,17 @@ def _runner():
     return CliRunner(env={"COLUMNS": "200", "TERM": "dumb"})
 
 
-def _invoke(specs, *, option=1, side_effect=None, batch_processor=None):
-    """``fetch`` を実行し、``(result, batch_processor_mock, processor_mock)`` を返す。"""
+class Invocation(NamedTuple):
+    """``fetch`` の 1 回の実行と、その途中で使われたモック。"""
+
+    result: object          # click の Result（exit_code / output）
+    batch_processor: MagicMock   # BatchProcessor クラスのモック（生成回数を見る）
+    processor: MagicMock         # その戻り値（process_date_range の呼ばれ方を見る）
+    create_database: MagicMock   # DB 生成に到達したかを見る
+
+
+def _invoke(specs, *, option=1, side_effect=None, progress=False) -> Invocation:
+    """``fetch`` を実行し、結果と関与したモックを返す。"""
     processor = MagicMock()
     if side_effect is not None:
         processor.process_date_range.side_effect = side_effect
@@ -73,7 +97,8 @@ def _invoke(specs, *, option=1, side_effect=None, batch_processor=None):
     args = ["--config", "config.yaml", "fetch", "--from", "20260820", "--to", "20260821"]
     for spec in specs:
         args += ["--spec", spec]
-    args += ["--option", str(option), "--db", "sqlite", "--no-cache", "--no-progress"]
+    args += ["--option", str(option), "--db", "sqlite", "--no-cache"]
+    args.append("--progress" if progress else "--no-progress")
 
     runner = _runner()
     with runner.isolated_filesystem():
@@ -86,7 +111,7 @@ def _invoke(specs, *, option=1, side_effect=None, batch_processor=None):
             patch("src.database.schema.create_all_tables"),
         ):
             result = runner.invoke(cli, args)
-    return result, factory, processor, create_database
+    return Invocation(result, factory, processor, create_database)
 
 
 def _processed_specs(processor):
@@ -94,11 +119,11 @@ def _processed_specs(processor):
 
 
 def test_single_spec_output_is_unchanged():
-    result, _, processor, _ = _invoke(["RACE"])
+    run = _invoke(["RACE"])
 
-    assert result.exit_code == 0, result.output
-    assert result.output == SINGLE_SPEC_GOLDEN
-    assert _processed_specs(processor) == ["RACE"]
+    assert run.result.exit_code == 0, run.result.output
+    assert run.result.output == SINGLE_SPEC_GOLDEN
+    assert _processed_specs(run.processor) == ["RACE"]
 
 
 def test_one_jvlink_session_serves_every_spec():
@@ -108,37 +133,37 @@ def test_one_jvlink_session_serves_every_spec():
     JVInit が走る。spec ごとに作り直すと option=4 の取得元ダイアログが spec 数ぶん
     出てしまい、このチケットの前提そのものが崩れる。
     """
-    result, factory, processor, _ = _invoke(["DIFN", "WOOD", "SLOP"])
+    run = _invoke(["DIFN", "WOOD", "SLOP"])
 
-    assert result.exit_code == 0, result.output
-    assert factory.call_count == 1
-    assert processor.process_date_range.call_count == 3
+    assert run.result.exit_code == 0, run.result.output
+    assert run.batch_processor.call_count == 1
+    assert run.processor.process_date_range.call_count == 3
 
 
 def test_specs_are_processed_in_the_order_given():
     """並べ替えは keibaai_cloud の持ち物（ADR-0025）。指定順をそのまま守る。"""
-    result, _, processor, _ = _invoke(["WOOD", "BLDN", "DIFN", "RACE"])
+    run = _invoke(["WOOD", "BLDN", "DIFN", "RACE"])
 
-    assert result.exit_code == 0, result.output
-    assert _processed_specs(processor) == ["WOOD", "BLDN", "DIFN", "RACE"]
+    assert run.result.exit_code == 0, run.result.output
+    assert _processed_specs(run.processor) == ["WOOD", "BLDN", "DIFN", "RACE"]
 
 
 def test_each_spec_repeats_the_header_and_statistics_block():
     """出力の口は増やさない。既存ブロックを dataspec ごとに繰り返すだけ。"""
-    result, _, _, _ = _invoke(["DIFN", "WOOD", "SLOP"])
+    run = _invoke(["DIFN", "WOOD", "SLOP"])
 
-    assert result.exit_code == 0, result.output
-    assert result.output.count("[OK] Fetch complete!") == 3
-    assert result.output.count("Statistics:") == 3
+    assert run.result.exit_code == 0, run.result.output
+    assert run.result.output.count("[OK] Fetch complete!") == 3
+    assert run.result.output.count("Statistics:") == 3
     for spec in ("DIFN", "WOOD", "SLOP"):
-        assert f"  Data spec:  {spec}" in result.output
+        assert f"  Data spec:  {spec}" in run.result.output
 
 
 def test_the_date_range_and_option_are_the_same_for_every_spec():
-    result, _, processor, _ = _invoke(["DIFN", "RACE"], option=4)
+    run = _invoke(["DIFN", "RACE"], option=4)
 
-    assert result.exit_code == 0, result.output
-    for call in processor.process_date_range.call_args_list:
+    assert run.result.exit_code == 0, run.result.output
+    for call in run.processor.process_date_range.call_args_list:
         assert call.kwargs["from_date"] == "20260820"
         assert call.kwargs["to_date"] == "20260821"
         assert call.kwargs["option"] == 4
@@ -146,19 +171,19 @@ def test_the_date_range_and_option_are_the_same_for_every_spec():
 
 def test_a_failing_spec_stops_the_run_before_the_next_one():
     """ADR-0023「止めて人に見せる」。以降を実行せず、終了コードで分かる。"""
-    result, _, processor, _ = _invoke(
+    run = _invoke(
         ["DIFN", "WOOD", "SLOP"],
         side_effect=[STATS, FetcherError("Historical fetch failed: boom"), STATS],
     )
 
-    assert result.exit_code != 0
-    assert _processed_specs(processor) == ["DIFN", "WOOD"]
-    assert "boom" in result.output
+    assert run.result.exit_code != 0
+    assert _processed_specs(run.processor) == ["DIFN", "WOOD"]
+    assert "boom" in run.result.output
 
 
 def test_setup_dialog_cancel_stops_the_whole_run():
     """取得元の選択が拒否された以上、後続も初回の選択を引き継げない。"""
-    result, _, processor, _ = _invoke(
+    run = _invoke(
         ["DIFN", "WOOD"],
         option=4,
         side_effect=[
@@ -169,34 +194,83 @@ def test_setup_dialog_cancel_stops_the_whole_run():
         ],
     )
 
-    assert result.exit_code != 0
-    assert _processed_specs(processor) == ["DIFN"]
-    assert "cancel" in result.output
+    assert run.result.exit_code != 0
+    assert _processed_specs(run.processor) == ["DIFN"]
+    assert "cancel" in run.result.output
 
 
 def test_a_retired_spec_anywhere_is_rejected_before_the_database():
     # DIFF は廃止済み（DIFN が後継）。2 番目に置いても DB より先に落ちる。
-    result, factory, _, create_database = _invoke(["RACE", "DIFF"])
+    run = _invoke(["RACE", "DIFF"])
 
-    assert result.exit_code == 1, result.output
-    create_database.assert_not_called()
-    factory.assert_not_called()
+    assert run.result.exit_code == 1, run.result.output
+    run.create_database.assert_not_called()
+    run.batch_processor.assert_not_called()
 
 
 def test_an_invalid_option_combination_anywhere_is_rejected_before_the_database():
     # DIFN は option=2（今週データ）では取得できない。
-    result, factory, _, create_database = _invoke(["RACE", "DIFN"], option=2)
+    run = _invoke(["RACE", "DIFN"], option=2)
 
-    assert result.exit_code == 1, result.output
-    assert "DIFN" in result.output
-    create_database.assert_not_called()
-    factory.assert_not_called()
+    assert run.result.exit_code == 1, run.result.output
+    assert "DIFN" in run.result.output
+    run.create_database.assert_not_called()
+    run.batch_processor.assert_not_called()
 
 
 @pytest.mark.parametrize("specs", [["RACE", "RACE"], ["DIFN", "RACE", "DIFN"]])
 def test_a_repeated_spec_is_processed_once_per_occurrence(specs):
     """重複の除去も呼び出し側の判断。jltsql は指定された回数だけ回す。"""
-    result, _, processor, _ = _invoke(specs)
+    run = _invoke(specs)
 
-    assert result.exit_code == 0, result.output
-    assert _processed_specs(processor) == specs
+    assert run.result.exit_code == 0, run.result.output
+    assert _processed_specs(run.processor) == specs
+
+
+def test_the_run_summary_uses_a_plural_label_so_it_is_not_read_as_a_spec_name():
+    """前置きの一覧行が dataspec 見出しと同じラベルだと、driver が spec 名として読む。
+
+    単数形 ``Data spec:`` は「いま処理している dataspec」だけを指すようにし、
+    実走全体の一覧は複数形にして分ける。
+    """
+    run = _invoke(["DIFN", "WOOD", "SLOP"])
+
+    assert run.result.exit_code == 0, run.result.output
+    assert "  Data specs: DIFN, WOOD, SLOP" in run.result.output
+    # 単数形は dataspec ごとの見出しとしてだけ、spec 数ぶん出る。
+    assert run.result.output.count("  Data spec:  ") == 3
+
+
+def test_a_single_spec_keeps_the_singular_label():
+    run = _invoke(["RACE"])
+
+    assert "  Data spec:  RACE" in run.result.output
+    assert "Data specs:" not in run.result.output
+
+
+def test_the_retired_reason_wins_over_the_option_combination_error():
+    """廃止済み種別の理由を option 組み合わせより先に返す順序は複数指定でも保つ。
+
+    DIFF は廃止済み、DIFN は option=2 では取得できない。両方に引っかかる要求で
+    先に出るのは廃止済みの理由でなければならない（単一指定のときと同じ）。
+    """
+    run = _invoke(["DIFN", "DIFF"], option=2)
+
+    assert run.result.exit_code == 1, run.result.output
+    assert "DIFF" in run.result.output
+    assert "option=2 では取得できません" not in run.result.output
+    run.create_database.assert_not_called()
+
+
+def test_progress_display_owns_the_per_spec_header_when_it_is_enabled():
+    """progress 有効時は JVLinkProgressDisplay が dataspec 見出しを出す。
+
+    CLI 側でも出すと 1 dataspec につき見出しが 2 つ並ぶので、そちらへ任せる。
+    """
+    run = _invoke(["DIFN", "WOOD"], progress=True)
+
+    assert run.result.exit_code == 0, run.result.output
+    assert "  Data spec:  DIFN" not in run.result.output
+    assert "  Data specs: DIFN, WOOD" in run.result.output
+    # Statistics ブロックは progress の有無によらず dataspec ごとに出る。
+    assert run.result.output.count("[OK] Fetch complete!") == 2

--- a/tests/test_fetch_multiple_dataspecs.py
+++ b/tests/test_fetch_multiple_dataspecs.py
@@ -16,6 +16,7 @@ from click.testing import CliRunner
 from src.cli.main import (
     FETCH_NOTE_DATE_FIELDS,
     FETCH_NOTE_TO_CLIENT_FILTER,
+    FETCH_NOTE_TO_RANGE_CHUNKED,
     FETCH_NOTE_TO_SINGLE_OPEN,
     cli,
 )
@@ -35,11 +36,12 @@ STATS = {
 
 # option=1 のガードレール注記そのものは #290 の対象外なので、文言は定数から組む。
 # ここで転記すると、注記を直しただけでこのテストが無関係な差分で落ちる。
+# RACE は範囲形式を使う dataspec なので、刻む側の注記が出る（#246）。
 _OPTION1_NOTES = "\n".join(
     f"Note: {note}"
     for note in (
         FETCH_NOTE_TO_CLIENT_FILTER,
-        FETCH_NOTE_TO_SINGLE_OPEN,
+        FETCH_NOTE_TO_RANGE_CHUNKED,
         FETCH_NOTE_DATE_FIELDS,
     )
 )
@@ -124,6 +126,23 @@ def test_single_spec_output_is_unchanged():
     assert run.result.exit_code == 0, run.result.output
     assert run.result.output == SINGLE_SPEC_GOLDEN
     assert _processed_specs(run.processor) == ["RACE"]
+
+
+def test_guardrail_notes_cover_the_whole_run_without_repeating():
+    """注記は実走に 1 回。刻める spec と刻めない spec が混ざれば両方 1 回ずつ出る。
+
+    RACE は暦年で刻み、DIFN は start-only（#246）。dataspec ごとに注記を
+    出し直すと、同じ文が dataspec の数だけ並ぶ。
+    """
+    run = _invoke(["RACE", "DIFN"])
+
+    assert run.result.exit_code == 0, run.result.output
+    # rich は 1 行が幅を超えると折り返すので、改行を畳んでから数える。
+    output = run.result.output.replace("\n", "")
+    assert output.count(FETCH_NOTE_TO_RANGE_CHUNKED) == 1
+    assert output.count(FETCH_NOTE_TO_SINGLE_OPEN) == 1
+    assert output.count(FETCH_NOTE_DATE_FIELDS) == 1
+    assert _processed_specs(run.processor) == ["RACE", "DIFN"]
 
 
 def test_one_jvlink_session_serves_every_spec():

--- a/tests/test_fetch_multiple_dataspecs.py
+++ b/tests/test_fetch_multiple_dataspecs.py
@@ -1,0 +1,202 @@
+"""``fetch`` は複数 dataspec を 1 JV-Link セッションで指定順に処理する。
+
+公式仕様は「dataspec を複数指定すると対象ファイル数が多い場合に JVRead が遅く
+なる」を既知障害として挙げ、回避策に「dataspec を個別に指定」を挙げている。
+したがって連結して 1 回の JVOpen にはせず、**JVOpen は dataspec ごと・セッション
+だけ 1 本**にする。並べ替えは呼び出し側の持ち物なので jltsql では行わない。
+"""
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from src.cli.main import cli
+from src.fetcher.base import FetcherError
+
+EXAMPLE_CONFIG = (
+    Path(__file__).resolve().parents[1] / "config" / "config.yaml.example"
+)
+
+STATS = {
+    "records_fetched": 10,
+    "records_parsed": 9,
+    "records_imported": 8,
+    "records_failed": 1,
+    "batches_processed": 2,
+}
+
+# 単一 --spec の出力は #290 の前後で一字一句変わってはいけない。rich の折り返しを
+# 固定するため COLUMNS を固定した上で丸ごと突き合わせる。
+SINGLE_SPEC_GOLDEN = """\
+Fetching historical data from JRA-VAN DataLab...
+
+  Data source: JRA (中央競馬)
+  Date range: 20260820 -- 20260821
+  Data spec:  RACE
+  Option:     1 (通常データ)
+  Database:   sqlite
+Note: --to は取得後のクライアント側日付フィルタであり、JVOpen の終端ではありません。
+Note: option=1/2 では --to は JVOpen の終端にならず、狭めてもサーバからのダウンロード量は減りません。
+Note: --to は Year+MonthDay または ChokyoDate（HC/WC の調教日）で判定します。対応する日付を持たないレコードは JV-Link 取得時に除外されず、その取得範囲は完全キャッシュとして記録されません。
+
+Processing data...
+
+[OK] Fetch complete!
+
+Statistics:
+  Fetched:  10
+  Parsed:   9
+  Imported: 8
+  Failed:   1
+  Batches:  2
+"""
+
+
+def _runner():
+    # rich の折り返し幅を固定して出力を決定的にする。
+    return CliRunner(env={"COLUMNS": "200", "TERM": "dumb"})
+
+
+def _invoke(specs, *, option=1, side_effect=None, batch_processor=None):
+    """``fetch`` を実行し、``(result, batch_processor_mock, processor_mock)`` を返す。"""
+    processor = MagicMock()
+    if side_effect is not None:
+        processor.process_date_range.side_effect = side_effect
+    else:
+        processor.process_date_range.return_value = STATS
+
+    factory = MagicMock(return_value=processor)
+    create_database = MagicMock(return_value=MagicMock())
+
+    args = ["--config", "config.yaml", "fetch", "--from", "20260820", "--to", "20260821"]
+    for spec in specs:
+        args += ["--spec", spec]
+    args += ["--option", str(option), "--db", "sqlite", "--no-cache", "--no-progress"]
+
+    runner = _runner()
+    with runner.isolated_filesystem():
+        Path("config.yaml").write_text(
+            EXAMPLE_CONFIG.read_text(encoding="utf-8"), encoding="utf-8"
+        )
+        with (
+            patch("src.importer.batch.BatchProcessor", factory),
+            patch("src.database.create_database_from_config", create_database),
+            patch("src.database.schema.create_all_tables"),
+        ):
+            result = runner.invoke(cli, args)
+    return result, factory, processor, create_database
+
+
+def _processed_specs(processor):
+    return [call.kwargs["data_spec"] for call in processor.process_date_range.call_args_list]
+
+
+def test_single_spec_output_is_unchanged():
+    result, _, processor, _ = _invoke(["RACE"])
+
+    assert result.exit_code == 0, result.output
+    assert result.output == SINGLE_SPEC_GOLDEN
+    assert _processed_specs(processor) == ["RACE"]
+
+
+def test_one_jvlink_session_serves_every_spec():
+    """BatchProcessor は 1 個だけ。spec ごとに作り直すと #287 の効果が消える。
+
+    ``BatchProcessor.__init__`` が ``HistoricalFetcher`` を 1 個作り、その生成時に
+    JVInit が走る。spec ごとに作り直すと option=4 の取得元ダイアログが spec 数ぶん
+    出てしまい、このチケットの前提そのものが崩れる。
+    """
+    result, factory, processor, _ = _invoke(["DIFN", "WOOD", "SLOP"])
+
+    assert result.exit_code == 0, result.output
+    assert factory.call_count == 1
+    assert processor.process_date_range.call_count == 3
+
+
+def test_specs_are_processed_in_the_order_given():
+    """並べ替えは keibaai_cloud の持ち物（ADR-0025）。指定順をそのまま守る。"""
+    result, _, processor, _ = _invoke(["WOOD", "BLDN", "DIFN", "RACE"])
+
+    assert result.exit_code == 0, result.output
+    assert _processed_specs(processor) == ["WOOD", "BLDN", "DIFN", "RACE"]
+
+
+def test_each_spec_repeats_the_header_and_statistics_block():
+    """出力の口は増やさない。既存ブロックを dataspec ごとに繰り返すだけ。"""
+    result, _, _, _ = _invoke(["DIFN", "WOOD", "SLOP"])
+
+    assert result.exit_code == 0, result.output
+    assert result.output.count("[OK] Fetch complete!") == 3
+    assert result.output.count("Statistics:") == 3
+    for spec in ("DIFN", "WOOD", "SLOP"):
+        assert f"  Data spec:  {spec}" in result.output
+
+
+def test_the_date_range_and_option_are_the_same_for_every_spec():
+    result, _, processor, _ = _invoke(["DIFN", "RACE"], option=4)
+
+    assert result.exit_code == 0, result.output
+    for call in processor.process_date_range.call_args_list:
+        assert call.kwargs["from_date"] == "20260820"
+        assert call.kwargs["to_date"] == "20260821"
+        assert call.kwargs["option"] == 4
+
+
+def test_a_failing_spec_stops_the_run_before_the_next_one():
+    """ADR-0023「止めて人に見せる」。以降を実行せず、終了コードで分かる。"""
+    result, _, processor, _ = _invoke(
+        ["DIFN", "WOOD", "SLOP"],
+        side_effect=[STATS, FetcherError("Historical fetch failed: boom"), STATS],
+    )
+
+    assert result.exit_code != 0
+    assert _processed_specs(processor) == ["DIFN", "WOOD"]
+    assert "boom" in result.output
+
+
+def test_setup_dialog_cancel_stops_the_whole_run():
+    """取得元の選択が拒否された以上、後続も初回の選択を引き継げない。"""
+    result, _, processor, _ = _invoke(
+        ["DIFN", "WOOD"],
+        option=4,
+        side_effect=[
+            FetcherError(
+                "Historical fetch failed: JVOpen setup dialog was cancelled"
+            ),
+            STATS,
+        ],
+    )
+
+    assert result.exit_code != 0
+    assert _processed_specs(processor) == ["DIFN"]
+    assert "cancel" in result.output
+
+
+def test_a_retired_spec_anywhere_is_rejected_before_the_database():
+    # DIFF は廃止済み（DIFN が後継）。2 番目に置いても DB より先に落ちる。
+    result, factory, _, create_database = _invoke(["RACE", "DIFF"])
+
+    assert result.exit_code == 1, result.output
+    create_database.assert_not_called()
+    factory.assert_not_called()
+
+
+def test_an_invalid_option_combination_anywhere_is_rejected_before_the_database():
+    # DIFN は option=2（今週データ）では取得できない。
+    result, factory, _, create_database = _invoke(["RACE", "DIFN"], option=2)
+
+    assert result.exit_code == 1, result.output
+    assert "DIFN" in result.output
+    create_database.assert_not_called()
+    factory.assert_not_called()
+
+
+@pytest.mark.parametrize("specs", [["RACE", "RACE"], ["DIFN", "RACE", "DIFN"]])
+def test_a_repeated_spec_is_processed_once_per_occurrence(specs):
+    """重複の除去も呼び出し側の判断。jltsql は指定された回数だけ回す。"""
+    result, _, processor, _ = _invoke(specs)
+
+    assert result.exit_code == 0, result.output
+    assert _processed_specs(processor) == specs

--- a/tests/test_jvinit_once_per_process.py
+++ b/tests/test_jvinit_once_per_process.py
@@ -1,0 +1,223 @@
+"""JVInit lifecycle contract: one JV-Link session per process.
+
+公式仕様の JVInit はアプリケーションの初期化であって JVOpen ごとの前処理では
+ない。ここでは COM を差し替えた ``JVLinkWrapper`` 越しに、同一プロセスで fetch を
+何度呼んでも JVInit は 1 回きりで、JVOpen と JVClose だけが fetch ごとに 1 組ずつ
+回ることを固定する。単一 dataspec・option=1（日次差分）の既存契約も併せて固定し、
+この lifecycle refactor が取得挙動を動かしていないことを示す。
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from src.fetcher.base import FetcherError
+from src.fetcher.historical import HistoricalFetcher
+from src.jvlink.bridge import JVLinkBridge
+from src.jvlink.wrapper import JVLinkError, JVLinkWrapper
+
+
+class RecordingJVLinkCom:
+    """固定シグネチャの COM ダブル。公式の呼び出し順をそのまま記録する。
+
+    ``MagicMock`` と違い、引数を落とした呼び出しはテスト失敗になる。
+    """
+
+    def __init__(self, *, init_result=0, records=("RA-RECORD",), open_result=None):
+        self.init_result = init_result
+        self.records = list(records)
+        self.open_result = open_result
+        self.calls = []
+        self._pending = []
+
+    # --- 公式 API -------------------------------------------------------
+    def JVInit(self, sid):
+        self.calls.append(("JVInit", sid))
+        return self.init_result
+
+    def JVOpen(
+        self,
+        data_spec,
+        fromtime,
+        option,
+        read_count,
+        download_count,
+        last_file_timestamp,
+    ):
+        self.calls.append(("JVOpen", data_spec, fromtime, option))
+        if self.open_result is not None:
+            self._pending = []
+            return self.open_result
+        self._pending = list(self.records)
+        return (0, len(self.records), 0, "20260820120000")
+
+    def JVRead(self, buff, size, filename):
+        if self._pending:
+            payload = self._pending.pop(0)
+            return (len(payload), payload, len(payload), "RACE.jvd")
+        return (0, "", 0, "")
+
+    def JVClose(self):
+        self.calls.append(("JVClose",))
+        return 0
+
+    # --- 参照用 ---------------------------------------------------------
+    def names(self):
+        return [call[0] for call in self.calls]
+
+    def count(self, name):
+        return self.names().count(name)
+
+    def opens(self):
+        return [call[1:] for call in self.calls if call[0] == "JVOpen"]
+
+
+def _record(index):
+    # to_date フィルタを通す実在日付を持たせる（日付なしレコードは常に通るため、
+    # フィルタ経路そのものを素通りさせない）。
+    return {"Year": "2026", "MonthDay": "0820", "headRecordSpec": "RA", "seq": index}
+
+
+def _historical_fetcher(com):
+    """COM だけを差し替えた本物の ``JVLinkWrapper`` で fetcher を組む。"""
+    wrapper = JVLinkWrapper.__new__(JVLinkWrapper)
+    wrapper.sid = "TEST"
+    wrapper._jvlink = com
+    wrapper._is_open = False
+    wrapper._needs_close = False
+    wrapper._com_initialized = False
+    wrapper._initialized = False
+
+    counter = {"n": 0}
+
+    def _parse(raw):
+        counter["n"] += 1
+        return _record(counter["n"])
+
+    factory = MagicMock()
+    factory.parse.side_effect = _parse
+
+    with (
+        patch("src.jvlink.bridge.find_bridge_executable", return_value=None),
+        patch("src.fetcher.base.JVLinkWrapper", return_value=wrapper),
+        patch("src.fetcher.base.ParserFactory", return_value=factory),
+    ):
+        return HistoricalFetcher(sid="TEST", show_progress=False)
+
+
+def test_three_fetches_in_one_process_share_a_single_jvinit():
+    com = RecordingJVLinkCom()
+    fetcher = _historical_fetcher(com)
+
+    for _ in range(3):
+        assert len(list(fetcher.fetch("RACE", "20260820", "20260820", option=1))) == 1
+
+    assert com.count("JVInit") == 1
+    assert com.count("JVOpen") == 3
+    assert com.count("JVClose") == 3
+    # JVInit は最初の 1 回だけで、以降は JVOpen/JVClose の対が並ぶ。
+    assert com.names() == [
+        "JVInit",
+        "JVOpen",
+        "JVClose",
+        "JVOpen",
+        "JVClose",
+        "JVOpen",
+        "JVClose",
+    ]
+
+
+def test_jvclose_still_pairs_with_every_jvopen_that_reports_no_data():
+    com = RecordingJVLinkCom(open_result=(-1, 0, 0, ""))
+    fetcher = _historical_fetcher(com)
+
+    for _ in range(3):
+        assert list(fetcher.fetch("RACE", "20260820", "20260820", option=1)) == []
+
+    assert com.count("JVInit") == 1
+    assert com.count("JVOpen") == 3
+    assert com.count("JVClose") == 3
+
+
+def test_a_failing_jvinit_never_reaches_jvopen():
+    # -101 は JVInit の sid 書式エラー（公式コード表）。
+    com = RecordingJVLinkCom(init_result=-101)
+
+    with pytest.raises(JVLinkError):
+        _historical_fetcher(com)
+
+    assert com.names() == ["JVInit"]
+    assert com.count("JVOpen") == 0
+
+
+def test_fetch_does_not_reissue_jvinit_after_a_stream_error():
+    com = RecordingJVLinkCom(open_result=(-203, 0, 0, ""))
+    fetcher = _historical_fetcher(com)
+
+    with pytest.raises(FetcherError):
+        list(fetcher.fetch("RACE", "20260820", "20260820", option=1))
+
+    assert com.count("JVInit") == 1
+
+
+def test_single_dataspec_daily_diff_keeps_its_option1_jvopen_contract():
+    """option=1 の単一 dataspec は従来どおり ``{from_date}000000`` の start-only。"""
+    com = RecordingJVLinkCom(records=("RA-1", "RA-2"))
+    fetcher = _historical_fetcher(com)
+
+    records = list(fetcher.fetch("RACE", "20260820", "20260821", option=1))
+
+    assert len(records) == 2
+    assert com.opens() == [("RACE", "20260820000000", 1)]
+    assert com.count("JVClose") == 1
+    assert fetcher.get_statistics()["records_parsed"] == 2
+
+
+def test_repeated_daily_diff_fetches_send_one_jvopen_per_request():
+    """日次差分を回し続けても、セッションは 1 本で JVOpen だけが増える。"""
+    com = RecordingJVLinkCom()
+    fetcher = _historical_fetcher(com)
+
+    list(fetcher.fetch("RACE", "20260820", "20260820", option=1))
+    list(fetcher.fetch("RACE", "20260821", "20260821", option=1))
+
+    assert com.count("JVInit") == 1
+    assert com.opens() == [
+        ("RACE", "20260820000000", 1),
+        ("RACE", "20260821000000", 1),
+    ]
+
+
+def test_wrapper_jv_init_reuses_the_established_session():
+    com = RecordingJVLinkCom()
+    wrapper = JVLinkWrapper.__new__(JVLinkWrapper)
+    wrapper.sid = "TEST"
+    wrapper._jvlink = com
+    wrapper._is_open = False
+    wrapper._needs_close = False
+    wrapper._com_initialized = False
+    wrapper._initialized = False
+
+    assert wrapper.jv_init() == 0
+    assert wrapper.jv_init() == 0
+    assert wrapper.jv_init() == 0
+
+    assert com.count("JVInit") == 1
+
+
+def test_bridge_jv_init_is_issued_once_per_bridge_process():
+    bridge = JVLinkBridge.__new__(JVLinkBridge)
+    bridge.sid = "TEST"
+    bridge._is_open = False
+    bridge._needs_close = False
+    bridge._initialized = False
+    bridge._process = MagicMock()
+    bridge._process.poll.return_value = None
+    bridge._start_process = MagicMock()
+    bridge._send_command = MagicMock(return_value={"status": "ok", "code": 0})
+
+    assert bridge.jv_init() == 0
+    assert bridge.jv_init() == 0
+
+    assert bridge._send_command.call_count == 1
+    assert bridge._send_command.call_args_list[0].args[0]["cmd"] == "init"

--- a/tests/test_jvinit_once_per_process.py
+++ b/tests/test_jvinit_once_per_process.py
@@ -167,14 +167,19 @@ def test_fetch_does_not_reissue_jvinit_after_a_stream_error():
 
 
 def test_single_dataspec_daily_diff_keeps_its_option1_jvopen_contract():
-    """option=1 の単一 dataspec は従来どおり ``{from_date}000000`` の start-only。"""
+    """単一 dataspec の option=1 は JVOpen 1 回。fromtime は master の形のまま。
+
+    RACE は範囲形式を使う dataspec なので、要求は暦年で刻まれた
+    ``{from}000000-{to}235959`` として届く（#246）。この hoist は JVOpen へ
+    渡す引数を動かさない。
+    """
     com = RecordingJVLinkCom(records=("RA-1", "RA-2"))
     fetcher = _historical_fetcher(com)
 
     records = list(fetcher.fetch("RACE", "20260820", "20260821", option=1))
 
     assert len(records) == 2
-    assert com.opens() == [("RACE", "20260820000000", 1)]
+    assert com.opens() == [("RACE", "20260820000000-20260821235959", 1)]
     assert com.count("JVClose") == 1
     assert fetcher.get_statistics()["records_parsed"] == 2
 
@@ -189,8 +194,8 @@ def test_repeated_daily_diff_fetches_send_one_jvopen_per_request():
 
     assert com.count("JVInit") == 1
     assert com.opens() == [
-        ("RACE", "20260820000000", 1),
-        ("RACE", "20260821000000", 1),
+        ("RACE", "20260820000000-20260820235959", 1),
+        ("RACE", "20260821000000-20260821235959", 1),
     ]
 
 

--- a/tests/test_jvinit_once_per_process.py
+++ b/tests/test_jvinit_once_per_process.py
@@ -13,7 +13,7 @@ import pytest
 
 from src.fetcher.base import FetcherError
 from src.fetcher.historical import HistoricalFetcher
-from src.jvlink.bridge import JVLinkBridge
+from src.jvlink.bridge import JVLinkBridge, JVLinkBridgeError
 from src.jvlink.wrapper import JVLinkError, JVLinkWrapper
 
 
@@ -78,8 +78,8 @@ def _record(index):
     return {"Year": "2026", "MonthDay": "0820", "headRecordSpec": "RA", "seq": index}
 
 
-def _historical_fetcher(com):
-    """COM だけを差し替えた本物の ``JVLinkWrapper`` で fetcher を組む。"""
+def _wrapper(com):
+    """COM だけを差し替えた本物の ``JVLinkWrapper``（``__init__`` は通さない）。"""
     wrapper = JVLinkWrapper.__new__(JVLinkWrapper)
     wrapper.sid = "TEST"
     wrapper._jvlink = com
@@ -87,6 +87,12 @@ def _historical_fetcher(com):
     wrapper._needs_close = False
     wrapper._com_initialized = False
     wrapper._initialized = False
+    return wrapper
+
+
+def _historical_fetcher(com):
+    """その wrapper を掴んだ fetcher を組む。"""
+    wrapper = _wrapper(com)
 
     counter = {"n": 0}
 
@@ -190,13 +196,7 @@ def test_repeated_daily_diff_fetches_send_one_jvopen_per_request():
 
 def test_wrapper_jv_init_reuses_the_established_session():
     com = RecordingJVLinkCom()
-    wrapper = JVLinkWrapper.__new__(JVLinkWrapper)
-    wrapper.sid = "TEST"
-    wrapper._jvlink = com
-    wrapper._is_open = False
-    wrapper._needs_close = False
-    wrapper._com_initialized = False
-    wrapper._initialized = False
+    wrapper = _wrapper(com)
 
     assert wrapper.jv_init() == 0
     assert wrapper.jv_init() == 0
@@ -205,19 +205,80 @@ def test_wrapper_jv_init_reuses_the_established_session():
     assert com.count("JVInit") == 1
 
 
-def test_bridge_jv_init_is_issued_once_per_bridge_process():
+def _bridge(*, init_code=0):
+    """``__init__`` を通さない bridge。プロセスは生きている扱いで組む。"""
     bridge = JVLinkBridge.__new__(JVLinkBridge)
     bridge.sid = "TEST"
     bridge._is_open = False
     bridge._needs_close = False
     bridge._initialized = False
+    bridge._download_count = None
     bridge._process = MagicMock()
     bridge._process.poll.return_value = None
     bridge._start_process = MagicMock()
-    bridge._send_command = MagicMock(return_value={"status": "ok", "code": 0})
+    bridge._send_command = MagicMock(
+        return_value={"status": "ok", "code": init_code}
+    )
+    return bridge
+
+
+def _bridge_commands(bridge):
+    return [call.args[0]["cmd"] for call in bridge._send_command.call_args_list]
+
+
+def test_bridge_jv_init_is_issued_once_per_bridge_process():
+    bridge = _bridge()
 
     assert bridge.jv_init() == 0
     assert bridge.jv_init() == 0
 
-    assert bridge._send_command.call_count == 1
-    assert bridge._send_command.call_args_list[0].args[0]["cmd"] == "init"
+    assert _bridge_commands(bridge) == ["init"]
+
+
+def test_bridge_jvinit_failure_never_reaches_jvopen():
+    bridge = _bridge(init_code=-101)
+
+    with pytest.raises(JVLinkBridgeError):
+        bridge.jv_init()
+
+    assert _bridge_commands(bridge) == ["init"]
+
+
+def test_bridge_reopens_its_session_when_the_process_died_mid_run():
+    """タイムアウトで bridge が落ちても、次の JVOpen がセッションを張り直す。
+
+    hoist 前は fetch ごとの JVInit がプロセスを起こし直していた。JVOpen 側に
+    復旧点を残さないと、一度落ちたプロセスで残りの取得が全滅する。
+    """
+    bridge = _bridge()
+    assert bridge.jv_init() == 0
+
+    commands = []
+
+    def _send(cmd, timeout=None):
+        # 本物の _send_command と同じ生存判定。落ちたプロセスでは送れない。
+        if bridge._process.poll() is not None:
+            raise JVLinkBridgeError("Bridge process is not running")
+        commands.append(cmd["cmd"])
+        if cmd["cmd"] == "init":
+            return {"status": "ok", "code": 0}
+        return {
+            "status": "ok",
+            "code": 0,
+            "readcount": 3,
+            "downloadcount": 0,
+            "lastfiletimestamp": "20260820120000",
+        }
+
+    def _restart():
+        bridge._process.poll.return_value = None
+
+    bridge._send_command = _send
+    bridge._start_process = _restart
+
+    # レスポンスタイムアウト相当: _abort_process がプロセスを落とした状態
+    bridge._process.poll.return_value = 1
+
+    assert bridge.jv_open("RACE", "20260820000000", 1)[0] == 0
+
+    assert commands == ["init", "open"]

--- a/tests/test_jvlink_transport_contract.py
+++ b/tests/test_jvlink_transport_contract.py
@@ -255,6 +255,9 @@ def test_invalid_or_inverted_dates_fail_before_any_jvlink_call(bad_from, bad_to)
     jvlink = MagicMock()
     jvlink.jv_open.return_value = (-1, 0, 0, "")
     fetcher = _historical_fetcher(jvlink)
+    # 生成時に一度だけ張る JV-Link セッションは測定対象外。
+    # fetch 側が JVInit を再発行しないことも併せて固定する。
+    jvlink.reset_mock()
 
     with pytest.raises(ValueError):
         list(fetcher.fetch("RACE", bad_from, bad_to, option=4))
@@ -267,6 +270,8 @@ def test_inverted_cache_range_fails_before_cache_lookup_or_jvlink_call():
     cache = MagicMock()
     jvlink = MagicMock()
     fetcher = _historical_fetcher(jvlink)
+    # 生成時の JVInit（セッション確立）は測定対象外。
+    jvlink.reset_mock()
 
     with pytest.raises(ValueError):
         list(fetcher.fetch_with_cache(cache, "RACE", "20260819", "20250820", 4))


### PR DESCRIPTION
## 解決したいこと

仕様書 p.10 は `JVInit` を「アプリケーションの初期化時に呼び出しを行ってください。`JVOpen` あるいは `JVRTOpen` の都度呼び出す必要はありません」としていますが、いまは `HistoricalFetcher.fetch()` の中で毎回呼んでいます。

そのため 1 プロセスで dataspec を複数取ろうとしても、セットアップ（option=3/4）の取得元ダイアログが **dataspec の数だけ出ます**。#246 で `JVOpen` を暦年に刻んだので、このままだと chunk の数だけ出かねません。

## 直したこと

**1. `JVInit` をプロセスにつき 1 回に**

- `BaseFetcher.__init__` で 1 回だけ呼び、`fetch()` は `JVOpen` から始まる
- `JVLinkWrapper.jv_init()` / `JVLinkBridge.jv_init()` を冪等にし、2 回目以降は確立済みセッションを再利用する。`cleanup()` / `reinitialize_com()` はフラグを戻す
- `RealtimeFetcher` の fetch 系 3 か所の `jv_init()` も削除
- **`JVClose` は変更なし**（従来どおり `JVOpen` 1 回につき 1 回）

**2. `--spec` を複数指定できるように**

```
jltsql fetch --from 19860101 --to 20261231 --option 4 \
             --spec DIFN --spec WOOD --spec SLOP --spec BLDN --spec RACE
```

- 指定順に処理する。並べ替えも重複除去もしない
- **dataspec を連結して 1 回の `JVOpen` にはまとめない。** 仕様 p.17 が複数指定を「対象ファイル数が多い場合に `JVRead` が遅くなる」既知障害として挙げ、回避策に個別指定を並べているため。`JVOpen` は dataspec ごと、共有するのはセッションだけ
- `BatchProcessor` は実走に 1 個。spec ごとに作り直すとダイアログが戻るのでテストで固定
- 廃止済み dataspec と option 組み合わせの検査を、DB に触る前に全 spec ぶん実施
- 途中の dataspec が失敗したら以降を実行せず終了コードで分かる。`-2`（ダイアログ cancel）も実走ごと停止
- 出力は既存の `[OK] Fetch complete!` ＋ Statistics が dataspec ごとに繰り返されるだけ。新しいフラグは無し。前置きの一覧行だけ `Data specs:` と複数形にして、単数形が「いま処理中の 1 件」を指すようにした

**`--spec` 単一指定の挙動は変わりません**（出力をゴールデンで固定。引数・キャッシュ配線・終了コードも同一）。



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Historical data fetches now support multiple `--spec` values in a single command.
  * Specifications are processed in the requested order with per-spec progress and statistics.
  * Invalid specifications and option combinations are rejected before database changes occur.
  * Processing stops if any specification fails.

* **Bug Fixes**
  * Improved JV-Link session handling prevents unnecessary reinitialization and supports recovery after process loss.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->