### PR TITLE
feat(fetcher): パースに失敗したレコードを同定できる形でログに残す

### DIFF
--- a/src/fetcher/base.py
+++ b/src/fetcher/base.py
@@ -3,6 +3,7 @@
 This module provides the base class for fetching JV-Data from JV-Link.
 """
 
+import base64
 import gc
 import time
 from abc import ABC, abstractmethod
@@ -40,6 +41,11 @@ class BaseFetcher(ABC):
         jvlink: JV-Link wrapper instance
         parser_factory: Parser factory instance
     """
+
+    # An odds or mining buffer runs to ~100KB and would be written three times
+    # over (this log, and the caller's raw and masked streams), so cap what a
+    # single failure can add.
+    FAILED_RECORD_BYTES_LOGGED = 4096
 
     def __init__(
         self,
@@ -230,18 +236,11 @@ class BaseFetcher(ABC):
                                 yield record_item
                         else:
                             self._records_failed += 1
-                            logger.warning(
-                                "Failed to parse record",
-                                record_num=self._records_fetched,
-                            )
+                            self._log_failed_record(buff, filename, error=None)
 
                     except Exception as e:
                         self._records_failed += 1
-                        logger.error(
-                            "Error parsing record",
-                            record_num=self._records_fetched,
-                            error=str(e),
-                        )
+                        self._log_failed_record(buff, filename, error=e)
 
                     # Periodic GC to free COM buffer references (every 10s).
                     # kmy-keiba frees COM buffers with Array.Resize(ref buff, 0) after each read.
@@ -333,6 +332,28 @@ class BaseFetcher(ABC):
                 filename=filename,
                 result=result,
             )
