### PR TITLE
feat(realtime): capture official time-series odds near post time and keep first-capture provenance

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -101,6 +101,20 @@ jltsql realtime odds-sokuho-timeseries --from 20260418 --to 20260419 --db postgr
 jltsql realtime odds-sokuho-timeseries --from 20260418 --to 20260419 --db sqlite --db-path data/keiba.db
 ```
 
+当日ライブ収集で全レースを再取得しない場合は、`timeseries` にレースレコードの
+発走時刻ウィンドウを明示します。次の例は、現在時刻（JST）から30分以内に発走し、
+発走後2分を超えていないレースだけを対象にします。
+
+```bat
+jltsql realtime timeseries --spec 0B41 --from 20260901 --to 20260901 --db postgresql --post-time-within-minutes 30 --post-time-not-past-minutes 2
+```
+
+両オプションの既定値は無効です。どちらかを指定した場合、`NL_RA` / `RT_RA` の
+`HassoTime`（レースの発走時刻）を使います。欠損、解釈不能、または同じ取得キーに
+複数の発走時刻がある場合は、該当キーを表示して JV-Link を開く前に停止します。
+これは取得後のオッズ行にある `HassoTime`（発表時刻）とは別の値です。
+ウィンドウ指定時に `--from` / `--to` を省略した場合の既定日付も JST で決めます。
+
 ## 範囲指定つき時系列オッズ quickstart
 
 SQLite / PostgreSQL に、指定範囲の通常データと公式1年保持の TS_O1/TS_O2 を投入します。

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -105,8 +105,10 @@ jltsql realtime odds-sokuho-timeseries --from 20260418 --to 20260419 --db sqlite
 
 旧版で作成した `TS_SOKUHO_O1`〜`TS_SOKUHO_O6` の主キー末尾に
 `CollectedAt` が残っている場合、通常の起動・テーブル準備・時系列オッズ書き込みは
-自動移行せず停止します。エラーには対象テーブルと、実行すべき次のコマンドが表示
-されます。
+自動移行せず停止します。PostgreSQL のエラーには対象テーブルと、最初に実行する
+読み取り専用 dry run の exact command が表示されます。この command に `--apply` は
+含まれず、データを変更しません。SQLite のエラーは in-place 移行コマンドを案内せず、
+backup と現行 schema での table 再構築を指示します。
 
 既定は読み取り専用の dry run です。全テーブルを検査する場合:
 
@@ -124,16 +126,17 @@ jltsql db migrate-sokuho-capture-identity --db postgresql --table TS_SOKUHO_O1 -
 ```
 
 対象が PostgreSQL の search path 外にある場合は schema を明示します。エラーに
-表示される exact command にも `--schema` が含まれます。
+表示される exact dry-run command にも `--schema` が含まれます。
 
 ```bat
 jltsql db migrate-sokuho-capture-identity --db postgresql --schema archive --table TS_SOKUHO_O2
 ```
 
-内容を確認し、すべての collector / writer を停止してから、`--apply` を明示します。
+内容を確認し、すべての collector / writer を停止してから、同じ command に
+`--apply` を明示します。データを変更するのは `--apply` を付けた実行だけです。
 
 ```bat
-jltsql db migrate-sokuho-capture-identity --db postgresql --table TS_SOKUHO_O2 --apply
+jltsql db migrate-sokuho-capture-identity --db postgresql --schema archive --table TS_SOKUHO_O2 --apply
 ```
 
 apply は指定した legacy table を1 transaction で処理し、grouping snapshot より前に
@@ -155,8 +158,13 @@ jltsql realtime timeseries --spec 0B41 --from 20260901 --to 20260901 --db postgr
 ```
 
 両オプションの既定値は無効です。どちらかを指定した場合、`NL_RA` / `RT_RA` の
-`HassoTime`（レースの発走時刻）を使います。欠損、解釈不能、または同じ取得キーに
-複数の発走時刻がある場合は、該当キーを表示して JV-Link を開く前に停止します。
+日付だけで有効な bound の完全な範囲外と確定できるキーを先に除外し、残る候補の
+`HassoTime`（レースの発走時刻）を使います。候補で発走時刻が欠損、strict な4桁
+`HHMM` として解釈不能、または同じ取得キー内で不一致の場合は、該当キーを表示して
+JV-Link を開く前に停止します。日付で除外済みのキーの発走時刻は解釈しません。
+表示する `considered` / `candidates` / `kept` / `future` / `past` / `date_excluded` は
+それぞれ全キー、発走時刻を評価した候補、保持数、理由別除外数、日付だけで除外した
+数です。
 これは取得後のオッズ行にある `HassoTime`（発表時刻）とは別の値です。
 ウィンドウ指定時に `--from` / `--to` を省略した場合の既定日付も JST で決めます。
 

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -101,6 +101,51 @@ jltsql realtime odds-sokuho-timeseries --from 20260418 --to 20260419 --db postgr
 jltsql realtime odds-sokuho-timeseries --from 20260418 --to 20260419 --db sqlite --db-path data/keiba.db
 ```
 
+## TS_SOKUHO 主キーの明示移行
+
+旧版で作成した `TS_SOKUHO_O1`〜`TS_SOKUHO_O6` の主キー末尾に
+`CollectedAt` が残っている場合、通常の起動・テーブル準備・時系列オッズ書き込みは
+自動移行せず停止します。エラーには対象テーブルと、実行すべき次のコマンドが表示
+されます。
+
+既定は読み取り専用の dry run です。全テーブルを検査する場合:
+
+```bat
+jltsql db migrate-sokuho-capture-identity --db postgresql
+```
+
+対象を限定するには `--table` を繰り返します。dry run は各テーブルについて、現在の
+主キー、総行数、発表単位の distinct group 数、削除予定行数、保持行の
+`CollectedAt` を最古の非 NULL 値へ書き換える group 数を表示します。読み取り専用
+transaction を使い、`ACCESS EXCLUSIVE` lock は取得しません。
+
+```bat
+jltsql db migrate-sokuho-capture-identity --db postgresql --table TS_SOKUHO_O1 --table TS_SOKUHO_O2
+```
+
+対象が PostgreSQL の search path 外にある場合は schema を明示します。エラーに
+表示される exact command にも `--schema` が含まれます。
+
+```bat
+jltsql db migrate-sokuho-capture-identity --db postgresql --schema archive --table TS_SOKUHO_O2
+```
+
+内容を確認し、すべての collector / writer を停止してから、`--apply` を明示します。
+
+```bat
+jltsql db migrate-sokuho-capture-identity --db postgresql --table TS_SOKUHO_O2 --apply
+```
+
+apply は指定した legacy table を1 transaction で処理し、grouping snapshot より前に
+`ACCESS EXCLUSIVE` lock を取得します。同じ発表の行は、最新 poll の列値と最古の
+非 NULL `CollectedAt` を持つ1行へ統合します。時刻検証、保持行数検証、DDL の
+いずれかが失敗すると全テーブルを rollback し、nonzero で終了します。
+
+SQLite に同じコマンドを実行しても database connection を開かず、in-place 移行は
+行わず nonzero で拒否します。
+SQLite は先に database をバックアップし、現行 schema で対象 table を再構築して
+ください。公式1年時系列の `TS_O1` / `TS_O2` はこの移行の対象外です。
+
 当日ライブ収集で全レースを再取得しない場合は、`timeseries` にレースレコードの
 発走時刻ウィンドウを明示します。次の例は、現在時刻（JST）から30分以内に発走し、
 発走後2分を超えていないレースだけを対象にします。

--- a/docs/timeseries_odds.md
+++ b/docs/timeseries_odds.md
@@ -57,6 +57,29 @@ PostgreSQL も同じ `quickstart_timeseries.bat --db postgresql --from <FROM> --
 公式長期時系列は `TS_O1` / `TS_O2`、開催週速報は
 `TS_SOKUHO_O1`〜`TS_SOKUHO_O6` に分けて保存します。
 
+当日の公式時系列をライブ判断用に小さく取得する場合は、`timeseries` の発走時刻
+ウィンドウを明示します。
+
+```bat
+jltsql realtime timeseries --spec 0B41 --from 20260901 --to 20260901 --db postgresql --post-time-within-minutes 30 --post-time-not-past-minutes 2
+```
+
+`--post-time-within-minutes` は現在時刻（JST）から指定分以内に発走するキーを残し、
+`--post-time-not-past-minutes` は発走後の許容分を超えたキーを除外します。未指定時は
+従来どおり日付範囲の全キーが対象です。フィルターが有効なときは `NL_RA` / `RT_RA`
+のレース発走時刻を検証し、欠損、解釈不能、または同じ JVRTOpen キーで不一致なら、
+該当キーを表示して取得前に停止します。
+
+時系列行を再取得した場合、同じ発表行の価格などは最新の訂正値へ更新しますが、
+`CollectedAt` はその発表行を最初に保有した時刻（最も早い非 NULL 値）を維持します。
+UTC オフセットが異なる ISO-8601 表現も同一の時刻軸へ正規化して比較します。
+従来の PostgreSQL `TS_SOKUHO_O*` で `CollectedAt` が主キーに含まれている場合は、
+取得前のスキーマ更新がテーブルをロックし、発表単位の主キーへ移行します。同じ発表
+の複数 poll は、最新 poll の価格などと最初の実取得時刻を組み合わせた1行に統合
+されます。SQLite の従来主キーは自動再構築せず、テーブル名を示して取得前に停止
+します。バックアップ後に現行スキーマで再構築してください。移行またはロールバック
+時はいずれも先に poll を停止し、writer と主キーの版を揃えてから再開してください。
+
 ## 重要な制約
 
 - JRA-VAN はすべての賭式について長期保持の時系列オッズを提供しているわけではありません。
@@ -64,7 +87,8 @@ PostgreSQL も同じ `quickstart_timeseries.bat --db postgresql --from <FROM> --
   `0B30` または `0B33`〜`0B36` を継続蓄積する必要があります。
 - jrvltsql は raw の時系列オッズを保存します。投資判断時刻は、利用側が
   `HassoTime` から選択してください。
-- `HassoTime` は発表時刻であり、必ずしも発走時刻と一致しません。
+- 時系列オッズ行の `HassoTime` は発表時刻であり、発走時刻ではありません。発走時刻
+  ウィンドウはレースレコード (`NL_RA` / `RT_RA`) 側の `HassoTime` を使います。
 - 過去バージョンで `0B30`〜`0B36` を取得した DB では、速報行が `TS_O*` に
   残っている可能性があります。新規評価では `TS_SOKUHO_O*` を使い、必要に応じて
   公式 `TS_O1` / `TS_O2` を再取得してください。

--- a/docs/timeseries_odds.md
+++ b/docs/timeseries_odds.md
@@ -73,12 +73,35 @@ jltsql realtime timeseries --spec 0B41 --from 20260901 --to 20260901 --db postgr
 時系列行を再取得した場合、同じ発表行の価格などは最新の訂正値へ更新しますが、
 `CollectedAt` はその発表行を最初に保有した時刻（最も早い非 NULL 値）を維持します。
 UTC オフセットが異なる ISO-8601 表現も同一の時刻軸へ正規化して比較します。
-従来の PostgreSQL `TS_SOKUHO_O*` で `CollectedAt` が主キーに含まれている場合は、
-取得前のスキーマ更新がテーブルをロックし、発表単位の主キーへ移行します。同じ発表
-の複数 poll は、最新 poll の価格などと最初の実取得時刻を組み合わせた1行に統合
-されます。SQLite の従来主キーは自動再構築せず、テーブル名を示して取得前に停止
-します。バックアップ後に現行スキーマで再構築してください。移行またはロールバック
-時はいずれも先に poll を停止し、writer と主キーの版を揃えてから再開してください。
+
+従来の `TS_SOKUHO_O*` で `CollectedAt` が主キー末尾に含まれている場合、PostgreSQL
+と SQLite のどちらも通常の起動・schema 準備・書き込みからは自動移行しません。
+対象 table と次の明示コマンドを表示して fail closed します。
+
+```bat
+jltsql db migrate-sokuho-capture-identity --db postgresql --table TS_SOKUHO_O2
+```
+
+既定は dry run で、現在の主キー、総行数、発表単位 group 数、削除予定行数、最古の
+非 NULL `CollectedAt` へ書き換える group 数を表示します。dry run は読み取り専用
+transaction であり、`ACCESS EXCLUSIVE` lock は取得しません。全テーブルの検査は
+`--table` を省略し、複数 table の限定は `--table` を繰り返します。
+search path 外の PostgreSQL schema は `--schema <SCHEMA>` を付けます。fail-closed
+message は対象 schema を保持した exact command を表示します。
+
+適用時は先にすべての poll / writer を停止し、結果を確認して `--apply` を付けます。
+
+```bat
+jltsql db migrate-sokuho-capture-identity --db postgresql --table TS_SOKUHO_O2 --apply
+```
+
+apply は指定 table 全体を1 transaction とし、全対象の lock を grouping snapshot
+より前に取得します。同じ発表の複数 poll は、最新 poll の価格などと最初の実取得
+時刻を組み合わせた1行に統合します。検証または DDL が失敗すれば全変更を rollback
+します。SQLite は database connection を開く前に dry run / apply のどちらも
+nonzero で拒否するため、database を
+バックアップして現行 schema で対象 table を再構築してください。公式1年時系列の
+`TS_O1` / `TS_O2` は既に発表 identity の主キーを持ち、この移行の対象外です。
 
 ## 重要な制約
 

--- a/docs/timeseries_odds.md
+++ b/docs/timeseries_odds.md
@@ -67,8 +67,11 @@ jltsql realtime timeseries --spec 0B41 --from 20260901 --to 20260901 --db postgr
 `--post-time-within-minutes` は現在時刻（JST）から指定分以内に発走するキーを残し、
 `--post-time-not-past-minutes` は発走後の許容分を超えたキーを除外します。未指定時は
 従来どおり日付範囲の全キーが対象です。フィルターが有効なときは `NL_RA` / `RT_RA`
-のレース発走時刻を検証し、欠損、解釈不能、または同じ JVRTOpen キーで不一致なら、
-該当キーを表示して取得前に停止します。
+の日付だけで有効な bound の完全な範囲外と確定できるキーを先に除外します。残る候補
+だけレース発走時刻を検証し、欠損、strict な4桁 `HHMM` として解釈不能、または同じ
+JVRTOpen キー内で不一致なら、該当キーを表示して取得前に停止します。日付で除外済み
+のキーの発走時刻は解釈しません。window summary は全キー、候補、保持数、未来・過去の
+理由別除外数、日付だけで除外した数を個別に表示します。
 
 時系列行を再取得した場合、同じ発表行の価格などは最新の訂正値へ更新しますが、
 `CollectedAt` はその発表行を最初に保有した時刻（最も早い非 NULL 値）を維持します。
@@ -76,7 +79,10 @@ UTC オフセットが異なる ISO-8601 表現も同一の時刻軸へ正規化
 
 従来の `TS_SOKUHO_O*` で `CollectedAt` が主キー末尾に含まれている場合、PostgreSQL
 と SQLite のどちらも通常の起動・schema 準備・書き込みからは自動移行しません。
-対象 table と次の明示コマンドを表示して fail closed します。
+PostgreSQL は対象 table と、最初に実行する次の読み取り専用 dry-run command を表示して
+fail closed します。runtime message の command に `--apply` は含まれず、データを変更
+しません。SQLite は in-place 移行をサポートしないため command を案内せず、backup と
+現行 schema での table 再構築を指示して fail closed します。
 
 ```bat
 jltsql db migrate-sokuho-capture-identity --db postgresql --table TS_SOKUHO_O2
@@ -87,12 +93,17 @@ jltsql db migrate-sokuho-capture-identity --db postgresql --table TS_SOKUHO_O2
 transaction であり、`ACCESS EXCLUSIVE` lock は取得しません。全テーブルの検査は
 `--table` を省略し、複数 table の限定は `--table` を繰り返します。
 search path 外の PostgreSQL schema は `--schema <SCHEMA>` を付けます。fail-closed
-message は対象 schema を保持した exact command を表示します。
-
-適用時は先にすべての poll / writer を停止し、結果を確認して `--apply` を付けます。
+message は対象 schema を保持した exact dry-run command を表示します。
 
 ```bat
