### PR TITLE
文字コード判定のスキップによる高速化

### DIFF
--- a/src/jvlink/wrapper.py
+++ b/src/jvlink/wrapper.py
@@ -120,16 +120,25 @@ def _recover_com_buffer(value, expected_size: int, method_name: str) -> bytes:
         # これで選ぶ。長さの合った候補だけを採る。
         candidates: list[bytes] = []
         failures: list[str] = []
-        for build in (
-            lambda: value.encode("latin-1"),
-            lambda: value.encode("cp932"),
-            lambda: _decode_via_cp1252_table(value, method_name),
-        ):
+
+        def build_candidate(build) -> bool:
+            """候補を 1 つ作る。作れたら True、作れなければ False。"""
             try:
                 candidates.append(build())
             except UnicodeEncodeError as exc:
                 bad = exc.object[exc.start]
                 failures.append(f"U+{ord(bad):04X}")
+                return False
+            return True
+
+        latin1_built = build_candidate(lambda: value.encode("latin-1"))
+        build_candidate(lambda: value.encode("cp932"))
+        # 表の経路は 1 文字ずつ Python で回るので高い（実走で実時間の 3.8%）。
+        # latin-1 が通った値は符号位置がすべて 0xFF 以下で、表の経路もその範囲を
+        # 1 文字 1 バイトで写すだけなので、同じバイト列にしかならない。候補は集合
+        # として突き合わせるため、作らずに飛ばしても選択も曖昧さの判定も変わらない。
+        if not latin1_built:
+            build_candidate(lambda: _decode_via_cp1252_table(value, method_name))
 
         # 長さがちょうど合うものを最優先する。「以上」だけで選ぶと、CP1252 で
         # marshaling されたバッファに cp932 を当てた結果（1 文字 2 バイトに

--- a/tests/test_jvlink_transport_contract.py
+++ b/tests/test_jvlink_transport_contract.py
@@ -828,3 +828,53 @@ def test_recover_com_buffer_rejects_disagreeing_oversized_prefixes():
 
     with pytest.raises(JVLinkError, match="ambiguous"):
         _recover_com_buffer("¢A", 1, "JVRead")
+
+
+def test_cp1252_table_matches_latin1_for_every_byte():
+    """latin-1 が通る値では、CP1252 表の経路は同じバイト列にしかならない。
+
+    符号位置 0xFF 以下は表の経路もそのまま 1 バイトで写すため。候補を飛ばして
+    よい根拠がこれなので、256 バイトすべてで押さえておく。
+    """
+    from src.jvlink.wrapper import _decode_via_cp1252_table
+
+    value = bytes(range(256)).decode("latin-1")
+
+    assert _decode_via_cp1252_table(value, "JVRead") == value.encode("latin-1")
+
+
+def test_recover_com_buffer_skips_the_per_character_table_when_latin1_fits(monkeypatch):
+    """latin-1 で戻せる値では、1 文字ずつ回す CP1252 表の候補を作らない。"""
+    import src.jvlink.wrapper as wrapper
+    from src.jvlink.wrapper import _recover_com_buffer
+
+    def fail(value, method_name):
+        raise AssertionError("_decode_via_cp1252_table should not be reached")
+
+    monkeypatch.setattr(wrapper, "_decode_via_cp1252_table", fail)
+    raw = b"RA7200212201987120509050109100" + b"\xb4" + b"A" * 1241
+    assert len(raw) == 1272
+
+    assert _recover_com_buffer(raw.decode("latin-1"), len(raw), "JVRead") == raw
+
+
+def test_recover_com_buffer_still_builds_the_table_candidate_when_latin1_fails(
+    monkeypatch,
+):
+    """latin-1 が失敗する値では、従来どおり CP1252 表の候補を作る。"""
+    import src.jvlink.wrapper as wrapper
+    from src.jvlink.wrapper import _decode_via_cp1252_table, _recover_com_buffer
+
+    reached = []
+
+    def spy(value, method_name):
+        reached.append(value)
+        return _decode_via_cp1252_table(value, method_name)
+
+    monkeypatch.setattr(wrapper, "_decode_via_cp1252_table", spy)
+    raw = b"A" * 10 + b"\x91\x92\x93\x94" + b"B" * 10  # CP1252 の ‘ ’ “ ”
+
+    recovered = _recover_com_buffer(raw.decode("cp1252"), len(raw), "JVRead")
+
+    assert recovered == raw
+    assert reached


### PR DESCRIPTION
## 目的

JVRead の取り込みを速くする。

## 何が起きているか

文字種類を候補 3 つ（latin-1 / cp932 / CP1252 表）を全部作ってから選んでいる。CP1252 表の経路は 1 文字ずつ Python で回るため高く、RACE の実走（6,485 records / 810.5 秒）のプロファイルでは 31.0 秒 = 実時間の 3.8% を占めていた。ほとんどのレコードは latin-1 で戻せるにもかかわらず、である。

## 変更（`src/jvlink/wrapper.py`）

文字コード判定をlatin-1 が通ったときだけ、CP1252 表の候補を作らない。

latin-1 が通った値は符号位置がすべて 0xFF 以下で、表の経路もその範囲を 1 文字 1 バイトで写すだけなので、同じバイト列にしかならない。候補は集合として突き合わせるため、作らずに飛ばしても結果は変わらない。

- 選択順・曖昧さの検出（`ambiguous`）・失敗時のメッセージ すべて不変
- latin-1 が失敗する値（CP932 / CP1252 で marshaling されたバッファ）は従来どおり表の経路を作る

## テスト

`tests/test_jvlink_transport_contract.py` に 3 件追加（新規ファイルなし）。

1. 256 バイトすべてで、表の経路が latin-1 と同じバイト列を返すこと（飛ばしてよい根拠）
2. latin-1 で戻せる値では表の経路へ到達しないこと
3. latin-1 が失敗する値では従来どおり表の経路を通ること

## 実測

1272 バイトの latin-1 レコード 6,485 件を `_recover_com_buffer` に通した時間: 0.327 秒 → 0.022 秒


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved character decoding reliability when recovering JV-Link communication buffers.
  * Avoided unnecessary fallback processing when Latin-1 decoding succeeds.
  * Preserved CP1252 fallback handling for cases where Latin-1 decoding fails.

* **Tests**
  * Added coverage for Latin-1 and CP1252 decoding behavior, including fallback scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->