+
+    def _log_failed_record(self, buff, filename, *, error) -> None:
+        """Log one rejected record with enough context to find it again.
+
+        A record number alone cannot identify a record: it counts this run, so a
+        re-run points it at a different record, and the buffer it came from is
+        gone by the time anyone reads the log (the download cache is purged on
+        failure). Name the file it arrived in and carry the bytes themselves, so
+        the record can be replayed through a parser afterwards.
+        """
+        record = bytes(buff) if buff else b""
+        logged = record[: self.FAILED_RECORD_BYTES_LOGGED]
+        logger.error(
+            "Failed to parse record",
+            jvd_file=filename,
+            record_num=self._records_fetched,
+            record_spec=record[:2].decode("ascii", errors="replace"),
+            error=str(error) if error is not None else None,
+            record_len=len(record),
+            record_b64=base64.b64encode(logged).decode("ascii"),
+            record_b64_truncated=len(record) > len(logged),
+        )
 
     def get_statistics(self) -> dict:
         """Get fetching statistics.

--- a/src/fetcher/historical.py
+++ b/src/fetcher/historical.py
@@ -717,11 +717,7 @@ class HistoricalFetcher(BaseFetcher):
                     parsed = self.parser_factory.parse(raw)
                     if not parsed:
                         self._records_failed += 1
-                        logger.warning(
-                            "Failed to parse cached record",
-                            record_num=self._records_fetched,
-                            data_spec=data_spec,
-                        )
+                        self._log_failed_record(raw, f"cache:{data_spec}", error=None)
                         continue
 
                     records = parsed if isinstance(parsed, list) else [parsed]
@@ -731,12 +727,7 @@ class HistoricalFetcher(BaseFetcher):
                         yield record
                 except Exception as error:
                     self._records_failed += 1
-                    logger.error(
-                        "Error parsing cached record",
-                        record_num=self._records_fetched,
-                        data_spec=data_spec,
-                        error=str(error),
-                    )
+                    self._log_failed_record(raw, f"cache:{data_spec}", error=error)
         else:
             # Cache miss: fetch from JV-Link, write to cache
             self.cache_manager = cache_manager

--- a/tests/test_failed_record_artifact.py
+++ b/tests/test_failed_record_artifact.py
@@ -1,0 +1,123 @@
+"""パースに失敗したレコードを、あとから同定して再生できる形でログに残すこと.
+
+見るのは fetch() が出すログ行そのもので、パーサの内部構造ではない。レコードは
+すべて合成（tests/fixtures/record_factory.py）で、実データの再取得を要求しない。
+
+このテストが確認しないこと:
+- どのフィールドのどの値で弾かれたか。それはパーサ自身が出す行に載る（この行が
+  持つのは、どのレコードだったかと、その中身）。
+"""
+
+from __future__ import annotations
+
+import base64
+from unittest.mock import MagicMock
+
+import structlog
+
+from src.fetcher.historical import HistoricalFetcher
+from src.parser.factory import ParserFactory
+from tests.fixtures.record_factory import make_se_record
+
+JV_READ_COMPLETE = 0
+FAILED_RECORD_EVENT = "Failed to parse record"
+
+
+def _fetcher(jv_read_results) -> HistoricalFetcher:
+    """JV-Link を持たない HistoricalFetcher（本物の ParserFactory を通す）."""
+    f = HistoricalFetcher.__new__(HistoricalFetcher)
+    f.parser_factory = ParserFactory()
+    f.cache_manager = None
+    f.show_progress = False
+    f.progress_display = None
+    f._service_key = None
+    f._records_fetched = f._records_parsed = f._records_failed = 0
+    f._files_processed = f._total_files = 0
+    f._start_time = 0.0
+    f._jvd_self_repair_attempts = f._jvd_replay_records_remaining = 0
+    f._recoverable_read_errors = 0
+    f._jv_open_context = f._jv_open_last_file_timestamp = f._fetch_task_id = None
+
+    f.jvlink = MagicMock()
+    f.jvlink.jv_init.return_value = None
+    f.jvlink.jv_open.return_value = (0, len(jv_read_results), 0, "20220110000000")
+    f.jvlink.jv_read.side_effect = jv_read_results
+    return f
+
+
+def _failures(records: list[tuple[bytes, str]]) -> list[dict]:
+    reads = [(len(buff), buff, filename) for buff, filename in records]
+    reads.append((JV_READ_COMPLETE, None, None))
+    fetcher = _fetcher(reads)
+    with structlog.testing.capture_logs() as logs:
+        list(fetcher.fetch("RACE", "20220101", "20221231", option=4))
+    return [entry for entry in logs if entry.get("event") == FAILED_RECORD_EVENT]
+
+
+def test_a_failed_record_names_the_file_it_arrived_in() -> None:
+    record = make_se_record(month_day="0231")
+
+    failure = _failures([(record, "SEVM2003129920230808162730.jvd")])[0]
+
+    assert failure["jvd_file"] == "SEVM2003129920230808162730.jvd"
+    assert failure["record_num"] == 1
+    assert failure["record_spec"] == "SE"
+    assert failure["log_level"] == "error"
+
+
+def test_a_failed_record_carries_its_own_bytes() -> None:
+    record = make_se_record(month_day="0231")
+
+    failure = _failures([(record, "f1.jvd")])[0]
+
+    assert failure["record_len"] == len(record)
+    assert failure["record_b64_truncated"] is False
+    assert base64.b64decode(failure["record_b64"]) == record
+
+
+def test_long_records_are_truncated_visibly() -> None:
+    record = make_se_record(month_day="0231") + b"X" * 8192
+
+    failure = _failures([(record, "f1.jvd")])[0]
+
+    assert failure["record_len"] == len(record)
+    assert failure["record_b64_truncated"] is True
+    assert base64.b64decode(failure["record_b64"]) == record[:4096]
+
+
+def test_every_failed_record_is_logged_separately() -> None:
+    records = [(make_se_record(month_day="0231", umaban=f"{n:02d}"), "f1.jvd") for n in (1, 2)]
+
+    failures = _failures(records)
+
+    assert [f["record_num"] for f in failures] == [1, 2]
+
+
+def test_cached_records_are_logged_the_same_way() -> None:
+    """キャッシュ再生経路も同じ失敗で、同じ困り方をする."""
+    record = make_se_record(month_day="0231")
+    cache = MagicMock()
+    cache.has_nl_range.return_value = True
+    cache.read_nl.return_value = iter([record])
+    fetcher = _fetcher([(JV_READ_COMPLETE, None, None)])
+
+    with structlog.testing.capture_logs() as logs:
+        list(fetcher.fetch_with_cache(cache, "RACE", "20220101", "20221231", option=4))
+
+    failure = [e for e in logs if e.get("event") == FAILED_RECORD_EVENT][0]
+    assert failure["jvd_file"] == "cache:RACE"
+    assert base64.b64decode(failure["record_b64"]) == record
+
+
+def test_an_unexpected_error_keeps_the_record_too() -> None:
+    record = make_se_record()
+    fetcher = _fetcher([(len(record), record, "f1.jvd"), (JV_READ_COMPLETE, None, None)])
+    fetcher.parser_factory = MagicMock()
+    fetcher.parser_factory.parse.side_effect = RuntimeError("boom")
+
+    with structlog.testing.capture_logs() as logs:
+        list(fetcher.fetch("RACE", "20220101", "20221231", option=4))
+
+    failure = [e for e in logs if e.get("event") == FAILED_RECORD_EVENT][0]
+    assert failure["error"] == "boom"
+    assert base64.b64decode(failure["record_b64"]) == record


### PR DESCRIPTION

パースに失敗した時、どのデータで失敗したのか、レコードのデータ内容がログにも残らず、解決できない。

失敗時に出るのは実行内の通し番号だけで、あとから同じレコードに辿り着けない。
連番は実行ごとに別のレコードを指し、生バッファは失敗時にダウンロード
キャッシュごとパージされる。結果、原因を確かめるには取り直すしか手が無い。

失敗した 1 件につき、それを同定して再生できるだけの情報を 1 行に出す。