-jltsql db migrate-sokuho-capture-identity --db postgresql --table TS_SOKUHO_O2 --apply
+jltsql db migrate-sokuho-capture-identity --db postgresql --schema archive --table TS_SOKUHO_O2
+```
+
+適用時は先にすべての poll / writer を停止し、dry run の結果を確認して同じ command に
+`--apply` を付けます。データを変更するのは `--apply` を付けた実行だけです。
+
+```bat
+jltsql db migrate-sokuho-capture-identity --db postgresql --schema archive --table TS_SOKUHO_O2 --apply
 ```
 
 apply は指定 table 全体を1 transaction とし、全対象の lock を grouping snapshot

--- a/src/cli/main.py
+++ b/src/cli/main.py
@@ -18,7 +18,6 @@ from src.utils.updater import (
     perform_update,
 )
 
-
 # Console for rich output (Windows cp932-safe)
 console = Console(legacy_windows=True)
 err_console = Console(stderr=True, legacy_windows=True)
@@ -132,9 +131,7 @@ def cli(ctx, config, verbose):
     """
     # Store context
     ctx.ensure_object(dict)
-    requested_config_path = (
-        Path(config) if config else Path.cwd() / "config" / "config.yaml"
-    )
+    requested_config_path = Path(config) if config else Path.cwd() / "config" / "config.yaml"
     ctx.obj["config_path"] = requested_config_path
     ctx.obj["config_explicit"] = config is not None
 
@@ -154,8 +151,7 @@ def cli(ctx, config, verbose):
             # Read-only bootstrap commands must work before initialization.
             if ctx.invoked_subcommand not in CONFIG_OPTIONAL_COMMANDS:
                 console.print(
-                    "[red]Error:[/red] Configuration file not found. "
-                    "Run 'jltsql init' first.",
+                    "[red]Error:[/red] Configuration file not found. " "Run 'jltsql init' first.",
                     style="bold",
                 )
                 sys.exit(1)
@@ -173,9 +169,7 @@ def cli(ctx, config, verbose):
             try:
                 setup_logging_from_config(cfg.to_dict())
             except (OSError, TypeError, ValueError) as exc:
-                raise ConfigError(
-                    f"Could not initialize logging ({type(exc).__name__})"
-                ) from exc
+                raise ConfigError(f"Could not initialize logging ({type(exc).__name__})") from exc
 
             # Override log level if verbose
             if verbose:
@@ -236,8 +230,7 @@ def init(ctx, force):
             load_config(config_yaml)
         except ConfigError as exc:
             console.print(
-                f"[red]Configuration Error:[/red] {exc}. "
-                "Repair the file or rerun with --force.",
+                f"[red]Configuration Error:[/red] {exc}. " "Repair the file or rerun with --force.",
                 style="bold",
             )
             ctx.exit(1)
@@ -256,8 +249,7 @@ def init(ctx, force):
     # template that is absent from installed wheels.
     if config_yaml.exists() and not force:
         console.print(
-            f"[yellow]Warning:[/yellow] {config_yaml} already exists. "
-            "Use --force to overwrite."
+            f"[yellow]Warning:[/yellow] {config_yaml} already exists. " "Use --force to overwrite."
         )
     else:
         import yaml
@@ -310,20 +302,18 @@ def version(check):
     commit_str = f" ({commit})" if commit else ""
 
     console.print(f"[bold]JLTSQL[/bold] version {current}{commit_str}")
-    console.print(f"Python: {sys.version.split()[0]} ({'32-bit' if sys.maxsize <= 2**31 else '64-bit'})")
+    console.print(
+        f"Python: {sys.version.split()[0]} ({'32-bit' if sys.maxsize <= 2**31 else '64-bit'})"
+    )
 
     console.print()
     console.print("[bold]対応データソース:[/bold]")
     from src.jvlink import is_jvlink_available
 
     if is_jvlink_available():
-        console.print(
-            "  - JRA-VAN DataLab (JV-Link transport): [green]利用可能[/green]"
-        )
+        console.print("  - JRA-VAN DataLab (JV-Link transport): [green]利用可能[/green]")
     else:
-        console.print(
-            "  - JRA-VAN DataLab (JV-Link transport): [red]未インストール[/red]"
-        )
+        console.print("  - JRA-VAN DataLab (JV-Link transport): [red]未インストール[/red]")
 
     if check:
         console.print()
@@ -369,9 +359,7 @@ def update(ctx, force):
         return
 
     if info and info["update_available"]:
-        console.print(
-            f"[yellow]New version available:[/yellow] {info['latest_version']}"
-        )
+        console.print(f"[yellow]New version available:[/yellow] {info['latest_version']}")
         console.print()
 
     console.print("[bold]Updating...[/bold]")
@@ -427,12 +415,21 @@ def update(ctx, force):
     "jv_option",
     type=int,
     default=1,
-    help="JVOpen option: 1=通常データ（差分）, 2=今週データ, 3=セットアップ（ダイアログ）, 4=分割セットアップ (default: 1)"
+    help="JVOpen option: 1=通常データ（差分）, 2=今週データ, 3=セットアップ（ダイアログ）, 4=分割セットアップ (default: 1)",
 )
-@click.option("--db", type=click.Choice(["sqlite", "postgresql"]), default=None, help="Database type (default: from config)")
+@click.option(
+    "--db",
+    type=click.Choice(["sqlite", "postgresql"]),
+    default=None,
+    help="Database type (default: from config)",
+)
 @click.option("--batch-size", default=1000, help="Batch size for imports (default: 1000)")
-@click.option("--progress/--no-progress", default=True, help="Show progress display (default: enabled)")
-@click.option("--use-cache/--no-cache", default=True, show_default=True, help="Use local cache if available")
+@click.option(
+    "--progress/--no-progress", default=True, help="Show progress display (default: enabled)"
+)
+@click.option(
+    "--use-cache/--no-cache", default=True, show_default=True, help="Use local cache if available"
+)
 @click.pass_context
 def fetch(ctx, date_from, date_to, data_spec, jv_option, db, batch_size, progress, use_cache):
     """Fetch historical data from JRA-VAN DataLab.
@@ -455,7 +452,9 @@ def fetch(ctx, date_from, date_to, data_spec, jv_option, db, batch_size, progres
 
     config = ctx.obj.get("config")
     if not config and not db:
-        console.print("[red]Error:[/red] No configuration found. Run 'jltsql init' first or use --db option.")
+        console.print(
+            "[red]Error:[/red] No configuration found. Run 'jltsql init' first or use --db option."
+        )
         sys.exit(1)
 
     # Determine database type
@@ -477,9 +476,12 @@ def fetch(ctx, date_from, date_to, data_spec, jv_option, db, batch_size, progres
     _reject_retired_data_spec(data_spec)
 
     from src.jvlink.constants import is_valid_jvopen_combination, JVOPEN_VALID_COMBINATIONS
+
     if not is_valid_jvopen_combination(data_spec, jv_option):
         console.print()
-        console.print(f"[red]Error:[/red] データ種別 '{data_spec}' は option={jv_option} では取得できません")
+        console.print(
+            f"[red]Error:[/red] データ種別 '{data_spec}' は option={jv_option} では取得できません"
+        )
         valid_specs = JVOPEN_VALID_COMBINATIONS.get(jv_option, [])
         console.print(f"       option={jv_option} で取得可能: {', '.join(valid_specs)}")
         sys.exit(1)
@@ -516,6 +518,7 @@ def fetch(ctx, date_from, date_to, data_spec, jv_option, db, batch_size, progres
             cache_mgr = None
             if use_cache:
                 from src.cache import CacheManager
+
                 cache_dir = config.get("cache.directory", "data/cache") if config else "data/cache"
                 cache_mgr = CacheManager(Path(cache_dir))
 
@@ -531,10 +534,7 @@ def fetch(ctx, date_from, date_to, data_spec, jv_option, db, batch_size, progres
                 console.print("[bold]Processing data...[/bold]")
 
             result = processor.process_date_range(
-                data_spec=data_spec,
-                from_date=date_from,
-                to_date=date_to,
-                option=jv_option
+                data_spec=data_spec, from_date=date_from, to_date=date_to, option=jv_option
             )
 
             # Show results
@@ -560,6 +560,7 @@ def fetch(ctx, date_from, date_to, data_spec, jv_option, db, batch_size, progres
 # ---------------------------------------------------------------------------
 # cache command group
 # ---------------------------------------------------------------------------
+
 
 @cli.group()
 @click.pass_context
@@ -596,23 +597,29 @@ def cache_info(ctx, cache_dir):
     if info["nl"]:
         click.echo("NL_ (蓄積系) cache:")
         for spec, s in info["nl"].items():
-            click.echo(f"  {spec:8s}  {s['complete_dates']:4}/{s['cached_dates']:4} dates complete"
-                       f"  {s['date_range']:22s}  {s['size_bytes']/1024:.0f} KB")
+            click.echo(
+                f"  {spec:8s}  {s['complete_dates']:4}/{s['cached_dates']:4} dates complete"
+                f"  {s['date_range']:22s}  {s['size_bytes']/1024:.0f} KB"
+            )
     else:
         click.echo("NL_ cache: (empty)")
 
     if info["rt"]:
         click.echo("\nRT_ (速報系) cache:")
         for spec, s in info["rt"].items():
-            click.echo(f"  {spec:6s}  {s['cached_dates']:4} dates"
-                       f"  {s['date_range']:22s}  {s['size_bytes']/1024:.0f} KB")
+            click.echo(
+                f"  {spec:6s}  {s['cached_dates']:4} dates"
+                f"  {s['date_range']:22s}  {s['size_bytes']/1024:.0f} KB"
+            )
     else:
         click.echo("\nRT_ cache: (empty)")
 
 
 @cache.command("build")
 @click.option("--spec", "data_spec", required=True, help="Data spec (RACE, DIFN, etc.)")
-@click.option("--from", "date_from", required=True, help="Start date YYYYMMDD (option=2 is not cacheable)")
+@click.option(
+    "--from", "date_from", required=True, help="Start date YYYYMMDD (option=2 is not cacheable)"
+)
 @click.option(
     "--to",
     "date_to",
@@ -622,10 +629,20 @@ def cache_info(ctx, cache_dir):
         "ChokyoDate prevent the range from being marked complete."
     ),
 )
-@click.option("--option", "jv_option", type=int, default=1, show_default=True,
-              help="JVOpen option: 1=通常, 2=今週, 3=setup, 4=split-setup")
-@click.option("--also-import", is_flag=True, default=False,
-              help="Also import records into DB (default: cache only)")
+@click.option(
+    "--option",
+    "jv_option",
+    type=int,
+    default=1,
+    show_default=True,
+    help="JVOpen option: 1=通常, 2=今週, 3=setup, 4=split-setup",
+)
+@click.option(
+    "--also-import",
+    is_flag=True,
+    default=False,
+    help="Also import records into DB (default: cache only)",
+)
 @click.option("--db", type=click.Choice(["sqlite", "postgresql"]), default=None)
 @click.option("--cache-dir", default="data/cache", show_default=True)
 @click.pass_context
@@ -707,8 +724,10 @@ def cache_build(ctx, data_spec, date_from, date_to, jv_option, also_import, db, 
     # Show updated cache info
     info = mgr.info()
     nl_info = info["nl"].get(data_spec.upper(), {})
-    click.echo(f"Cache: {nl_info.get('complete_dates', 0)} dates, "
-               f"{nl_info.get('size_bytes', 0)/1024:.0f} KB")
+    click.echo(
+        f"Cache: {nl_info.get('complete_dates', 0)} dates, "
+        f"{nl_info.get('size_bytes', 0)/1024:.0f} KB"
+    )
 
 
 @cache.command("clear")
@@ -728,6 +747,7 @@ def cache_clear(ctx, spec, date_str, rt, cache_dir):
       jltsql cache clear --spec RACE --date 20260328
     """
     from src.cache import CacheManager
+
     mgr = CacheManager(Path(cache_dir))
     deleted = mgr.clear(spec=spec, date_str=date_str, rt=rt)
     target = "RT_" if rt else "NL_"
@@ -767,10 +787,12 @@ def cache_rebuild(ctx, data_spec, date_from, date_to, jv_option, cache_dir):
         raise click.ClickException(str(exc)) from exc
 
     from src.cache import CacheManager
+
     mgr = CacheManager(Path(cache_dir))
 
     # Clear first
     from datetime import datetime, timedelta
+
     d = datetime.strptime(date_from, "%Y%m%d").date()
     end = datetime.strptime(date_to, "%Y%m%d").date()
     deleted = 0
@@ -780,18 +802,30 @@ def cache_rebuild(ctx, data_spec, date_from, date_to, jv_option, cache_dir):
     click.echo(f"Cleared {deleted} existing cache files.")
 
     # Rebuild via cache build
-    ctx.invoke(cache_build, data_spec=data_spec, date_from=date_from,
-               date_to=date_to, jv_option=jv_option, also_import=False,
-               db=None, cache_dir=cache_dir)
+    ctx.invoke(
+        cache_build,
+        data_spec=data_spec,
+        date_from=date_from,
+        date_to=date_to,
+        jv_option=jv_option,
+        also_import=False,
+        db=None,
+        cache_dir=cache_dir,
+    )
 
 
 # ---------------------------------------------------------------------------
 # cache s3-setup: configure encrypted S3 credentials
 # ---------------------------------------------------------------------------
 
+
 @cache.command("s3-setup")
-@click.option("--cred-file", default="config/s3_credentials.enc", show_default=True,
-              help="Path to store encrypted credentials")
+@click.option(
+    "--cred-file",
+    default="config/s3_credentials.enc",
+    show_default=True,
+    help="Path to store encrypted credentials",
+)
 @click.pass_context
 def cache_s3_setup(ctx, cred_file):
     """Configure and store encrypted S3/R2 credentials.
@@ -842,6 +876,7 @@ def cache_s3_setup(ctx, cred_file):
     if click.confirm("\nTest connection now?", default=True):
         try:
             from src.cache.s3_sync import S3Syncer
+
             syncer = S3Syncer(cache_dir=Path("data/cache"), credentials=credentials)
             syncer.test_connection()
             click.echo("[OK] Connection successful!")
@@ -854,11 +889,13 @@ def cache_s3_setup(ctx, cred_file):
 # cache sync: upload / download / bidirectional sync with S3
 # ---------------------------------------------------------------------------
 
+
 @cache.command("sync")
 @click.option("--upload", "direction", flag_value="upload", help="Local → S3 only")
 @click.option("--download", "direction", flag_value="download", help="S3 → local only")
-@click.option("--both", "direction", flag_value="both", default=True,
-              help="Bidirectional sync (default)")
+@click.option(
+    "--both", "direction", flag_value="both", default=True, help="Bidirectional sync (default)"
+)
 @click.option("--dry-run", is_flag=True, help="Show what would be transferred (no actual transfer)")
 @click.option("--cache-dir", default="data/cache", show_default=True)
 @click.option("--cred-file", default="config/s3_credentials.enc", show_default=True)
@@ -904,20 +941,26 @@ def cache_sync(ctx, direction, dry_run, cache_dir, cred_file):
             on_progress=on_progress,
         )
 
-        click.echo(f"Bucket: {credentials['bucket_name']}  "
-                   f"Prefix: {credentials.get('prefix', 'jrvltsql-cache')}\n")
+        click.echo(
+            f"Bucket: {credentials['bucket_name']}  "
+            f"Prefix: {credentials.get('prefix', 'jrvltsql-cache')}\n"
+        )
 
         if direction == "upload":
             stats = syncer.upload(dry_run=dry_run)
-            click.echo(f"\nUploaded: {stats['uploaded']:,} files "
-                       f"({stats['bytes']/1024/1024:.1f} MB)  "
-                       f"Skipped: {stats['skipped']:,}  Errors: {stats['errors']:,}")
+            click.echo(
+                f"\nUploaded: {stats['uploaded']:,} files "
+                f"({stats['bytes']/1024/1024:.1f} MB)  "
+                f"Skipped: {stats['skipped']:,}  Errors: {stats['errors']:,}"
+            )
 
         elif direction == "download":
             stats = syncer.download(dry_run=dry_run)
-            click.echo(f"\nDownloaded: {stats['downloaded']:,} files "
-                       f"({stats['bytes']/1024/1024:.1f} MB)  "
-                       f"Skipped: {stats['skipped']:,}  Errors: {stats['errors']:,}")
+            click.echo(
+                f"\nDownloaded: {stats['downloaded']:,} files "
+                f"({stats['bytes']/1024/1024:.1f} MB)  "
+                f"Skipped: {stats['skipped']:,}  Errors: {stats['errors']:,}"
+            )
 
         else:  # both
             stats = syncer.sync(dry_run=dry_run)
@@ -942,7 +985,12 @@ def cache_sync(ctx, direction, dry_run, cache_dir, cred_file):
 @click.option("--daemon", is_flag=True, help="Run in background")
 @click.option("--spec", "data_spec", default="RACE", help="Data specification (default: RACE)")
 @click.option("--interval", default=60, help="Polling interval in seconds (default: 60)")
-@click.option("--db", type=click.Choice(["sqlite", "postgresql"]), default=None, help="Database type (default: from config)")
+@click.option(
+    "--db",
+    type=click.Choice(["sqlite", "postgresql"]),
+    default=None,
+    help="Database type (default: from config)",
+)
 @click.pass_context
 def monitor(ctx, daemon, data_spec, interval, db):
     """Start real-time monitoring.
@@ -958,7 +1006,9 @@ def monitor(ctx, daemon, data_spec, interval, db):
 
     config = ctx.obj.get("config")
     if not config and not db:
-        console.print("[red]Error:[/red] No configuration found. Run 'jltsql init' first or use --db option.")
+        console.print(
+            "[red]Error:[/red] No configuration found. Run 'jltsql init' first or use --db option."
+        )
         sys.exit(1)
 
     # Determine database type
@@ -1011,6 +1061,7 @@ def monitor(ctx, daemon, data_spec, interval, db):
                 # Foreground mode - wait for Ctrl+C
                 try:
                     import time
+
                     while True:
                         time.sleep(1)
                 except KeyboardInterrupt:
@@ -1036,7 +1087,12 @@ def stop(ctx):
 
 
 @cli.command()
-@click.option("--db", type=click.Choice(["sqlite", "postgresql"]), default=None, help="Database type (default: from config)")
+@click.option(
+    "--db",
+    type=click.Choice(["sqlite", "postgresql"]),
+    default=None,
+    help="Database type (default: from config)",
+)
 @click.option("--all", "create_all", is_flag=True, help="Create both NL_ and RT_ tables")
 @click.option("--nl-only", is_flag=True, help="Create only NL_ (Normal Load) tables")
 @click.option("--rt-only", is_flag=True, help="Create only RT_ (Real-Time) tables")
@@ -1058,7 +1114,9 @@ def create_tables(ctx, db, create_all, nl_only, rt_only):
 
     config = ctx.obj.get("config")
     if not config and not db:
-        console.print("[red]Error:[/red] No configuration found. Run 'jltsql init' first or use --db option.")
+        console.print(
+            "[red]Error:[/red] No configuration found. Run 'jltsql init' first or use --db option."
+        )
         sys.exit(1)
 
     # Determine database type
@@ -1081,9 +1139,13 @@ def create_tables(ctx, db, create_all, nl_only, rt_only):
         with database:
             # Determine which tables to create
             if nl_only:
-                tables_to_create = {name: sql for name, sql in SCHEMAS.items() if name.startswith("NL_")}
+                tables_to_create = {
+                    name: sql for name, sql in SCHEMAS.items() if name.startswith("NL_")
+                }
             elif rt_only:
-                tables_to_create = {name: sql for name, sql in SCHEMAS.items() if name.startswith("RT_")}
+                tables_to_create = {
+                    name: sql for name, sql in SCHEMAS.items() if name.startswith("RT_")
+                }
             else:
                 tables_to_create = SCHEMAS
 
@@ -1095,10 +1157,11 @@ def create_tables(ctx, db, create_all, nl_only, rt_only):
             failed_count = 0
 
             with Progress(
-                TextColumn("[progress.description]{task.description}"),
-                console=console
+                TextColumn("[progress.description]{task.description}"), console=console
             ) as progress:
-                task = progress.add_task(f"[cyan]Creating {len(tables_to_create)} tables...", total=len(tables_to_create))
+                task = progress.add_task(
+                    f"[cyan]Creating {len(tables_to_create)} tables...", total=len(tables_to_create)
+                )
 
                 for table_name, schema_sql in tables_to_create.items():
                     progress.update(task, description=f"[cyan]Creating {table_name}...")
@@ -1108,7 +1171,9 @@ def create_tables(ctx, db, create_all, nl_only, rt_only):
                         verify_table_schema(database, table_name, schema_sql)
                         created_count += 1
                     except Exception as e:
-                        console.print(f"[yellow]Warning:[/yellow] Failed to create {table_name}: {e}")
+                        console.print(
+                            f"[yellow]Warning:[/yellow] Failed to create {table_name}: {e}"
+                        )
                         failed_count += 1
 
                     progress.advance(task)
@@ -1118,9 +1183,7 @@ def create_tables(ctx, db, create_all, nl_only, rt_only):
             console.print(f"[green][OK][/green] Created {created_count} tables")
             if failed_count > 0:
                 console.print(f"[yellow][!!][/yellow] Failed to create {failed_count} tables")
-                raise RuntimeError(
-                    f"Schema preparation failed for {failed_count} table(s)"
-                )
+                raise RuntimeError(f"Schema preparation failed for {failed_count} table(s)")
 
             # Show table statistics
             nl_tables = len([n for n in tables_to_create if n.startswith("NL_")])
@@ -1139,7 +1202,12 @@ def create_tables(ctx, db, create_all, nl_only, rt_only):
 
 
 @cli.command()
-@click.option("--db", type=click.Choice(["sqlite", "postgresql"]), default=None, help="Database type (default: from config)")
+@click.option(
+    "--db",
+    type=click.Choice(["sqlite", "postgresql"]),
+    default=None,
+    help="Database type (default: from config)",
+)
 @click.option("--table", help="Create indexes for specific table only")
 @click.pass_context
 def create_indexes(ctx, db, table):
@@ -1163,7 +1231,9 @@ def create_indexes(ctx, db, table):
 
     config = ctx.obj.get("config")
     if not config and not db:
-        console.print("[red]Error:[/red] No configuration found. Run 'jltsql init' first or use --db option.")
+        console.print(
+            "[red]Error:[/red] No configuration found. Run 'jltsql init' first or use --db option."
+        )
         sys.exit(1)
 
     # Determine database type
@@ -1210,13 +1280,19 @@ def create_indexes(ctx, db, table):
                 total_tables = len(results)
 
                 console.print()
-                console.print(f"[green][OK][/green] Created {total_indexes} indexes across {total_tables} tables")
+                console.print(
+                    f"[green][OK][/green] Created {total_indexes} indexes across {total_tables} tables"
+                )
 
                 # Show breakdown
                 console.print()
                 console.print("[bold]Index Statistics:[/bold]")
-                nl_indexes = sum(count for table, count in results.items() if table.startswith("NL_"))
-                rt_indexes = sum(count for table, count in results.items() if table.startswith("RT_"))
+                nl_indexes = sum(
+                    count for table, count in results.items() if table.startswith("NL_")
+                )
+                rt_indexes = sum(
+                    count for table, count in results.items() if table.startswith("RT_")
+                )
 
                 console.print(f"  NL_* tables: {nl_indexes} indexes")
                 console.print(f"  RT_* tables: {rt_indexes} indexes")
@@ -1234,10 +1310,21 @@ def create_indexes(ctx, db, table):
 
 @cli.command()
 @click.option("--table", required=True, help="Table name to export")
-@click.option("--format", "output_format", type=click.Choice(["csv", "json", "parquet"]), default="csv", help="Output format (default: csv)")
+@click.option(
+    "--format",
+    "output_format",
+    type=click.Choice(["csv", "json", "parquet"]),
+    default="csv",
+    help="Output format (default: csv)",
+)
 @click.option("--output", "-o", required=True, type=click.Path(), help="Output file path")
 @click.option("--where", help="SQL WHERE clause (e.g., '開催年月日 >= 20240101')")
-@click.option("--db", type=click.Choice(["sqlite", "postgresql"]), default=None, help="Database type (default: from config)")
+@click.option(
+    "--db",
+    type=click.Choice(["sqlite", "postgresql"]),
+    default=None,
+    help="Database type (default: from config)",
+)
 @click.pass_context
 def export(ctx, table, output_format, output, where, db):
     """Export data from database to file.
@@ -1260,7 +1347,9 @@ def export(ctx, table, output_format, output, where, db):
 
     config = ctx.obj.get("config")
     if not config and not db:
-        console.print("[red]Error:[/red] No configuration found. Run 'jltsql init' first or use --db option.")
+        console.print(
+            "[red]Error:[/red] No configuration found. Run 'jltsql init' first or use --db option."
+        )
         sys.exit(1)
 
     # Determine database type
@@ -1295,8 +1384,11 @@ def export(ctx, table, output_format, output, where, db):
             # Validate table name to prevent SQL injection
             # Only allow alphanumeric characters and underscores
             import re
-            if not re.match(r'^[A-Za-z0-9_]+$', table):
-                console.print(f"[red]Error:[/red] Invalid table name '{table}'. Only alphanumeric characters and underscores are allowed.")
+
+            if not re.match(r"^[A-Za-z0-9_]+$", table):
+                console.print(
+                    f"[red]Error:[/red] Invalid table name '{table}'. Only alphanumeric characters and underscores are allowed."
+                )
                 sys.exit(1)
 
             # Build query
@@ -1305,16 +1397,18 @@ def export(ctx, table, output_format, output, where, db):
                 # WARNING: The WHERE clause is not parameterized and may be vulnerable to SQL injection.
                 # This feature is intended for CLI/internal use only.
                 # DO NOT expose this to untrusted input or web interfaces.
-                console.print("[yellow]Warning:[/yellow] WHERE clause is not parameterized. Use only with trusted input.")
+                console.print(
+                    "[yellow]Warning:[/yellow] WHERE clause is not parameterized. Use only with trusted input."
+                )
                 sql += f" WHERE {where}"
 
             console.print(f"[dim]Executing: {sql}[/dim]\n")
 
             # Fetch data
             from rich.progress import Progress, TextColumn
+
             with Progress(
-                TextColumn("[progress.description]{task.description}"),
-                console=console
+                TextColumn("[progress.description]{task.description}"), console=console
             ) as progress:
                 task = progress.add_task("[cyan]Fetching data...", total=None)
                 rows = database.fetch_all(sql)
@@ -1330,6 +1424,7 @@ def export(ctx, table, output_format, output, where, db):
 
             if output_format == "csv":
                 import csv
+
                 with open(output_path, "w", newline="", encoding="utf-8") as f:
                     if rows:
                         writer = csv.DictWriter(f, fieldnames=rows[0].keys())
@@ -1338,12 +1433,14 @@ def export(ctx, table, output_format, output, where, db):
 
             elif output_format == "json":
                 import json
+
                 with open(output_path, "w", encoding="utf-8") as f:
                     json.dump(rows, f, ensure_ascii=False, indent=2)
 
             elif output_format == "parquet":
                 try:
                     import pandas as pd
+
                     df = pd.DataFrame(rows)
                     df.to_parquet(output_path, index=False)
                 except ImportError:
@@ -1383,9 +1480,7 @@ def config(ctx, show, set_value, get_key):
 
     # Find config file. The path is captured before the bootstrap command
     # deliberately skips normal configuration loading.
-    config_path = Path(
-        ctx.obj.get("config_path", Path.cwd() / "config" / "config.yaml")
-    )
+    config_path = Path(ctx.obj.get("config_path", Path.cwd() / "config" / "config.yaml"))
     if ctx.obj.get("config"):
         config_obj = ctx.obj["config"]
         config_dict = config_obj.to_dict()
@@ -1406,6 +1501,7 @@ def config(ctx, show, set_value, get_key):
 
         # Pretty print config
         from rich.tree import Tree
+
         tree = Tree("JLTSQL Configuration")
 
         # JV-Link section
@@ -1451,7 +1547,9 @@ def config(ctx, show, set_value, get_key):
 
     # Set value (future implementation)
     elif set_value:
-        console.print("[yellow]Note:[/yellow] Configuration modification via CLI is not yet implemented.")
+        console.print(
+            "[yellow]Note:[/yellow] Configuration modification via CLI is not yet implemented."
+        )
         console.print(f"Please edit {config_path} manually.")
         console.print()
         console.print(f"You wanted to set: {set_value}")
@@ -1484,26 +1582,16 @@ SOKUHO_TIMESERIES_ODDS_SPECS = "0B30"
 
 @realtime.command()
 @click.option(
-    "--specs",
-    default="0B12",
-    help="Comma-separated data specs to monitor (default: 0B12)"
+    "--specs", default="0B12", help="Comma-separated data specs to monitor (default: 0B12)"
 )
 @click.option(
     "--db",
     type=click.Choice(["sqlite", "postgresql"]),
     default=None,
-    help="Database type (default: from config)"
+    help="Database type (default: from config)",
 )
-@click.option(
-    "--batch-size",
-    default=100,
-    help="Batch size for imports (default: 100)"
-)
-@click.option(
-    "--no-create-tables",
-    is_flag=True,
-    help="Don't auto-create missing tables"
-)
+@click.option("--batch-size", default=100, help="Batch size for imports (default: 100)")
+@click.option("--no-create-tables", is_flag=True, help="Don't auto-create missing tables")
 @click.pass_context
 def start(ctx, specs, db, batch_size, no_create_tables):
     """Start realtime monitoring service.
@@ -1569,7 +1657,7 @@ def start(ctx, specs, db, batch_size, no_create_tables):
             data_specs=data_specs,
             sid=config.get("jvlink.sid", "JLTSQL") if config else "JLTSQL",
             batch_size=batch_size,
-            auto_create_tables=not no_create_tables
+            auto_create_tables=not no_create_tables,
         )
 
         # Start monitoring
@@ -1595,6 +1683,7 @@ def start(ctx, specs, db, batch_size, no_create_tables):
             console.print("\nPress Ctrl+C to stop...\n")
             try:
                 import time
+
                 while monitor.status.is_running:
                     time.sleep(2)
                     # Periodically show stats
@@ -1603,7 +1692,7 @@ def start(ctx, specs, db, batch_size, no_create_tables):
                         f"\rImported: {status['records_imported']:,} | "
                         f"Failed: {status['records_failed']:,} | "
                         f"Uptime: {status['uptime_seconds']:.0f}s",
-                        end=""
+                        end="",
                     )
             except KeyboardInterrupt:
                 console.print("\n\n[yellow]Stopping monitoring...[/yellow]")
@@ -1686,6 +1775,18 @@ def realtime_stop(ctx):
     help="End date in YYYYMMDD format (default: today)",
 )
 @click.option(
+    "--post-time-within-minutes",
+    type=click.IntRange(min=0),
+    default=None,
+    help="Keep races whose NL_RA/RT_RA post time is at most N minutes ahead",
+)
+@click.option(
+    "--post-time-not-past-minutes",
+    type=click.IntRange(min=0),
+    default=None,
+    help="Drop races whose NL_RA/RT_RA post time is more than M minutes past",
+)
+@click.option(
     "--db",
     type=click.Choice(["sqlite", "postgresql"]),
     default=None,
@@ -1698,7 +1799,16 @@ def realtime_stop(ctx):
     help="SQLite database path (overrides config)",
 )
 @click.pass_context
-def timeseries(ctx, spec, from_date, to_date, db, db_path):
+def timeseries(
+    ctx,
+    spec,
+    from_date,
+    to_date,
+    post_time_within_minutes,
+    post_time_not_past_minutes,
+    db,
+    db_path,
+):
     """Fetch time series odds data from JV-Link.
 
     Fetches odds time-series data for races already in the database.
@@ -1716,8 +1826,10 @@ def timeseries(ctx, spec, from_date, to_date, db, db_path):
       jltsql realtime timeseries
       jltsql realtime timeseries --spec 0B41,0B42 --from-date 20250426
       jltsql realtime timeseries --spec 0B30 --from-date 20260418
+      jltsql realtime timeseries --spec 0B41 --from-date 20260901 --to-date 20260901 \
+        --post-time-within-minutes 30 --post-time-not-past-minutes 2
     """
-    from datetime import datetime, timedelta
+    from datetime import datetime, timedelta, timezone
     from src.database import create_database_from_config, DatabaseError
     from src.database.sqlite_handler import SQLiteDatabase
     from src.fetcher.realtime import RealtimeFetcher
@@ -1743,20 +1855,41 @@ def timeseries(ctx, spec, from_date, to_date, db, db_path):
     # Resolve path
     database_path = str(Path(database_path).resolve())
 
-    # Default date range (1 year for JVRTOpen)
-    if not from_date:
-        one_year_ago = datetime.now() - timedelta(days=365)
-        from_date = one_year_ago.strftime("%Y%m%d")
-    if not to_date:
-        to_date = datetime.now().strftime("%Y%m%d")
+    # Preserve the legacy host-local defaults when the opt-in window is off.
+    # A live window is explicitly defined in JST, so its implicit dates must
+    # use that same clock (especially during 00:00-08:59 JST on UTC hosts).
+    window_requested = (
+        post_time_within_minutes is not None or post_time_not_past_minutes is not None
+    )
+    if window_requested:
+        default_now = datetime.now(timezone(timedelta(hours=9), name="JST"))
+        if not from_date:
+            from_date = (default_now - timedelta(days=365)).strftime("%Y%m%d")
+        if not to_date:
+            to_date = default_now.strftime("%Y%m%d")
+    else:
+        # Keep the untouched path byte-identical to the pre-window behavior.
+        if not from_date:
+            one_year_ago = datetime.now() - timedelta(days=365)
+            from_date = one_year_ago.strftime("%Y%m%d")
+        if not to_date:
+            to_date = datetime.now().strftime("%Y%m%d")
 
     # Parse multiple specs
     specs_list = [s.strip() for s in spec.split(",")]
 
     console.print("[bold cyan]Fetching time series odds data...[/bold cyan]\n")
     console.print(f"  Data specs:    {', '.join(specs_list)}")
-    console.print(f"  Database:      {database_path if db_type == 'sqlite' else 'PostgreSQL'} ({db_type})")
+    console.print(
+        f"  Database:      {database_path if db_type == 'sqlite' else 'PostgreSQL'} ({db_type})"
+    )
     console.print(f"  Date range:    {from_date} - {to_date}")
+    if post_time_within_minutes is not None or post_time_not_past_minutes is not None:
+        console.print(
+            "  Post window:   "
+            f"within={post_time_within_minutes if post_time_within_minutes is not None else 'off'}m, "
+            f"not-past={post_time_not_past_minutes if post_time_not_past_minutes is not None else 'off'}m"
+        )
     console.print()
 
     try:
@@ -1764,9 +1897,7 @@ def timeseries(ctx, spec, from_date, to_date, db, db_path):
         # timeseries writes to be mirrored, so defer to the shared factory.
         if db_type in ("postgresql", "dual"):
             try:
-                database = create_database_from_config(
-                    config, db_type_override=db_type
-                )
+                database = create_database_from_config(config, db_type_override=db_type)
             except (ValueError, DatabaseError) as exc:
                 console.print(f"[red]Error:[/red] {exc}")
                 sys.exit(1)
@@ -1776,9 +1907,9 @@ def timeseries(ctx, spec, from_date, to_date, db, db_path):
             database = SQLiteDatabase(db_config)
 
         with database:
-            # Ensure official/sokuho time-series tables exist.
-            from src.database.schema import SCHEMAS
-            schema_registry = SCHEMAS
+            # Migrate, create, and verify each target before JV-Link opens.
+            from src.database.timeseries_capture import prepare_time_series_odds_table
+
             for spec_code in specs_list:
                 # Map spec to table name
                 table_map = {
@@ -1803,9 +1934,8 @@ def timeseries(ctx, spec, from_date, to_date, db, db_path):
                 }
                 table_names = table_map.get(spec_code, "")
                 for table_name in [name for name in table_names.split(",") if name]:
-                    if table_name in schema_registry:
-                        database.create_table(table_name, schema_registry[table_name])
-                        console.print(f"  [green][OK][/green] Table {table_name} ready")
+                    prepare_time_series_odds_table(database, table_name)
+                    console.print(f"  [green][OK][/green] Table {table_name} ready")
 
             # PostgreSQL DDL starts a physical transaction. Close the setup
             # boundary so every persistence batch owns and commits only its
@@ -1821,7 +1951,9 @@ def timeseries(ctx, spec, from_date, to_date, db, db_path):
             total_success = 0
             total_errors = 0
             default_save_batch_size = 100 if db_type in ("postgresql", "dual") else 5000
-            save_batch_size = int(os.getenv("JRVLTSQL_TS_SAVE_BATCH_SIZE", str(default_save_batch_size)))
+            save_batch_size = int(
+                os.getenv("JRVLTSQL_TS_SAVE_BATCH_SIZE", str(default_save_batch_size))
+            )
 
             def flush_batch(records_batch):
                 nonlocal total_success, total_errors
@@ -1852,13 +1984,20 @@ def timeseries(ctx, spec, from_date, to_date, db, db_path):
 
                     def report_key_progress(progress):
                         key_progress.update(progress)
+                        if progress.get("status") == "window_filter":
+                            console.print(
+                                "  Window: "
+                                f"considered={progress.get('considered_keys', 0):,} "
+                                f"kept={progress.get('window_kept_keys', 0):,} "
+                                f"future={progress.get('dropped_too_far_future', 0):,} "
+                                f"past={progress.get('dropped_too_far_past', 0):,}"
+                            )
+                            return
                         processed = int(progress.get("processed_keys", 0))
                         total = int(progress.get("total_keys", 0))
                         status = str(progress.get("status", ""))
                         should_print = (
-                            processed == total
-                            or status == "success"
-                            or processed % 25 == 0
+                            processed == total or status == "success" or processed % 25 == 0
                         )
                         if not should_print:
                             return
@@ -1885,6 +2024,8 @@ def timeseries(ctx, spec, from_date, to_date, db, db_path):
                         to_date=to_date,
                         pg_config=pg_config,
                         progress_callback=report_key_progress,
+                        post_time_within_minutes=post_time_within_minutes,
+                        post_time_not_past_minutes=post_time_not_past_minutes,
                     ):
                         # The fetcher already expands O1-O6 arrays into row
                         # dictionaries. Save parsed rows directly to avoid
@@ -1912,7 +2053,9 @@ def timeseries(ctx, spec, from_date, to_date, db, db_path):
                             f"errors={key_progress['error_keys']:,} "
                             f"records={key_progress['total_records']:,}"
                         )
-                    console.print(f"  [green][OK][/green] {spec_code}: {record_count:,} records processed")
+                    console.print(
+                        f"  [green][OK][/green] {spec_code}: {record_count:,} records processed"
+                    )
 
                 except Exception as e:
                     console.print(f"  [red][ERROR][/red] {spec_code}: Error - {e}")

--- a/src/cli/main.py
+++ b/src/cli/main.py
@@ -2100,9 +2100,12 @@ def timeseries(
                             console.print(
                                 "  Window: "
                                 f"considered={progress.get('considered_keys', 0):,} "
+                                f"candidates={progress.get('window_candidate_keys', 0):,} "
                                 f"kept={progress.get('window_kept_keys', 0):,} "
                                 f"future={progress.get('dropped_too_far_future', 0):,} "
-                                f"past={progress.get('dropped_too_far_past', 0):,}"
+                                f"past={progress.get('dropped_too_far_past', 0):,} "
+                                "date_excluded="
+                                f"{progress.get('skipped_out_of_window_by_date', 0):,}"
                             )
                             return
                         processed = int(progress.get("processed_keys", 0))

--- a/src/cli/main.py
+++ b/src/cli/main.py
@@ -558,6 +558,118 @@ def fetch(ctx, date_from, date_to, data_spec, jv_option, db, batch_size, progres
 
 
 # ---------------------------------------------------------------------------
+# database maintenance command group
+# ---------------------------------------------------------------------------
+
+
+@cli.group("db")
+def database_maintenance():
+    """Run explicit database maintenance operations."""
+    pass
+
+
+@database_maintenance.command("migrate-sokuho-capture-identity")
+@click.option(
+    "--db",
+    "database_type",
+    type=click.Choice(["sqlite", "postgresql"]),
+    default=None,
+    help="Database type (default: from config)",
+)
+@click.option(
+    "--table",
+    "table_names",
+    type=click.Choice(
+        [f"TS_SOKUHO_O{number}" for number in range(1, 7)],
+        case_sensitive=False,
+    ),
+    multiple=True,
+    help="Restrict migration to this table; repeat for multiple tables",
+)
+@click.option(
+    "--schema",
+    "schema_name",
+    default=None,
+    help="PostgreSQL schema containing the selected tables (default: search path)",
+)
+@click.option(
+    "--apply",
+    is_flag=True,
+    default=False,
+    help="Apply the migration (default: dry-run report only)",
+)
+@click.pass_context
+def migrate_sokuho_capture_identity(ctx, database_type, table_names, schema_name, apply):
+    """Report or explicitly migrate legacy TS_SOKUHO primary keys.
+
+    Dry run is the default. Stop all collectors before using --apply.
+    SQLite is intentionally refused and requires backup plus table rebuild.
+    """
+    from src.database import create_database_from_config, DatabaseError
+    from src.database.migration import (
+        SchemaMigrationError,
+        SOKUHO_CAPTURE_TABLES,
+        apply_sokuho_capture_identity_migration,
+        normalize_sokuho_capture_identity_tables,
+        preview_sokuho_capture_identity_migration,
+        validate_sokuho_capture_identity_operator_backend,
+    )
+
+    config = ctx.obj.get("config")
+    resolved_database_type = database_type or (
+        config.get("database.type", "sqlite") if config else "sqlite"
+    )
+
+    try:
+        requested_tables = tuple(table_name.upper() for table_name in table_names)
+        if schema_name:
+            requested_tables = tuple(
+                f"{schema_name}.{table_name}"
+                for table_name in (requested_tables or SOKUHO_CAPTURE_TABLES)
+            )
+        selected_tables = normalize_sokuho_capture_identity_tables(requested_tables or None)
+        validate_sokuho_capture_identity_operator_backend(
+            resolved_database_type,
+            selected_tables,
+        )
+        database = create_database_from_config(
+            config,
+            db_type_override=resolved_database_type,
+        )
+        with database:
+            if apply:
+                reports = apply_sokuho_capture_identity_migration(
+                    database,
+                    selected_tables,
+                )
+            else:
+                reports = preview_sokuho_capture_identity_migration(
+                    database,
+                    selected_tables,
+                )
+    except (DatabaseError, SchemaMigrationError, ValueError) as exc:
+        raise click.ClickException(str(exc)) from exc
+
+    click.echo("Sokuho capture-identity migration: " f"{'APPLY' if apply else 'DRY RUN'}")
+    for report in reports:
+        primary_key = ", ".join(report.primary_key) or "(none)"
+        click.echo(f"Table: {report.table_name}")
+        click.echo(f"  Status: {report.status}")
+        click.echo(f"  Current primary key: {primary_key}")
+        click.echo(f"  Total rows: {report.total_rows}")
+        click.echo("  Distinct publication groups: " f"{report.distinct_publication_groups}")
+        click.echo(f"  Rows that would be deleted: {report.rows_to_delete}")
+        click.echo(
+            "  Groups whose CollectedAt would be rewritten to earliest non-NULL: "
+            f"{report.collected_at_rewrite_groups}"
+        )
+    if apply:
+        click.echo("Migration apply completed.")
+    else:
+        click.echo("Dry run only; no changes were applied.")
+
+
+# ---------------------------------------------------------------------------
 # cache command group
 # ---------------------------------------------------------------------------
 

--- a/src/database/base.py
+++ b/src/database/base.py
@@ -7,6 +7,7 @@ from abc import ABC, abstractmethod
 from typing import Any, Dict, List, Optional
 
 from src.database.timeseries_capture import (
+    is_sokuho_time_series_odds_capture_table,
     is_time_series_odds_capture_table,
     unqualified_table_name,
 )
@@ -207,6 +208,11 @@ class BaseDatabase(ABC):
         if not data:
             raise DatabaseError("No data provided for insert")
 
+        if is_sokuho_time_series_odds_capture_table(table_name):
+            from src.database.migration import ensure_sokuho_capture_identity_for_write
+
+            ensure_sokuho_capture_identity_for_write(self, table_name)
+
         columns = list(data.keys())
         values = list(data.values())
         placeholders = ", ".join(["?" for _ in columns])
@@ -255,6 +261,11 @@ class BaseDatabase(ABC):
         """
         if not data_list:
             raise DatabaseError("No data provided for insert")
+
+        if is_sokuho_time_series_odds_capture_table(table_name):
+            from src.database.migration import ensure_sokuho_capture_identity_for_write
+
+            ensure_sokuho_capture_identity_for_write(self, table_name)
 
         # Use the union of all row keys.  Expanded JV-Data records such as O1
         # intentionally produce heterogeneous rows (horse odds vs bracket odds).

--- a/src/database/base.py
+++ b/src/database/base.py
@@ -6,6 +6,10 @@ This module provides the abstract base class for database operations.
 from abc import ABC, abstractmethod
 from typing import Any, Dict, List, Optional
 
+from src.database.timeseries_capture import (
+    is_time_series_odds_capture_table,
+    unqualified_table_name,
+)
 from src.utils.logger import get_logger
 
 logger = get_logger(__name__)
@@ -209,11 +213,17 @@ class BaseDatabase(ABC):
         # Quote column names using database-specific method
         quoted_columns = [self._quote_identifier(col) for col in columns]
 
-        # Use INSERT OR REPLACE to handle duplicates (UPSERT behavior)
-        # This ensures that running imports multiple times updates existing records
-        # rather than causing constraint violations or creating duplicates
-        insert_clause = "INSERT OR REPLACE INTO" if use_replace else "INSERT INTO"
-        sql = f"{insert_clause} {table_name} ({', '.join(quoted_columns)}) VALUES ({placeholders})"
+        if use_replace and is_time_series_odds_capture_table(table_name):
+            update_set = self._sqlite_time_series_update_set(table_name, columns, quoted_columns)
+            sql = (
+                f"INSERT INTO {table_name} ({', '.join(quoted_columns)}) "
+                f"VALUES ({placeholders}) ON CONFLICT DO UPDATE SET {update_set}"
+            )
+        else:
+            # Keep the generic SQLite path byte-for-byte equivalent for every
+            # unrelated table.
+            insert_clause = "INSERT OR REPLACE INTO" if use_replace else "INSERT INTO"
+            sql = f"{insert_clause} {table_name} ({', '.join(quoted_columns)}) VALUES ({placeholders})"
 
         return self.execute(sql, tuple(values))
 
@@ -260,16 +270,52 @@ class BaseDatabase(ABC):
         # Quote column names using database-specific method
         quoted_columns = [self._quote_identifier(col) for col in columns]
 
-        # Use INSERT OR REPLACE to handle duplicates (UPSERT behavior)
-        # This ensures that running imports multiple times updates existing records
-        # rather than causing constraint violations or creating duplicates
-        insert_clause = "INSERT OR REPLACE INTO" if use_replace else "INSERT INTO"
-        sql = f"{insert_clause} {table_name} ({', '.join(quoted_columns)}) VALUES ({placeholders})"
+        if use_replace and is_time_series_odds_capture_table(table_name):
+            update_set = self._sqlite_time_series_update_set(table_name, columns, quoted_columns)
+            sql = (
+                f"INSERT INTO {table_name} ({', '.join(quoted_columns)}) "
+                f"VALUES ({placeholders}) ON CONFLICT DO UPDATE SET {update_set}"
+            )
+        else:
+            # Keep the generic SQLite path byte-for-byte equivalent for every
+            # unrelated table.
+            insert_clause = "INSERT OR REPLACE INTO" if use_replace else "INSERT INTO"
+            sql = f"{insert_clause} {table_name} ({', '.join(quoted_columns)}) VALUES ({placeholders})"
 
         # Extract values in correct order for each row
         parameters_list = [tuple(row.get(col) for col in columns) for row in data_list]
 
         return self.executemany(sql, parameters_list)
+
+    def _sqlite_time_series_update_set(
+        self,
+        table_name: str,
+        columns: List[str],
+        quoted_columns: List[str],
+    ) -> str:
+        """Build the time-series-only SQLite conflict assignments."""
+        assignments = []
+        # SQLite accepts ``main.TS_O2`` as an INSERT target, but the stored row
+        # in an UPSERT expression is qualified by the table name alone.
+        qualified_table = self._quote_identifier(unqualified_table_name(table_name))
+        for column, quoted_column in zip(columns, quoted_columns, strict=True):
+            if column.lower() != "collectedat":
+                assignments.append(f"{quoted_column} = excluded.{quoted_column}")
+                continue
+
+            stored = f"{qualified_table}.{quoted_column}"
+            incoming = f"excluded.{quoted_column}"
+            # The connection UDF converts offset-aware ISO text to integer UTC
+            # microseconds; raw string ordering is wrong across UTC offsets.
+            assignments.append(
+                f"{quoted_column} = CASE "
+                f"WHEN {incoming} IS NULL THEN {stored} "
+                f"WHEN {stored} IS NULL THEN {incoming} "
+                f"WHEN jltsql_capture_epoch_us({incoming}) "
+                f"< jltsql_capture_epoch_us({stored}) THEN {incoming} "
+                f"ELSE {stored} END"
+            )
+        return ", ".join(assignments)
 
     def commit(self) -> None:
         """Commit current transaction.

--- a/src/database/dual_handler.py
+++ b/src/database/dual_handler.py
@@ -22,6 +22,7 @@ from typing import Any, Dict, List, Optional
 from src.utils.logger import get_logger
 
 from .base import BaseDatabase, DatabaseError
+from .timeseries_capture import is_sokuho_time_series_odds_capture_table
 
 logger = get_logger(__name__)
 
@@ -130,9 +131,7 @@ class DualDatabase(BaseDatabase):
             try:
                 self._secondary.disconnect()
             except Exception as e:
-                logger.warning(
-                    f"DualDatabase: secondary disconnect failed: {e}"
-                )
+                logger.warning(f"DualDatabase: secondary disconnect failed: {e}")
         self._connection = None
         self._transaction_active = False
 
@@ -163,6 +162,10 @@ class DualDatabase(BaseDatabase):
         if self._secondary.is_connected():
             targets.append(self._secondary)
         return tuple(targets)
+
+    def get_sokuho_guard_targets(self) -> tuple[BaseDatabase, BaseDatabase]:
+        """Return every configured backend for fail-closed Sokuho checks."""
+        return self._primary, self._secondary
 
     # ------------------------------------------------------------------
     # Reads: primary only
@@ -195,15 +198,12 @@ class DualDatabase(BaseDatabase):
                 self._secondary.execute(sql, parameters)
             except Exception as e:
                 logger.warning(
-                    f"DualDatabase: secondary execute failed: {e} "
-                    f"(sql={sql[:80]!r})"
+                    f"DualDatabase: secondary execute failed: {e} " f"(sql={sql[:80]!r})"
                 )
                 self._secondary_errors += 1
                 self._secondary_in_sync = False
                 if self._transaction_active:
-                    raise DatabaseError(
-                        f"DualDatabase: secondary execute failed: {e}"
-                    ) from e
+                    raise DatabaseError(f"DualDatabase: secondary execute failed: {e}") from e
         return result
 
     def executemany(self, sql: str, parameters_list: List[tuple]) -> Any:
@@ -213,25 +213,18 @@ class DualDatabase(BaseDatabase):
                 self._secondary.executemany(sql, parameters_list)
             except Exception as e:
                 logger.warning(
-                    f"DualDatabase: secondary executemany failed: {e} "
-                    f"(sql={sql[:80]!r})"
+                    f"DualDatabase: secondary executemany failed: {e} " f"(sql={sql[:80]!r})"
                 )
                 self._secondary_errors += 1
                 self._secondary_in_sync = False
                 if self._transaction_active:
-                    raise DatabaseError(
-                        f"DualDatabase: secondary executemany failed: {e}"
-                    ) from e
+                    raise DatabaseError(f"DualDatabase: secondary executemany failed: {e}") from e
         return result
 
-    def fetch_one(
-        self, sql: str, parameters: Optional[tuple] = None
-    ) -> Optional[Dict[str, Any]]:
+    def fetch_one(self, sql: str, parameters: Optional[tuple] = None) -> Optional[Dict[str, Any]]:
         return self._primary.fetch_one(sql, parameters)
 
-    def fetch_all(
-        self, sql: str, parameters: Optional[tuple] = None
-    ) -> List[Dict[str, Any]]:
+    def fetch_all(self, sql: str, parameters: Optional[tuple] = None) -> List[Dict[str, Any]]:
         return self._primary.fetch_all(sql, parameters)
 
     def table_exists(self, table_name: str) -> bool:
@@ -272,9 +265,7 @@ class DualDatabase(BaseDatabase):
         try:
             self._secondary.create_table(table_name, schema)
         except Exception as e:
-            logger.warning(
-                f"DualDatabase: secondary create_table failed for {table_name}: {e}"
-            )
+            logger.warning(f"DualDatabase: secondary create_table failed for {table_name}: {e}")
             self._secondary_errors += 1
             self._secondary_in_sync = False
 
@@ -284,13 +275,16 @@ class DualDatabase(BaseDatabase):
         data: Dict[str, Any],
         use_replace: bool = True,
     ) -> int:
+        if is_sokuho_time_series_odds_capture_table(table_name):
+            from .migration import ensure_sokuho_capture_identity_for_write
+
+            for target in self.get_sokuho_guard_targets():
+                ensure_sokuho_capture_identity_for_write(target, table_name)
         rows = self._primary.insert(table_name, data, use_replace)
         try:
             self._secondary.insert(table_name, data, use_replace)
         except Exception as e:
-            logger.warning(
-                f"DualDatabase: secondary insert failed for {table_name}: {e}"
-            )
+            logger.warning(f"DualDatabase: secondary insert failed for {table_name}: {e}")
             self._secondary_errors += 1
             self._secondary_in_sync = False
             if self._transaction_active:
@@ -305,6 +299,11 @@ class DualDatabase(BaseDatabase):
         data_list: List[Dict[str, Any]],
         use_replace: bool = True,
     ) -> int:
+        if is_sokuho_time_series_odds_capture_table(table_name):
+            from .migration import ensure_sokuho_capture_identity_for_write
+
+            for target in self.get_sokuho_guard_targets():
+                ensure_sokuho_capture_identity_for_write(target, table_name)
         rows = self._primary.insert_many(table_name, data_list, use_replace)
         try:
             self._secondary.insert_many(table_name, data_list, use_replace)

--- a/src/database/migration.py
+++ b/src/database/migration.py
@@ -402,7 +402,7 @@ def sokuho_capture_identity_operator_command(
     table_name: str,
     database_type: str = "postgresql",
 ) -> str:
-    """Return the exact explicit command named by startup and write guards."""
+    """Return the exact read-only dry-run command named by write guards."""
     normalized = _normalize_sokuho_table_reference(table_name)
     schema_option = ""
     if "." in normalized:
@@ -410,25 +410,29 @@ def sokuho_capture_identity_operator_command(
         schema_option = f"--schema {schema_name} "
     return (
         f"{SOKUHO_CAPTURE_IDENTITY_MIGRATION_COMMAND} --db {database_type} "
-        f"{schema_option}--table {normalized} --apply"
+        f"{schema_option}--table {normalized}"
     )
 
 
 def legacy_sokuho_capture_identity_message(db: BaseDatabase, table_name: str) -> str:
     """Build the shared actionable refusal for startup and write paths."""
     normalized = _normalize_sokuho_table_reference(table_name)
-    message = (
+    refusal = (
         f"{normalized} uses the legacy primary key ending in CollectedAt; "
-        "startup and time-series odds writes are blocked. Stop all collectors, "
-        "then run exactly: "
-        f"{sokuho_capture_identity_operator_command(normalized, db.get_db_type())}"
+        "startup and time-series odds writes are blocked."
     )
     if db.get_db_type() == "sqlite":
-        message += (
-            ". SQLite cannot migrate this key in place; the command will refuse "
-            "and require a backup and rebuild with the current schema"
+        return (
+            f"{refusal} SQLite cannot migrate this key in place; create a "
+            "backup and rebuild the table with the current schema"
         )
-    return message
+    return (
+        f"{refusal} First run this read-only "
+        "dry run (the default; it does not change data): "
+        f"{sokuho_capture_identity_operator_command(normalized, db.get_db_type())}. "
+        "Review the report, stop all collectors, then rerun the same command with "
+        "--apply; --apply mutates the table"
+    )
 
 
 def _expected_sokuho_primary_key(table_name: str) -> List[str]:

--- a/src/database/migration.py
+++ b/src/database/migration.py
@@ -5,14 +5,17 @@ Detects schema mismatches in existing tables and applies safe migrations.
 The production PostgreSQL database is used by near-real-time collectors, so
 ``quickstart`` must never wipe tables implicitly. Migrations are additive only:
 missing columns are added with ``ALTER TABLE`` and extra/renamed columns are
-preserved. Primary-key changes fail closed and require an operator-managed
-migration outside these startup paths.
+preserved. Primary-key changes fail closed except for the exact PostgreSQL
+TS_SOKUHO capture-key correction implemented below. Legacy SQLite Sokuho keys
+are rejected without mutation and require an operator-managed rebuild.
 """
 
 import re
 from typing import Dict, List, Optional, Set
+from uuid import uuid4
 
 from src.database.base import BaseDatabase
+from src.database.timeseries_capture import capture_timestamp_epoch_microseconds
 from src.utils.logger import get_logger
 
 logger = get_logger(__name__)
@@ -20,6 +23,9 @@ logger = get_logger(__name__)
 
 class SchemaMigrationError(RuntimeError):
     """Raised when a table cannot satisfy its required schema safely."""
+
+
+_SOKUHO_CAPTURE_TABLES = frozenset(f"TS_SOKUHO_O{number}" for number in range(1, 7))
 
 
 def _migration_targets(db: BaseDatabase) -> tuple[BaseDatabase, ...]:
@@ -307,6 +313,138 @@ def _add_missing_columns(
     return added
 
 
+def _validate_existing_capture_stamps(db: BaseDatabase, table_name: str) -> None:
+    """Reject a legacy Sokuho identity migration if a real stamp is invalid."""
+    table_identifier = _table_identifier(db, table_name)
+    rows = db.fetch_all(
+        f"SELECT DISTINCT CollectedAt AS collectedat FROM {table_identifier} "
+        "WHERE CollectedAt IS NOT NULL"
+    )
+    invalid = []
+    for row in rows:
+        value = row.get("collectedat")
+        try:
+            capture_timestamp_epoch_microseconds(value)
+        except (TypeError, ValueError):
+            invalid.append(repr(value))
+    if invalid:
+        examples = ", ".join(invalid[:5])
+        suffix = " ..." if len(invalid) > 5 else ""
+        raise SchemaMigrationError(
+            f"Cannot migrate {table_name}: invalid offset-aware CollectedAt values "
+            f"[{examples}{suffix}]"
+        )
+
+
+def _is_legacy_sokuho_capture_identity(
+    table_name: str,
+    existing_pk: List[str],
+    expected_pk: List[str],
+) -> bool:
+    """Recognize only the shipped Sokuho key that ended in CollectedAt."""
+    if table_name.upper() not in _SOKUHO_CAPTURE_TABLES:
+        return False
+    existing = [column.lower() for column in existing_pk]
+    expected = [column.lower() for column in expected_pk]
+    return existing == [*expected, "collectedat"]
+
+
+def _postgresql_migrate_sokuho_capture_identity(
+    db: BaseDatabase,
+    table_name: str,
+    expected_pk: List[str],
+    *,
+    commit: bool,
+) -> None:
+    """Collapse legacy PostgreSQL polls and replace the primary key atomically."""
+    table_identifier = _table_identifier(db, table_name)
+    temp_name = f"__jltsql_{table_name.lower()}_capture_pk_{uuid4().hex}"
+    temp_create_identifier = f'"{temp_name}"'
+    temp_identifier = f'pg_temp."{temp_name}"'
+    key_columns = [column.lower() for column in expected_pk]
+    partition = ", ".join(key_columns)
+    grouped_keys = " AND ".join(f"existing.{column} = grouped.{column}" for column in key_columns)
+
+    db.begin_transaction()
+    try:
+        # The DELETE must operate on the same population as the grouping
+        # snapshot. Lock first so a concurrent collector cannot insert a
+        # correction that the migration would then delete unseen.
+        db.execute(f"LOCK TABLE {table_identifier} IN ACCESS EXCLUSIVE MODE")
+        _validate_existing_capture_stamps(db, table_name)
+        constraint = db.fetch_one(
+            "SELECT conname FROM pg_constraint "
+            "WHERE conrelid = to_regclass(?) AND contype = 'p'",
+            (table_name.lower(),),
+        )
+        if not constraint or not constraint.get("conname"):
+            raise SchemaMigrationError(
+                f"Cannot migrate {table_name}: primary key constraint not found"
+            )
+        constraint_identifier = '"' + str(constraint["conname"]).replace('"', '""') + '"'
+        db.execute(
+            f"CREATE TEMP TABLE {temp_create_identifier} ON COMMIT DROP AS "
+            f"SELECT {partition}, "
+            "(ARRAY_AGG(ctid ORDER BY (collectedat IS NULL), "
+            "collectedat::timestamptz DESC, ctid DESC))[1] AS keep_tid, "
+            "(ARRAY_AGG(collectedat ORDER BY (collectedat IS NULL), "
+            "collectedat::timestamptz ASC, ctid ASC))[1] AS earliest_collectedat "
+            f"FROM {table_identifier} GROUP BY {partition}"
+        )
+        db.execute(
+            f"DELETE FROM {table_identifier} AS existing USING {temp_identifier} AS grouped "
+            f"WHERE {grouped_keys} AND existing.ctid <> grouped.keep_tid"
+        )
+        db.execute(
+            f"UPDATE {table_identifier} AS existing "
+            f"SET collectedat = grouped.earliest_collectedat "
+            f"FROM {temp_identifier} AS grouped WHERE existing.ctid = grouped.keep_tid"
+        )
+        db.execute(f"ALTER TABLE {table_identifier} DROP CONSTRAINT {constraint_identifier}")
+        db.execute(f"ALTER TABLE {table_identifier} ALTER COLUMN collectedat DROP NOT NULL")
+        db.execute(f"ALTER TABLE {table_identifier} ADD PRIMARY KEY ({', '.join(key_columns)})")
+        remaining = db.fetch_one(f"SELECT COUNT(*) AS count FROM {table_identifier}")["count"]
+        grouped = db.fetch_one(f"SELECT COUNT(*) AS count FROM {temp_identifier}")["count"]
+        if remaining != grouped:
+            raise SchemaMigrationError(
+                f"Cannot migrate {table_name}: retained {remaining} of {grouped} publication rows"
+            )
+        db.execute(f"DROP TABLE {temp_identifier}")
+        if commit:
+            db.commit()
+    except Exception as exc:
+        db.rollback()
+        if isinstance(exc, SchemaMigrationError):
+            raise
+        raise SchemaMigrationError(f"Failed to migrate {table_name}: {exc}") from exc
+
+
+def _migrate_sokuho_capture_identity(
+    db: BaseDatabase,
+    table_name: str,
+    expected_pk: List[str],
+    *,
+    commit: bool,
+) -> None:
+    """Apply the one approved primary-key correction for Sokuho tables."""
+    if db.get_db_type() != "postgresql":
+        raise SchemaMigrationError(
+            f"Automatic SQLite migration refused for {table_name}: legacy primary key "
+            "includes CollectedAt; back up and rebuild this table with the current "
+            "schema before polling"
+        )
+    logger.warning(
+        f"Migrating {table_name} from poll identity to publication identity; "
+        "latest values and earliest real CollectedAt will be retained"
+    )
+    _postgresql_migrate_sokuho_capture_identity(
+        db,
+        table_name,
+        expected_pk,
+        commit=commit,
+    )
+
+
 def migrate_table_if_needed(
     db: BaseDatabase,
     table_name: str,
@@ -351,6 +489,18 @@ def migrate_table_if_needed(
 
     existing_pk_lower = [column.lower() for column in existing_pk]
     expected_pk_lower = [column.lower() for column in expected_pk]
+    existing_columns_lower = {column.lower() for column in existing_columns}
+    expected_columns_lower = {column.lower() for column in expected_columns}
+    if existing_columns_lower == expected_columns_lower and _is_legacy_sokuho_capture_identity(
+        table_name, existing_pk, expected_pk
+    ):
+        _migrate_sokuho_capture_identity(
+            db,
+            table_name,
+            expected_pk,
+            commit=commit,
+        )
+        return True
     if expected_pk_lower and existing_pk_lower != expected_pk_lower:
         logger.warning(
             f"Primary key mismatch for {table_name}: "
@@ -368,8 +518,8 @@ def migrate_table_if_needed(
     # Without this, every PG run sees a "mismatch" between schema.py's CamelCase
     # column names and information_schema's lowercased names, triggering a DROP+
     # recreate on every call to create_all_tables() — which silently wipes data.
-    existing_lower = {c.lower() for c in existing_columns}
-    expected_lower = {c.lower() for c in expected_columns}
+    existing_lower = existing_columns_lower
+    expected_lower = expected_columns_lower
     if existing_lower == expected_lower:
         return False
 

--- a/src/database/migration.py
+++ b/src/database/migration.py
@@ -5,17 +5,21 @@ Detects schema mismatches in existing tables and applies safe migrations.
 The production PostgreSQL database is used by near-real-time collectors, so
 ``quickstart`` must never wipe tables implicitly. Migrations are additive only:
 missing columns are added with ``ALTER TABLE`` and extra/renamed columns are
-preserved. Primary-key changes fail closed except for the exact PostgreSQL
-TS_SOKUHO capture-key correction implemented below. Legacy SQLite Sokuho keys
-are rejected without mutation and require an operator-managed rebuild.
+preserved. Primary-key changes always fail closed during ordinary startup.
+The PostgreSQL TS_SOKUHO capture-key correction is available only through the
+explicit operator command; SQLite requires an operator-managed rebuild.
 """
 
 import re
+from dataclasses import dataclass
 from typing import Dict, List, Optional, Set
 from uuid import uuid4
 
 from src.database.base import BaseDatabase
-from src.database.timeseries_capture import capture_timestamp_epoch_microseconds
+from src.database.timeseries_capture import (
+    capture_timestamp_epoch_microseconds,
+    unqualified_table_name,
+)
 from src.utils.logger import get_logger
 
 logger = get_logger(__name__)
@@ -25,12 +29,36 @@ class SchemaMigrationError(RuntimeError):
     """Raised when a table cannot satisfy its required schema safely."""
 
 
-_SOKUHO_CAPTURE_TABLES = frozenset(f"TS_SOKUHO_O{number}" for number in range(1, 7))
+SOKUHO_CAPTURE_TABLES = tuple(f"TS_SOKUHO_O{number}" for number in range(1, 7))
+_SOKUHO_CAPTURE_TABLE_SET = frozenset(SOKUHO_CAPTURE_TABLES)
+SOKUHO_CAPTURE_IDENTITY_MIGRATION_COMMAND = "jltsql db migrate-sokuho-capture-identity"
 
 
-def _migration_targets(db: BaseDatabase) -> tuple[BaseDatabase, ...]:
+@dataclass(frozen=True)
+class SokuhoCaptureIdentityMigrationReport:
+    """One table's deterministic operator migration report."""
+
+    table_name: str
+    status: str
+    primary_key: tuple[str, ...]
+    total_rows: int
+    distinct_publication_groups: int
+    rows_to_delete: int
+    collected_at_rewrite_groups: int
+    applied: bool = False
+
+
+def _migration_targets(
+    db: BaseDatabase,
+    *,
+    include_disconnected_sokuho_targets: bool = False,
+) -> tuple[BaseDatabase, ...]:
     """Return concrete databases that must be migrated independently."""
-    getter = getattr(db, "get_migration_targets", None)
+    getter = None
+    if include_disconnected_sokuho_targets:
+        getter = getattr(db, "get_sokuho_guard_targets", None)
+    if getter is None:
+        getter = getattr(db, "get_migration_targets", None)
     if getter is None:
         return (db,)
     targets = tuple(getter())
@@ -200,6 +228,27 @@ def _table_identifier(db: BaseDatabase, table_name: str) -> str:
     return f'"{table_name}"'
 
 
+def _sqlite_table_info_pragma(table_name: str) -> str:
+    """Return a quoted PRAGMA that preserves an optional SQLite schema."""
+
+    def quote(identifier: str) -> str:
+        normalized = identifier.strip('`"[]')
+        escaped = normalized.replace('"', '""')
+        return f'"{escaped}"'
+
+    if "." in table_name:
+        schema_name, unqualified_name = table_name.rsplit(".", 1)
+        return f"PRAGMA {quote(schema_name)}.table_info({quote(unqualified_name)})"
+    return f"PRAGMA table_info({quote(table_name)})"
+
+
+def _sokuho_table_exists_strict(db: BaseDatabase, table_name: str) -> bool:
+    """Check a Sokuho table without losing an SQLite schema qualifier."""
+    if db.get_db_type() == "sqlite":
+        return bool(db.fetch_all(_sqlite_table_info_pragma(table_name)))
+    return db.table_exists_strict(table_name)
+
+
 def _get_existing_columns(db: BaseDatabase, table_name: str) -> Set[str]:
     """Get existing column names for a table."""
     if db.get_db_type() == "postgresql":
