### PR TITLE
perf(postgresql): insert_many を executemany 化して SQL 再解析をなくす

### DIFF
--- a/src/database/postgresql_handler.py
+++ b/src/database/postgresql_handler.py
@@ -787,7 +787,9 @@ class PostgreSQLDatabase(BaseDatabase):
             use_replace: If True, use ON CONFLICT DO UPDATE (default: True)
 
         Returns:
-            Number of rows inserted/updated
+            Number of rows sent to PostgreSQL, after in-batch deduplication.
+            Not the driver rowcount: callers bind this value
+            (importer.py, importer_optimized.py).
 
         Raises:
             DatabaseError: If insert fails
@@ -806,8 +808,7 @@ class PostgreSQLDatabase(BaseDatabase):
                 if column not in seen_columns:
                     columns.append(column)
                     seen_columns.add(column)
-        placeholders = ", ".join(["?" for _ in columns])
-        row_placeholders = f"({placeholders})"
+        row_placeholders = "({})".format(", ".join(["?" for _ in columns]))
         # Quote column names (lowercase for PostgreSQL)
         quoted_columns = [self._quote_identifier(col) for col in columns]
 
@@ -835,20 +836,16 @@ class PostgreSQLDatabase(BaseDatabase):
         else:
             conflict_sql = ""
 
