### PR TITLE
perf: 列型と blank-text のテーブル判定をループの外へ出す

### DIFF
--- a/src/database/postgresql_handler.py
+++ b/src/database/postgresql_handler.py
@@ -21,6 +21,7 @@ except ImportError:
         )
 
 from src.database.base import BaseDatabase, DatabaseError
+from src.database.schema_types import get_table_column_types
 from src.utils.logger import get_logger
 
 logger = get_logger(__name__)
@@ -645,7 +646,7 @@ class PostgreSQLDatabase(BaseDatabase):
             raise DatabaseError(f"PostgreSQL reconnect failed: {e}")
 
     @staticmethod
-    def _normalize_insert_value(table_name: str, column: str, value: Any) -> Any:
+    def _normalize_insert_value(column_type: Optional[str], value: Any) -> Any:
         """Normalize parser output before PostgreSQL binding.
 
         JV-Data parsers preserve blank numeric fields as empty strings for
@@ -653,13 +654,6 @@ class PostgreSQLDatabase(BaseDatabase):
         convert only blank/placeholder numeric fields to NULL and leave text
         fields intact. Odds records use '*' placeholders for unavailable odds.
         """
-        try:
-            from src.database.schema_types import get_column_type
-
-            column_type = get_column_type(table_name, column)
-        except Exception:
-            column_type = None
-
         if column_type not in ("INTEGER", "BIGINT", "REAL"):
             return value
 
@@ -688,8 +682,12 @@ class PostgreSQLDatabase(BaseDatabase):
     @classmethod
     def _normalize_insert_data(cls, table_name: str, data: Dict[str, Any]) -> Dict[str, Any]:
         """Normalize a row dictionary for PostgreSQL inserts."""
+        try:
+            column_types = get_table_column_types(table_name)
+        except Exception:
+            column_types = {}
         return {
-            column: cls._normalize_insert_value(table_name, column, value)
+            column: cls._normalize_insert_value(column_types.get(column), value)
             for column, value in data.items()
         }
 

--- a/src/importer/importer.py
+++ b/src/importer/importer.py
@@ -7783,6 +7783,17 @@ def convert_record_types(record: dict, table_name: str) -> dict:
     if not column_types:
         return record
 
+    # テーブル側の判定はレコード内で不変なので、フィールドのループへ入る前に
+    # 1 回だけ引く。RACE の実走はフィールドを約 3,600 万回回すため、ここを
+    # ループ内に置くと同じ判定が数億回走る。
+    is_cs_record = record.get("RecordSpec") == "CS"
+    is_hn = table_name in _HN_STORAGE_TABLES
+    is_odds = table_name in _ODDS_STORAGE_TABLES
+    is_h6 = table_name in _H6_STORAGE_TABLES
+    is_h1 = table_name in _H1_STORAGE_TABLES
+    is_um = table_name in _UM_ERASE_STORAGE_TABLES
+    is_sk = table_name in _SK_STORAGE_TABLES
+
     converted = {}
 
     for field_name, value in record.items():
@@ -7792,8 +7803,8 @@ def convert_record_types(record: dict, table_name: str) -> dict:
         col_type = column_types[field_name]
 
         if (
-            field_name == "CourseEx"
-            and record.get("RecordSpec") == "CS"
+            is_cs_record
+            and field_name == "CourseEx"
             and isinstance(value, str)
             and not value.strip()
         ):