@@ -209,7 +258,7 @@ def _get_existing_columns(db: BaseDatabase, table_name: str) -> Set[str]:
             (table_name.lower(),),
         )
     else:
-        existing_info = db.fetch_all(f'PRAGMA table_info("{table_name}")')
+        existing_info = db.fetch_all(_sqlite_table_info_pragma(table_name))
     return {row["name"] for row in existing_info}
 
 
@@ -249,7 +298,7 @@ def _get_existing_column_types(db: BaseDatabase, table_name: str) -> Dict[str, s
             (table_name.lower(),),
         )
     else:
-        rows = db.fetch_all(f'PRAGMA table_info("{table_name}")')
+        rows = db.fetch_all(_sqlite_table_info_pragma(table_name))
     return {str(row["name"]).lower(): str(row.get("type") or "") for row in rows}
 
 
@@ -269,7 +318,7 @@ def _get_existing_primary_key_columns(db: BaseDatabase, table_name: str) -> List
         )
         return [row["name"] for row in rows]
 
-    rows = db.fetch_all(f'PRAGMA table_info("{table_name}")')
+    rows = db.fetch_all(_sqlite_table_info_pragma(table_name))
 
     def pk_position(row) -> int:
         try:
@@ -342,107 +391,418 @@ def _is_legacy_sokuho_capture_identity(
     expected_pk: List[str],
 ) -> bool:
     """Recognize only the shipped Sokuho key that ended in CollectedAt."""
-    if table_name.upper() not in _SOKUHO_CAPTURE_TABLES:
+    if unqualified_table_name(table_name).upper() not in _SOKUHO_CAPTURE_TABLE_SET:
         return False
     existing = [column.lower() for column in existing_pk]
     expected = [column.lower() for column in expected_pk]
     return existing == [*expected, "collectedat"]
 
 
-def _postgresql_migrate_sokuho_capture_identity(
+def sokuho_capture_identity_operator_command(
+    table_name: str,
+    database_type: str = "postgresql",
+) -> str:
+    """Return the exact explicit command named by startup and write guards."""
+    normalized = _normalize_sokuho_table_reference(table_name)
+    schema_option = ""
+    if "." in normalized:
+        schema_name, normalized = normalized.rsplit(".", 1)
+        schema_option = f"--schema {schema_name} "
+    return (
+        f"{SOKUHO_CAPTURE_IDENTITY_MIGRATION_COMMAND} --db {database_type} "
+        f"{schema_option}--table {normalized} --apply"
+    )
+
+
+def legacy_sokuho_capture_identity_message(db: BaseDatabase, table_name: str) -> str:
+    """Build the shared actionable refusal for startup and write paths."""
+    normalized = _normalize_sokuho_table_reference(table_name)
+    message = (
+        f"{normalized} uses the legacy primary key ending in CollectedAt; "
+        "startup and time-series odds writes are blocked. Stop all collectors, "
+        "then run exactly: "
+        f"{sokuho_capture_identity_operator_command(normalized, db.get_db_type())}"
+    )
+    if db.get_db_type() == "sqlite":
+        message += (
+            ". SQLite cannot migrate this key in place; the command will refuse "
+            "and require a backup and rebuild with the current schema"
+        )
+    return message
+
+
+def _expected_sokuho_primary_key(table_name: str) -> List[str]:
+    from src.database.schema import SCHEMAS
+
+    normalized = unqualified_table_name(table_name).upper()
+    if normalized not in _SOKUHO_CAPTURE_TABLE_SET:
+        raise SchemaMigrationError(f"Unsupported Sokuho migration table: {table_name}")
+    expected_pk = _extract_primary_key_columns(SCHEMAS[normalized])
+    if not expected_pk:
+        raise SchemaMigrationError(f"Expected primary key is unavailable for {normalized}")
+    return expected_pk
+
+
+def _unavailable_sokuho_target_message(db: BaseDatabase, table_name: str) -> str:
+    normalized = _normalize_sokuho_table_reference(table_name)
+    return (
+        f"Cannot verify {normalized} capture identity on the configured "
+        f"{db.get_db_type()} database because it is not connected; reconnect "
+        "it and rerun startup before collecting"
+    )
+
+
+def ensure_sokuho_capture_identity_for_write(
+    db: BaseDatabase,
+    table_name: str,
+    existing_pk: Optional[List[str]] = None,
+) -> None:
+    """Fail before a Sokuho write can preserve legacy poll identity."""
+    normalized = unqualified_table_name(table_name).upper()
+    if normalized not in _SOKUHO_CAPTURE_TABLE_SET:
+        return
+    if existing_pk is None and not db.is_connected():
+        raise SchemaMigrationError(_unavailable_sokuho_target_message(db, table_name))
+    expected_pk = _expected_sokuho_primary_key(normalized)
+    primary_key = (
+        existing_pk
+        if existing_pk is not None
+        else _get_existing_primary_key_columns(db, table_name)
+    )
+    if _is_legacy_sokuho_capture_identity(normalized, primary_key, expected_pk):
+        raise SchemaMigrationError(legacy_sokuho_capture_identity_message(db, table_name))
+
+
+def _normalize_sokuho_table_reference(table_name: str) -> str:
+    """Validate and canonicalize an optional unquoted schema plus Sokuho table."""
+    raw_name = str(table_name).strip()
+    if raw_name.count(".") > 1:
+        raise SchemaMigrationError(f"Unsupported Sokuho migration table: {table_name}")
+    schema_name = ""
+    if "." in raw_name:
+        schema_name, raw_name = raw_name.rsplit(".", 1)
+        schema_name = schema_name.strip('`"[]').lower()
+        if not re.fullmatch(r"[a-z_][a-z0-9_]*", schema_name):
+            raise SchemaMigrationError(
+                f"Unsupported PostgreSQL schema for Sokuho migration: {schema_name!r}"
+            )
+    normalized = raw_name.strip('`"[]').upper()
+    if normalized not in _SOKUHO_CAPTURE_TABLE_SET:
+        raise SchemaMigrationError(f"Unsupported Sokuho migration table: {table_name}")
+    return f"{schema_name}.{normalized}" if schema_name else normalized
+
+
+def normalize_sokuho_capture_identity_tables(
+    table_names: Optional[List[str] | tuple[str, ...]],
+) -> tuple[str, ...]:
+    """Return validated, deterministic operator table references."""
+    if not table_names:
+        return SOKUHO_CAPTURE_TABLES
+    requested = {_normalize_sokuho_table_reference(name) for name in table_names}
+    order = {name: index for index, name in enumerate(SOKUHO_CAPTURE_TABLES)}
+    return tuple(
+        sorted(
+            requested,
+            key=lambda name: (order[unqualified_table_name(name).upper()], name.lower()),
+        )
+    )
+
+
+def validate_sokuho_capture_identity_operator_backend(
+    database_type: str,
+    table_names: tuple[str, ...],
+) -> None:
+    """Refuse unsupported backends before a maintenance connection is opened."""
+    normalized_type = str(database_type).lower()
+    if normalized_type == "postgresql":
+        return
+    names = ", ".join(table_names)
+    if normalized_type == "sqlite":
+        raise SchemaMigrationError(
+            f"SQLite migration refused for {names}: legacy primary keys cannot be "
+            "changed safely in place; back up the database and rebuild each table "
+            "with the current schema before polling"
+        )
+    raise SchemaMigrationError(
+        f"Sokuho capture-identity migration requires PostgreSQL, got {database_type}"
+    )
+
+
+def _require_postgresql_operator_migration(
+    db: BaseDatabase,
+    table_names: tuple[str, ...],
+) -> None:
+    validate_sokuho_capture_identity_operator_backend(db.get_db_type(), table_names)
+
+
+def _classify_sokuho_table(
+    db: BaseDatabase,
+    table_name: str,
+) -> tuple[str, List[str], List[str]]:
+    expected_pk = _expected_sokuho_primary_key(table_name)
+    if not db.table_exists_strict(table_name):
+        return "missing", [], expected_pk
+    existing_pk = _get_existing_primary_key_columns(db, table_name)
+    if [column.lower() for column in existing_pk] == [column.lower() for column in expected_pk]:
+        return "current", existing_pk, expected_pk
+    if _is_legacy_sokuho_capture_identity(table_name, existing_pk, expected_pk):
+        return "legacy", existing_pk, expected_pk
+    raise SchemaMigrationError(
+        f"Cannot migrate {table_name}: unsupported primary key "
+        f"existing={existing_pk}, expected={expected_pk}"
+    )
+
+
+def _current_or_missing_sokuho_report(
+    db: BaseDatabase,
+    table_name: str,
+    status: str,
+    existing_pk: List[str],
+) -> SokuhoCaptureIdentityMigrationReport:
+    total_rows = 0
+    if status == "current":
+        row = db.fetch_one(
+            f"SELECT COUNT(*) AS total_rows FROM {_table_identifier(db, table_name)}"
+        )
+        total_rows = int((row or {}).get("total_rows") or 0)
+    return SokuhoCaptureIdentityMigrationReport(
+        table_name=table_name,
+        status=status,
+        primary_key=tuple(existing_pk),
+        total_rows=total_rows,
+        distinct_publication_groups=total_rows,
+        rows_to_delete=0,
+        collected_at_rewrite_groups=0,
+    )
+
+
+def _legacy_sokuho_stats(
     db: BaseDatabase,
     table_name: str,
     expected_pk: List[str],
-    *,
-    commit: bool,
-) -> None:
-    """Collapse legacy PostgreSQL polls and replace the primary key atomically."""
+) -> tuple[int, int, int, int]:
     table_identifier = _table_identifier(db, table_name)