-        inserted = 0
-        max_params = 30000
-        chunk_size = max(1, max_params // max(1, len(columns)))
-        for start in range(0, len(data_list), chunk_size):
-            chunk = data_list[start:start + chunk_size]
-            values_sql = ", ".join([row_placeholders] * len(chunk))
-            sql = (
-                f"INSERT INTO {table_name} ({', '.join(quoted_columns)}) "
-                f"VALUES {values_sql}{conflict_sql}"
-            )
-            flat_values = []
-            for row in chunk:
-                flat_values.extend(row.get(col) for col in columns)
-            self.execute(sql, tuple(flat_values))
-            inserted += len(chunk)
+        # One single-row template for the whole batch. A multi-row
+        # "VALUES (...), (...)" statement exceeded psycopg's cacheable query
+        # limits (4096 bytes / 50 parameters), so every chunk was re-parsed
+        # client side; that re-parsing was 15% of a full import
+        # (keibaai_cloud#280). executemany parses once and pipelines the rows.
+        sql = (
+            f"INSERT INTO {table_name} ({', '.join(quoted_columns)}) "
+            f"VALUES {row_placeholders}{conflict_sql}"
+        )
+        parameter_rows = [tuple(row.get(col) for col in columns) for row in data_list]
+        self.executemany(sql, parameter_rows)
 
-        return inserted
+        return len(data_list)

--- a/tests/test_postgresql.py
+++ b/tests/test_postgresql.py
@@ -17,6 +17,7 @@
 
 import os
 import sys
+from contextlib import contextmanager
 from pathlib import Path
 
 import pytest
@@ -178,6 +179,58 @@ def test_dedupe_rows_by_primary_key_keeps_last_row():
     assert deduped[0]["Kumi"] == "01-02"
     assert deduped[0]["Odds"] == 10.5
     assert deduped[1]["Kumi"] == "01-03"
+
+
+def test_insert_many_binds_one_row_template_through_executemany(monkeypatch):
+    """One batch must parse one statement, not one per chunk of rows.
+
+    psycopg refuses to cache a query longer than 4096 bytes or carrying more
+    than 50 parameters, so the old multi-row ``VALUES (...), (...)`` statement
+    re-parsed the whole SQL string on every chunk (keibaai_cloud#280).
+    A single-row template stays inside both limits and is parsed once.
+    """
+    from unittest.mock import MagicMock
+
+    import src.database.postgresql_handler as postgresql_handler
+
+    monkeypatch.setattr(postgresql_handler, "DRIVER", "psycopg")
+    monkeypatch.setattr(
+        postgresql_handler.PostgreSQLDatabase,
+        "_get_primary_key_columns",
+        lambda self, table_name: ["year", "kumi"],
+    )
+
+    database = postgresql_handler.PostgreSQLDatabase({})
+    database._connection = MagicMock()
+    cursor = MagicMock()
+    # rowcount must not leak into the return value; see the return assertion below.
+    cursor.rowcount = 999
+    database._cursor = cursor
+
+    rows = [
+        {"Year": 2026, "Kumi": "01-02", "Odds": 10.0},
+        # Expanded records are ragged: this row binds the column union too.
+        {"Year": 2026, "Kumi": "01-03", "Ninki": 2},
+        # Same conflict key as the first row.
+        {"Year": 2026, "Kumi": "01-02", "Odds": 10.5},
+    ]
+
+    inserted = database.insert_many("test_batch_upsert", rows, use_replace=True)
+
+    cursor.execute.assert_not_called()
+    # One placeholder group for the whole batch, not one per row.
+    assert cursor.executemany.call_args.args[0] == (
+        "INSERT INTO test_batch_upsert (year, kumi, odds, ninki) "
+        "VALUES (%s, %s, %s, %s) ON CONFLICT (year, kumi) "
+        "DO UPDATE SET odds = EXCLUDED.odds, ninki = EXCLUDED.ninki"
+    )
+    # _dedupe_rows_by_primary_key still collapses the in-batch duplicate.
+    assert list(cursor.executemany.call_args.args[1]) == [
+        (2026, "01-02", 10.5, None),
+        (2026, "01-03", None, 2),
+    ]
+    # len(data_list), not cursor.rowcount: callers bind this value.
+    assert inserted == 2
 
 
 def test_pg8000_explicit_batch_transaction(monkeypatch):
@@ -675,3 +728,105 @@ def test_table_exists_and_column_lookups_respect_search_path():
         db.execute("SET search_path TO public")
         db.commit()
         db.disconnect()
+
+
+@contextmanager
+def _live_batch_table(table):
+    """Yield a connected handler owning one throwaway upsert table."""
+    from src.database.postgresql_handler import PostgreSQLDatabase
+
+    db = PostgreSQLDatabase(postgresql_test_config())
+    db.connect()
+    try:
+        db.execute(f"DROP TABLE IF EXISTS {table}")
+        db.execute(
+            f"""
+            CREATE TABLE {table} (
+                year INTEGER NOT NULL,
+                kumi TEXT NOT NULL,
+                ninki INTEGER NOT NULL,
+                PRIMARY KEY (year, kumi)
+            )
+            """
+        )
+        db.commit()
+        yield db
+    finally:
+        db.rollback()
+        db.execute(f"DROP TABLE IF EXISTS {table}")
+        db.commit()
+        db.disconnect()
+
+
+def _rows_of(db, table):
+    return [
+        (row["kumi"], row["ninki"])
+        for row in db.fetch_all(f"SELECT kumi, ninki FROM {table} ORDER BY kumi")
+    ]
+
+
+@postgresql_integration
+def test_insert_many_upsert_round_trip_against_live_postgresql():
+    """``ON CONFLICT DO UPDATE`` semantics survive the executemany rewrite.
+
+    keibaai_cloud#280 replaced the multi-row ``VALUES`` statement with a
+    single-row template driven by ``executemany``. Last row wins inside a
+    batch, a re-run updates instead of duplicating, and the return value
+    counts the deduped rows.
+    """
+    table = "test_insert_many_upsert"
+    with _live_batch_table(table) as db:
+        first_batch = [
+            {"Year": 2026, "Kumi": "01-02", "Ninki": 1},
+            {"Year": 2026, "Kumi": "01-03", "Ninki": 2},
+            # Same conflict key as the first row: the last one wins.
+            {"Year": 2026, "Kumi": "01-02", "Ninki": 3},
+        ]
+        assert db.insert_many(table, first_batch, use_replace=True) == 2
+        db.commit()
+        assert _rows_of(db, table) == [("01-02", 3), ("01-03", 2)]
+
+        # Re-inserting the same conflict keys updates in place.
+        second_batch = [
+            {"Year": 2026, "Kumi": "01-02", "Ninki": 4},
+            {"Year": 2026, "Kumi": "01-04", "Ninki": 5},
+        ]
+        assert db.insert_many(table, second_batch, use_replace=True) == 2
+        db.commit()
+        assert _rows_of(db, table) == [("01-02", 4), ("01-03", 2), ("01-04", 5)]
+
+
+@postgresql_integration
+def test_insert_many_rejects_whole_batch_containing_an_invalid_row():
+    """A bad row anywhere in the batch fails the batch, leaving nothing behind.
+
+    ``executemany`` runs one statement per row over a psycopg pipeline, so the
+    error surfaces from a different call site than the old single multi-row
+    statement did. What callers rely on must not change: ``DatabaseError``
+    reaches them, no row of the failed batch is persisted, and the connection
+    is still usable afterwards.
+    """
+    from src.database.base import DatabaseError
+
+    table = "test_insert_many_invalid_row"
+    with _live_batch_table(table) as db:
+        db.execute(f"INSERT INTO {table} (year, kumi, ninki) VALUES (2026, '00-00', 9)")
+        db.commit()
+
+        poisoned_batch = [
+            {"Year": 2026, "Kumi": "01-02", "Ninki": 1},
+            # NOT NULL violation in the middle of the batch.
+            {"Year": 2026, "Kumi": "01-03", "Ninki": None},
+            {"Year": 2026, "Kumi": "01-04", "Ninki": 2},
+        ]
+        with pytest.raises(DatabaseError):
+            db.insert_many(table, poisoned_batch, use_replace=True)
+
+        # The rollback scope is the batch: the row before the bad one is gone
+        # too, while work committed before the batch survives.
+        assert _rows_of(db, table) == [("00-00", 9)]
+
+        # The handler rolled the failed transaction back: the session is clean.
+        assert db.insert_many(table, [{"Year": 2026, "Kumi": "02-01", "Ninki": 7}]) == 1
+        db.commit()
+        assert _rows_of(db, table) == [("00-00", 9), ("02-01", 7)]


### PR DESCRIPTION
PostgreSQL の一括挿入で、SQL のクライアント側再解析に取り込み時間の 15% を使っていた処理を改善し、性能を良くします。

## 何を変えたか

`src/database/postgresql_handler.py` の `insert_many` が、最大 30,000 プレースホルダの複数行 `INSERT ... VALUES (...), (...)` をチャンクごとに組み立て直していました。psycopg は 4,096 バイト / 50 パラメータを超えるクエリをキャッシュしないため、毎チャンクでSQL 文字列をクライアント側で解析し直していました。

## 意図的に変えていないところ

- **`ON CONFLICT` 節の組み立ては現行のまま。** SQL の `VALUES` 部分だけを差し替えています。
- **戻り値は `len(data_list)`（重複除去後）のまま。** 基底クラス `src/database/base.py` は `self.executemany(...)`（= rowcount）を返しますが、その形を持ち込むと報告値が変わります。呼び出し側が束縛しています（`importer.py:3621`、`importer_optimized.py:1100`）。
- **`_dedupe_rows_by_primary_key` は残しています。** executemany で「同一文で同じ conflict key を 2 回」の制約は消えますが、外して得られるのは約 7% だけで、重複が二重計上されて戻り値が変わります。