@@ -7801,7 +7812,7 @@ def convert_record_types(record: dict, table_name: str) -> dict:
             continue
 
         if (
-            table_name in _HN_STORAGE_TABLES
+            is_hn
             and field_name in _HN_BLANK_TEXT_FIELDS
             and isinstance(value, str)
             and not value.strip()
@@ -7813,7 +7824,7 @@ def convert_record_types(record: dict, table_name: str) -> dict:
             continue
 
         if (
-            table_name in _ODDS_STORAGE_TABLES
+            is_odds
             and field_name in _ODDS_BLANK_TEXT_FIELDS
             and isinstance(value, str)
             and not value.strip()
@@ -7824,7 +7835,7 @@ def convert_record_types(record: dict, table_name: str) -> dict:
             continue
 
         if (
-            table_name in _H6_STORAGE_TABLES
+            is_h6
             and field_name in _H6_BLANK_TEXT_FIELDS
             and isinstance(value, str)
             and not value.strip()
@@ -7835,7 +7846,7 @@ def convert_record_types(record: dict, table_name: str) -> dict:
             continue
 
         if (
-            table_name in _H1_STORAGE_TABLES
+            is_h1
             and field_name in _H1_BLANK_TEXT_FIELDS
             and isinstance(value, str)
             and not value.strip()
@@ -7846,7 +7857,7 @@ def convert_record_types(record: dict, table_name: str) -> dict:
             continue
 
         if (
-            table_name in _UM_ERASE_STORAGE_TABLES
+            is_um
             and field_name in _UM_BLANK_TEXT_FIELDS
             and isinstance(value, str)
             and not value.strip()
@@ -7858,7 +7869,7 @@ def convert_record_types(record: dict, table_name: str) -> dict:
             continue
 
         if (
-            table_name in _SK_STORAGE_TABLES
+            is_sk
             and field_name in _SK_BLANK_TEXT_FIELDS
             and isinstance(value, str)
             and not value.strip()

--- a/tests/test_importer_clean_record.py
+++ b/tests/test_importer_clean_record.py
@@ -169,3 +169,39 @@ def test_jravan_schema_types_cover_every_declared_sql_type():
     se_types = get_table_column_types("UMA_RACE")
     assert se_types["Bamei3"] == "TEXT"
     assert se_types["DMTime"] == "REAL"
+
+
+# convert_record_types の blank-text ブロック 6 個と 1 対 1 に対応する。テーブル
+# 判定をループ外へ引き上げた際にブロックを 1 つ落とせば、その行が落ちる。
+BLANK_TEXT_CASES = [
+    ("HANSYOKU", "BameiEng"),
+    ("NL_O1", "FukuNinki"),
+    ("HYOSU_SANRENTAN", "Ninki"),
+    ("HYOSU_SANREN", "Ninki"),
+    ("NL_UM", "Bamei"),
+    ("NL_SK", "SanchiName"),
+]
+
+
+@pytest.mark.parametrize("table_name,field_name", BLANK_TEXT_CASES)
+def test_blank_provider_value_is_kept_as_empty_string(table_name, field_name):
+    """空白も提供値である項目は、NULL に落とさず空文字のまま保つ。"""
+    from src.importer.importer import convert_record_types
+
+    assert convert_record_types({field_name: "   "}, table_name)[field_name] == ""
+
+
+def test_blank_text_outside_every_family_still_becomes_null():
+    from src.importer.importer import convert_record_types
+
+    assert convert_record_types({"Hondai": "   "}, "NL_RA")["Hondai"] is None
+
+
+def test_course_ex_blank_is_kept_only_for_cs_records():
+    from src.importer.importer import convert_record_types
+
+    kept = convert_record_types({"RecordSpec": "CS", "CourseEx": "  "}, "NL_CS")
+    assert kept["CourseEx"] == ""
+
+    dropped = convert_record_types({"RecordSpec": "RA", "CourseEx": "  "}, "NL_CS")
+    assert dropped["CourseEx"] is None

--- a/tests/test_postgresql.py
+++ b/tests/test_postgresql.py
@@ -131,6 +131,31 @@ def test_setup_pg_test_db_uses_shared_contract_connect_timeout_and_quoted_identi
     assert "password-value" not in capsys.readouterr().out
 
 
+@pytest.mark.parametrize("table_name", ["NL_RA", "NL_O1"])
+def test_normalize_row_matches_per_column_type_lookup(table_name):
+    """行ごとに 1 回引いた列型が、列ごとに引いた場合と同じ結果を出すこと。"""
+    from src.database.postgresql_handler import PostgreSQLDatabase
+    from src.database.schema_types import get_column_type, get_table_column_types
+
+    row = {
+        column: ["", "  ", "***", "0103*****", "42", "12.5", None][index % 7]
+        for index, column in enumerate(get_table_column_types(table_name))
+    }
+    assert PostgreSQLDatabase._normalize_insert_data(table_name, row) == {
+        column: PostgreSQLDatabase._normalize_insert_value(
+            get_column_type(table_name, column), value
+        )
+        for column, value in row.items()
+    }
+
+
+def test_normalize_row_leaves_an_unknown_table_untouched():
+    from src.database.postgresql_handler import PostgreSQLDatabase
+
+    row = {"Whatever": "  ", "Another": "42"}
+    assert PostgreSQLDatabase._normalize_insert_data("NO_SUCH_TABLE", row) == row
+
+
 def test_normalize_blank_numeric_insert_values():
     """PostgreSQL inserts convert blank numeric JV-Data fields to NULL."""
     from src.database.postgresql_handler import PostgreSQLDatabase


### PR DESCRIPTION
## 解決したい問題

取り込みが遅い。RACE の取り込みは 866,865 行で 810 秒。**行が変わっても答えの変わらない判定を、セルごと・フィールドごとに引き直していた**箇所が 2 つあった。

### 1. 列の型を、セル 1 個ごとに引いていた（`postgresql_handler.py`）

`_normalize_insert_value` が関数の本体で `from src.database.schema_types import get_column_type` を実行し、そのままセルごとに型を引いていた。103 列の行なら import 文 103 回、スキーマ参照 103 回。

| 関数 | self | 呼び出し |
|---|---:|---:|
| `_normalize_insert_value` | 14.6 s | 16,421,739 |
| `get_column_type` | 11.8 s | 16,421,739 |
| `get_table_column_types` | 3.7 s | 17,289,468 |

### 2. テーブル判定を、フィールド 1 個ごとにやり直していた（`importer.py`）

`convert_record_types` の `table_name in _X_STORAGE_TABLES and field_name in ...` という 6 個の判定は、前半がテーブルにしか依存しないのに全フィールドで評価されていた。`record.get("RecordSpec")` も同じ。RACE はフィールドを約 3,600 万回回すので、この不変な判定が数億回走っていた。

## 直しかた

どちらも「同じ答えを何度も計算していたのをやめる」だけで、出力は変わらない。

1. import をモジュール先頭へ移し、型マップを **行ごとに 1 回**だけ引いて渡す
2. 6 個のテーブル判定と `RecordSpec` を、ループへ入る **前に 1 回**だけ評価して局所変数に置く


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Preserved intended blank text values during record import while continuing to convert unrelated blanks to null values.
  - Improved handling of imported data across supported record types.

- **Tests**
  - Added coverage for blank-text conversion scenarios.
  - Added validation for database value normalization, including unknown tables.

- **Performance**
  - Streamlined data type resolution during imports and database operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->