-    temp_name = f"__jltsql_{table_name.lower()}_capture_pk_{uuid4().hex}"
-    temp_create_identifier = f'"{temp_name}"'
-    temp_identifier = f'pg_temp."{temp_name}"'
-    key_columns = [column.lower() for column in expected_pk]
-    partition = ", ".join(key_columns)
-    grouped_keys = " AND ".join(f"existing.{column} = grouped.{column}" for column in key_columns)
-
-    db.begin_transaction()
-    try:
-        # The DELETE must operate on the same population as the grouping
-        # snapshot. Lock first so a concurrent collector cannot insert a
-        # correction that the migration would then delete unseen.
-        db.execute(f"LOCK TABLE {table_identifier} IN ACCESS EXCLUSIVE MODE")
-        _validate_existing_capture_stamps(db, table_name)
-        constraint = db.fetch_one(
-            "SELECT conname FROM pg_constraint "
-            "WHERE conrelid = to_regclass(?) AND contype = 'p'",
-            (table_name.lower(),),
-        )
-        if not constraint or not constraint.get("conname"):
-            raise SchemaMigrationError(
-                f"Cannot migrate {table_name}: primary key constraint not found"
-            )
-        constraint_identifier = '"' + str(constraint["conname"]).replace('"', '""') + '"'
-        db.execute(
-            f"CREATE TEMP TABLE {temp_create_identifier} ON COMMIT DROP AS "
-            f"SELECT {partition}, "
-            "(ARRAY_AGG(ctid ORDER BY (collectedat IS NULL), "
-            "collectedat::timestamptz DESC, ctid DESC))[1] AS keep_tid, "
+    partition = ", ".join(column.lower() for column in expected_pk)
+    row = (
+        db.fetch_one(
+            "WITH publication_groups AS ("
+            "SELECT COUNT(*) AS group_size, "
+            "(ARRAY_AGG(collectedat ORDER BY (collectedat IS NULL), "
+            "collectedat::timestamptz DESC, ctid DESC))[1] AS latest_collectedat, "
             "(ARRAY_AGG(collectedat ORDER BY (collectedat IS NULL), "
             "collectedat::timestamptz ASC, ctid ASC))[1] AS earliest_collectedat "
             f"FROM {table_identifier} GROUP BY {partition}"
+            ") SELECT COALESCE(SUM(group_size), 0) AS total_rows, "
+            "COUNT(*) AS publication_groups, "
+            "COALESCE(SUM(group_size - 1), 0) AS rows_to_delete, "
+            "COUNT(*) FILTER (WHERE latest_collectedat IS DISTINCT FROM "
+            "earliest_collectedat) AS rewrite_groups FROM publication_groups"
         )
-        db.execute(
-            f"DELETE FROM {table_identifier} AS existing USING {temp_identifier} AS grouped "
-            f"WHERE {grouped_keys} AND existing.ctid <> grouped.keep_tid"
+        or {}
+    )
+    return (
+        int(row.get("total_rows") or 0),
+        int(row.get("publication_groups") or 0),
+        int(row.get("rows_to_delete") or 0),
+        int(row.get("rewrite_groups") or 0),
+    )
+
+
+def _legacy_sokuho_report(
+    db: BaseDatabase,
+    table_name: str,
+    existing_pk: List[str],
+    expected_pk: List[str],
+) -> SokuhoCaptureIdentityMigrationReport:
+    _validate_existing_capture_stamps(db, table_name)
+    total_rows, publication_groups, rows_to_delete, rewrite_groups = _legacy_sokuho_stats(
+        db, table_name, expected_pk
+    )
+    return SokuhoCaptureIdentityMigrationReport(
+        table_name=table_name,
+        status="legacy",
+        primary_key=tuple(existing_pk),
+        total_rows=total_rows,
+        distinct_publication_groups=publication_groups,
+        rows_to_delete=rows_to_delete,
+        collected_at_rewrite_groups=rewrite_groups,
+    )
+
+
+def preview_sokuho_capture_identity_migration(
+    db: BaseDatabase,
+    table_names: Optional[List[str] | tuple[str, ...]] = None,
+) -> List[SokuhoCaptureIdentityMigrationReport]:
+    """Report the migration under one read-only snapshot without table locks."""
+    selected = normalize_sokuho_capture_identity_tables(table_names)
+    _require_postgresql_operator_migration(db, selected)
+    if db.has_pending_transaction():
+        raise SchemaMigrationError(
+            "Sokuho migration preview requires a fresh connection without a pending transaction"
         )
-        db.execute(
-            f"UPDATE {table_identifier} AS existing "
-            f"SET collectedat = grouped.earliest_collectedat "
-            f"FROM {temp_identifier} AS grouped WHERE existing.ctid = grouped.keep_tid"
-        )
-        db.execute(f"ALTER TABLE {table_identifier} DROP CONSTRAINT {constraint_identifier}")
-        db.execute(f"ALTER TABLE {table_identifier} ALTER COLUMN collectedat DROP NOT NULL")
-        db.execute(f"ALTER TABLE {table_identifier} ADD PRIMARY KEY ({', '.join(key_columns)})")
-        remaining = db.fetch_one(f"SELECT COUNT(*) AS count FROM {table_identifier}")["count"]
-        grouped = db.fetch_one(f"SELECT COUNT(*) AS count FROM {temp_identifier}")["count"]
-        if remaining != grouped:
-            raise SchemaMigrationError(
-                f"Cannot migrate {table_name}: retained {remaining} of {grouped} publication rows"
-            )
-        db.execute(f"DROP TABLE {temp_identifier}")
-        if commit:
-            db.commit()
+
+    db.begin_transaction()
+    try:
+        db.execute("SET TRANSACTION ISOLATION LEVEL REPEATABLE READ READ ONLY")
+        reports = []
+        for table_name in selected:
+            status, existing_pk, expected_pk = _classify_sokuho_table(db, table_name)
+            if status == "legacy":
+                reports.append(_legacy_sokuho_report(db, table_name, existing_pk, expected_pk))
+            else:
+                reports.append(
+                    _current_or_missing_sokuho_report(db, table_name, status, existing_pk)
+                )
+        db.rollback()
+        return reports
     except Exception as exc:
         db.rollback()
         if isinstance(exc, SchemaMigrationError):
             raise
-        raise SchemaMigrationError(f"Failed to migrate {table_name}: {exc}") from exc
+        raise SchemaMigrationError(f"Failed to preview Sokuho migration: {exc}") from exc
 
 
-def _migrate_sokuho_capture_identity(
+def _create_locked_sokuho_snapshot(
     db: BaseDatabase,
     table_name: str,
     expected_pk: List[str],
-    *,
-    commit: bool,
-) -> None:
-    """Apply the one approved primary-key correction for Sokuho tables."""
-    if db.get_db_type() != "postgresql":
-        raise SchemaMigrationError(
-            f"Automatic SQLite migration refused for {table_name}: legacy primary key "
-            "includes CollectedAt; back up and rebuild this table with the current "
-            "schema before polling"
+) -> tuple[str, str, SokuhoCaptureIdentityMigrationReport]:
+    """Create one grouping snapshot after the caller holds ACCESS EXCLUSIVE."""
+    table_identifier = _table_identifier(db, table_name)
+    temp_name = f"__jltsql_{table_name.lower()}_capture_pk_{uuid4().hex}"
+    temp_identifier = f'pg_temp."{temp_name}"'
+    key_columns = [column.lower() for column in expected_pk]
+    partition = ", ".join(key_columns)
+
+    _validate_existing_capture_stamps(db, table_name)
+    constraint = db.fetch_one(
+        "SELECT conname FROM pg_constraint " "WHERE conrelid = to_regclass(?) AND contype = 'p'",
+        (table_name.lower(),),
+    )
+    if not constraint or not constraint.get("conname"):
+        raise SchemaMigrationError(f"Cannot migrate {table_name}: primary key constraint not found")
+    constraint_identifier = '"' + str(constraint["conname"]).replace('"', '""') + '"'
+    db.execute(
+        f'CREATE TEMP TABLE "{temp_name}" ON COMMIT DROP AS '
+        f"SELECT {partition}, COUNT(*) AS group_size, "
+        "(ARRAY_AGG(ctid ORDER BY (collectedat IS NULL), "
+        "collectedat::timestamptz DESC, ctid DESC))[1] AS keep_tid, "
+        "(ARRAY_AGG(collectedat ORDER BY (collectedat IS NULL), "
+        "collectedat::timestamptz DESC, ctid DESC))[1] AS latest_collectedat, "
+        "(ARRAY_AGG(collectedat ORDER BY (collectedat IS NULL), "
+        "collectedat::timestamptz ASC, ctid ASC))[1] AS earliest_collectedat "
+        f"FROM {table_identifier} GROUP BY {partition}"
+    )
+    row = (
+        db.fetch_one(
+            f"SELECT COALESCE(SUM(group_size), 0) AS total_rows, "
+            f"COUNT(*) AS publication_groups, "
+            f"COALESCE(SUM(group_size - 1), 0) AS rows_to_delete, "
+            f"COUNT(*) FILTER (WHERE latest_collectedat IS DISTINCT FROM "
+            f"earliest_collectedat) AS rewrite_groups FROM {temp_identifier}"
         )
-    logger.warning(
-        f"Migrating {table_name} from poll identity to publication identity; "
-        "latest values and earliest real CollectedAt will be retained"
+        or {}
     )
-    _postgresql_migrate_sokuho_capture_identity(
-        db,
-        table_name,
-        expected_pk,
-        commit=commit,
+    existing_pk = _get_existing_primary_key_columns(db, table_name)
+    report = SokuhoCaptureIdentityMigrationReport(
+        table_name=table_name,
+        status="migrated",
+        primary_key=tuple(existing_pk),
+        total_rows=int(row.get("total_rows") or 0),
+        distinct_publication_groups=int(row.get("publication_groups") or 0),
+        rows_to_delete=int(row.get("rows_to_delete") or 0),
+        collected_at_rewrite_groups=int(row.get("rewrite_groups") or 0),
+        applied=True,
     )
+    return temp_identifier, constraint_identifier, report
+
+
+def _apply_locked_sokuho_table_migration(
+    db: BaseDatabase,
+    table_name: str,
+    expected_pk: List[str],
+) -> SokuhoCaptureIdentityMigrationReport:
+    table_identifier = _table_identifier(db, table_name)
+    key_columns = [column.lower() for column in expected_pk]
+    grouped_keys = " AND ".join(f"existing.{column} = grouped.{column}" for column in key_columns)
+    temp_identifier, constraint_identifier, report = _create_locked_sokuho_snapshot(
+        db, table_name, expected_pk
+    )
+    db.execute(
+        f"DELETE FROM {table_identifier} AS existing USING {temp_identifier} AS grouped "
+        f"WHERE {grouped_keys} AND existing.ctid <> grouped.keep_tid"
+    )
+    db.execute(
+        f"UPDATE {table_identifier} AS existing "
+        f"SET collectedat = grouped.earliest_collectedat "
+        f"FROM {temp_identifier} AS grouped WHERE existing.ctid = grouped.keep_tid"
+    )
+    db.execute(f"ALTER TABLE {table_identifier} DROP CONSTRAINT {constraint_identifier}")
+    db.execute(f"ALTER TABLE {table_identifier} ALTER COLUMN collectedat DROP NOT NULL")
+    db.execute(f"ALTER TABLE {table_identifier} ADD PRIMARY KEY ({', '.join(key_columns)})")
+    remaining_row = db.fetch_one(f"SELECT COUNT(*) AS count FROM {table_identifier}") or {}
+    remaining = int(remaining_row.get("count") or 0)
+    if remaining != report.distinct_publication_groups:
+        raise SchemaMigrationError(
+            f"Cannot migrate {table_name}: retained {remaining} of "
+            f"{report.distinct_publication_groups} publication rows"
+        )
+    db.execute(f"DROP TABLE {temp_identifier}")
+    return report
+
+
+def apply_sokuho_capture_identity_migration(
+    db: BaseDatabase,
+    table_names: Optional[List[str] | tuple[str, ...]] = None,
+) -> List[SokuhoCaptureIdentityMigrationReport]:
+    """Explicitly migrate selected PostgreSQL Sokuho tables in one transaction."""
+    selected = normalize_sokuho_capture_identity_tables(table_names)
+    _require_postgresql_operator_migration(db, selected)
+    if db.has_pending_transaction():
+        raise SchemaMigrationError(
+            "Sokuho migration apply requires a fresh connection without a pending transaction"
+        )
+
+    db.begin_transaction()
+    try:
+        initial = {table_name: _classify_sokuho_table(db, table_name) for table_name in selected}
+        legacy_tables = [
+            table_name for table_name in selected if initial[table_name][0] == "legacy"
+        ]
+        if legacy_tables:
+            lock_targets = ", ".join(
+                _table_identifier(db, table_name) for table_name in legacy_tables
+            )
+            # All target locks precede every grouping snapshot. The canonical
+            # table order also prevents two operator commands taking locks in
+            # opposite orders.
+            db.execute(f"LOCK TABLE {lock_targets} IN ACCESS EXCLUSIVE MODE")
+
+        reports = []
+        for table_name in selected:
+            status, existing_pk, expected_pk = _classify_sokuho_table(db, table_name)
+            if status == "legacy":
+                if table_name not in legacy_tables:
+                    raise SchemaMigrationError(
+                        f"Cannot migrate {table_name}: it changed to a legacy primary key "
+                        "before an ACCESS EXCLUSIVE lock was acquired; retry the command"
+                    )
+                logger.warning(
+                    f"Explicitly migrating {table_name} from poll identity to "
+                    "publication identity"
+                )
+                reports.append(_apply_locked_sokuho_table_migration(db, table_name, expected_pk))
+            else:
+                reports.append(
+                    _current_or_missing_sokuho_report(db, table_name, status, existing_pk)
+                )
+        db.commit()
+        return reports
+    except Exception as exc:
+        db.rollback()
+        if isinstance(exc, SchemaMigrationError):
+            raise
+        raise SchemaMigrationError(f"Failed to apply Sokuho migration: {exc}") from exc
 
 
 def migrate_table_if_needed(
@@ -465,8 +825,18 @@ def migrate_table_if_needed(
     Returns:
         True if a schema change was applied, False otherwise
     """
-    targets = _migration_targets(db)
+    is_sokuho_table = unqualified_table_name(table_name).upper() in _SOKUHO_CAPTURE_TABLE_SET
+    targets = _migration_targets(
+        db,
+        include_disconnected_sokuho_targets=is_sokuho_table,
+    )
     if targets != (db,):
+        if is_sokuho_table:
+            for target in targets:
+                if not target.is_connected():
+                    raise SchemaMigrationError(
+                        _unavailable_sokuho_target_message(target, table_name)
+                    )
         migrated = False
         for target in targets:
             migrated = (
@@ -474,7 +844,12 @@ def migrate_table_if_needed(
             )
         return migrated
 
-    if not db.table_exists(table_name):
+    table_exists = (
+        _sokuho_table_exists_strict(db, table_name)
+        if is_sokuho_table
+        else db.table_exists(table_name)
+    )
+    if not table_exists:
         return False
 
     expected_definitions = _extract_column_definitions(schema_sql)
@@ -491,16 +866,8 @@ def migrate_table_if_needed(
     expected_pk_lower = [column.lower() for column in expected_pk]
     existing_columns_lower = {column.lower() for column in existing_columns}
     expected_columns_lower = {column.lower() for column in expected_columns}
-    if existing_columns_lower == expected_columns_lower and _is_legacy_sokuho_capture_identity(
-        table_name, existing_pk, expected_pk
-    ):
-        _migrate_sokuho_capture_identity(
-            db,
-            table_name,
-            expected_pk,
-            commit=commit,
-        )
-        return True
+    if _is_legacy_sokuho_capture_identity(table_name, existing_pk, expected_pk):
+        raise SchemaMigrationError(legacy_sokuho_capture_identity_message(db, table_name))
     if expected_pk_lower and existing_pk_lower != expected_pk_lower:
         logger.warning(
             f"Primary key mismatch for {table_name}: "
@@ -588,8 +955,18 @@ def verify_table_schema(
     refuse to alter a mismatched key and whose dedicated writer verifies the
     complete schema before storing a matching record.
     """
-    targets = _migration_targets(db)
+    is_sokuho_table = unqualified_table_name(table_name).upper() in _SOKUHO_CAPTURE_TABLE_SET
+    targets = _migration_targets(
+        db,
+        include_disconnected_sokuho_targets=is_sokuho_table,
+    )
     if targets != (db,):
+        if is_sokuho_table:
+            for target in targets:
+                if not target.is_connected():
+                    raise SchemaMigrationError(
+                        _unavailable_sokuho_target_message(target, table_name)
+                    )
         for target in targets:
             verify_table_schema(
                 target,
@@ -600,7 +977,12 @@ def verify_table_schema(
             )
         return
 
-    if not db.table_exists_strict(table_name):
+    table_exists = (
+        _sokuho_table_exists_strict(db, table_name)
+        if is_sokuho_table
+        else db.table_exists_strict(table_name)
+    )
+    if not table_exists:
         raise SchemaMigrationError(f"Required table does not exist: {table_name}")
 
     expected_definitions = _extract_column_definitions(schema_sql)
@@ -617,6 +999,9 @@ def verify_table_schema(
     existing_pk = _get_existing_primary_key_columns(db, table_name)
     existing_pk_lower = [column.lower() for column in existing_pk]
     expected_pk_lower = [column.lower() for column in expected_pk]
+
+    if _is_legacy_sokuho_capture_identity(table_name, existing_pk, expected_pk):
+        raise SchemaMigrationError(legacy_sokuho_capture_identity_message(db, table_name))
 
     expected_text_types = {
         column.lower(): _definition_type(definition)

--- a/src/database/postgresql_handler.py
+++ b/src/database/postgresql_handler.py
@@ -8,10 +8,12 @@ from typing import Any, Dict, List, Optional
 try:
     import psycopg
     from psycopg.rows import dict_row
+
     DRIVER = "psycopg"
 except ImportError:
     try:
         import pg8000.native
+
         DRIVER = "pg8000"
     except ImportError:
         raise ImportError(
@@ -22,6 +24,11 @@ except ImportError:
 
 from src.database.base import BaseDatabase, DatabaseError
 from src.database.schema_types import get_table_column_types
+from src.database.timeseries_capture import (
+    earliest_capture_value,
+    is_time_series_odds_capture_table,
+    unqualified_table_name,
+)
 from src.utils.logger import get_logger
 
 logger = get_logger(__name__)
@@ -89,14 +96,9 @@ class PostgreSQLDatabase(BaseDatabase):
             # issued BEGIN, which is represented by _transaction_active.
             return False
         try:
-            return (
-                self._connection.info.transaction_status
-                != psycopg.pq.TransactionStatus.IDLE
-            )
+            return self._connection.info.transaction_status != psycopg.pq.TransactionStatus.IDLE
         except Exception as exc:
-            raise DatabaseError(
-                f"Failed to inspect PostgreSQL transaction state: {exc}"
-            ) from exc
+            raise DatabaseError(f"Failed to inspect PostgreSQL transaction state: {exc}") from exc
 
     def _quote_identifier(self, identifier: str) -> str:
         """Convert identifier to PostgreSQL-compatible form (lowercase, unquoted).
@@ -138,10 +140,10 @@ class PostgreSQLDatabase(BaseDatabase):
             result = []
             for row in rows:
                 if isinstance(row, dict):
-                    result.append(row.get('attname', '').lower())
+                    result.append(row.get("attname", "").lower())
                 elif isinstance(row, (list, tuple)):
                     # pg8000.native returns list of lists
-                    result.append(str(row[0]).lower() if row else '')
+                    result.append(str(row[0]).lower() if row else "")
                 else:
                     result.append(str(row).lower())
             return result
@@ -224,7 +226,7 @@ class PostgreSQLDatabase(BaseDatabase):
 
             logger.info(
                 f"Connected to PostgreSQL database: {self.host}:{self.port}/{self.database}",
-                driver=DRIVER
+                driver=DRIVER,
             )
             self._transaction_active = False
 
@@ -284,7 +286,11 @@ class PostgreSQLDatabase(BaseDatabase):
 
             if DRIVER == "pg8000":
                 # pg8000.native uses connection.run() for execution with dict params
-                self._connection.run(sql, **params) if isinstance(params, dict) else self._connection.run(sql)
+                (
+                    self._connection.run(sql, **params)
+                    if isinstance(params, dict)
+                    else self._connection.run(sql)
+                )
                 return self._connection.row_count
             else:  # psycopg
                 if params:
@@ -321,7 +327,9 @@ class PostgreSQLDatabase(BaseDatabase):
                 total_rows = 0
                 for params in parameters_list:
                     # Convert SQL and parameters for each execution
-                    converted_sql, converted_params = self._convert_placeholders_and_params(sql, params)
+                    converted_sql, converted_params = self._convert_placeholders_and_params(
+                        sql, params
+                    )
                     if isinstance(converted_params, dict):
                         self._connection.run(converted_sql, **converted_params)
                     else:
@@ -369,7 +377,11 @@ class PostgreSQLDatabase(BaseDatabase):
                 if not rows:
                     return None
                 # Get column names from connection.columns
-                columns = [col['name'] for col in self._connection.columns] if self._connection.columns else []
+                columns = (
+                    [col["name"] for col in self._connection.columns]
+                    if self._connection.columns
+                    else []
+                )
                 if columns and rows:
                     return dict(zip(columns, rows[0]))
                 return rows[0] if rows else None
@@ -416,7 +428,11 @@ class PostgreSQLDatabase(BaseDatabase):
                 if not rows:
                     return []
                 # Get column names from connection.columns
-                columns = [col['name'] for col in self._connection.columns] if self._connection.columns else []
+                columns = (
+                    [col["name"] for col in self._connection.columns]
+                    if self._connection.columns
+                    else []
+                )
                 if columns:
                     return [dict(zip(columns, row)) for row in rows]
                 return rows  # Return as-is if no column info
@@ -613,9 +629,7 @@ class PostgreSQLDatabase(BaseDatabase):
                     self._transaction_active = False
                     logger.debug("pg8000 ROLLBACK sent")
                 except Exception as e:
-                    logger.warning(
-                        f"pg8000 ROLLBACK failed ({e}); reconnecting"
-                    )
+                    logger.warning(f"pg8000 ROLLBACK failed ({e}); reconnecting")
                     self._reconnect()
                     self._transaction_active = False
             else:  # psycopg
@@ -695,6 +709,8 @@ class PostgreSQLDatabase(BaseDatabase):
     def _dedupe_rows_by_primary_key(
         rows: List[Dict[str, Any]],
         pk_columns: List[str],
+        *,
+        preserve_earliest_collected_at: bool = False,
     ) -> List[Dict[str, Any]]:
         """Deduplicate one VALUES batch by primary key before PostgreSQL upsert.
 
@@ -705,23 +721,62 @@ class PostgreSQLDatabase(BaseDatabase):
         if not rows or not pk_columns:
             return rows
 
-        column_by_lower = {
-            column.lower(): column
-            for row in rows
-            for column in row.keys()
-        }
+        column_by_lower = {column.lower(): column for row in rows for column in row.keys()}
         resolved_pk_columns = [column_by_lower.get(column.lower()) for column in pk_columns]
         if any(column is None for column in resolved_pk_columns):
             return rows
 
+        capture_column = column_by_lower.get("collectedat")
         deduped: Dict[tuple, Dict[str, Any]] = {}
         order: List[tuple] = []
         for row in rows:
             key = tuple(row.get(column) for column in resolved_pk_columns)
             if key not in deduped:
                 order.append(key)
-            deduped[key] = row
+                deduped[key] = row
+                continue
+            if preserve_earliest_collected_at and capture_column is not None:
+                previous_capture = deduped[key].get(capture_column)
+                merged = row.copy()
+                merged[capture_column] = earliest_capture_value(
+                    previous_capture,
+                    row.get(capture_column),
+                )
+                deduped[key] = merged
+            else:
+                deduped[key] = row
         return [deduped[key] for key in order]
+
+    @staticmethod
+    def _conflict_update_set(
+        table_name: str,
+        quoted_columns: List[str],
+        pk_columns: List[str],
+    ) -> str:
+        """Build conflict assignments without changing unrelated-table SQL."""
+        update_columns = [col for col in quoted_columns if col.lower() not in pk_columns]
+        preserve_capture = is_time_series_odds_capture_table(table_name) and "collectedat" in {
+            column.lower() for column in quoted_columns
+        }
+        assignments = []
+        qualified_table = unqualified_table_name(table_name).lower()
+        for column in update_columns:
+            if not preserve_capture or column.lower() != "collectedat":
+                assignments.append(f"{column} = EXCLUDED.{column}")
+                continue
+
+            stored = f"{qualified_table}.{column}"
+            incoming = f"excluded.{column}"
+            # CollectedAt is TEXT in production. Cast both ISO-8601 values to
+            # timestamptz so different explicit offsets compare as instants.
+            assignments.append(
+                f"{column} = CASE "
+                f"WHEN {incoming} IS NULL THEN {stored} "
+                f"WHEN {stored} IS NULL THEN {incoming} "
+                f"WHEN {incoming}::timestamptz < {stored}::timestamptz "
+                f"THEN {incoming} ELSE {stored} END"
+            )
+        return ", ".join(assignments)
 
     def insert(self, table_name: str, data: Dict[str, Any], use_replace: bool = True) -> int:
         """Insert single row into table.
@@ -756,9 +811,8 @@ class PostgreSQLDatabase(BaseDatabase):
             if pk_columns:
                 # Build ON CONFLICT DO UPDATE clause
                 # UPDATE all columns except primary key columns
-                update_columns = [col for col in quoted_columns if col.lower() not in pk_columns]
-                if update_columns:
-                    update_set = ", ".join([f"{col} = EXCLUDED.{col}" for col in update_columns])
+                update_set = self._conflict_update_set(table_name, quoted_columns, pk_columns)
+                if update_set:
                     pk_list = ", ".join(pk_columns)
                     sql = f"INSERT INTO {table_name} ({', '.join(quoted_columns)}) VALUES ({placeholders}) ON CONFLICT ({pk_list}) DO UPDATE SET {update_set}"
                 else:
@@ -774,7 +828,9 @@ class PostgreSQLDatabase(BaseDatabase):
 
         return self.execute(sql, tuple(values))
 
-    def insert_many(self, table_name: str, data_list: List[Dict[str, Any]], use_replace: bool = True) -> int:
+    def insert_many(
+        self, table_name: str, data_list: List[Dict[str, Any]], use_replace: bool = True
+    ) -> int:
         """Insert multiple rows into table.
 
         PostgreSQL uses INSERT ... ON CONFLICT ... DO UPDATE instead of INSERT OR REPLACE.
@@ -812,14 +868,17 @@ class PostgreSQLDatabase(BaseDatabase):
         if use_replace:
             # Get primary key columns for this table
             pk_columns = self._get_primary_key_columns(table_name)
-            data_list = self._dedupe_rows_by_primary_key(data_list, pk_columns)
+            data_list = self._dedupe_rows_by_primary_key(
+                data_list,
+                pk_columns,
+                preserve_earliest_collected_at=is_time_series_odds_capture_table(table_name),
+            )
 
             if pk_columns:
                 # Build ON CONFLICT DO UPDATE clause
                 # UPDATE all columns except primary key columns
-                update_columns = [col for col in quoted_columns if col.lower() not in pk_columns]
-                if update_columns:
-                    update_set = ", ".join([f"{col} = EXCLUDED.{col}" for col in update_columns])
+                update_set = self._conflict_update_set(table_name, quoted_columns, pk_columns)
+                if update_set:
                     pk_list = ", ".join(pk_columns)
                     conflict_sql = f" ON CONFLICT ({pk_list}) DO UPDATE SET {update_set}"
                 else:
@@ -837,7 +896,7 @@ class PostgreSQLDatabase(BaseDatabase):
         max_params = 30000
         chunk_size = max(1, max_params // max(1, len(columns)))
         for start in range(0, len(data_list), chunk_size):
-            chunk = data_list[start:start + chunk_size]
+            chunk = data_list[start : start + chunk_size]
             values_sql = ", ".join([row_placeholders] * len(chunk))
             sql = (
                 f"INSERT INTO {table_name} ({', '.join(quoted_columns)}) "

--- a/src/database/postgresql_handler.py
+++ b/src/database/postgresql_handler.py
@@ -26,6 +26,7 @@ from src.database.base import BaseDatabase, DatabaseError
 from src.database.schema_types import get_table_column_types
 from src.database.timeseries_capture import (
     earliest_capture_value,
+    is_sokuho_time_series_odds_capture_table,
     is_time_series_odds_capture_table,
     unqualified_table_name,
 )
@@ -148,7 +149,7 @@ class PostgreSQLDatabase(BaseDatabase):
                     result.append(str(row).lower())
             return result
         except Exception as e:
-            if self._transaction_active:
+            if self._transaction_active or is_sokuho_time_series_odds_capture_table(table_name):
                 raise
             logger.warning(f"Could not get primary key for {table_name}: {e}")
             return []
@@ -797,6 +798,13 @@ class PostgreSQLDatabase(BaseDatabase):
         if not data:
             raise DatabaseError("No data provided for insert")
 
+        resolved_pk_columns = None
+        if is_sokuho_time_series_odds_capture_table(table_name):
+            from src.database.migration import ensure_sokuho_capture_identity_for_write
+
+            resolved_pk_columns = self._get_primary_key_columns(table_name)
+            ensure_sokuho_capture_identity_for_write(self, table_name, resolved_pk_columns)
+
         data = self._normalize_insert_data(table_name, data)
         columns = list(data.keys())
         values = list(data.values())
@@ -806,7 +814,11 @@ class PostgreSQLDatabase(BaseDatabase):
 
         if use_replace:
             # Get primary key columns for this table
-            pk_columns = self._get_primary_key_columns(table_name)
+            pk_columns = (
+                resolved_pk_columns
+                if resolved_pk_columns is not None
+                else self._get_primary_key_columns(table_name)
+            )
 
             if pk_columns:
                 # Build ON CONFLICT DO UPDATE clause
@@ -849,6 +861,13 @@ class PostgreSQLDatabase(BaseDatabase):
         if not data_list:
             raise DatabaseError("No data provided for insert")
 
+        resolved_pk_columns = None
+        if is_sokuho_time_series_odds_capture_table(table_name):
+            from src.database.migration import ensure_sokuho_capture_identity_for_write
+
+            resolved_pk_columns = self._get_primary_key_columns(table_name)
+            ensure_sokuho_capture_identity_for_write(self, table_name, resolved_pk_columns)
+
         data_list = [self._normalize_insert_data(table_name, row) for row in data_list]
 
         # Use the union of all row keys. Expanded records can be heterogeneous
@@ -867,7 +886,11 @@ class PostgreSQLDatabase(BaseDatabase):
 
         if use_replace:
             # Get primary key columns for this table
-            pk_columns = self._get_primary_key_columns(table_name)
+            pk_columns = (
+                resolved_pk_columns
+                if resolved_pk_columns is not None
+                else self._get_primary_key_columns(table_name)
+            )
             data_list = self._dedupe_rows_by_primary_key(
                 data_list,
                 pk_columns,

--- a/src/database/schema.py
+++ b/src/database/schema.py
@@ -2727,10 +2727,7 @@ def _build_sokuho_timeseries_schema(source_table: str, target_table: str) -> str
         "RecordSpec TEXT,\n            SourceSpec TEXT,\n",
         1,
     )
-    return schema_sql.replace(
-        "HassoTime)",
-        "HassoTime, SourceSpec, CollectedAt)",
-    )
+    return schema_sql.replace("HassoTime)", "HassoTime, SourceSpec)")
 
 
 for _source_table, _target_table in (

--- a/src/database/schema_metadata.py
+++ b/src/database/schema_metadata.py
@@ -1742,7 +1742,7 @@ for _source_table, _target_table in (
             "nullable": False,
         },
     )
-    _metadata["primary_key"] = [*_metadata["primary_key"], "SourceSpec", "CollectedAt"]
+    _metadata["primary_key"] = [*_metadata["primary_key"], "SourceSpec"]
     TABLE_METADATA[_target_table] = _metadata
 
 

--- a/src/database/sqlite_handler.py
+++ b/src/database/sqlite_handler.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 from src.database.base import BaseDatabase, DatabaseError
+from src.database.timeseries_capture import capture_timestamp_epoch_microseconds
 from src.utils.logger import get_logger
 
 logger = get_logger(__name__)
@@ -59,9 +60,7 @@ class SQLiteDatabase(BaseDatabase):
         try:
             return bool(self._connection.in_transaction)
         except Exception as exc:
-            raise DatabaseError(
-                f"Failed to inspect SQLite transaction state: {exc}"
-            ) from exc
+            raise DatabaseError(f"Failed to inspect SQLite transaction state: {exc}") from exc
 
     def connect(self) -> None:
         """Establish SQLite database connection.
@@ -87,6 +86,12 @@ class SQLiteDatabase(BaseDatabase):
             self._connection.execute("PRAGMA synchronous = NORMAL")  # 同期モードを緩和
             self._connection.execute("PRAGMA cache_size = -64000")  # 64MBキャッシュ
             self._connection.execute("PRAGMA temp_store = MEMORY")  # 一時テーブルをメモリに
+            self._connection.create_function(
+                "jltsql_capture_epoch_us",
+                1,
+                capture_timestamp_epoch_microseconds,
+                deterministic=True,
+            )
             # Use Row factory for dict-like access
             self._connection.row_factory = sqlite3.Row
             self._cursor = self._connection.cursor()

--- a/src/database/timeseries_capture.py
+++ b/src/database/timeseries_capture.py
@@ -9,12 +9,19 @@ TIME_SERIES_ODDS_CAPTURE_TABLES = frozenset(
         *(f"TS_SOKUHO_O{number}" for number in range(1, 7)),
     }
 )
+SOKUHO_TIME_SERIES_ODDS_CAPTURE_TABLES = frozenset(f"TS_SOKUHO_O{number}" for number in range(1, 7))
 
 
 def is_time_series_odds_capture_table(table_name: str) -> bool:
     """Return whether CollectedAt is evidence of first possession in this table."""
     unqualified = table_name.rsplit(".", 1)[-1].strip('"`').upper()
     return unqualified in TIME_SERIES_ODDS_CAPTURE_TABLES
+
+
+def is_sokuho_time_series_odds_capture_table(table_name: str) -> bool:
+    """Return whether a write targets a dedicated Sokuho capture table."""
+    unqualified = table_name.rsplit(".", 1)[-1].strip('"`').upper()
+    return unqualified in SOKUHO_TIME_SERIES_ODDS_CAPTURE_TABLES
 
 
 def unqualified_table_name(table_name: str) -> str:

--- a/src/database/timeseries_capture.py
+++ b/src/database/timeseries_capture.py
@@ -1,0 +1,71 @@
+"""Shared capture-time rules for odds publication time-series tables."""
+
+from datetime import UTC, datetime
+from typing import Any
+
+TIME_SERIES_ODDS_CAPTURE_TABLES = frozenset(
+    {
+        *(f"TS_O{number}" for number in range(1, 7)),
+        *(f"TS_SOKUHO_O{number}" for number in range(1, 7)),
+    }
+)
+
+
+def is_time_series_odds_capture_table(table_name: str) -> bool:
+    """Return whether CollectedAt is evidence of first possession in this table."""
+    unqualified = table_name.rsplit(".", 1)[-1].strip('"`').upper()
+    return unqualified in TIME_SERIES_ODDS_CAPTURE_TABLES
+
+
+def unqualified_table_name(table_name: str) -> str:
+    """Return a schema-free table identifier for row qualification."""
+    return table_name.rsplit(".", 1)[-1].strip('"`')
+
+
+def capture_timestamp_epoch_microseconds(value: Any) -> int:
+    """Normalize an offset-aware ISO timestamp for exact instant comparison.
+
+    CollectedAt is TEXT in the live schema. Comparing its raw ISO strings is
+    incorrect when two equivalent representations use different UTC offsets.
+    Returning integer UTC microseconds also avoids SQLite julianday precision
+    loss for collector stamps that include microseconds.
+    """
+    if isinstance(value, datetime):
+        parsed = value
+    elif isinstance(value, str):
+        parsed = datetime.fromisoformat(value.strip())
+    else:
+        raise ValueError(f"CollectedAt must be an ISO-8601 timestamp, got {value!r}")
+
+    if parsed.tzinfo is None or parsed.utcoffset() is None:
+        raise ValueError(f"CollectedAt must include a UTC offset, got {value!r}")
+
+    normalized = parsed.astimezone(UTC)
+    epoch = datetime(1970, 1, 1, tzinfo=UTC)
+    delta = normalized - epoch
+    return delta.days * 86_400_000_000 + delta.seconds * 1_000_000 + delta.microseconds
+
+
+def earliest_capture_value(first: Any, second: Any) -> Any:
+    """Return the earlier real capture, retaining the non-NULL side."""
+    if first is None:
+        return second
+    if second is None:
+        return first
+    if capture_timestamp_epoch_microseconds(second) < capture_timestamp_epoch_microseconds(first):
+        return second
+    return first
+
+
+def prepare_time_series_odds_table(database: Any, table_name: str) -> None:
+    """Migrate, create, and verify one capture-evidence table before polling."""
+    if not is_time_series_odds_capture_table(table_name):
+        raise ValueError(f"Not a time-series odds capture table: {table_name}")
+
+    from src.database.migration import migrate_table_if_needed, verify_table_schema
+    from src.database.schema import SCHEMAS
+
+    schema_sql = SCHEMAS[unqualified_table_name(table_name).upper()]
+    migrate_table_if_needed(database, table_name, schema_sql)
+    database.execute(schema_sql)
+    verify_table_schema(database, table_name, schema_sql)

--- a/src/fetcher/realtime.py
+++ b/src/fetcher/realtime.py
@@ -3,21 +3,122 @@
 This module provides realtime data fetching from JV-Link.
 """
 
-from typing import Callable, Iterable, Iterator, Optional, List
+from collections.abc import Callable, Iterable, Iterator
+from datetime import datetime, timedelta, timezone
+from typing import Optional
 
 from src.fetcher.base import BaseFetcher, FetcherError
 from src.jvlink.constants import (
+    JYO_CODES,
     JV_RT_SUCCESS,
     JVRTOPEN_SPEED_REPORT_SPECS,
     JVRTOPEN_TIME_SERIES_SPECS,
-    is_valid_jvrtopen_spec,
-    is_time_series_spec,
     generate_time_series_key,
-    JYO_CODES,
+    is_time_series_spec,
 )
 from src.utils.logger import get_logger
 
 logger = get_logger(__name__)
+
+# Japan has observed UTC+09:00 year-round since 1951.  A fixed offset avoids
+# making the base/SQLite installation depend on an IANA tzdata package, which
+# is not present by default on Windows.
+JST = timezone(timedelta(hours=9), name="JST")
+
+
+def _now_jst() -> datetime:
+    """Return the race-window reference clock in Japan time."""
+    return datetime.now(JST)
+
+
+def _filter_race_rows_by_post_time(
+    race_rows: list[tuple],
+    *,
+    post_time_within_minutes: Optional[int],
+    post_time_not_past_minutes: Optional[int],
+) -> tuple[list[tuple], dict[str, int]]:
+    """Validate, de-duplicate, and filter race rows by NL/RT_RA post time."""
+    now = _now_jst()
+    if now.tzinfo is None or now.utcoffset() is None:
+        raise FetcherError("Race post-time window clock must be timezone-aware")
+    now = now.astimezone(JST)
+
+    grouped: dict[str, list[tuple]] = {}
+    for row in race_rows:
+        if len(row) != 7:
+            raise FetcherError(
+                "Race post-time window requires Year, MonthDay, JyoCD, "
+                "Kaiji, Nichiji, RaceNum, and HassoTime"
+            )
+        year, monthday, jyo_cd, _kaiji, _nichiji, race_num, _post_time = row
+        try:
+            date_str = f"{int(year):04d}{int(monthday):04d}"
+            datetime.strptime(date_str, "%Y%m%d")
+            jyo_cd_text = str(jyo_cd).strip().zfill(2)
+            key = generate_time_series_key(date_str, jyo_cd_text, int(race_num))
+        except (TypeError, ValueError) as exc:
+            raise FetcherError(
+                "Race post-time window cannot name invalid race identity " f"{row[:6]!r}: {exc}"
+            ) from exc
+        grouped.setdefault(key, []).append(row)
+
+    validated: list[tuple[tuple, datetime]] = []
+    problems: list[str] = []
+    for key, rows in grouped.items():
+        raw_post_times = [row[6] for row in rows]
+        normalized_post_times = {
+            str(value).strip()
+            for value in raw_post_times
+            if value is not None and str(value).strip()
+        }
+        if any(value is None or not str(value).strip() for value in raw_post_times):
+            problems.append(f"{key}: missing HassoTime")
+            continue
+        if len(normalized_post_times) != 1:
+            values = ", ".join(sorted(normalized_post_times))
+            problems.append(f"{key}: ambiguous HassoTime values [{values}]")
+            continue
+
+        post_time_text = next(iter(normalized_post_times))
+        if (
+            len(post_time_text) != 4
+            or not post_time_text.isdigit()
+            or int(post_time_text[:2]) > 23
+            or int(post_time_text[2:]) > 59
+        ):
+            problems.append(f"{key}: unparsable HassoTime {post_time_text!r}")
+            continue
+
+        post_time = datetime.strptime(f"{key[:8]}{post_time_text}", "%Y%m%d%H%M").replace(
+            tzinfo=JST
+        )
+        validated.append((rows[0][:6], post_time))
+
+    if problems:
+        raise FetcherError("Race post-time window rejected keys: " + "; ".join(problems))
+
+    kept: list[tuple] = []
+    dropped_too_far_future = 0
+    dropped_too_far_past = 0
+    for row, post_time in validated:
+        minutes_until_post = (post_time - now).total_seconds() / 60
+        if post_time_within_minutes is not None and minutes_until_post > post_time_within_minutes:
+            dropped_too_far_future += 1
+        elif (
+            post_time_not_past_minutes is not None
+            and minutes_until_post < -post_time_not_past_minutes
+        ):
+            dropped_too_far_past += 1
+        else:
+            kept.append(row)
+
+    stats = {
+        "considered_keys": len(grouped),
+        "window_kept_keys": len(kept),
+        "dropped_too_far_future": dropped_too_far_future,
+        "dropped_too_far_past": dropped_too_far_past,
+    }
+    return kept, stats
 
 
 def materialize_complete_records(
@@ -81,8 +182,7 @@ class RealtimeFetcher(BaseFetcher):
         """Keep realtime snapshots fail-fast on corrupt JV-Link files."""
         self._delete_corrupt_file_best_effort(error_code, filename)
         raise FetcherError(
-            f"Realtime JVRead returned {error_code} for "
-            f"{filename or 'an unknown file'}"
+            f"Realtime JVRead returned {error_code} for " f"{filename or 'an unknown file'}"
         )
 
     def fetch(
@@ -131,14 +231,14 @@ class RealtimeFetcher(BaseFetcher):
 
         if data_spec not in RT_DATA_SPECS:
             logger.warning(
-                f"Unknown data spec: {data_spec}. "
-                "Proceeding anyway, but this may not be valid."
+                f"Unknown data spec: {data_spec}. " "Proceeding anyway, but this may not be valid."
             )
 
         # Default key to today's date if not specified
         # JVRTOpen requires a date key (YYYYMMDD) to function properly
         if key is None:
             from datetime import datetime
+
             key = datetime.now().strftime("%Y%m%d")
             logger.debug("Using today's date as key", key=key)
 
@@ -193,7 +293,7 @@ class RealtimeFetcher(BaseFetcher):
             raise
         except Exception as e:
             # -114: 契約外エラーはdebugレベル
-            if '-114' in str(e):
+            if "-114" in str(e):
                 logger.debug("Realtime fetch skipped (not subscribed)", error=str(e))
             else:
                 logger.error("Realtime fetch error", error=str(e))
@@ -319,6 +419,7 @@ class RealtimeFetcher(BaseFetcher):
         # Generate date if not provided
         if date is None:
             from datetime import datetime
+
             date = datetime.now().strftime("%Y%m%d")
 
         # Generate key: YYYYMMDDJJRR
@@ -373,6 +474,8 @@ class RealtimeFetcher(BaseFetcher):
         to_date: Optional[str] = None,
         pg_config: Optional[dict] = None,
         progress_callback: Optional[Callable[[dict], None]] = None,
+        post_time_within_minutes: Optional[int] = None,
+        post_time_not_past_minutes: Optional[int] = None,
     ) -> Iterator[dict]:
         """Fetch time series odds for races registered in the database.
 
@@ -407,6 +510,10 @@ class RealtimeFetcher(BaseFetcher):
                        of SQLite.
             progress_callback: Optional callback called after each race key is
                                attempted. Receives counters and key status.
+            post_time_within_minutes: Keep keys no more than this many minutes
+                                      before their race-record post time.
+            post_time_not_past_minutes: Drop keys more than this many minutes
+                                        after their race-record post time.
 
         Yields:
             Dictionary of parsed record data
@@ -437,22 +544,55 @@ class RealtimeFetcher(BaseFetcher):
                 f"Time series specs: {', '.join(sorted(JVRTOPEN_TIME_SERIES_SPECS.keys()))}"
             )
 
+        for option_name, option_value in (
+            ("post_time_within_minutes", post_time_within_minutes),
+            ("post_time_not_past_minutes", post_time_not_past_minutes),
+        ):
+            if option_value is not None and option_value < 0:
+                raise FetcherError(f"{option_name} must be zero or greater")
+        window_filter_requested = (
+            post_time_within_minutes is not None or post_time_not_past_minutes is not None
+        )
+
         # Forward-only 0B15 cards are stored in RT_RA, while historical RACE
         # records are stored in NL_RA. Use both sources and de-duplicate the
         # key-bearing columns. This exposes no result fields: only the race
         # identity is used to construct the JVRTOpen request key.
         if pg_config:
-            rt_union = (
+            if window_filter_requested:
+                rt_union = (
+                    """
+                        UNION
+                        SELECT year, monthday, jyocd, kaiji, nichiji, racenum, hassotime
+                        FROM rt_ra
+                    """
+                    if self._postgres_table_exists(pg_config, "rt_ra")
+                    else ""
+                )
+                distinct = "" if rt_union else " DISTINCT"
+                query = f"""
+                    WITH race_targets AS (
+                        SELECT year, monthday, jyocd, kaiji, nichiji, racenum, hassotime
+                        FROM nl_ra
+                        {rt_union}
+                    )
+                    SELECT{distinct}
+                        year, monthday, jyocd, kaiji, nichiji, racenum, hassotime
+                    FROM race_targets
+                    WHERE 1=1
                 """
+            else:
+                rt_union = (
+                    """
                     UNION
                     SELECT year, monthday, jyocd, kaiji, nichiji, racenum
                     FROM rt_ra
                 """
-                if self._postgres_table_exists(pg_config, "rt_ra")
-                else ""
-            )
-            distinct = "" if rt_union else " DISTINCT"
-            query = f"""
+                    if self._postgres_table_exists(pg_config, "rt_ra")
+                    else ""
+                )
+                distinct = "" if rt_union else " DISTINCT"
+                query = f"""
                 WITH race_targets AS (
                     SELECT year, monthday, jyocd, kaiji, nichiji, racenum
                     FROM nl_ra
@@ -474,27 +614,45 @@ class RealtimeFetcher(BaseFetcher):
             from contextlib import closing
 
             with closing(sqlite3.connect(db_path)) as conn:
-                has_rt_ra = (
-                    conn.execute(
-                        """
+                has_rt_ra = conn.execute("""
                         SELECT 1
                         FROM sqlite_master
                         WHERE type = 'table' AND lower(name) = lower('RT_RA')
-                        """
-                    ).fetchone()
-                    is not None
+                        """).fetchone() is not None
+            if window_filter_requested:
+                rt_union = (
+                    """
+                        UNION
+                        SELECT Year, MonthDay, JyoCD, Kaiji, Nichiji, RaceNum, HassoTime
+                        FROM RT_RA
+                    """
+                    if has_rt_ra
+                    else ""
                 )
-            rt_union = (
+                distinct = "" if rt_union else " DISTINCT"
+                query = f"""
+                    WITH race_targets AS (
+                        SELECT Year, MonthDay, JyoCD, Kaiji, Nichiji, RaceNum, HassoTime
+                        FROM NL_RA
+                        {rt_union}
+                    )
+                    SELECT{distinct}
+                        Year, MonthDay, JyoCD, Kaiji, Nichiji, RaceNum, HassoTime
+                    FROM race_targets
+                    WHERE 1=1
                 """
+            else:
+                rt_union = (
+                    """
                     UNION
                     SELECT Year, MonthDay, JyoCD, Kaiji, Nichiji, RaceNum
                     FROM RT_RA
                 """
-                if has_rt_ra
-                else ""
-            )
-            distinct = "" if rt_union else " DISTINCT"
-            query = f"""
+                    if has_rt_ra
+                    else ""
+                )
+                distinct = "" if rt_union else " DISTINCT"
+                query = f"""
                 WITH race_targets AS (
                     SELECT Year, MonthDay, JyoCD, Kaiji, Nichiji, RaceNum
                     FROM NL_RA
@@ -551,6 +709,12 @@ class RealtimeFetcher(BaseFetcher):
         else:
             query += " ORDER BY Year, MonthDay, JyoCD, RaceNum"
 
+        log_context = {}
+        if window_filter_requested:
+            log_context = {
+                "post_time_within_minutes": post_time_within_minutes,
+                "post_time_not_past_minutes": post_time_not_past_minutes,
+            }
         logger.info(
             "Starting batch time series fetch from database",
             data_spec=data_spec,
@@ -558,12 +722,15 @@ class RealtimeFetcher(BaseFetcher):
             db_path="postgresql" if pg_config else db_path,
             from_date=from_date,
             to_date=to_date,
+            **log_context,
         )
 
         # Get race keys from database
         try:
             if pg_config:
-                race_rows = self._fetch_time_series_race_rows_from_postgres(query, params, pg_config)
+                race_rows = self._fetch_time_series_race_rows_from_postgres(
+                    query, params, pg_config
+                )
             else:
                 import sqlite3
                 from contextlib import closing
@@ -574,6 +741,29 @@ class RealtimeFetcher(BaseFetcher):
                     race_rows = cursor.fetchall()
         except Exception as e:
             raise FetcherError(f"Database query failed: {e}")
+
+        window_stats: Optional[dict[str, int]] = None
+        if window_filter_requested:
+            race_rows, window_stats = _filter_race_rows_by_post_time(
+                race_rows,
+                post_time_within_minutes=post_time_within_minutes,
+                post_time_not_past_minutes=post_time_not_past_minutes,
+            )
+            logger.info("Applied race post-time window", **window_stats)
+            if progress_callback:
+                progress_callback(
+                    {
+                        "status": "window_filter",
+                        "key": None,
+                        "processed_keys": 0,
+                        "total_keys": len(race_rows),
+                        **window_stats,
+                        "success_keys": 0,
+                        "no_data_keys": 0,
+                        "error_keys": 0,
+                        "total_records": 0,
+                    }
+                )
 
         if not race_rows:
             logger.warning("No races found in database for the specified criteria")
@@ -601,7 +791,9 @@ class RealtimeFetcher(BaseFetcher):
                 year, monthday, jyo_cd, kaiji, nichiji, race_num = row
 
                 # Build date string: YYYYMMDD
-                date_str = f"{year}{monthday:04d}" if isinstance(monthday, int) else f"{year}{monthday}"
+                date_str = (
+                    f"{year}{monthday:04d}" if isinstance(monthday, int) else f"{year}{monthday}"
+                )
 
                 # Convert values to proper types. Kaiji/Nichiji are selected
                 # from NL_RA for auditability, but JVRTOpen odds time-series
@@ -614,7 +806,7 @@ class RealtimeFetcher(BaseFetcher):
                     logger.warning(f"Invalid key parameters: {e}")
                     error_keys += 1
                     if progress_callback:
-                        progress_callback({
+                        progress = {
                             "status": "invalid_key",
                             "key": None,
                             "processed_keys": processed_keys,
@@ -624,7 +816,10 @@ class RealtimeFetcher(BaseFetcher):
                             "error_keys": error_keys,
                             "records_for_key": 0,
                             "total_records": total_records,
-                        })
+                        }
+                        if window_stats:
+                            progress.update(window_stats)
+                        progress_callback(progress)
                     continue
 
                 records_for_key = 0
@@ -674,7 +869,7 @@ class RealtimeFetcher(BaseFetcher):
                 except Exception as e:
                     error_keys += 1
                     key_status = "exception"
-                    if '-114' in str(e):
+                    if "-114" in str(e):
                         logger.debug("Not subscribed for key", key=key, error=str(e))
                     else:
                         logger.warning("Error fetching key", key=key, error=str(e))
@@ -684,7 +879,7 @@ class RealtimeFetcher(BaseFetcher):
                     except Exception:
                         pass
                     if progress_callback:
-                        progress_callback({
+                        progress = {
                             "status": key_status,
                             "key": key,
                             "processed_keys": processed_keys,
@@ -694,7 +889,10 @@ class RealtimeFetcher(BaseFetcher):
                             "error_keys": error_keys,
                             "records_for_key": records_for_key,
                             "total_records": total_records,
-                        })
+                        }
+                        if window_stats:
+                            progress.update(window_stats)
+                        progress_callback(progress)
 
         finally:
             try:
@@ -702,6 +900,7 @@ class RealtimeFetcher(BaseFetcher):
             except Exception:
                 pass
 
+        summary_context = window_stats or {}
         logger.info(
             "Batch time series fetch completed",
             data_spec=data_spec,
@@ -710,6 +909,7 @@ class RealtimeFetcher(BaseFetcher):
             no_data_keys=no_data_keys,
             error_keys=error_keys,
             total_records=total_records,
+            **summary_context,
         )
 
     @staticmethod
@@ -762,8 +962,8 @@ class RealtimeFetcher(BaseFetcher):
         data_spec: str,
         from_date: str,
         to_date: str,
-        jyo_codes: Optional[List[str]] = None,
-        race_nums: Optional[List[int]] = None,
+        jyo_codes: Optional[list[str]] = None,
+        race_nums: Optional[list[int]] = None,
     ) -> Iterator[dict]:
         """Fetch time series data for multiple races in a date range.
 
@@ -962,7 +1162,7 @@ class RealtimeFetcher(BaseFetcher):
                         except Exception as e:
                             error_keys += 1
                             # -114: 契約外エラーは警告として処理
-                            if '-114' in str(e):
+                            if "-114" in str(e):
                                 logger.debug("Not subscribed for key", key=key, error=str(e))
                             else:
                                 logger.warning("Error fetching key", key=key, error=str(e))
@@ -1037,15 +1237,11 @@ class RealtimeFetcher(BaseFetcher):
                     "PostgreSQL driver not installed. Install psycopg[binary]."
                 ) from exc
             except Exception as exc:
-                raise FetcherError(
-                    f"Could not check whether {table_name} exists: {exc}"
-                ) from exc
+                raise FetcherError(f"Could not check whether {table_name} exists: {exc}") from exc
         except FetcherError:
             raise
         except Exception as exc:
-            raise FetcherError(
-                f"Could not check whether {table_name} exists: {exc}"
-            ) from exc
+            raise FetcherError(f"Could not check whether {table_name} exists: {exc}") from exc
 
     def __enter__(self):
         """Context manager entry."""

--- a/src/fetcher/realtime.py
+++ b/src/fetcher/realtime.py
@@ -37,13 +37,14 @@ def _filter_race_rows_by_post_time(
     post_time_within_minutes: Optional[int],
     post_time_not_past_minutes: Optional[int],
 ) -> tuple[list[tuple], dict[str, int]]:
-    """Validate, de-duplicate, and filter race rows by NL/RT_RA post time."""
+    """Date-filter, validate, de-duplicate, and post-time-filter race rows."""
     now = _now_jst()
     if now.tzinfo is None or now.utcoffset() is None:
         raise FetcherError("Race post-time window clock must be timezone-aware")
     now = now.astimezone(JST)
 
     grouped: dict[str, list[tuple]] = {}
+    race_dates: dict[str, datetime] = {}
     for row in race_rows:
         if len(row) != 7:
             raise FetcherError(
@@ -53,7 +54,7 @@ def _filter_race_rows_by_post_time(
         year, monthday, jyo_cd, _kaiji, _nichiji, race_num, _post_time = row
         try:
             date_str = f"{int(year):04d}{int(monthday):04d}"
-            datetime.strptime(date_str, "%Y%m%d")
+            race_date = datetime.strptime(date_str, "%Y%m%d").replace(tzinfo=JST)
             jyo_cd_text = str(jyo_cd).strip().zfill(2)
             key = generate_time_series_key(date_str, jyo_cd_text, int(race_num))
         except (TypeError, ValueError) as exc:
@@ -61,10 +62,37 @@ def _filter_race_rows_by_post_time(
                 "Race post-time window cannot name invalid race identity " f"{row[:6]!r}: {exc}"
             ) from exc
         grouped.setdefault(key, []).append(row)
+        race_dates.setdefault(key, race_date)
+
+    latest_allowed = (
+        now + timedelta(minutes=post_time_within_minutes)
+        if post_time_within_minutes is not None
+        else None
+    )
+    earliest_allowed = (
+        now - timedelta(minutes=post_time_not_past_minutes)
+        if post_time_not_past_minutes is not None
+        else None
+    )
+    candidates: dict[str, list[tuple]] = {}
+    dropped_too_far_future = 0
+    dropped_too_far_past = 0
+    skipped_out_of_window_by_date = 0
+    for key, rows in grouped.items():
+        race_date_start = race_dates[key]
+        race_date_end = race_date_start + timedelta(days=1) - timedelta(minutes=1)
+        if latest_allowed is not None and race_date_start > latest_allowed:
+            dropped_too_far_future += 1
+            skipped_out_of_window_by_date += 1
+        elif earliest_allowed is not None and race_date_end < earliest_allowed:
+            dropped_too_far_past += 1
+            skipped_out_of_window_by_date += 1
+        else:
+            candidates[key] = rows
 
     validated: list[tuple[tuple, datetime]] = []
     problems: list[str] = []
-    for key, rows in grouped.items():
+    for key, rows in candidates.items():
         raw_post_times = [row[6] for row in rows]
         normalized_post_times = {
             str(value).strip()
@@ -82,6 +110,7 @@ def _filter_race_rows_by_post_time(
         post_time_text = next(iter(normalized_post_times))
         if (
             len(post_time_text) != 4
+            or not post_time_text.isascii()
             or not post_time_text.isdigit()
             or int(post_time_text[:2]) > 23
             or int(post_time_text[2:]) > 59
@@ -98,8 +127,6 @@ def _filter_race_rows_by_post_time(
         raise FetcherError("Race post-time window rejected keys: " + "; ".join(problems))
 
     kept: list[tuple] = []
-    dropped_too_far_future = 0
-    dropped_too_far_past = 0
     for row, post_time in validated:
         minutes_until_post = (post_time - now).total_seconds() / 60
         if post_time_within_minutes is not None and minutes_until_post > post_time_within_minutes:
@@ -114,9 +141,11 @@ def _filter_race_rows_by_post_time(
 
     stats = {
         "considered_keys": len(grouped),
+        "window_candidate_keys": len(candidates),
         "window_kept_keys": len(kept),
         "dropped_too_far_future": dropped_too_far_future,
         "dropped_too_far_past": dropped_too_far_past,
+        "skipped_out_of_window_by_date": skipped_out_of_window_by_date,
     }
     return kept, stats
 

--- a/src/realtime/updater.py
+++ b/src/realtime/updater.py
@@ -1502,27 +1502,26 @@ class RealtimeUpdater:
             "TS_SOKUHO_O1": [
                 "Year", "MonthDay", "JyoCD", "Kaiji", "Nichiji",
                 "RaceNum", "Umaban", "Kumi", "HassoTime", "SourceSpec",
-                "CollectedAt",
             ],
             "TS_SOKUHO_O2": [
                 "Year", "MonthDay", "JyoCD", "Kaiji", "Nichiji",
-                "RaceNum", "Kumi", "HassoTime", "SourceSpec", "CollectedAt",
+                "RaceNum", "Kumi", "HassoTime", "SourceSpec",
             ],
             "TS_SOKUHO_O3": [
                 "Year", "MonthDay", "JyoCD", "Kaiji", "Nichiji",
-                "RaceNum", "Kumi", "HassoTime", "SourceSpec", "CollectedAt",
+                "RaceNum", "Kumi", "HassoTime", "SourceSpec",
             ],
             "TS_SOKUHO_O4": [
                 "Year", "MonthDay", "JyoCD", "Kaiji", "Nichiji",
-                "RaceNum", "Kumi", "HassoTime", "SourceSpec", "CollectedAt",
+                "RaceNum", "Kumi", "HassoTime", "SourceSpec",
             ],
             "TS_SOKUHO_O5": [
                 "Year", "MonthDay", "JyoCD", "Kaiji", "Nichiji",
-                "RaceNum", "Kumi", "HassoTime", "SourceSpec", "CollectedAt",
+                "RaceNum", "Kumi", "HassoTime", "SourceSpec",
             ],
             "TS_SOKUHO_O6": [
                 "Year", "MonthDay", "JyoCD", "Kaiji", "Nichiji",
-                "RaceNum", "Kumi", "HassoTime", "SourceSpec", "CollectedAt",
+                "RaceNum", "Kumi", "HassoTime", "SourceSpec",
             ],
 
             # Weather and horse-weight tables

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -20,38 +20,38 @@ class TestCLIBasic(unittest.TestCase):
 
     def test_cli_help(self):
         """Test CLI help output."""
-        result = self.runner.invoke(cli, ['--help'])
+        result = self.runner.invoke(cli, ["--help"])
         self.assertEqual(result.exit_code, 0)
-        self.assertIn('JLTSQL', result.output)
-        self.assertIn('init', result.output)
-        self.assertIn('fetch', result.output)
-        self.assertIn('monitor', result.output)
+        self.assertIn("JLTSQL", result.output)
+        self.assertIn("init", result.output)
+        self.assertIn("fetch", result.output)
+        self.assertIn("monitor", result.output)
 
     def test_version_command(self):
         """Version is available before a configuration file exists."""
         with patch("src.cli.main.Path.exists", return_value=False):
-            result = self.runner.invoke(cli, ['version'])
+            result = self.runner.invoke(cli, ["version"])
         self.assertEqual(result.exit_code, 0)
-        self.assertIn('JLTSQL version', result.output)
+        self.assertIn("JLTSQL version", result.output)
         self.assertTrue(
-            'Python version' in result.output or 'Python:' in result.output,
-            f"Expected 'Python version' or 'Python:' in output: {result.output}"
+            "Python version" in result.output or "Python:" in result.output,
+            f"Expected 'Python version' or 'Python:' in output: {result.output}",
         )
 
     def test_status_command(self):
         """Status is available before a configuration file exists; fetch is not."""
         with patch("src.cli.main.Path.exists", return_value=False):
-            result = self.runner.invoke(cli, ['status'])
+            result = self.runner.invoke(cli, ["status"])
             fetch_result = self.runner.invoke(
                 cli,
-                ['fetch', '--from', '2024-01-01', '--to', '2024-01-02', '--spec', 'RACE'],
+                ["fetch", "--from", "2024-01-01", "--to", "2024-01-02", "--spec", "RACE"],
             )
         self.assertEqual(result.exit_code, 0)
-        self.assertIn('JLTSQL Status', result.output)
-        self.assertIn('Version', result.output)
+        self.assertIn("JLTSQL Status", result.output)
+        self.assertIn("Version", result.output)
         # Data-acquiring commands stay behind the configuration gate.
         self.assertEqual(fetch_result.exit_code, 1)
-        self.assertIn('Configuration file not found', fetch_result.output)
+        self.assertIn("Configuration file not found", fetch_result.output)
 
     def test_isolated_filesystem_preserves_click_temp_dir_contract(self):
         """The compatibility runner retains Click's optional parent directory."""
@@ -91,19 +91,19 @@ class TestInitCommand(unittest.TestCase):
     def test_init_with_force(self):
         """Test init with --force flag."""
         with self.runner.isolated_filesystem():
-            config_dir = Path('config')
+            config_dir = Path("config")
             config_dir.mkdir(exist_ok=True)
 
-            example_file = config_dir / 'config.yaml.example'
-            example_file.write_text('# Example')
+            example_file = config_dir / "config.yaml.example"
+            example_file.write_text("# Example")
 
-            config_file = config_dir / 'config.yaml'
-            config_file.write_text('# Existing')
+            config_file = config_dir / "config.yaml"
+            config_file.write_text("# Existing")
 
-            result = self.runner.invoke(cli, ['init', '--force'])
+            result = self.runner.invoke(cli, ["init", "--force"])
 
             self.assertEqual(result.exit_code, 0)
-            self.assertIn('Created configuration file', result.output)
+            self.assertIn("Created configuration file", result.output)
 
     def test_init_rejects_a_global_config_path_instead_of_ignoring_it(self):
         """Init has a CWD target and must not silently ignore --config."""
@@ -170,8 +170,8 @@ class TestCreateTablesCommand(unittest.TestCase):
         """Test create-tables with SQLite."""
         with self.runner.isolated_filesystem():
             # Create config directory and file
-            Path('config').mkdir()
-            Path('config/config.yaml').write_text("""
+            Path("config").mkdir()
+            Path("config/config.yaml").write_text("""
 database:
   type: sqlite
   path: data/test.db
@@ -182,12 +182,9 @@ jvlink:
   service_key: ""
 """)
             # Create data directory
-            Path('data').mkdir()
+            Path("data").mkdir()
 
-            result = self.runner.invoke(cli, [
-                'create-tables',
-                '--db', 'sqlite'
-            ])
+            result = self.runner.invoke(cli, ["create-tables", "--db", "sqlite"])
 
             # Command should execute (may have various exit codes depending on config/environment)
             # Just verify it doesn't crash with exception
@@ -199,8 +196,8 @@ jvlink:
         """Test create-tables with --db flag works."""
         with self.runner.isolated_filesystem():
             # Create config directory and file
-            Path('config').mkdir()
-            Path('config/config.yaml').write_text("""
+            Path("config").mkdir()
+            Path("config/config.yaml").write_text("""
 database:
   type: sqlite
   path: data/test.db
@@ -210,12 +207,9 @@ databases:
 jvlink:
   service_key: ""
 """)
-            Path('data').mkdir()
+            Path("data").mkdir()
 
-            result = self.runner.invoke(cli, [
-                'create-tables',
-                '--db', 'sqlite'
-            ])
+            result = self.runner.invoke(cli, ["create-tables", "--db", "sqlite"])
 
             # Should attempt to execute (may succeed or fail, but command should parse)
             self.assertIsNotNone(result)
@@ -224,8 +218,7 @@ jvlink:
         """Existing RT tables are migrated before CREATE IF NOT EXISTS."""
         with self.runner.isolated_filesystem():
             config_path = Path("config.yaml")
-            config_path.write_text(
-                """
+            config_path.write_text("""
 database:
   type: sqlite
 databases:
@@ -234,18 +227,17 @@ databases:
     path: test.db
 jvlink:
   service_key: ""
-"""
-            )
+""")
             database = MagicMock()
 
-            with patch(
-                "src.database.create_database_from_config",
-                return_value=database,
-            ), patch(
-                "src.database.migration.migrate_all_tables"
-            ) as migrate_all_tables, patch(
-                "src.database.migration.verify_table_schema"
-            ) as verify_table_schema:
+            with (
+                patch(
+                    "src.database.create_database_from_config",
+                    return_value=database,
+                ),
+                patch("src.database.migration.migrate_all_tables") as migrate_all_tables,
+                patch("src.database.migration.verify_table_schema") as verify_table_schema,
+            ):
                 result = self.runner.invoke(
                     cli,
                     [
@@ -271,8 +263,7 @@ jvlink:
     def test_create_tables_fails_when_schema_verification_fails(self):
         with self.runner.isolated_filesystem():
             config_path = Path("config.yaml")
-            config_path.write_text(
-                """
+            config_path.write_text("""
 database:
   type: sqlite
 databases:
@@ -281,18 +272,19 @@ databases:
     path: test.db
 jvlink:
   service_key: ""
-"""
-            )
+""")
             database = MagicMock()
 
-            with patch(
-                "src.database.create_database_from_config",
-                return_value=database,
-            ), patch(
-                "src.database.migration.migrate_all_tables"
-            ), patch(
-                "src.database.migration.verify_table_schema",
-                side_effect=RuntimeError("unsafe schema"),
+            with (
+                patch(
+                    "src.database.create_database_from_config",
+                    return_value=database,
+                ),
+                patch("src.database.migration.migrate_all_tables"),
+                patch(
+                    "src.database.migration.verify_table_schema",
+                    side_effect=RuntimeError("unsafe schema"),
+                ),
             ):
                 result = self.runner.invoke(
                     cli,
@@ -319,89 +311,88 @@ class TestFetchCommand(unittest.TestCase):
 
     def test_fetch_missing_arguments(self):
         """Test fetch command with missing arguments."""
-        result = self.runner.invoke(cli, ['fetch'])
+        result = self.runner.invoke(cli, ["fetch"])
 
         # Should fail due to missing required arguments (--from, --to, --spec)
         self.assertNotEqual(result.exit_code, 0)
         # Check if error message contains missing required option
         self.assertTrue(
-            '--from' in result.output.lower() or
-            '--to' in result.output.lower() or
-            '--spec' in result.output.lower() or
-            result.exception is not None
+            "--from" in result.output.lower()
+            or "--to" in result.output.lower()
+            or "--spec" in result.output.lower()
+            or result.exception is not None
         )
 
     def test_fetch_help_explains_option_dependent_date_semantics(self):
-        example_config = (
-            Path(__file__).resolve().parents[1] / 'config' / 'config.yaml.example'
-        )
+        example_config = Path(__file__).resolve().parents[1] / "config" / "config.yaml.example"
         with self.runner.isolated_filesystem():
-            config_path = Path('config.yaml')
+            config_path = Path("config.yaml")
             config_path.write_text(
-                example_config.read_text(encoding='utf-8'),
-                encoding='utf-8',
+                example_config.read_text(encoding="utf-8"),
+                encoding="utf-8",
             )
             result = self.runner.invoke(
                 cli,
-                ['--config', str(config_path), 'fetch', '--help'],
+                ["--config", str(config_path), "fetch", "--help"],
             )
 
         self.assertEqual(result.exit_code, 0, result.output)
-        help_text = ' '.join(result.output.split())
-        self.assertIn('current race-cycle data', help_text)
-        self.assertIn('Sunday or Monday may cover two cycles', help_text)
-        self.assertIn('ChokyoDate', help_text)
-        self.assertIn('one JVOpen per calendar year', help_text)
-        self.assertIn('live-verified RACE, except option 2', help_text)
-        self.assertIn('opens once from the start point only', help_text)
+        help_text = " ".join(result.output.split())
+        self.assertIn("current race-cycle data", help_text)
+        self.assertIn("Sunday or Monday may cover two cycles", help_text)
+        self.assertIn("ChokyoDate", help_text)
+        self.assertIn("one JVOpen per calendar year", help_text)
+        self.assertIn("live-verified RACE, except option 2", help_text)
+        self.assertIn("opens once from the start point only", help_text)
 
-    @patch('src.database.create_database_from_config')
-    def test_fetch_rejects_invalid_dates_before_database_initialization(
-        self, mock_create_database
-    ):
-        example_config = (
-            Path(__file__).resolve().parents[1] / 'config' / 'config.yaml.example'
-        )
+    @patch("src.database.create_database_from_config")
+    def test_fetch_rejects_invalid_dates_before_database_initialization(self, mock_create_database):
+        example_config = Path(__file__).resolve().parents[1] / "config" / "config.yaml.example"
         with self.runner.isolated_filesystem():
-            config_path = Path('config.yaml')
+            config_path = Path("config.yaml")
             config_path.write_text(
-                example_config.read_text(encoding='utf-8'),
-                encoding='utf-8',
+                example_config.read_text(encoding="utf-8"),
+                encoding="utf-8",
             )
             result = self.runner.invoke(
                 cli,
                 [
-                    '--config', str(config_path),
-                    'fetch',
-                    '--from', '20260820',
-                    '--to', '20250820',
-                    '--spec', 'RACE',
-                    '--db', 'sqlite',
+                    "--config",
+                    str(config_path),
+                    "fetch",
+                    "--from",
+                    "20260820",
+                    "--to",
+                    "20250820",
+                    "--spec",
+                    "RACE",
+                    "--db",
+                    "sqlite",
                 ],
             )
 
         self.assertEqual(result.exit_code, 1, result.output)
-        self.assertIn('from_date must not be after to_date', result.output)
+        self.assertIn("from_date must not be after to_date", result.output)
         mock_create_database.assert_not_called()
 
-    @patch('src.importer.batch.BatchProcessor')
+    @patch("src.importer.batch.BatchProcessor")
     def test_fetch_with_all_args(self, mock_batch_processor):
         """Test fetch command with all arguments."""
         # Setup mocks
         mock_processor_instance = MagicMock()
         mock_processor_instance.process_date_range.return_value = {
-            'records_fetched': 10,
-            'records_parsed': 10,
-            'records_imported': 10,
-            'records_failed': 0,
-            'batches_processed': 1
+            "records_fetched": 10,
+            "records_parsed": 10,
+            "records_imported": 10,
+            "records_failed": 0,
+            "batches_processed": 1,
         }
         mock_batch_processor.return_value = mock_processor_instance
 
         with self.runner.isolated_filesystem():
             # Create config directory and file
-            Path('config').mkdir()
-            Path('config/config.yaml').write_text("""
+            Path("config").mkdir()
+            Path("config/config.yaml").write_text("""
 database:
   type: sqlite
   path: data/test.db
@@ -411,15 +402,22 @@ databases:
 jvlink:
   service_key: test_key
 """)
-            Path('data').mkdir()
+            Path("data").mkdir()
 
-            result = self.runner.invoke(cli, [
-                'fetch',
-                '--from', '20240101',
-                '--to', '20240131',
-                '--spec', 'RACE',
-                '--db', 'sqlite'
-            ])
+            result = self.runner.invoke(
+                cli,
+                [
+                    "fetch",
+                    "--from",
+                    "20240101",
+                    "--to",
+                    "20240131",
+                    "--spec",
+                    "RACE",
+                    "--db",
+                    "sqlite",
+                ],
+            )
 
             # Should execute (may fail due to missing JV-Link, but that's OK for CLI test)
             # Just verify command structure works
@@ -432,38 +430,38 @@ class TestCacheBuildCommand(unittest.TestCase):
     def setUp(self):
         self.runner = CliRunner()
 
-    @patch('src.cache.CacheManager')
-    def test_commands_reject_invalid_dates_before_cache_lookup(
-        self, mock_cache_manager
-    ):
-        example_config = (
-            Path(__file__).resolve().parents[1] / 'config' / 'config.yaml.example'
-        )
+    @patch("src.cache.CacheManager")
+    def test_commands_reject_invalid_dates_before_cache_lookup(self, mock_cache_manager):
+        example_config = Path(__file__).resolve().parents[1] / "config" / "config.yaml.example"
         with self.runner.isolated_filesystem():
-            config_path = Path('config.yaml')
+            config_path = Path("config.yaml")
             config_path.write_text(
-                example_config.read_text(encoding='utf-8'),
-                encoding='utf-8',
+                example_config.read_text(encoding="utf-8"),
+                encoding="utf-8",
             )
-            for command in ('build', 'rebuild'):
+            for command in ("build", "rebuild"):
                 with self.subTest(command=command):
                     mock_cache_manager.reset_mock()
                     result = self.runner.invoke(
                         cli,
                         [
-                            '--config', str(config_path),
-                            'cache', command,
-                            '--spec', 'RACE',
-                            '--from', '20260820',
-                            '--to', '20250820',
-                            '--option', '4',
+                            "--config",
+                            str(config_path),
+                            "cache",
+                            command,
+                            "--spec",
+                            "RACE",
+                            "--from",
+                            "20260820",
+                            "--to",
+                            "20250820",
+                            "--option",
+                            "4",
                         ],
                     )
 
                     self.assertEqual(result.exit_code, 1, result.output)
-                    self.assertIn(
-                        'from_date must not be after to_date', result.output
-                    )
+                    self.assertIn("from_date must not be after to_date", result.output)
                     mock_cache_manager.assert_not_called()
 
 
@@ -474,22 +472,22 @@ class TestMonitorCommand(unittest.TestCase):
         """Set up test fixtures."""
         self.runner = CliRunner()
 
-    @patch('src.realtime.monitor.RealtimeMonitor')
+    @patch("src.realtime.monitor.RealtimeMonitor")
     def test_monitor_daemon_mode(self, mock_monitor):
         """Test monitor command in daemon mode."""
         # Setup mocks
         mock_monitor_instance = MagicMock()
         mock_monitor_instance.get_status.return_value = {
-            'started_at': '2024-01-01 00:00:00',
-            'running': True
+            "started_at": "2024-01-01 00:00:00",
+            "running": True,
         }
         mock_monitor_instance.start.return_value = None
         mock_monitor.return_value = mock_monitor_instance
 
         with self.runner.isolated_filesystem():
             # Create config directory and file
-            Path('config').mkdir()
-            Path('config/config.yaml').write_text("""
+            Path("config").mkdir()
+            Path("config/config.yaml").write_text("""
 database:
   type: sqlite
   path: data/test.db
@@ -499,13 +497,9 @@ databases:
 jvlink:
   service_key: ""
 """)
-            Path('data').mkdir()
+            Path("data").mkdir()
 
-            result = self.runner.invoke(cli, [
-                'monitor',
-                '--daemon',
-                '--db', 'sqlite'
-            ])
+            result = self.runner.invoke(cli, ["monitor", "--daemon", "--db", "sqlite"])
 
             # Should execute (may fail due to config/JV-Link, but command structure should work)
             self.assertIsNotNone(result)
@@ -516,6 +510,11 @@ class TestRealtimeTimeseriesCommand(unittest.TestCase):
 
     def setUp(self):
         self.runner = CliRunner()
+        self.prepare_table_patcher = patch(
+            "src.database.timeseries_capture.prepare_time_series_odds_table"
+        )
+        self.prepare_table = self.prepare_table_patcher.start()
+        self.addCleanup(self.prepare_table_patcher.stop)
 
     def test_timeseries_commits_table_setup_and_fails_closed_on_batch_error(self):
         database = MagicMock()
@@ -543,8 +542,7 @@ class TestRealtimeTimeseriesCommand(unittest.TestCase):
 
         with self.runner.isolated_filesystem():
             config_path = Path("config.yaml")
-            config_path.write_text(
-                """
+            config_path.write_text("""
 database:
   type: postgresql
 databases:
@@ -553,14 +551,11 @@ databases:
 jvlink:
   sid: TEST
 auto_update_check: false
-"""
-            )
-            with patch(
-                "src.database.create_database_from_config", return_value=database
-            ), patch(
-                "src.fetcher.realtime.RealtimeFetcher", return_value=fetcher
-            ), patch(
-                "src.realtime.updater.RealtimeUpdater", return_value=updater
+""")
+            with (
+                patch("src.database.create_database_from_config", return_value=database),
+                patch("src.fetcher.realtime.RealtimeFetcher", return_value=fetcher),
+                patch("src.realtime.updater.RealtimeUpdater", return_value=updater),
             ):
                 result = self.runner.invoke(
                     cli,
@@ -581,9 +576,193 @@ auto_update_check: false
                 )
 
         self.assertEqual(result.exit_code, 1, result.output)
+        self.prepare_table.assert_called_once_with(database, "TS_O1")
         self.assertEqual(pending_at_batch, [False])
         self.assertNotIn("[OK] 0B41", result.output)
         self.assertNotIn("Complete!", result.output)
+
+    def test_timeseries_rejects_unsafe_table_before_fetcher_initialization(self):
+        database = MagicMock()
+        database.__enter__.return_value = database
+        database.__exit__.return_value = None
+        self.prepare_table.side_effect = RuntimeError(
+            "legacy primary key includes CollectedAt; back up and rebuild"
+        )
+
+        with self.runner.isolated_filesystem():
+            config_path = Path("config.yaml")
+            config_path.write_text("""
+database:
+  type: postgresql
+databases:
+  postgresql:
+    enabled: true
+jvlink:
+  sid: TEST
+auto_update_check: false
+""")
+            with (
+                patch("src.database.create_database_from_config", return_value=database),
+                patch("src.fetcher.realtime.RealtimeFetcher") as fetcher_class,
+            ):
+                result = self.runner.invoke(
+                    cli,
+                    [
+                        "--config",
+                        str(config_path),
+                        "realtime",
+                        "timeseries",
+                        "--spec",
+                        "0B32",
+                        "--from",
+                        "20260901",
+                        "--to",
+                        "20260901",
+                        "--db",
+                        "postgresql",
+                    ],
+                )
+
+        self.assertEqual(result.exit_code, 1, result.output)
+        self.prepare_table.assert_called_once_with(database, "TS_SOKUHO_O2")
+        fetcher_class.assert_not_called()
+        database.commit.assert_not_called()
+        self.assertIn("legacy primary key includes CollectedAt", result.output)
+        self.assertNotIn("Table TS_SOKUHO_O2 ready", result.output)
+
+    def test_timeseries_passes_race_window_options_and_reports_selection(self):
+        database = MagicMock()
+        database.__enter__.return_value = database
+        database.__exit__.return_value = None
+        fetcher = MagicMock()
+
+        def fetch_rows(**kwargs):
+            callback = kwargs["progress_callback"]
+            callback(
+                {
+                    "status": "window_filter",
+                    "key": None,
+                    "processed_keys": 0,
+                    "total_keys": 1,
+                    "considered_keys": 3,
+                    "window_kept_keys": 1,
+                    "dropped_too_far_future": 1,
+                    "dropped_too_far_past": 1,
+                    "success_keys": 0,
+                    "no_data_keys": 0,
+                    "error_keys": 0,
+                    "total_records": 0,
+                }
+            )
+            return iter(())
+
+        fetcher.fetch_time_series_batch_from_db.side_effect = fetch_rows
+        updater = MagicMock()
+
+        with self.runner.isolated_filesystem():
+            config_path = Path("config.yaml")
+            config_path.write_text("""
+database:
+  type: postgresql
+databases:
+  postgresql:
+    enabled: true
+jvlink:
+  sid: TEST
+auto_update_check: false
+""")
+            with (
+                patch("src.database.create_database_from_config", return_value=database),
+                patch("src.fetcher.realtime.RealtimeFetcher", return_value=fetcher),
+                patch("src.realtime.updater.RealtimeUpdater", return_value=updater),
+            ):
+                result = self.runner.invoke(
+                    cli,
+                    [
+                        "--config",
+                        str(config_path),
+                        "realtime",
+                        "timeseries",
+                        "--spec",
+                        "0B41",
+                        "--from",
+                        "20260901",
+                        "--to",
+                        "20260901",
+                        "--db",
+                        "postgresql",
+                        "--post-time-within-minutes",
+                        "30",
+                        "--post-time-not-past-minutes",
+                        "2",
+                    ],
+                )
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        call_kwargs = fetcher.fetch_time_series_batch_from_db.call_args.kwargs
+        self.assertEqual(call_kwargs["post_time_within_minutes"], 30)
+        self.assertEqual(call_kwargs["post_time_not_past_minutes"], 2)
+        self.assertIn("considered=3", result.output)
+        self.assertIn("kept=1", result.output)
+        self.assertIn("future=1", result.output)
+        self.assertIn("past=1", result.output)
+
+    def test_timeseries_window_implicit_dates_use_jst(self):
+        from datetime import datetime as real_datetime
+
+        database = MagicMock()
+        database.__enter__.return_value = database
+        database.__exit__.return_value = None
+        fetcher = MagicMock()
+        fetcher.fetch_time_series_batch_from_db.return_value = iter(())
+        updater = MagicMock()
+
+        with self.runner.isolated_filesystem():
+            config_path = Path("config.yaml")
+            config_path.write_text("""
+database:
+  type: postgresql
+databases:
+  postgresql:
+    enabled: true
+jvlink:
+  sid: TEST
+auto_update_check: false
+""")
+            with (
+                patch("src.database.create_database_from_config", return_value=database),
+                patch("src.fetcher.realtime.RealtimeFetcher", return_value=fetcher),
+                patch("src.realtime.updater.RealtimeUpdater", return_value=updater),
+                patch("datetime.datetime") as datetime_mock,
+            ):
+                # 2026-08-31 15:30 UTC is already 2026-09-01 in JST.  The CLI
+                # passes a fixed UTC+09:00 tzinfo to datetime.now().
+                datetime_mock.now.return_value = real_datetime.fromisoformat(
+                    "2026-09-01T00:30:00+09:00"
+                )
+                result = self.runner.invoke(
+                    cli,
+                    [
+                        "--config",
+                        str(config_path),
+                        "realtime",
+                        "timeseries",
+                        "--spec",
+                        "0B41",
+                        "--db",
+                        "postgresql",
+                        "--post-time-within-minutes",
+                        "30",
+                    ],
+                )
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        call_kwargs = fetcher.fetch_time_series_batch_from_db.call_args.kwargs
+        self.assertEqual(call_kwargs["from_date"], "20250901")
+        self.assertEqual(call_kwargs["to_date"], "20260901")
+        window_clock_calls = [call for call in datetime_mock.now.call_args_list if call.args]
+        self.assertEqual(len(window_clock_calls), 1)
+        self.assertEqual(window_clock_calls[0].args[0].utcoffset(None).total_seconds(), 32400)
 
 
 class TestExportCommand(unittest.TestCase):
@@ -595,35 +774,35 @@ class TestExportCommand(unittest.TestCase):
 
     def test_export_missing_table(self):
         """Test export without table argument."""
-        result = self.runner.invoke(cli, ['export', '--output', 'test.csv'])
+        result = self.runner.invoke(cli, ["export", "--output", "test.csv"])
 
         # Should fail due to missing --table
         self.assertNotEqual(result.exit_code, 0)
 
     def test_export_missing_output(self):
         """Test export without output argument."""
-        result = self.runner.invoke(cli, ['export', '--table', 'NL_RA'])
+        result = self.runner.invoke(cli, ["export", "--table", "NL_RA"])
 
         # Should fail due to missing --output
         self.assertNotEqual(result.exit_code, 0)
 
-    @patch('src.database.sqlite_handler.SQLiteDatabase')
+    @patch("src.database.sqlite_handler.SQLiteDatabase")
     def test_export_csv_format(self, mock_db):
         """Test export to CSV format."""
         # Setup mocks
         mock_db_instance = MagicMock()
         mock_db_instance.table_exists.return_value = True
         mock_db_instance.fetch_all.return_value = [
-            {'id': 1, 'name': 'Test1'},
-            {'id': 2, 'name': 'Test2'}
+            {"id": 1, "name": "Test1"},
+            {"id": 2, "name": "Test2"},
         ]
         mock_db.return_value.__enter__ = MagicMock(return_value=mock_db_instance)
         mock_db.return_value.__exit__ = MagicMock(return_value=None)
 
         with self.runner.isolated_filesystem():
             # Create config
-            Path('config').mkdir()
-            Path('config/config.yaml').write_text("""
+            Path("config").mkdir()
+            Path("config/config.yaml").write_text("""
 databases:
   sqlite:
     path: data/test.db
@@ -633,31 +812,26 @@ jvlink:
   service_key: ""
 """)
 
-            result = self.runner.invoke(cli, [
-                'export',
-                '--table', 'NL_RA',
-                '--output', 'test.csv',
-                '--format', 'csv'
-            ])
+            result = self.runner.invoke(
+                cli, ["export", "--table", "NL_RA", "--output", "test.csv", "--format", "csv"]
+            )
 
             # May fail due to config issues but command structure should work
             self.assertIsNotNone(result)
 
-    @patch('src.database.sqlite_handler.SQLiteDatabase')
+    @patch("src.database.sqlite_handler.SQLiteDatabase")
     def test_export_json_format(self, mock_db):
         """Test export to JSON format."""
         # Setup mocks
         mock_db_instance = MagicMock()
         mock_db_instance.table_exists.return_value = True
-        mock_db_instance.fetch_all.return_value = [
-            {'id': 1, 'name': 'Test'}
-        ]
+        mock_db_instance.fetch_all.return_value = [{"id": 1, "name": "Test"}]
         mock_db.return_value.__enter__ = MagicMock(return_value=mock_db_instance)
         mock_db.return_value.__exit__ = MagicMock(return_value=None)
 
         with self.runner.isolated_filesystem():
-            Path('config').mkdir()
-            Path('config/config.yaml').write_text("""
+            Path("config").mkdir()
+            Path("config/config.yaml").write_text("""
 databases:
   sqlite:
     path: data/test.db
@@ -667,12 +841,9 @@ jvlink:
   service_key: ""
 """)
 
-            result = self.runner.invoke(cli, [
-                'export',
-                '--table', 'NL_SE',
-                '--output', 'test.json',
-                '--format', 'json'
-            ])
+            result = self.runner.invoke(
+                cli, ["export", "--table", "NL_SE", "--output", "test.json", "--format", "json"]
+            )
 
             self.assertIsNotNone(result)
 
@@ -680,8 +851,8 @@ jvlink:
         """Test export with WHERE clause."""
         with self.runner.isolated_filesystem():
             # Create config directory and file
-            Path('config').mkdir()
-            Path('config/config.yaml').write_text("""
+            Path("config").mkdir()
+            Path("config/config.yaml").write_text("""
 database:
   type: sqlite
   path: data/test.db
@@ -691,15 +862,22 @@ databases:
 jvlink:
   service_key: ""
 """)
-            Path('data').mkdir()
+            Path("data").mkdir()
 
-            result = self.runner.invoke(cli, [
-                'export',
-                '--table', 'NL_RA',
-                '--where', "開催年月日 >= 20240101",
-                '--output', 'filtered.csv',
-                '--db', 'sqlite'
-            ])
+            result = self.runner.invoke(
+                cli,
+                [
+                    "export",
+                    "--table",
+                    "NL_RA",
+                    "--where",
+                    "開催年月日 >= 20240101",
+                    "--output",
+                    "filtered.csv",
+                    "--db",
+                    "sqlite",
+                ],
+            )
 
             # Should attempt to execute
             self.assertIsNotNone(result)
@@ -715,8 +893,8 @@ class TestConfigCommand(unittest.TestCase):
     def test_config_show(self):
         """Test config --show command."""
         with self.runner.isolated_filesystem():
-            Path('config').mkdir()
-            Path('config/config.yaml').write_text("""
+            Path("config").mkdir()
+            Path("config/config.yaml").write_text("""
 database:
   type: sqlite
   path: data/keiba.db
@@ -733,17 +911,17 @@ logging:
     path: logs/jltsql.log
 """)
 
-            result = self.runner.invoke(cli, ['config', '--show'])
+            result = self.runner.invoke(cli, ["config", "--show"])
 
             # Should show configuration
             self.assertEqual(result.exit_code, 0)
-            self.assertIn('Configuration', result.output)
+            self.assertIn("Configuration", result.output)
 
     def test_config_get_existing_key(self):
         """Test config --get with existing key."""
         with self.runner.isolated_filesystem():
-            Path('config').mkdir()
-            Path('config/config.yaml').write_text("""
+            Path("config").mkdir()
+            Path("config/config.yaml").write_text("""
 databases:
   sqlite:
     path: data/keiba.db
@@ -753,16 +931,16 @@ jvlink:
   service_key: ""
 """)
 
-            result = self.runner.invoke(cli, ['config', '--get', 'databases.sqlite.path'])
+            result = self.runner.invoke(cli, ["config", "--get", "databases.sqlite.path"])
 
             if result.exit_code == 0:
-                self.assertIn('keiba.db', result.output)
+                self.assertIn("keiba.db", result.output)
 
     def test_config_get_nonexistent_key(self):
         """Test config --get with non-existent key."""
         with self.runner.isolated_filesystem():
-            Path('config').mkdir()
-            Path('config/config.yaml').write_text("""
+            Path("config").mkdir()
+            Path("config/config.yaml").write_text("""
 database:
   type: sqlite
 databases:
@@ -772,17 +950,17 @@ databases:
 jvlink: {}
 """)
 
-            result = self.runner.invoke(cli, ['config', '--get', 'nonexistent.key'])
+            result = self.runner.invoke(cli, ["config", "--get", "nonexistent.key"])
 
             # Should fail
             self.assertNotEqual(result.exit_code, 0)
-            self.assertIn('not found', result.output)
+            self.assertIn("not found", result.output)
 
     def test_config_set_shows_warning(self):
         """Test config --set shows not implemented warning."""
         with self.runner.isolated_filesystem():
-            Path('config').mkdir()
-            Path('config/config.yaml').write_text("""
+            Path("config").mkdir()
+            Path("config/config.yaml").write_text("""
 database:
   type: sqlite
 databases:
@@ -792,16 +970,16 @@ databases:
 jvlink: {}
 """)
 
-            result = self.runner.invoke(cli, ['config', '--set', 'database.type=sqlite'])
+            result = self.runner.invoke(cli, ["config", "--set", "database.type=sqlite"])
 
             # Should show not implemented message
-            self.assertIn('not yet implemented', result.output)
+            self.assertIn("not yet implemented", result.output)
 
     def test_config_default_shows_tree(self):
         """Test config without arguments shows tree."""
         with self.runner.isolated_filesystem():
-            Path('config').mkdir()
-            Path('config/config.yaml').write_text("""
+            Path("config").mkdir()
+            Path("config/config.yaml").write_text("""
 database:
   type: sqlite
   path: data/test.db
@@ -815,7 +993,7 @@ logging:
   level: DEBUG
 """)
 
-            result = self.runner.invoke(cli, ['config'])
+            result = self.runner.invoke(cli, ["config"])
 
             # Should show config tree
             self.assertEqual(result.exit_code, 0)
@@ -962,5 +1140,5 @@ auto_update_check: "false"
             self.assertNotIn("Traceback", result.output)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -68,6 +68,176 @@ class TestCLIBasic(unittest.TestCase):
             )
 
 
+class TestDatabaseMaintenanceCommand(unittest.TestCase):
+    def setUp(self):
+        self.runner = CliRunner()
+
+    def test_sokuho_migration_defaults_to_dry_run_and_forwards_table_restriction(self):
+        from src.database.migration import SokuhoCaptureIdentityMigrationReport
+
+        database = MagicMock()
+        database.__enter__.return_value = database
+        database.__exit__.return_value = None
+        report = SokuhoCaptureIdentityMigrationReport(
+            table_name="TS_SOKUHO_O3",
+            status="legacy",
+            primary_key=("year", "collectedat"),
+            total_rows=7,
+            distinct_publication_groups=3,
+            rows_to_delete=4,
+            collected_at_rewrite_groups=2,
+        )
+
+        with self.runner.isolated_filesystem():
+            self.assertEqual(self.runner.invoke(cli, ["init"]).exit_code, 0)
+            with (
+                patch(
+                    "src.database.create_database_from_config",
+                    return_value=database,
+                ),
+                patch(
+                    "src.database.migration.preview_sokuho_capture_identity_migration",
+                    return_value=[report],
+                ) as preview,
+                patch(
+                    "src.database.migration.apply_sokuho_capture_identity_migration"
+                ) as apply_migration,
+                patch("src.cli.main.auto_update_check_notice", return_value=None),
+            ):
+                result = self.runner.invoke(
+                    cli,
+                    [
+                        "db",
+                        "migrate-sokuho-capture-identity",
+                        "--db",
+                        "postgresql",
+                        "--table",
+                        "TS_SOKUHO_O3",
+                    ],
+                )
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        preview.assert_called_once_with(database, ("TS_SOKUHO_O3",))
+        apply_migration.assert_not_called()
+        self.assertIn("DRY RUN", result.output)
+        self.assertIn("Total rows: 7", result.output)
+        self.assertIn("Distinct publication groups: 3", result.output)
+        self.assertIn("Rows that would be deleted: 4", result.output)
+        self.assertIn(
+            "Groups whose CollectedAt would be rewritten to earliest non-NULL: 2",
+            result.output,
+        )
+        self.assertIn("no changes were applied", result.output)
+
+    def test_sokuho_migration_apply_requires_explicit_flag(self):
+        from src.database.migration import SokuhoCaptureIdentityMigrationReport
+
+        database = MagicMock()
+        database.__enter__.return_value = database
+        database.__exit__.return_value = None
+        report = SokuhoCaptureIdentityMigrationReport(
+            table_name="TS_SOKUHO_O2",
+            status="migrated",
+            primary_key=("year", "collectedat"),
+            total_rows=2,
+            distinct_publication_groups=1,
+            rows_to_delete=1,
+            collected_at_rewrite_groups=1,
+            applied=True,
+        )
+
+        with self.runner.isolated_filesystem():
+            self.assertEqual(self.runner.invoke(cli, ["init"]).exit_code, 0)
+            with (
+                patch(
+                    "src.database.create_database_from_config",
+                    return_value=database,
+                ),
+                patch(
+                    "src.database.migration.apply_sokuho_capture_identity_migration",
+                    return_value=[report],
+                ) as apply_migration,
+                patch("src.cli.main.auto_update_check_notice", return_value=None),
+            ):
+                result = self.runner.invoke(
+                    cli,
+                    [
+                        "db",
+                        "migrate-sokuho-capture-identity",
+                        "--db",
+                        "postgresql",
+                        "--table",
+                        "TS_SOKUHO_O2",
+                        "--apply",
+                    ],
+                )
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        apply_migration.assert_called_once_with(database, ("TS_SOKUHO_O2",))
+        self.assertIn("APPLY", result.output)
+        self.assertIn("Migration apply completed", result.output)
+
+    def test_sokuho_migration_sqlite_refusal_is_nonzero(self):
+        with self.runner.isolated_filesystem():
+            self.assertEqual(self.runner.invoke(cli, ["init"]).exit_code, 0)
+            with (
+                patch("src.cli.main.auto_update_check_notice", return_value=None),
+                patch("src.database.create_database_from_config") as create_database,
+            ):
+                result = self.runner.invoke(
+                    cli,
+                    [
+                        "db",
+                        "migrate-sokuho-capture-identity",
+                        "--db",
+                        "sqlite",
+                        "--table",
+                        "TS_SOKUHO_O2",
+                    ],
+                )
+        create_database.assert_not_called()
+
+        self.assertNotEqual(result.exit_code, 0)
+        self.assertIn("SQLite migration refused", result.output)
+        self.assertIn("back up", result.output)
+        self.assertIn("rebuild", result.output)
+
+    def test_sokuho_migration_schema_qualifies_selected_tables(self):
+        database = MagicMock()
+        database.__enter__.return_value = database
+        database.__exit__.return_value = None
+
+        with self.runner.isolated_filesystem():
+            self.assertEqual(self.runner.invoke(cli, ["init"]).exit_code, 0)
+            with (
+                patch(
+                    "src.database.create_database_from_config",
+                    return_value=database,
+                ),
+                patch(
+                    "src.database.migration.preview_sokuho_capture_identity_migration",
+                    return_value=[],
+                ) as preview,
+                patch("src.cli.main.auto_update_check_notice", return_value=None),
+            ):
+                result = self.runner.invoke(
+                    cli,
+                    [
+                        "db",
+                        "migrate-sokuho-capture-identity",
+                        "--db",
+                        "postgresql",
+                        "--schema",
+                        "archive",
+                        "--table",
+                        "TS_SOKUHO_O4",
+                    ],
+                )
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        preview.assert_called_once_with(database, ("archive.TS_SOKUHO_O4",))
+
+
 class TestInitCommand(unittest.TestCase):
     """Test init command."""
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -815,9 +815,11 @@ auto_update_check: false
                     "processed_keys": 0,
                     "total_keys": 1,
                     "considered_keys": 3,
+                    "window_candidate_keys": 3,
                     "window_kept_keys": 1,
                     "dropped_too_far_future": 1,
                     "dropped_too_far_past": 1,
+                    "skipped_out_of_window_by_date": 0,
                     "success_keys": 0,
                     "no_data_keys": 0,
                     "error_keys": 0,
@@ -873,9 +875,11 @@ auto_update_check: false
         self.assertEqual(call_kwargs["post_time_within_minutes"], 30)
         self.assertEqual(call_kwargs["post_time_not_past_minutes"], 2)
         self.assertIn("considered=3", result.output)
+        self.assertIn("candidates=3", result.output)
         self.assertIn("kept=1", result.output)
         self.assertIn("future=1", result.output)
         self.assertIn("past=1", result.output)
+        self.assertIn("date_excluded=0", result.output)
 
     def test_timeseries_window_implicit_dates_use_jst(self):
         from datetime import datetime as real_datetime

--- a/tests/test_realtime.py
+++ b/tests/test_realtime.py
@@ -1481,7 +1481,7 @@ class TestRealtimeUpdater(unittest.TestCase):
             self.updater._get_primary_keys("TS_SOKUHO_O2"),
             [
                 "Year", "MonthDay", "JyoCD", "Kaiji", "Nichiji",
-                "RaceNum", "Kumi", "HassoTime", "SourceSpec", "CollectedAt",
+                "RaceNum", "Kumi", "HassoTime", "SourceSpec",
             ],
         )
         self.assertEqual(

--- a/tests/test_time_series.py
+++ b/tests/test_time_series.py
@@ -497,14 +497,149 @@ def test_sqlite_race_window_keeps_near_post_and_reports_drop_reasons(tmp_path, m
         "processed_keys": 0,
         "total_keys": 1,
         "considered_keys": 3,
+        "window_candidate_keys": 3,
         "window_kept_keys": 1,
         "dropped_too_far_future": 1,
         "dropped_too_far_past": 1,
+        "skipped_out_of_window_by_date": 0,
         "success_keys": 0,
         "no_data_keys": 0,
         "error_keys": 0,
         "total_records": 0,
     }
+
+
+def test_race_window_skips_malformed_post_time_on_out_of_window_date(tmp_path, monkeypatch):
+    import sqlite3
+    from contextlib import closing
+
+    from src.fetcher.realtime import RealtimeFetcher
+
+    _fixed_window_now(monkeypatch)
+    db_path = tmp_path / "date-excluded.db"
+    with closing(sqlite3.connect(db_path)) as conn:
+        conn.execute("""
+            CREATE TABLE NL_RA (
+                Year INTEGER, MonthDay INTEGER, JyoCD TEXT, Kaiji INTEGER,
+                Nichiji INTEGER, RaceNum INTEGER, HassoTime TEXT
+            )
+            """)
+        conn.executemany(
+            "INSERT INTO NL_RA VALUES (?, ?, ?, ?, ?, ?, ?)",
+            [
+                (2026, 901, "05", 3, 4, 1, "1230"),
+                (2026, 902, "05", 3, 4, 1, "not-a-time"),
+            ],
+        )
+        conn.commit()
+
+    progress = []
+    fetcher = object.__new__(RealtimeFetcher)
+    fetcher.jvlink = _window_jvlink()
+
+    assert (
+        list(
+            fetcher.fetch_time_series_batch_from_db(
+                data_spec="0B41",
+                db_path=str(db_path),
+                from_date="20260901",
+                to_date="20260902",
+                post_time_within_minutes=30,
+                progress_callback=progress.append,
+            )
+        )
+        == []
+    )
+
+    assert fetcher.jvlink.opened == [("0B41", "202609010501")]
+    assert progress[0]["considered_keys"] == 2
+    assert progress[0]["window_candidate_keys"] == 1
+    assert progress[0]["window_kept_keys"] == 1
+    assert progress[0]["dropped_too_far_future"] == 1
+    assert progress[0]["dropped_too_far_past"] == 0
+    assert progress[0]["skipped_out_of_window_by_date"] == 1
+
+
+def test_race_window_boundary_date_is_evaluated_by_post_time(tmp_path, monkeypatch):
+    import sqlite3
+    from contextlib import closing
+    from datetime import datetime
+
+    import src.fetcher.realtime as realtime_module
+    from src.fetcher.realtime import JST, RealtimeFetcher
+
+    monkeypatch.setattr(
+        realtime_module,
+        "_now_jst",
+        lambda: datetime(2026, 9, 1, 0, 0, tzinfo=JST),
+        raising=False,
+    )
+    db_path = tmp_path / "boundary-date.db"
+    with closing(sqlite3.connect(db_path)) as conn:
+        conn.execute("""
+            CREATE TABLE NL_RA (
+                Year INTEGER, MonthDay INTEGER, JyoCD TEXT, Kaiji INTEGER,
+                Nichiji INTEGER, RaceNum INTEGER, HassoTime TEXT
+            )
+            """)
+        conn.executemany(
+            "INSERT INTO NL_RA VALUES (?, ?, ?, ?, ?, ?, ?)",
+            [
+                (2026, 831, "05", 3, 4, 1, "1200"),
+                (2026, 831, "05", 3, 4, 2, "2359"),
+            ],
+        )
+        conn.commit()
+
+    progress = []
+    fetcher = object.__new__(RealtimeFetcher)
+    fetcher.jvlink = _window_jvlink()
+
+    assert (
+        list(
+            fetcher.fetch_time_series_batch_from_db(
+                data_spec="0B41",
+                db_path=str(db_path),
+                from_date="20260831",
+                to_date="20260831",
+                post_time_within_minutes=30,
+                post_time_not_past_minutes=2,
+                progress_callback=progress.append,
+            )
+        )
+        == []
+    )
+
+    assert fetcher.jvlink.opened == [("0B41", "202608310502")]
+    assert progress[0]["considered_keys"] == 2
+    assert progress[0]["window_candidate_keys"] == 2
+    assert progress[0]["window_kept_keys"] == 1
+    assert progress[0]["dropped_too_far_future"] == 0
+    assert progress[0]["dropped_too_far_past"] == 1
+    assert progress[0]["skipped_out_of_window_by_date"] == 0
+
+
+@pytest.mark.parametrize(
+    ("race_row", "within_minutes", "not_past_minutes", "race_key"),
+    [
+        ((2026, 831, "05", 3, 4, 1, "930"), 30, None, "202608310501"),
+        ((2026, 902, "05", 3, 4, 1, "930"), None, 2, "202609020501"),
+    ],
+)
+def test_race_window_disabled_bound_does_not_date_exclude_candidate(
+    monkeypatch, race_row, within_minutes, not_past_minutes, race_key
+):
+    from src.fetcher.base import FetcherError
+    from src.fetcher.realtime import _filter_race_rows_by_post_time
+
+    _fixed_window_now(monkeypatch)
+
+    with pytest.raises(FetcherError, match=rf"{race_key}.*unparsable"):
+        _filter_race_rows_by_post_time(
+            [race_row],
+            post_time_within_minutes=within_minutes,
+            post_time_not_past_minutes=not_past_minutes,
+        )
 
 
 def test_postgresql_race_window_filters_rows_from_pg_source(monkeypatch):
@@ -557,11 +692,14 @@ def test_postgresql_race_window_filters_rows_from_pg_source(monkeypatch):
     ("post_times", "reason"),
     [
         ([None], "missing"),
-        (["not-a-time"], "unparsable"),
+        (["930"], "unparsable"),
+        (["１２３０"], "unparsable"),
         (["1230", "1231"], "ambiguous"),
     ],
 )
-def test_race_window_fails_closed_and_names_bad_race_key(tmp_path, monkeypatch, post_times, reason):
+def test_race_window_candidate_fails_closed_and_names_bad_race_key(
+    tmp_path, monkeypatch, post_times, reason
+):
     import sqlite3
     from contextlib import closing
 

--- a/tests/test_time_series.py
+++ b/tests/test_time_series.py
@@ -8,9 +8,12 @@
 import sys
 from pathlib import Path
 
+import pytest
+
 # プロジェクトルートをパスに追加
 project_root = Path(__file__).parent.parent
 sys.path.insert(0, str(project_root))
+
 
 def test_key_generation():
     """キー生成関数のテスト"""
@@ -79,8 +82,7 @@ def test_fetch_time_series_batch_from_db_uses_simple_key():
     with tempfile.TemporaryDirectory(dir="/tmp") as temp_dir:
         db_path = Path(temp_dir) / "keiba.db"
         with closing(sqlite3.connect(db_path)) as conn:
-            conn.execute(
-                """
+            conn.execute("""
                 CREATE TABLE NL_RA (
                     Year INTEGER,
                     MonthDay INTEGER,
@@ -89,8 +91,7 @@ def test_fetch_time_series_batch_from_db_uses_simple_key():
                     Nichiji INTEGER,
                     RaceNum INTEGER
                 )
-                """
-            )
+                """)
             conn.execute("INSERT INTO NL_RA VALUES (2025, 1201, '05', 5, 8, 11)")
             conn.commit()
 
@@ -143,8 +144,7 @@ def test_fetch_time_series_batch_from_db_closes_no_data_stream():
     with tempfile.TemporaryDirectory(dir="/tmp") as temp_dir:
         db_path = Path(temp_dir) / "keiba.db"
         with closing(sqlite3.connect(db_path)) as conn:
-            conn.execute(
-                """
+            conn.execute("""
                 CREATE TABLE NL_RA (
                     Year INTEGER,
                     MonthDay INTEGER,
@@ -153,11 +153,11 @@ def test_fetch_time_series_batch_from_db_closes_no_data_stream():
                     Nichiji INTEGER,
                     RaceNum INTEGER
                 )
-                """
-            )
+                """)
             conn.execute("INSERT INTO NL_RA VALUES (2025, 1201, '05', 5, 8, 11)")
 
             conn.commit()
+
         class FakeJVLink:
             def __init__(self):
                 self.opened = []
@@ -208,8 +208,7 @@ def test_fetch_time_series_batch_from_db_discards_partial_key():
     with tempfile.TemporaryDirectory(dir="/tmp") as temp_dir:
         db_path = Path(temp_dir) / "keiba.db"
         with closing(sqlite3.connect(db_path)) as conn:
-            conn.execute(
-                """
+            conn.execute("""
                 CREATE TABLE NL_RA (
                     Year INTEGER,
                     MonthDay INTEGER,
@@ -218,8 +217,7 @@ def test_fetch_time_series_batch_from_db_discards_partial_key():
                     Nichiji INTEGER,
                     RaceNum INTEGER
                 )
-                """
-            )
+                """)
             conn.execute("INSERT INTO NL_RA VALUES (2025, 1201, '05', 5, 8, 11)")
             conn.commit()
 
@@ -418,6 +416,252 @@ def test_fetch_time_series_batch_from_postgres_supports_missing_rt_ra(monkeypatc
     assert "FROM rt_ra" not in captured["query"]
     assert records == [{"RecordSpec": "O2", "_raw": b"O2"}]
 
+
+def _fixed_window_now(monkeypatch):
+    from datetime import datetime, timedelta, timezone
+
+    import src.fetcher.realtime as realtime_module
+
+    now = datetime(2026, 9, 1, 12, 0, tzinfo=timezone(timedelta(hours=9)))
+    monkeypatch.setattr(realtime_module, "_now_jst", lambda: now, raising=False)
+
+
+def _window_jvlink():
+    class FakeJVLink:
+        def __init__(self):
+            self.opened = []
+            self.init_calls = 0
+
+        def jv_init(self):
+            self.init_calls += 1
+            return 0
+
+        def jv_rt_open(self, data_spec, key):
+            self.opened.append((data_spec, key))
+            return -1, 0
+
+        def jv_close(self):
+            return 0
+
+    return FakeJVLink()
+
+
+def test_sqlite_race_window_keeps_near_post_and_reports_drop_reasons(tmp_path, monkeypatch):
+    import sqlite3
+    from contextlib import closing
+
+    from src.fetcher.realtime import RealtimeFetcher
+
+    _fixed_window_now(monkeypatch)
+    db_path = tmp_path / "window.db"
+    with closing(sqlite3.connect(db_path)) as conn:
+        conn.execute("""
+            CREATE TABLE NL_RA (
+                Year INTEGER, MonthDay INTEGER, JyoCD TEXT, Kaiji INTEGER,
+                Nichiji INTEGER, RaceNum INTEGER, HassoTime TEXT
+            )
+            """)
+        conn.executemany(
+            "INSERT INTO NL_RA VALUES (?, ?, ?, ?, ?, ?, ?)",
+            [
+                (2026, 901, "05", 3, 4, 1, "1230"),
+                (2026, 901, "05", 3, 4, 2, "1231"),
+                (2026, 901, "05", 3, 4, 3, "1157"),
+            ],
+        )
+        conn.commit()
+
+    progress = []
+    fetcher = object.__new__(RealtimeFetcher)
+    fetcher.jvlink = _window_jvlink()
+
+    assert (
+        list(
+            fetcher.fetch_time_series_batch_from_db(
+                data_spec="0B41",
+                db_path=str(db_path),
+                from_date="20260901",
+                to_date="20260901",
+                post_time_within_minutes=30,
+                post_time_not_past_minutes=2,
+                progress_callback=progress.append,
+            )
+        )
+        == []
+    )
+
+    assert fetcher.jvlink.opened == [("0B41", "202609010501")]
+    assert progress[0] == {
+        "status": "window_filter",
+        "key": None,
+        "processed_keys": 0,
+        "total_keys": 1,
+        "considered_keys": 3,
+        "window_kept_keys": 1,
+        "dropped_too_far_future": 1,
+        "dropped_too_far_past": 1,
+        "success_keys": 0,
+        "no_data_keys": 0,
+        "error_keys": 0,
+        "total_records": 0,
+    }
+
+
+def test_postgresql_race_window_filters_rows_from_pg_source(monkeypatch):
+    from src.fetcher.realtime import RealtimeFetcher
+
+    _fixed_window_now(monkeypatch)
+    captured = {}
+
+    def fake_pg_rows(query, params, pg_config):
+        captured["query"] = query
+        return [
+            (2026, 901, "05", 3, 4, 1, "1230"),
+            (2026, 901, "05", 3, 4, 2, "1231"),
+            (2026, 901, "05", 3, 4, 3, "1157"),
+        ]
+
+    monkeypatch.setattr(
+        RealtimeFetcher,
+        "_fetch_time_series_race_rows_from_postgres",
+        staticmethod(fake_pg_rows),
+    )
+    monkeypatch.setattr(
+        RealtimeFetcher,
+        "_postgres_table_exists",
+        staticmethod(lambda _config, _table_name: False),
+    )
+    fetcher = object.__new__(RealtimeFetcher)
+    fetcher.jvlink = _window_jvlink()
+
+    assert (
+        list(
+            fetcher.fetch_time_series_batch_from_db(
+                data_spec="0B42",
+                db_path="ignored.sqlite",
+                from_date="20260901",
+                to_date="20260901",
+                pg_config={"host": "localhost", "database": "keiba"},
+                post_time_within_minutes=30,
+                post_time_not_past_minutes=2,
+            )
+        )
+        == []
+    )
+
+    assert "hassotime" in captured["query"].lower()
+    assert fetcher.jvlink.opened == [("0B42", "202609010501")]
+
+
+@pytest.mark.parametrize(
+    ("post_times", "reason"),
+    [
+        ([None], "missing"),
+        (["not-a-time"], "unparsable"),
+        (["1230", "1231"], "ambiguous"),
+    ],
+)
+def test_race_window_fails_closed_and_names_bad_race_key(tmp_path, monkeypatch, post_times, reason):
+    import sqlite3
+    from contextlib import closing
+
+    import pytest
+
+    from src.fetcher.base import FetcherError
+    from src.fetcher.realtime import RealtimeFetcher
+
+    _fixed_window_now(monkeypatch)
+    db_path = tmp_path / f"bad-{reason}.db"
+    with closing(sqlite3.connect(db_path)) as conn:
+        conn.execute("""
+            CREATE TABLE NL_RA (
+                Year INTEGER, MonthDay INTEGER, JyoCD TEXT, Kaiji INTEGER,
+                Nichiji INTEGER, RaceNum INTEGER, HassoTime TEXT
+            )
+            """)
+        conn.executemany(
+            "INSERT INTO NL_RA VALUES (2026, 901, '05', 3, 4, 1, ?)",
+            [(post_time,) for post_time in post_times],
+        )
+        conn.commit()
+
+    fetcher = object.__new__(RealtimeFetcher)
+    fetcher.jvlink = _window_jvlink()
+
+    with pytest.raises(FetcherError, match=rf"202609010501.*{reason}"):
+        list(
+            fetcher.fetch_time_series_batch_from_db(
+                data_spec="0B41",
+                db_path=str(db_path),
+                from_date="20260901",
+                to_date="20260901",
+                post_time_within_minutes=30,
+            )
+        )
+    assert fetcher.jvlink.init_calls == 0
+
+
+def test_race_window_off_leaves_legacy_postgresql_query_and_rows_untouched(monkeypatch):
+    from unittest.mock import MagicMock
+
+    from src.fetcher.realtime import RealtimeFetcher
+
+    captured = {}
+
+    def fake_pg_rows(query, params, pg_config):
+        captured["query"] = query
+        return [(2026, 901, "05", 3, 4, 1)]
+
+    monkeypatch.setattr(
+        RealtimeFetcher,
+        "_fetch_time_series_race_rows_from_postgres",
+        staticmethod(fake_pg_rows),
+    )
+    monkeypatch.setattr(
+        RealtimeFetcher,
+        "_postgres_table_exists",
+        staticmethod(lambda _config, _table_name: False),
+    )
+    monkeypatch.setattr(
+        "src.fetcher.realtime._now_jst",
+        MagicMock(side_effect=AssertionError("off path must not read the clock")),
+        raising=False,
+    )
+    fetcher = object.__new__(RealtimeFetcher)
+    fetcher.jvlink = _window_jvlink()
+
+    list(
+        fetcher.fetch_time_series_batch_from_db(
+            data_spec="0B41",
+            db_path="ignored.sqlite",
+            from_date="20260901",
+            to_date="20260901",
+            pg_config={"host": "localhost", "database": "keiba"},
+        )
+    )
+
+    expected_query = """
+                WITH race_targets AS (
+                    SELECT year, monthday, jyocd, kaiji, nichiji, racenum
+                    FROM nl_ra
+                    <RT_UNION>
+                )
+                SELECT DISTINCT
+                    year, monthday, jyocd, kaiji, nichiji, racenum
+                FROM race_targets
+                WHERE 1=1
+            """.replace("<RT_UNION>", "")
+    expected_query += " AND (year > %s OR (year = %s AND monthday >= %s))"
+    expected_query += " AND (year < %s OR (year = %s AND monthday <= %s))"
+    expected_query += (
+        " AND LPAD(CAST(jyocd AS TEXT), 2, '0') "
+        "IN ('01','02','03','04','05','06','07','08','09','10')"
+    )
+    expected_query += " ORDER BY year, monthday, jyocd, racenum"
+    assert captured["query"] == expected_query
+    assert fetcher.jvlink.opened == [("0B41", "202609010501")]
+
+
 def test_odds_parsers_expand_combination_arrays():
     """O1-O6 parsers should expand embedded odds arrays into row lists."""
     from src.parser.o1_parser import O1Parser
@@ -434,9 +678,30 @@ def test_odds_parsers_expand_combination_arrays():
     assert O4Parser.RECORD_LENGTH == 4031
     assert O5Parser.RECORD_LENGTH == 12293
     assert O6Parser.RECORD_LENGTH == 83285
-    assert "PRIMARY KEY (Year, MonthDay, JyoCD, Kaiji, Nichiji, RaceNum, Umaban, Kumi)" in SCHEMAS["NL_O1"]
-    assert "PRIMARY KEY (Year, MonthDay, JyoCD, Kaiji, Nichiji, RaceNum, Umaban, Kumi)" in SCHEMAS["RT_O1"]
-    header_o1 = b"O1" + b"4" + b"20260419" + b"2026" + b"0419" + b"06" + b"03" + b"08" + b"11" + b"04191549" + b"18" + b"18" + b"777" + b"3"
+    assert (
+        "PRIMARY KEY (Year, MonthDay, JyoCD, Kaiji, Nichiji, RaceNum, Umaban, Kumi)"
+        in SCHEMAS["NL_O1"]
+    )
+    assert (
+        "PRIMARY KEY (Year, MonthDay, JyoCD, Kaiji, Nichiji, RaceNum, Umaban, Kumi)"
+        in SCHEMAS["RT_O1"]
+    )
+    header_o1 = (
+        b"O1"
+        + b"4"
+        + b"20260419"
+        + b"2026"
+        + b"0419"
+        + b"06"
+        + b"03"
+        + b"08"
+        + b"11"
+        + b"04191549"
+        + b"18"
+        + b"18"
+        + b"777"
+        + b"3"
+    )
     tan = b"01012301" + b"02045602" + b"0" * (26 * 8)
     fuku = b"010010002001" + b"020030004002" + b"0" * (26 * 12)
     wakuren = b"120123401" + b"130567802" + b"0" * (34 * 9)
@@ -451,13 +716,23 @@ def test_odds_parsers_expand_combination_arrays():
     assert rows_o1[-1]["Kumi"] == "13"
     assert rows_o1[-1]["Umaban"] == "0"
 
-    header_combo = b"O2" + b"4" + b"20260419" + b"2026" + b"0419" + b"06" + b"03" + b"08" + b"11" + b"04191549" + b"18" + b"18" + b"7"
+    header_combo = (
+        b"O2"
+        + b"4"
+        + b"20260419"
+        + b"2026"
+        + b"0419"
+        + b"06"
+        + b"03"
+        + b"08"
+        + b"11"
+        + b"04191549"
+        + b"18"
+        + b"18"
+        + b"7"
+    )
     raw_o2 = (
-        header_combo
-        + b"0102000123010"
-        + b"0103000456020"
-        + b"0" * (151 * 13)
-        + b"00000000999\r\n"
+        header_combo + b"0102000123010" + b"0103000456020" + b"0" * (151 * 13) + b"00000000999\r\n"
     )
     assert len(raw_o2) == O2Parser.RECORD_LENGTH
     rows_o2 = O2Parser().parse(raw_o2)
@@ -483,11 +758,7 @@ def test_odds_parsers_expand_combination_arrays():
 
     header_o4 = b"O4" + header_combo[2:]
     raw_o4 = (
-        header_o4
-        + b"0102000123010"
-        + b"0201000456020"
-        + b"0" * (304 * 13)
-        + b"00000000666\r\n"
+        header_o4 + b"0102000123010" + b"0201000456020" + b"0" * (304 * 13) + b"00000000666\r\n"
     )
     assert len(raw_o4) == O4Parser.RECORD_LENGTH
     rows_o4 = O4Parser().parse(raw_o4)
@@ -498,11 +769,7 @@ def test_odds_parsers_expand_combination_arrays():
 
     header_o5 = b"O5" + header_combo[2:]
     raw_o5 = (
-        header_o5
-        + b"010203000123010"
-        + b"010204000456020"
-        + b"0" * (814 * 15)
-        + b"00000000555\r\n"
+        header_o5 + b"010203000123010" + b"010204000456020" + b"0" * (814 * 15) + b"00000000555\r\n"
     )
     assert len(raw_o5) == O5Parser.RECORD_LENGTH
     rows_o5 = O5Parser().parse(raw_o5)
@@ -552,8 +819,16 @@ def test_list_methods():
     print(f"\nlist_data_specs(): {len(all_specs)} specs (速報+時系列)")
 
     assert set(specs) == {
-        "0B20", "0B30", "0B31", "0B32", "0B33",
-        "0B34", "0B35", "0B36", "0B41", "0B42",
+        "0B20",
+        "0B30",
+        "0B31",
+        "0B32",
+        "0B33",
+        "0B34",
+        "0B35",
+        "0B36",
+        "0B41",
+        "0B42",
     }
     assert set(tracks) == {f"{code:02d}" for code in range(1, 11)}
     assert set(specs) <= set(all_specs)
@@ -672,8 +947,7 @@ def test_fetch_time_series_batch_from_db_includes_rt_ra_targets():
         db_path = Path(temp_dir) / "keiba.db"
         with closing(sqlite3.connect(db_path)) as conn:
             for table in ("NL_RA", "RT_RA"):
-                conn.execute(
-                    f"""
+                conn.execute(f"""
                     CREATE TABLE {table} (
                         Year INTEGER,
                         MonthDay INTEGER,
@@ -682,8 +956,7 @@ def test_fetch_time_series_batch_from_db_includes_rt_ra_targets():
                         Nichiji INTEGER,
                         RaceNum INTEGER
                     )
-                    """
-                )
+                    """)
             # Shared in both tables plus one that only the card feed knows.
             conn.execute("INSERT INTO NL_RA VALUES (2025, 1201, '05', 5, 8, 11)")
             conn.execute("INSERT INTO RT_RA VALUES (2025, 1201, '05', 5, 8, 11)")
@@ -734,8 +1007,7 @@ def test_fetch_time_series_batch_from_db_works_without_rt_ra():
     with tempfile.TemporaryDirectory(dir="/tmp") as temp_dir:
         db_path = Path(temp_dir) / "keiba.db"
         with closing(sqlite3.connect(db_path)) as conn:
-            conn.execute(
-                """
+            conn.execute("""
                 CREATE TABLE NL_RA (
                     Year INTEGER,
                     MonthDay INTEGER,
@@ -744,8 +1016,7 @@ def test_fetch_time_series_batch_from_db_works_without_rt_ra():
                     Nichiji INTEGER,
                     RaceNum INTEGER
                 )
-                """
-            )
+                """)
             conn.execute("INSERT INTO NL_RA VALUES (2025, 1201, '05', 5, 8, 11)")
             conn.commit()
 
@@ -807,9 +1078,7 @@ def test_postgres_table_probe_resolves_like_the_query(monkeypatch):
         def close(self):
             pass
 
-    monkeypatch.setattr(
-        "psycopg.connect", lambda **_kwargs: _Connection(), raising=False
-    )
+    monkeypatch.setattr("psycopg.connect", lambda **_kwargs: _Connection(), raising=False)
     assert RealtimeFetcher._postgres_table_exists({}, "rt_ra") is True
     assert "to_regclass" in captured["query"]
     assert "information_schema" not in captured["query"]

--- a/tests/test_timeseries_capture.py
+++ b/tests/test_timeseries_capture.py
@@ -207,10 +207,9 @@ def test_sqlite_legacy_sokuho_key_fails_closed_without_schema_or_row_changes(tmp
         assert "TS_SOKUHO_O2 uses the legacy primary key ending in CollectedAt" in str(
             startup_error.value
         )
-        assert (
-            "jltsql db migrate-sokuho-capture-identity --db sqlite " "--table TS_SOKUHO_O2 --apply"
-        ) in str(startup_error.value)
         assert "backup and rebuild" in str(startup_error.value)
+        assert "migrate-sokuho-capture-identity" not in str(startup_error.value)
+        assert "--apply" not in str(startup_error.value)
 
         with pytest.raises(SchemaMigrationError) as write_error:
             database.insert(
@@ -272,13 +271,14 @@ def test_dual_write_preflights_legacy_secondary_before_primary_mutation(tmp_path
 
         with pytest.raises(
             SchemaMigrationError,
-            match="TS_SOKUHO_O2.*migrate-sokuho-capture-identity",
-        ):
+            match="TS_SOKUHO_O2.*backup and rebuild",
+        ) as error:
             database.insert(
                 "TS_SOKUHO_O2",
                 _sokuho_o2_row(collected_at="2026-09-01T02:00:00+00:00"),
             )
 
+        assert "migrate-sokuho-capture-identity" not in str(error.value)
         assert primary.fetch_one("SELECT COUNT(*) AS count FROM TS_SOKUHO_O2") == {"count": 0}
         assert secondary.fetch_one("SELECT COUNT(*) AS count FROM TS_SOKUHO_O2") == {"count": 1}
     finally:
@@ -314,8 +314,7 @@ def test_dual_write_names_postgresql_override_for_legacy_postgresql_target(tmp_p
             )
 
         assert (
-            "jltsql db migrate-sokuho-capture-identity --db postgresql "
-            "--table TS_SOKUHO_O2 --apply"
+            "jltsql db migrate-sokuho-capture-identity --db postgresql " "--table TS_SOKUHO_O2."
         ) in str(error.value)
         assert primary.fetch_one("SELECT COUNT(*) AS count FROM TS_SOKUHO_O2") == {"count": 0}
     finally:
@@ -385,7 +384,9 @@ def test_schema_qualified_sqlite_sokuho_write_fails_closed(tmp_path, write_metho
             getattr(database, write_method)("main.TS_SOKUHO_O2", payload)
 
         assert str(error.value) == str(startup_error.value)
-        assert "--db sqlite --schema main --table TS_SOKUHO_O2 --apply" in str(error.value)
+        assert "main.TS_SOKUHO_O2 uses the legacy primary key" in str(error.value)
+        assert "backup and rebuild" in str(error.value)
+        assert "migrate-sokuho-capture-identity" not in str(error.value)
         assert database.fetch_one("SELECT COUNT(*) AS count FROM TS_SOKUHO_O2") == {"count": 0}
     finally:
         database.disconnect()
@@ -453,8 +454,10 @@ def test_postgresql_schema_qualified_legacy_message_preserves_schema():
     assert "archive.TS_SOKUHO_O2 uses the legacy primary key" in message
     assert (
         "jltsql db migrate-sokuho-capture-identity --db postgresql "
-        "--schema archive --table TS_SOKUHO_O2 --apply"
+        "--schema archive --table TS_SOKUHO_O2."
     ) in message
+    assert "read-only dry run (the default; it does not change data)" in message
+    assert "--apply mutates the table" in message
 
 
 def test_unrelated_sqlite_table_keeps_replace_behavior(tmp_path):
@@ -624,7 +627,7 @@ def test_postgresql_sokuho_startup_and_write_fail_closed_then_explicit_migration
     with pytest.raises(SchemaMigrationError) as startup_error:
         prepare_time_series_odds_table(database, table_name)
     assert (
-        "jltsql db migrate-sokuho-capture-identity --db postgresql " "--table TS_SOKUHO_O2 --apply"
+        "jltsql db migrate-sokuho-capture-identity --db postgresql " "--table TS_SOKUHO_O2."
     ) in str(startup_error.value)
     database.rollback()
 

--- a/tests/test_timeseries_capture.py
+++ b/tests/test_timeseries_capture.py
@@ -1,0 +1,504 @@
+"""Decision-time provenance contracts for time-series odds writes."""
+
+import os
+from threading import Event, Thread
+from unittest.mock import MagicMock
+from uuid import uuid4
+
+import pytest
+
+from src.database.schema import SCHEMAS
+from src.database.sqlite_handler import SQLiteDatabase
+from src.database.timeseries_capture import prepare_time_series_odds_table
+
+
+def _o2_row(*, collected_at, odds: float = 10.0, kumi: str = "0102") -> dict:
+    return {
+        "RecordSpec": "O2",
+        "DataKubun": "1",
+        "Year": 2026,
+        "MonthDay": 901,
+        "JyoCD": "05",
+        "Kaiji": 3,
+        "Nichiji": 4,
+        "RaceNum": 1,
+        "HassoTime": "09011200",
+        "Kumi": kumi,
+        "Odds": odds,
+        "CollectedAt": collected_at,
+    }
+
+
+def _sqlite_ts_o2(tmp_path) -> SQLiteDatabase:
+    database = SQLiteDatabase({"path": str(tmp_path / "timeseries.db")})
+    database.connect()
+    database.create_table("TS_O2", SCHEMAS["TS_O2"])
+    return database
+
+
+def _sokuho_o2_row(*, collected_at, odds: float = 10.0, kumi: str = "0102") -> dict:
+    return {
+        **_o2_row(collected_at=collected_at, odds=odds, kumi=kumi),
+        "SourceSpec": "0B32",
+    }
+
+
+def test_prepare_time_series_odds_table_creates_and_verifies_current_schema(tmp_path):
+    database = SQLiteDatabase({"path": str(tmp_path / "prepared.db")})
+    database.connect()
+    try:
+        prepare_time_series_odds_table(database, "TS_O2")
+
+        assert database.table_exists("TS_O2") is True
+        database.insert("TS_O2", _o2_row(collected_at="2026-09-01T03:00:00+00:00"))
+        assert database.fetch_one("SELECT CollectedAt FROM TS_O2") == {
+            "CollectedAt": "2026-09-01T03:00:00+00:00"
+        }
+    finally:
+        database.disconnect()
+
+
+def test_sqlite_later_recapture_keeps_first_stamp_and_corrected_price_wins(tmp_path):
+    database = _sqlite_ts_o2(tmp_path)
+    try:
+        database.insert_many(
+            "TS_O2",
+            [_o2_row(collected_at="2026-09-01T03:00:00+00:00", odds=10.0)],
+        )
+        database.insert_many(
+            "TS_O2",
+            [_o2_row(collected_at="2026-09-01T03:05:00+00:00", odds=12.5)],
+        )
+
+        row = database.fetch_one("SELECT Odds, CollectedAt FROM TS_O2")
+        assert row == {
+            "Odds": 12.5,
+            "CollectedAt": "2026-09-01T03:00:00+00:00",
+        }
+    finally:
+        database.disconnect()
+
+
+def test_sqlite_earlier_recapture_moves_stamp_back(tmp_path):
+    database = _sqlite_ts_o2(tmp_path)
+    try:
+        database.insert("TS_O2", _o2_row(collected_at="2026-09-01T03:05:00+00:00"))
+        database.insert("TS_O2", _o2_row(collected_at="2026-09-01T03:00:00+00:00"))
+
+        assert database.fetch_one("SELECT CollectedAt FROM TS_O2") == {
+            "CollectedAt": "2026-09-01T03:00:00+00:00"
+        }
+    finally:
+        database.disconnect()
+
+
+@pytest.mark.parametrize(
+    ("stored", "incoming", "expected"),
+    [
+        (
+            "2026-09-01T03:00:00+00:00",
+            None,
+            "2026-09-01T03:00:00+00:00",
+        ),
+        (
+            None,
+            "2026-09-01T03:00:00+00:00",
+            "2026-09-01T03:00:00+00:00",
+        ),
+        (None, None, None),
+    ],
+    ids=["incoming-null", "stored-null", "both-null"],
+)
+def test_sqlite_capture_stamp_is_null_safe(tmp_path, stored, incoming, expected):
+    database = _sqlite_ts_o2(tmp_path)
+    try:
+        database.insert("TS_O2", _o2_row(collected_at=stored))
+        database.insert("TS_O2", _o2_row(collected_at=incoming))
+
+        assert database.fetch_one("SELECT CollectedAt FROM TS_O2") == {"CollectedAt": expected}
+    finally:
+        database.disconnect()
+
+
+def test_sqlite_capture_comparison_normalizes_iso_offsets(tmp_path):
+    database = _sqlite_ts_o2(tmp_path)
+    try:
+        # 09:30 +09:00 is 00:30 UTC and therefore earlier than 01:00 UTC,
+        # even though the raw strings sort in the opposite order.
+        database.insert("TS_O2", _o2_row(collected_at="2026-09-01T09:30:00+09:00"))
+        database.insert("TS_O2", _o2_row(collected_at="2026-09-01T01:00:00+00:00"))
+
+        assert database.fetch_one("SELECT CollectedAt FROM TS_O2") == {
+            "CollectedAt": "2026-09-01T09:30:00+09:00"
+        }
+    finally:
+        database.disconnect()
+
+
+def test_sqlite_sokuho_uses_publication_identity_and_keeps_earliest_capture(tmp_path):
+    database = SQLiteDatabase({"path": str(tmp_path / "sokuho.db")})
+    database.connect()
+    try:
+        database.create_table("TS_SOKUHO_O2", SCHEMAS["TS_SOKUHO_O2"])
+        database.insert(
+            "TS_SOKUHO_O2",
+            _sokuho_o2_row(collected_at="2026-09-01T03:05:00+00:00", odds=10.0),
+        )
+        database.insert(
+            "TS_SOKUHO_O2",
+            _sokuho_o2_row(collected_at="2026-09-01T03:00:00+00:00", odds=12.5),
+        )
+
+        assert database.fetch_all("SELECT Odds, CollectedAt FROM TS_SOKUHO_O2") == [
+            {"Odds": 12.5, "CollectedAt": "2026-09-01T03:00:00+00:00"}
+        ]
+    finally:
+        database.disconnect()
+
+
+def test_sqlite_legacy_sokuho_key_fails_closed_without_schema_or_row_changes(tmp_path):
+    from src.database.migration import SchemaMigrationError, migrate_table_if_needed
+
+    database = SQLiteDatabase({"path": str(tmp_path / "legacy-sokuho.db")})
+    database.connect()
+    try:
+        current_schema = SCHEMAS["TS_SOKUHO_O2"]
+        legacy_schema = current_schema.replace(
+            "HassoTime, SourceSpec)",
+            "HassoTime, SourceSpec, CollectedAt)",
+        ).replace("Odds REAL,", "Odds REAL CHECK (Odds >= 0),")
+        database.create_table("TS_SOKUHO_O2", legacy_schema)
+        database.insert(
+            "TS_SOKUHO_O2",
+            _sokuho_o2_row(collected_at="2026-09-01T09:30:00+09:00", odds=10.0),
+        )
+        database.insert(
+            "TS_SOKUHO_O2",
+            _sokuho_o2_row(collected_at="2026-09-01T01:00:00+00:00", odds=12.5),
+        )
+        database.commit()
+        schema_before = database.fetch_one(
+            "SELECT sql FROM sqlite_master WHERE name = 'TS_SOKUHO_O2'"
+        )["sql"]
+
+        with pytest.raises(SchemaMigrationError, match="TS_SOKUHO_O2.*back up and rebuild"):
+            migrate_table_if_needed(database, "TS_SOKUHO_O2", current_schema)
+
+        assert (
+            database.fetch_one("SELECT sql FROM sqlite_master WHERE name = 'TS_SOKUHO_O2'")["sql"]
+            == schema_before
+        )
+        assert database.fetch_all(
+            "SELECT Odds, CollectedAt FROM TS_SOKUHO_O2 ORDER BY CollectedAt"
+        ) == [
+            {"Odds": 12.5, "CollectedAt": "2026-09-01T01:00:00+00:00"},
+            {"Odds": 10.0, "CollectedAt": "2026-09-01T09:30:00+09:00"},
+        ]
+        primary_key_rows = [
+            row for row in database.fetch_all('PRAGMA table_info("TS_SOKUHO_O2")') if row["pk"]
+        ]
+        primary_key = [row["name"] for row in sorted(primary_key_rows, key=lambda row: row["pk"])]
+        assert primary_key[-1] == "CollectedAt"
+    finally:
+        database.disconnect()
+
+
+def test_schema_qualified_sqlite_timeseries_upsert_uses_unqualified_row_name(tmp_path):
+    database = _sqlite_ts_o2(tmp_path)
+    try:
+        database.insert("main.TS_O2", _o2_row(collected_at="2026-09-01T03:05:00+00:00"))
+        database.insert("main.TS_O2", _o2_row(collected_at="2026-09-01T03:00:00+00:00"))
+        assert database.fetch_one("SELECT CollectedAt FROM TS_O2") == {
+            "CollectedAt": "2026-09-01T03:00:00+00:00"
+        }
+    finally:
+        database.disconnect()
+
+
+@pytest.mark.parametrize("table_name", ["TS_O2", "TS_SOKUHO_O2"])
+def test_postgresql_timeseries_upsert_normalizes_offsets_and_is_null_safe(table_name):
+    from src.database.postgresql_handler import PostgreSQLDatabase
+
+    database = PostgreSQLDatabase({})
+    database._get_primary_key_columns = MagicMock(  # type: ignore[method-assign]
+        return_value=[
+            "year",
+            "monthday",
+            "jyocd",
+            "kaiji",
+            "nichiji",
+            "racenum",
+            "kumi",
+            "hassotime",
+            *(("sourcespec",) if table_name.startswith("TS_SOKUHO_") else ()),
+        ]
+    )
+    database.execute = MagicMock(return_value=1)  # type: ignore[method-assign]
+    row = _o2_row(collected_at="2026-09-01T03:00:00+00:00", odds=12.5)
+    if table_name.startswith("TS_SOKUHO_"):
+        row["SourceSpec"] = "0B32"
+
+    database.insert(table_name, row)
+
+    sql = database.execute.call_args.args[0].lower()
+    assert "excluded.collectedat is null" in sql
+    assert f"{table_name.lower()}.collectedat is null" in sql
+    assert "excluded.collectedat::timestamptz" in sql
+    assert f"{table_name.lower()}.collectedat::timestamptz" in sql
+    assert "odds = excluded.odds" in sql
+
+
+def test_unrelated_sqlite_table_keeps_replace_behavior(tmp_path):
+    database = SQLiteDatabase({"path": str(tmp_path / "unrelated.db")})
+    database.connect()
+    try:
+        database.execute(
+            "CREATE TABLE OTHER_ODDS (Id INTEGER PRIMARY KEY, Price REAL, CollectedAt TEXT)"
+        )
+        database.insert("OTHER_ODDS", {"Id": 1, "Price": 10.0, "CollectedAt": "old"})
+        database.insert("OTHER_ODDS", {"Id": 1, "Price": 12.5, "CollectedAt": None})
+
+        assert database.fetch_one("SELECT Price, CollectedAt FROM OTHER_ODDS") == {
+            "Price": 12.5,
+            "CollectedAt": None,
+        }
+    finally:
+        database.disconnect()
+
+
+def test_postgresql_batch_dedupe_keeps_last_price_and_earliest_capture():
+    from src.database.postgresql_handler import PostgreSQLDatabase
+
+    rows = [
+        _o2_row(collected_at="2026-09-01T09:30:00+09:00", odds=10.0),
+        _o2_row(collected_at="2026-09-01T01:00:00+00:00", odds=12.5),
+    ]
+
+    deduped = PostgreSQLDatabase._dedupe_rows_by_primary_key(
+        rows,
+        ["year", "monthday", "jyocd", "kaiji", "nichiji", "racenum", "kumi", "hassotime"],
+        preserve_earliest_collected_at=True,
+    )
+
+    assert deduped == [_o2_row(collected_at="2026-09-01T09:30:00+09:00", odds=12.5)]
+
+
+@pytest.fixture
+def postgresql_timeseries_db():
+    if os.getenv("JLTSQL_RUN_POSTGRESQL_INTEGRATION") != "1":
+        pytest.skip("Set JLTSQL_RUN_POSTGRESQL_INTEGRATION=1 to run PostgreSQL tests")
+
+    from scripts.setup_pg_test_db import postgresql_test_config
+    from src.database.postgresql_handler import PostgreSQLDatabase
+
+    database = PostgreSQLDatabase(postgresql_test_config())
+    schema_name = f"jlt_ts_capture_{uuid4().hex[:12]}"
+    database.connect()
+    try:
+        database.execute(f"CREATE SCHEMA {schema_name}")
+        database.execute(f"SET search_path TO {schema_name}")
+        database.commit()
+        yield database
+    finally:
+        try:
+            database.rollback()
+            database.execute(f"DROP SCHEMA IF EXISTS {schema_name} CASCADE")
+            database.commit()
+        finally:
+            database.disconnect()
+
+
+@pytest.mark.parametrize("table_name", ["TS_O2", "TS_SOKUHO_O2"])
+def test_postgresql_timeseries_capture_behavior(postgresql_timeseries_db, table_name):
+    database = postgresql_timeseries_db
+    database.execute(SCHEMAS[table_name])
+    database.commit()
+    row_factory = _sokuho_o2_row if table_name.startswith("TS_SOKUHO_") else _o2_row
+
+    database.insert(table_name, row_factory(collected_at="2026-09-01T01:00:00+00:00"))
+    database.insert(
+        table_name,
+        row_factory(collected_at="2026-09-01T03:05:00+00:00", odds=12.5),
+    )
+    database.insert(
+        table_name,
+        row_factory(collected_at="2026-09-01T09:30:00+09:00", odds=13.0),
+    )
+    database.insert(
+        table_name,
+        row_factory(collected_at=None, odds=14.0),
+    )
+    database.insert(
+        table_name,
+        row_factory(collected_at=None, kumi="0203"),
+    )
+    database.insert(
+        table_name,
+        row_factory(collected_at="2026-09-01T02:00:00+00:00", kumi="0203"),
+    )
+    database.insert(
+        table_name,
+        row_factory(collected_at=None, kumi="0304"),
+    )
+    database.insert(
+        table_name,
+        row_factory(collected_at=None, odds=15.0, kumi="0304"),
+    )
+    database.commit()
+
+    assert database.fetch_all(
+        f"SELECT kumi, odds, collectedat FROM {table_name} ORDER BY kumi"
+    ) == [
+        {
+            "kumi": "0102",
+            "odds": 14.0,
+            "collectedat": "2026-09-01T09:30:00+09:00",
+        },
+        {
+            "kumi": "0203",
+            "odds": 10.0,
+            "collectedat": "2026-09-01T02:00:00+00:00",
+        },
+        {"kumi": "0304", "odds": 15.0, "collectedat": None},
+    ]
+
+
+def test_postgresql_legacy_sokuho_key_migration(postgresql_timeseries_db):
+    from src.database.migration import migrate_table_if_needed
+
+    database = postgresql_timeseries_db
+    current_schema = SCHEMAS["TS_SOKUHO_O2"]
+    legacy_schema = current_schema.replace(
+        "HassoTime, SourceSpec)",
+        "HassoTime, SourceSpec, CollectedAt)",
+    )
+    database.execute(legacy_schema)
+    database.commit()
+    database.insert(
+        "TS_SOKUHO_O2",
+        _sokuho_o2_row(collected_at="2026-09-01T09:30:00+09:00", odds=10.0),
+    )
+    database.insert(
+        "TS_SOKUHO_O2",
+        _sokuho_o2_row(collected_at="2026-09-01T01:00:00+00:00", odds=12.5),
+    )
+    database.commit()
+
+    assert migrate_table_if_needed(database, "TS_SOKUHO_O2", current_schema) is True
+    assert database.fetch_all("SELECT odds, collectedat FROM TS_SOKUHO_O2") == [
+        {"odds": 12.5, "collectedat": "2026-09-01T09:30:00+09:00"}
+    ]
+    assert database._get_primary_key_columns("TS_SOKUHO_O2")[-1] == "sourcespec"
+    assert (
+        database.fetch_all(
+            "SELECT tablename FROM pg_tables "
+            "WHERE schemaname = current_schema() AND tablename LIKE '__jltsql_%'"
+        )
+        == []
+    )
+
+
+def test_postgresql_sokuho_migration_locks_out_concurrent_correction(
+    postgresql_timeseries_db,
+):
+    from scripts.setup_pg_test_db import postgresql_test_config
+    from src.database.migration import migrate_table_if_needed
+    from src.database.postgresql_handler import PostgreSQLDatabase
+
+    database = postgresql_timeseries_db
+    current_schema = database.fetch_one("SELECT current_schema() AS name")["name"]
+    current_table_schema = SCHEMAS["TS_SOKUHO_O2"]
+    legacy_schema = current_table_schema.replace(
+        "HassoTime, SourceSpec)",
+        "HassoTime, SourceSpec, CollectedAt)",
+    )
+    database.execute(legacy_schema)
+    database.commit()
+    database.insert(
+        "TS_SOKUHO_O2",
+        _sokuho_o2_row(collected_at="2026-09-01T09:30:00+09:00", odds=10.0),
+    )
+    database.insert(
+        "TS_SOKUHO_O2",
+        _sokuho_o2_row(collected_at="2026-09-01T01:00:00+00:00", odds=12.5),
+    )
+    database.commit()
+
+    collector = PostgreSQLDatabase(postgresql_test_config())
+    collector.connect()
+    collector.execute(f"SET search_path TO {current_schema}")
+    collector.commit()
+    lock_acquired = Event()
+    release_migration = Event()
+    correction_started = Event()
+    correction_finished = Event()
+    errors = []
+    original_execute = database.execute
+
+    def guarded_execute(sql, parameters=None):
+        result = original_execute(sql, parameters)
+        if sql.startswith("LOCK TABLE"):
+            lock_acquired.set()
+            if not release_migration.wait(5):
+                raise AssertionError("test did not release PostgreSQL migration lock")
+        return result
+
+    def migrate():
+        try:
+            migrate_table_if_needed(database, "TS_SOKUHO_O2", current_table_schema)
+        except Exception as exc:  # pragma: no cover - reported by assertion below
+            errors.append(exc)
+
+    def write_correction():
+        correction_started.set()
+        try:
+            collector.insert(
+                "TS_SOKUHO_O2",
+                _sokuho_o2_row(collected_at="2026-09-01T03:10:00+00:00", odds=15.0),
+            )
+            collector.commit()
+        except Exception as exc:  # pragma: no cover - reported by assertion below
+            errors.append(exc)
+        finally:
+            correction_finished.set()
+
+    database.execute = guarded_execute  # type: ignore[method-assign]
+    migration_thread = Thread(target=migrate)
+    correction_thread = Thread(target=write_correction)
+    try:
+        migration_thread.start()
+        assert lock_acquired.wait(5)
+        correction_thread.start()
+        assert correction_started.wait(5)
+        assert correction_finished.wait(0.25) is False
+        release_migration.set()
+        migration_thread.join(10)
+        correction_thread.join(10)
+        assert migration_thread.is_alive() is False
+        assert correction_thread.is_alive() is False
+        # This writer resolved the old PK before it blocked on the table lock,
+        # so PostgreSQL rejects its now-stale ON CONFLICT target visibly after
+        # the migration. The correction was not silently inserted and deleted.
+        assert len(errors) == 1
+        assert "no unique or exclusion constraint" in str(errors[0])
+        assert database.fetch_all("SELECT odds, collectedat FROM TS_SOKUHO_O2") == [
+            {"odds": 12.5, "collectedat": "2026-09-01T09:30:00+09:00"}
+        ]
+
+        # A normal retry resolves the new identity and applies the correction.
+        collector.insert(
+            "TS_SOKUHO_O2",
+            _sokuho_o2_row(collected_at="2026-09-01T03:10:00+00:00", odds=15.0),
+        )
+        collector.commit()
+        assert database.fetch_all("SELECT odds, collectedat FROM TS_SOKUHO_O2") == [
+            {"odds": 15.0, "collectedat": "2026-09-01T09:30:00+09:00"}
+        ]
+    finally:
+        release_migration.set()
+        if migration_thread.ident is not None:
+            migration_thread.join(10)
+        if correction_thread.ident is not None:
+            correction_thread.join(10)
+        database.execute = original_execute  # type: ignore[method-assign]
+        collector.disconnect()

--- a/tests/test_timeseries_capture.py
+++ b/tests/test_timeseries_capture.py
@@ -1,7 +1,6 @@
 """Decision-time provenance contracts for time-series odds writes."""
 
 import os
-from threading import Event, Thread
 from unittest.mock import MagicMock
 from uuid import uuid4
 
@@ -41,6 +40,23 @@ def _sokuho_o2_row(*, collected_at, odds: float = 10.0, kumi: str = "0102") -> d
         **_o2_row(collected_at=collected_at, odds=odds, kumi=kumi),
         "SourceSpec": "0B32",
     }
+
+
+def _raw_insert(database, table_name: str, row: dict) -> None:
+    """Seed legacy schemas without passing through the guarded writer."""
+    columns = list(row)
+    placeholders = ", ".join("?" for _ in columns)
+    database.execute(
+        f"INSERT INTO {table_name} ({', '.join(columns)}) VALUES ({placeholders})",
+        tuple(row[column] for column in columns),
+    )
+
+
+def _legacy_sokuho_schema(table_name: str) -> str:
+    return SCHEMAS[table_name].replace(
+        "HassoTime, SourceSpec)",
+        "HassoTime, SourceSpec, CollectedAt)",
+    )
 
 
 def test_prepare_time_series_odds_table_creates_and_verifies_current_schema(tmp_path):
@@ -157,22 +173,27 @@ def test_sqlite_sokuho_uses_publication_identity_and_keeps_earliest_capture(tmp_
 
 
 def test_sqlite_legacy_sokuho_key_fails_closed_without_schema_or_row_changes(tmp_path):
-    from src.database.migration import SchemaMigrationError, migrate_table_if_needed
+    from src.database.migration import (
+        SchemaMigrationError,
+        apply_sokuho_capture_identity_migration,
+        preview_sokuho_capture_identity_migration,
+    )
 
     database = SQLiteDatabase({"path": str(tmp_path / "legacy-sokuho.db")})
     database.connect()
     try:
         current_schema = SCHEMAS["TS_SOKUHO_O2"]
-        legacy_schema = current_schema.replace(
-            "HassoTime, SourceSpec)",
-            "HassoTime, SourceSpec, CollectedAt)",
-        ).replace("Odds REAL,", "Odds REAL CHECK (Odds >= 0),")
+        legacy_schema = _legacy_sokuho_schema("TS_SOKUHO_O2").replace(
+            "Odds REAL,", "Odds REAL CHECK (Odds >= 0),"
+        )
         database.create_table("TS_SOKUHO_O2", legacy_schema)
-        database.insert(
+        _raw_insert(
+            database,
             "TS_SOKUHO_O2",
             _sokuho_o2_row(collected_at="2026-09-01T09:30:00+09:00", odds=10.0),
         )
-        database.insert(
+        _raw_insert(
+            database,
             "TS_SOKUHO_O2",
             _sokuho_o2_row(collected_at="2026-09-01T01:00:00+00:00", odds=12.5),
         )
@@ -181,8 +202,35 @@ def test_sqlite_legacy_sokuho_key_fails_closed_without_schema_or_row_changes(tmp
             "SELECT sql FROM sqlite_master WHERE name = 'TS_SOKUHO_O2'"
         )["sql"]
 
-        with pytest.raises(SchemaMigrationError, match="TS_SOKUHO_O2.*back up and rebuild"):
-            migrate_table_if_needed(database, "TS_SOKUHO_O2", current_schema)
+        with pytest.raises(SchemaMigrationError) as startup_error:
+            prepare_time_series_odds_table(database, "TS_SOKUHO_O2")
+        assert "TS_SOKUHO_O2 uses the legacy primary key ending in CollectedAt" in str(
+            startup_error.value
+        )
+        assert (
+            "jltsql db migrate-sokuho-capture-identity --db sqlite " "--table TS_SOKUHO_O2 --apply"
+        ) in str(startup_error.value)
+        assert "backup and rebuild" in str(startup_error.value)
+
+        with pytest.raises(SchemaMigrationError) as write_error:
+            database.insert(
+                "TS_SOKUHO_O2",
+                _sokuho_o2_row(
+                    collected_at="2026-09-01T02:00:00+00:00",
+                    odds=15.0,
+                ),
+            )
+        assert str(write_error.value) == str(startup_error.value)
+
+        for operator_function in (
+            preview_sokuho_capture_identity_migration,
+            apply_sokuho_capture_identity_migration,
+        ):
+            with pytest.raises(
+                SchemaMigrationError,
+                match="SQLite migration refused.*back up.*rebuild",
+            ):
+                operator_function(database, ["TS_SOKUHO_O2"])
 
         assert (
             database.fetch_one("SELECT sql FROM sqlite_master WHERE name = 'TS_SOKUHO_O2'")["sql"]
@@ -203,6 +251,111 @@ def test_sqlite_legacy_sokuho_key_fails_closed_without_schema_or_row_changes(tmp
         database.disconnect()
 
 
+def test_dual_write_preflights_legacy_secondary_before_primary_mutation(tmp_path):
+    from src.database.dual_handler import DualDatabase
+    from src.database.migration import SchemaMigrationError
+
+    primary = SQLiteDatabase({"path": str(tmp_path / "primary.db")})
+    secondary = SQLiteDatabase({"path": str(tmp_path / "secondary.db")})
+    database = DualDatabase(primary, secondary)
+    database.connect()
+    try:
+        primary.execute(SCHEMAS["TS_SOKUHO_O2"])
+        secondary.execute(_legacy_sokuho_schema("TS_SOKUHO_O2"))
+        _raw_insert(
+            secondary,
+            "TS_SOKUHO_O2",
+            _sokuho_o2_row(collected_at="2026-09-01T01:00:00+00:00"),
+        )
+        primary.commit()
+        secondary.commit()
+
+        with pytest.raises(
+            SchemaMigrationError,
+            match="TS_SOKUHO_O2.*migrate-sokuho-capture-identity",
+        ):
+            database.insert(
+                "TS_SOKUHO_O2",
+                _sokuho_o2_row(collected_at="2026-09-01T02:00:00+00:00"),
+            )
+
+        assert primary.fetch_one("SELECT COUNT(*) AS count FROM TS_SOKUHO_O2") == {"count": 0}
+        assert secondary.fetch_one("SELECT COUNT(*) AS count FROM TS_SOKUHO_O2") == {"count": 1}
+    finally:
+        database.disconnect()
+
+
+def test_dual_write_names_postgresql_override_for_legacy_postgresql_target(tmp_path):
+    from src.database.dual_handler import DualDatabase
+    from src.database.migration import (
+        SchemaMigrationError,
+        _extract_primary_key_columns,
+    )
+    from src.database.postgresql_handler import PostgreSQLDatabase
+
+    primary = SQLiteDatabase({"path": str(tmp_path / "dual-primary.db")})
+    primary.connect()
+    primary.execute(SCHEMAS["TS_SOKUHO_O2"])
+    primary.commit()
+    secondary = PostgreSQLDatabase({})
+    secondary._connection = object()
+    expected_pk = _extract_primary_key_columns(SCHEMAS["TS_SOKUHO_O2"])
+    assert expected_pk is not None
+    secondary.fetch_all = MagicMock(  # type: ignore[method-assign]
+        return_value=[{"name": column.lower()} for column in [*expected_pk, "CollectedAt"]]
+    )
+    database = DualDatabase(primary, secondary)
+
+    try:
+        with pytest.raises(SchemaMigrationError) as error:
+            database.insert(
+                "TS_SOKUHO_O2",
+                _sokuho_o2_row(collected_at="2026-09-01T02:00:00+00:00"),
+            )
+
+        assert (
+            "jltsql db migrate-sokuho-capture-identity --db postgresql "
+            "--table TS_SOKUHO_O2 --apply"
+        ) in str(error.value)
+        assert primary.fetch_one("SELECT COUNT(*) AS count FROM TS_SOKUHO_O2") == {"count": 0}
+    finally:
+        primary.disconnect()
+        secondary._connection = None
+
+
+@pytest.mark.parametrize("write_method", ["insert", "insert_many"])
+def test_dual_sokuho_startup_and_write_refuse_disconnected_secondary(
+    tmp_path,
+    write_method,
+):
+    from src.database.dual_handler import DualDatabase
+    from src.database.migration import SchemaMigrationError
+
+    primary = SQLiteDatabase({"path": str(tmp_path / f"primary-{write_method}.db")})
+    secondary = SQLiteDatabase({"path": str(tmp_path / f"secondary-{write_method}.db")})
+    primary.connect()
+    primary.execute(SCHEMAS["TS_SOKUHO_O2"].replace("            Odds REAL,\n", ""))
+    primary.commit()
+    database = DualDatabase(primary, secondary)
+
+    try:
+        with pytest.raises(SchemaMigrationError, match="not connected"):
+            prepare_time_series_odds_table(database, "TS_SOKUHO_O2")
+        columns_after_refusal = {
+            row["name"].lower() for row in primary.fetch_all('PRAGMA table_info("TS_SOKUHO_O2")')
+        }
+        assert "odds" not in columns_after_refusal
+
+        row = _sokuho_o2_row(collected_at="2026-09-01T02:00:00+00:00")
+        payload = [row] if write_method == "insert_many" else row
+        with pytest.raises(SchemaMigrationError, match="not connected"):
+            getattr(database, write_method)("TS_SOKUHO_O2", payload)
+
+        assert primary.fetch_one("SELECT COUNT(*) AS count FROM TS_SOKUHO_O2") == {"count": 0}
+    finally:
+        primary.disconnect()
+
+
 def test_schema_qualified_sqlite_timeseries_upsert_uses_unqualified_row_name(tmp_path):
     database = _sqlite_ts_o2(tmp_path)
     try:
@@ -211,6 +364,29 @@ def test_schema_qualified_sqlite_timeseries_upsert_uses_unqualified_row_name(tmp
         assert database.fetch_one("SELECT CollectedAt FROM TS_O2") == {
             "CollectedAt": "2026-09-01T03:00:00+00:00"
         }
+    finally:
+        database.disconnect()
+
+
+@pytest.mark.parametrize("write_method", ["insert", "insert_many"])
+def test_schema_qualified_sqlite_sokuho_write_fails_closed(tmp_path, write_method):
+    from src.database.migration import SchemaMigrationError
+
+    database = SQLiteDatabase({"path": str(tmp_path / f"qualified-{write_method}.db")})
+    database.connect()
+    try:
+        database.execute(_legacy_sokuho_schema("TS_SOKUHO_O2"))
+        row = _sokuho_o2_row(collected_at="2026-09-01T03:00:00+00:00")
+        payload = [row] if write_method == "insert_many" else row
+
+        with pytest.raises(SchemaMigrationError, match="legacy primary key") as startup_error:
+            prepare_time_series_odds_table(database, "main.TS_SOKUHO_O2")
+        with pytest.raises(SchemaMigrationError, match="legacy primary key") as error:
+            getattr(database, write_method)("main.TS_SOKUHO_O2", payload)
+
+        assert str(error.value) == str(startup_error.value)
+        assert "--db sqlite --schema main --table TS_SOKUHO_O2 --apply" in str(error.value)
+        assert database.fetch_one("SELECT COUNT(*) AS count FROM TS_SOKUHO_O2") == {"count": 0}
     finally:
         database.disconnect()
 
@@ -246,6 +422,39 @@ def test_postgresql_timeseries_upsert_normalizes_offsets_and_is_null_safe(table_
     assert "excluded.collectedat::timestamptz" in sql
     assert f"{table_name.lower()}.collectedat::timestamptz" in sql
     assert "odds = excluded.odds" in sql
+
+
+def test_postgresql_sokuho_write_fails_closed_when_primary_key_catalog_is_unreadable():
+    from src.database.base import DatabaseError
+    from src.database.postgresql_handler import PostgreSQLDatabase
+
+    database = PostgreSQLDatabase({})
+    database.fetch_all = MagicMock(  # type: ignore[method-assign]
+        side_effect=DatabaseError("catalog unavailable")
+    )
+    database.execute = MagicMock(return_value=1)  # type: ignore[method-assign]
+
+    with pytest.raises(DatabaseError, match="catalog unavailable"):
+        database.insert(
+            "TS_SOKUHO_O2",
+            _sokuho_o2_row(collected_at="2026-09-01T03:00:00+00:00"),
+        )
+
+    database.execute.assert_not_called()
+
+
+def test_postgresql_schema_qualified_legacy_message_preserves_schema():
+    from src.database.migration import legacy_sokuho_capture_identity_message
+    from src.database.postgresql_handler import PostgreSQLDatabase
+
+    database = PostgreSQLDatabase({})
+    message = legacy_sokuho_capture_identity_message(database, "archive.TS_SOKUHO_O2")
+
+    assert "archive.TS_SOKUHO_O2 uses the legacy primary key" in message
+    assert (
+        "jltsql db migrate-sokuho-capture-identity --db postgresql "
+        "--schema archive --table TS_SOKUHO_O2 --apply"
+    ) in message
 
 
 def test_unrelated_sqlite_table_keeps_replace_behavior(tmp_path):
@@ -363,32 +572,266 @@ def test_postgresql_timeseries_capture_behavior(postgresql_timeseries_db, table_
     ]
 
 
-def test_postgresql_legacy_sokuho_key_migration(postgresql_timeseries_db):
-    from src.database.migration import migrate_table_if_needed
+def _create_postgresql_legacy_sokuho(database, table_name: str) -> None:
+    odds_number = int(table_name.rsplit("O", 1)[1])
+
+    def row(*, collected_at: str, odds: float) -> dict:
+        record = _sokuho_o2_row(collected_at=collected_at, odds=odds)
+        record["RecordSpec"] = f"O{odds_number}"
+        record["SourceSpec"] = f"0B3{odds_number}"
+        if odds_number == 3:
+            record["OddsLow"] = record.pop("Odds")
+            record["OddsHigh"] = odds + 1.0
+        return record
+
+    database.execute(_legacy_sokuho_schema(table_name))
+    _raw_insert(
+        database,
+        table_name,
+        row(
+            collected_at="2026-09-01T09:30:00+09:00",
+            odds=10.0,
+        ),
+    )
+    _raw_insert(
+        database,
+        table_name,
+        row(
+            collected_at="2026-09-01T01:00:00+00:00",
+            odds=12.5,
+        ),
+    )
+    database.commit()
+
+
+def test_postgresql_sokuho_startup_and_write_fail_closed_then_explicit_migration(
+    postgresql_timeseries_db,
+):
+    from src.database.migration import (
+        SchemaMigrationError,
+        apply_sokuho_capture_identity_migration,
+        preview_sokuho_capture_identity_migration,
+    )
 
     database = postgresql_timeseries_db
-    current_schema = SCHEMAS["TS_SOKUHO_O2"]
-    legacy_schema = current_schema.replace(
-        "HassoTime, SourceSpec)",
-        "HassoTime, SourceSpec, CollectedAt)",
+    table_name = "TS_SOKUHO_O2"
+    _create_postgresql_legacy_sokuho(database, table_name)
+    before_rows = database.fetch_all(
+        f"SELECT odds, collectedat FROM {table_name} ORDER BY collectedat"
     )
-    database.execute(legacy_schema)
-    database.commit()
+    database.rollback()
+
+    with pytest.raises(SchemaMigrationError) as startup_error:
+        prepare_time_series_odds_table(database, table_name)
+    assert (
+        "jltsql db migrate-sokuho-capture-identity --db postgresql " "--table TS_SOKUHO_O2 --apply"
+    ) in str(startup_error.value)
+    database.rollback()
+
+    with pytest.raises(SchemaMigrationError) as write_error:
+        database.insert(
+            table_name,
+            _sokuho_o2_row(
+                collected_at="2026-09-01T03:10:00+00:00",
+                odds=15.0,
+            ),
+        )
+    assert str(write_error.value) == str(startup_error.value)
+    database.rollback()
+
+    executed_sql = []
+    original_execute = database.execute
+
+    def tracked_execute(sql, parameters=None):
+        executed_sql.append(sql)
+        return original_execute(sql, parameters)
+
+    database.execute = tracked_execute  # type: ignore[method-assign]
+    try:
+        reports = preview_sokuho_capture_identity_migration(database, [table_name])
+    finally:
+        database.execute = original_execute  # type: ignore[method-assign]
+
+    assert len(reports) == 1
+    report = reports[0]
+    assert report.status == "legacy"
+    assert report.total_rows == 2
+    assert report.distinct_publication_groups == 1
+    assert report.rows_to_delete == 1
+    assert report.collected_at_rewrite_groups == 1
+    assert any("REPEATABLE READ READ ONLY" in sql for sql in executed_sql)
+    assert not any("ACCESS EXCLUSIVE" in sql for sql in executed_sql)
+    assert (
+        database.fetch_all(f"SELECT odds, collectedat FROM {table_name} ORDER BY collectedat")
+        == before_rows
+    )
+    assert database._get_primary_key_columns(table_name)[-1] == "collectedat"
+    database.rollback()
+
+    executed_sql = []
+    database.execute = tracked_execute  # type: ignore[method-assign]
+    try:
+        applied_reports = apply_sokuho_capture_identity_migration(database, [table_name])
+    finally:
+        database.execute = original_execute  # type: ignore[method-assign]
+
+    assert applied_reports[0].applied is True
+    lock_index = next(
+        index for index, sql in enumerate(executed_sql) if sql.startswith("LOCK TABLE")
+    )
+    snapshot_index = next(
+        index for index, sql in enumerate(executed_sql) if sql.startswith("CREATE TEMP TABLE")
+    )
+    assert lock_index < snapshot_index
+    assert database.fetch_all(f"SELECT odds, collectedat FROM {table_name}") == [
+        {"odds": 12.5, "collectedat": "2026-09-01T09:30:00+09:00"}
+    ]
+    assert database._get_primary_key_columns(table_name)[-1] == "sourcespec"
+    assert (
+        database.fetch_all(
+            "SELECT tablename FROM pg_tables "
+            "WHERE schemaname = current_schema() AND tablename LIKE '__jltsql_%'"
+        )
+        == []
+    )
+    database.rollback()
+
     database.insert(
-        "TS_SOKUHO_O2",
+        table_name,
+        _sokuho_o2_row(
+            collected_at="2026-09-01T03:10:00+00:00",
+            odds=15.0,
+        ),
+    )
+    database.commit()
+    assert database.fetch_all(f"SELECT odds, collectedat FROM {table_name}") == [
+        {"odds": 15.0, "collectedat": "2026-09-01T09:30:00+09:00"}
+    ]
+
+
+def test_postgresql_sokuho_migration_table_restriction(postgresql_timeseries_db):
+    from src.database.migration import apply_sokuho_capture_identity_migration
+
+    database = postgresql_timeseries_db
+    _create_postgresql_legacy_sokuho(database, "TS_SOKUHO_O3")
+    _create_postgresql_legacy_sokuho(database, "TS_SOKUHO_O4")
+
+    reports = apply_sokuho_capture_identity_migration(
+        database,
+        ["TS_SOKUHO_O3"],
+    )
+
+    assert [report.table_name for report in reports] == ["TS_SOKUHO_O3"]
+    assert database._get_primary_key_columns("TS_SOKUHO_O3")[-1] == "sourcespec"
+    assert database._get_primary_key_columns("TS_SOKUHO_O4")[-1] == "collectedat"
+
+
+def test_postgresql_sokuho_migration_preserves_schema_qualified_target(
+    postgresql_timeseries_db,
+):
+    from src.database.migration import (
+        apply_sokuho_capture_identity_migration,
+        preview_sokuho_capture_identity_migration,
+    )
+
+    database = postgresql_timeseries_db
+    schema_name = f"jltsql_sokuho_{uuid4().hex}"
+    table_name = f"{schema_name}.TS_SOKUHO_O2"
+    legacy_schema = _legacy_sokuho_schema("TS_SOKUHO_O2").replace(
+        "CREATE TABLE IF NOT EXISTS TS_SOKUHO_O2",
+        f"CREATE TABLE IF NOT EXISTS {table_name}",
+        1,
+    )
+    database.execute(f"CREATE SCHEMA {schema_name}")
+    database.execute(legacy_schema)
+    _raw_insert(
+        database,
+        table_name,
         _sokuho_o2_row(collected_at="2026-09-01T09:30:00+09:00", odds=10.0),
     )
-    database.insert(
-        "TS_SOKUHO_O2",
+    _raw_insert(
+        database,
+        table_name,
         _sokuho_o2_row(collected_at="2026-09-01T01:00:00+00:00", odds=12.5),
     )
     database.commit()
 
-    assert migrate_table_if_needed(database, "TS_SOKUHO_O2", current_schema) is True
-    assert database.fetch_all("SELECT odds, collectedat FROM TS_SOKUHO_O2") == [
-        {"odds": 12.5, "collectedat": "2026-09-01T09:30:00+09:00"}
-    ]
-    assert database._get_primary_key_columns("TS_SOKUHO_O2")[-1] == "sourcespec"
+    try:
+        preview = preview_sokuho_capture_identity_migration(database, [table_name])
+        assert preview[0].table_name == table_name
+        assert preview[0].rows_to_delete == 1
+
+        applied = apply_sokuho_capture_identity_migration(database, [table_name])
+        assert applied[0].table_name == table_name
+        assert database._get_primary_key_columns(table_name)[-1] == "sourcespec"
+        assert database.fetch_all(f"SELECT odds, collectedat FROM {table_name}") == [
+            {"odds": 12.5, "collectedat": "2026-09-01T09:30:00+09:00"}
+        ]
+    finally:
+        database.rollback()
+        database.execute(f"DROP SCHEMA IF EXISTS {schema_name} CASCADE")
+        database.commit()
+
+
+def test_sokuho_apply_rolls_back_if_unlocked_table_becomes_legacy(monkeypatch):
+    import src.database.migration as migration
+
+    database = MagicMock()
+    database.get_db_type.return_value = "postgresql"
+    database.has_pending_transaction.return_value = False
+    expected_pk = migration._expected_sokuho_primary_key("TS_SOKUHO_O2")
+    classifications = iter(
+        [
+            ("current", expected_pk, expected_pk),
+            ("legacy", [*expected_pk, "CollectedAt"], expected_pk),
+        ]
+    )
+    monkeypatch.setattr(
+        migration,
+        "_classify_sokuho_table",
+        lambda _database, _table_name: next(classifications),
+    )
+
+    with pytest.raises(
+        migration.SchemaMigrationError,
+        match="before an ACCESS EXCLUSIVE lock was acquired",
+    ):
+        migration.apply_sokuho_capture_identity_migration(database, ["TS_SOKUHO_O2"])
+
+    database.rollback.assert_called_once_with()
+    database.commit.assert_not_called()
+
+
+def test_postgresql_sokuho_migration_rolls_back_every_table_on_failure(
+    postgresql_timeseries_db,
+):
+    from src.database.migration import (
+        SchemaMigrationError,
+        apply_sokuho_capture_identity_migration,
+    )
+
+    database = postgresql_timeseries_db
+    table_names = ["TS_SOKUHO_O5", "TS_SOKUHO_O6"]
+    for table_name in table_names:
+        _create_postgresql_legacy_sokuho(database, table_name)
+
+    original_execute = database.execute
+
+    def injected_failure(sql, parameters=None):
+        if sql.startswith("ALTER TABLE ts_sokuho_o6 DROP CONSTRAINT"):
+            raise RuntimeError("injected migration failure")
+        return original_execute(sql, parameters)
+
+    database.execute = injected_failure  # type: ignore[method-assign]
+    try:
+        with pytest.raises(SchemaMigrationError, match="injected migration failure"):
+            apply_sokuho_capture_identity_migration(database, table_names)
+    finally:
+        database.execute = original_execute  # type: ignore[method-assign]
+
+    for table_name in table_names:
+        assert database._get_primary_key_columns(table_name)[-1] == "collectedat"
+        assert database.fetch_one(f"SELECT COUNT(*) AS count FROM {table_name}") == {"count": 2}
     assert (
         database.fetch_all(
             "SELECT tablename FROM pg_tables "
@@ -398,107 +841,34 @@ def test_postgresql_legacy_sokuho_key_migration(postgresql_timeseries_db):
     )
 
 
-def test_postgresql_sokuho_migration_locks_out_concurrent_correction(
+def test_postgresql_sokuho_migration_rejects_invalid_collected_at(
     postgresql_timeseries_db,
 ):
-    from scripts.setup_pg_test_db import postgresql_test_config
-    from src.database.migration import migrate_table_if_needed
-    from src.database.postgresql_handler import PostgreSQLDatabase
+    from src.database.migration import (
+        SchemaMigrationError,
+        apply_sokuho_capture_identity_migration,
+        preview_sokuho_capture_identity_migration,
+    )
 
     database = postgresql_timeseries_db
-    current_schema = database.fetch_one("SELECT current_schema() AS name")["name"]
-    current_table_schema = SCHEMAS["TS_SOKUHO_O2"]
-    legacy_schema = current_table_schema.replace(
-        "HassoTime, SourceSpec)",
-        "HassoTime, SourceSpec, CollectedAt)",
-    )
-    database.execute(legacy_schema)
-    database.commit()
-    database.insert(
-        "TS_SOKUHO_O2",
-        _sokuho_o2_row(collected_at="2026-09-01T09:30:00+09:00", odds=10.0),
-    )
-    database.insert(
-        "TS_SOKUHO_O2",
-        _sokuho_o2_row(collected_at="2026-09-01T01:00:00+00:00", odds=12.5),
+    table_name = "TS_SOKUHO_O2"
+    database.execute(_legacy_sokuho_schema(table_name))
+    _raw_insert(
+        database,
+        table_name,
+        _sokuho_o2_row(collected_at="not-an-offset-timestamp"),
     )
     database.commit()
 
-    collector = PostgreSQLDatabase(postgresql_test_config())
-    collector.connect()
-    collector.execute(f"SET search_path TO {current_schema}")
-    collector.commit()
-    lock_acquired = Event()
-    release_migration = Event()
-    correction_started = Event()
-    correction_finished = Event()
-    errors = []
-    original_execute = database.execute
+    for operator_function in (
+        preview_sokuho_capture_identity_migration,
+        apply_sokuho_capture_identity_migration,
+    ):
+        with pytest.raises(
+            SchemaMigrationError,
+            match="invalid offset-aware CollectedAt",
+        ):
+            operator_function(database, [table_name])
 
-    def guarded_execute(sql, parameters=None):
-        result = original_execute(sql, parameters)
-        if sql.startswith("LOCK TABLE"):
-            lock_acquired.set()
-            if not release_migration.wait(5):
-                raise AssertionError("test did not release PostgreSQL migration lock")
-        return result
-
-    def migrate():
-        try:
-            migrate_table_if_needed(database, "TS_SOKUHO_O2", current_table_schema)
-        except Exception as exc:  # pragma: no cover - reported by assertion below
-            errors.append(exc)
-
-    def write_correction():
-        correction_started.set()
-        try:
-            collector.insert(
-                "TS_SOKUHO_O2",
-                _sokuho_o2_row(collected_at="2026-09-01T03:10:00+00:00", odds=15.0),
-            )
-            collector.commit()
-        except Exception as exc:  # pragma: no cover - reported by assertion below
-            errors.append(exc)
-        finally:
-            correction_finished.set()
-
-    database.execute = guarded_execute  # type: ignore[method-assign]
-    migration_thread = Thread(target=migrate)
-    correction_thread = Thread(target=write_correction)
-    try:
-        migration_thread.start()
-        assert lock_acquired.wait(5)
-        correction_thread.start()
-        assert correction_started.wait(5)
-        assert correction_finished.wait(0.25) is False
-        release_migration.set()
-        migration_thread.join(10)
-        correction_thread.join(10)
-        assert migration_thread.is_alive() is False
-        assert correction_thread.is_alive() is False
-        # This writer resolved the old PK before it blocked on the table lock,
-        # so PostgreSQL rejects its now-stale ON CONFLICT target visibly after
-        # the migration. The correction was not silently inserted and deleted.
-        assert len(errors) == 1
-        assert "no unique or exclusion constraint" in str(errors[0])
-        assert database.fetch_all("SELECT odds, collectedat FROM TS_SOKUHO_O2") == [
-            {"odds": 12.5, "collectedat": "2026-09-01T09:30:00+09:00"}
-        ]
-
-        # A normal retry resolves the new identity and applies the correction.
-        collector.insert(
-            "TS_SOKUHO_O2",
-            _sokuho_o2_row(collected_at="2026-09-01T03:10:00+00:00", odds=15.0),
-        )
-        collector.commit()
-        assert database.fetch_all("SELECT odds, collectedat FROM TS_SOKUHO_O2") == [
-            {"odds": 15.0, "collectedat": "2026-09-01T09:30:00+09:00"}
-        ]
-    finally:
-        release_migration.set()
-        if migration_thread.ident is not None:
-            migration_thread.join(10)
-        if correction_thread.ident is not None:
-            correction_thread.join(10)
-        database.execute = original_execute  # type: ignore[method-assign]
-        collector.disconnect()
+    assert database._get_primary_key_columns(table_name)[-1] == "collectedat"
+    assert database.fetch_one(f"SELECT COUNT(*) AS count FROM {table_name}") == {"count": 1}


### PR DESCRIPTION
## Summary

`realtime timeseries` could only be pointed at a date range, so capturing official one-year time-series odds (`0B41`/`0B42`) live meant fetching a whole race day (~250k records) per invocation — unusable inside a minute-granularity collector slot. And when a publication that was already stored got fetched again, the generic upsert overwrote `CollectedAt`, destroying the proof that the price had been held *before* the decision instant. Both are prerequisites for strict decision-odds evidence.

Three changes:

1. **Opt-in post-time window on race-key selection** (SQLite and PostgreSQL sources, both default off so existing behavior is unchanged):

```
realtime timeseries --spec 0B41 --post-time-within-minutes 20 --post-time-not-past-minutes 1
  keys considered=N kept=K dropped=D (reason=outside_window / ...)
```

Post time comes from `nl_ra.hassotime` (the race post time — distinct from the odds record's `hassotime`, which is the publication stamp). A key inside the requested window whose post time is missing, not strict 4-digit `HHMM`, or conflicting across rows fails closed and names the affected keys. The two bounds are independent: `within` alone does not exclude already-started races.

2. **First-capture provenance on time-series odds tables only** (`TS_O1`, `TS_O2`, other `TS_O*`, `TS_SOKUHO_O1..O6`). On conflict the row still takes the newest values (a corrected price must land), but `CollectedAt` keeps the *earliest non-NULL* observation:

```
collectedat := earliest_non_null(existing, incoming)   -- compared as instants across UTC offsets,
                                                       -- stored as the original text
```

NULL/NULL stays NULL; one-sided NULL keeps the non-NULL stamp. No other table's conflict behavior changes.

3. **Publication identity for Sokuho keys, with the destructive part behind an operator command.** The shipped `TS_SOKUHO_O*` primary key ended in `CollectedAt`, i.e. each poll was its own row, which is what made "earliest capture" unrepresentable. The new key drops `CollectedAt`. Collapsing existing polls deletes rows, so it is **not** done implicitly from any startup/quickstart path — those now fail closed naming the table and the command to run (PostgreSQL, SQLite, and dual mode), as does a time-series write against a table still carrying the legacy key:

```
jltsql db migrate-sokuho-capture-identity [--db sqlite|postgresql] [--schema S] [--table TS_SOKUHO_O1]... [--apply]
```

Dry run is the default, is read-only, takes no `ACCESS EXCLUSIVE`, and reports per table: current key, rows, distinct publication groups, rows that would be deleted, groups whose `CollectedAt` would be rewritten. `--apply` runs one rollback-safe transaction that locks `ACCESS EXCLUSIVE` before taking the grouping snapshot (so a concurrent collector correction cannot be deleted unseen), validates every existing stamp, keeps the latest values with the earliest non-NULL `CollectedAt`, and aborts unless retained rows equal group count. SQLite refuses before opening a connection and tells the operator to back up and rebuild.

Deploy order matters: after this ships, Sokuho writes stay fail-closed until the operator migration is applied.

## Verification

Local only — GitHub Actions is currently blocked org-wide by an Actions budget, so no CI run exists for this branch.

```
focused                     24 passed, 4 skipped
broad (affected modules)   233 passed, 14 skipped, 18 subtests
full suite               4,850 passed, 511 skipped
disposable PostgreSQL 17     17 passed
fatal flake8                 0
targeted black --check     PASS
```

No live provider fetch and no write to the staging database was performed from tests or verification; PostgreSQL coverage uses disposable containers.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added race post-time window filters for realtime timeseries retrieval.
  - Added database maintenance tooling to preview and apply Sokuho primary-key migrations.
  - Added automatic JST date handling when post-time filters are used.

- **Bug Fixes**
  - Time-series updates now preserve the earliest capture timestamp while applying newer odds values.
  - Legacy Sokuho table layouts fail safely with migration guidance.
  - Added validation for missing, invalid, or ambiguous race post times.

- **Documentation**
  - Documented migration procedures, filtering options, locking, rollback behavior, and database limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->