### PR TITLE
release: 2.1.0 (prospective official time-series odds capture)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@
 
 該当なし。
 
+## [2.1.0] - 2026-09-02
+
+### 2.1.0
+
+- `realtime odds-timeseries`に`--post-time-within-minutes` /
+  `--post-time-not-past-minutes`を追加し、発走前のレースだけを対象に公式
+  時系列オッズ（0B41/0B42）を取得できるようにした。発走時刻は`NL_RA`/`RT_RA`
+  から解決し、欠損・不正・曖昧な発走時刻はfail closedする。
+- 時系列オッズtableのupsertで`CollectedAt`を最初の捕捉時刻として保持する
+  （再取得で上書きしない）。SQLiteとPostgreSQLで同一挙動。
+- 速報oddsのPKをpublication identityへ修正。既存行の集約はDELETEを伴うため
+  起動時の暗黙実行をやめ、operator専用コマンド（既定dry-run、`--apply`で適用）
+  に分離した。
+
 ## [2.0.0] - 2026-08-27
 
 ### 2.0.0

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,24 @@
+# jrvltsql v2.1.0 Release Notes
+
+`2.1.0` is a minor release on top of `2.0.0`. It adds prospective capture of the
+official one-year time-series odds (`0B41`/`0B42`) and fixes capture provenance;
+no schema rebuild or reimport is required relative to `2.0.0`.
+
+What `2.1.0` adds over `2.0.0`:
+
+- `realtime odds-timeseries` accepts `--post-time-within-minutes` and
+  `--post-time-not-past-minutes`, so a scheduled run can fetch only the races
+  whose post time is still ahead instead of the whole day. Post time is resolved
+  from `NL_RA`/`RT_RA`; missing, malformed, or ambiguous post times fail closed
+  rather than being silently kept or dropped
+- time-series odds upserts preserve `CollectedAt` as the first capture time, so a
+  later refetch cannot erase the evidence that a price was held before the
+  decision time. SQLite and PostgreSQL behave identically
+- the sokuho odds primary key is publication identity. Because collapsing
+  existing rows deletes data, the migration is no longer run implicitly at
+  startup or on the write path; it is an explicit operator command that defaults
+  to dry-run and applies only with `--apply`
+
 # jrvltsql v2.0.0 Release Notes
 
 `2.0.0` is the stable major release built from the provider, SQLite,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "jltsql"
-version = "2.0.0"
+version = "2.1.0"
 description = "JRA-VAN DataLab の競馬データをSQLite・PostgreSQLにインポートするツール"
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,3 +1,3 @@
 """jrvltsql - JRA-VAN データ取得・管理ツール"""
 
-__version__ = "2.0.0"
+__version__ = "2.1.0"

--- a/tests/test_public_setup_contract.py
+++ b/tests/test_public_setup_contract.py
@@ -135,7 +135,7 @@ def test_removed_public_setup_contract_is_recorded_for_2_0() -> None:
     assert "RECORD_TYPE_O1" in release_notes
     assert "RECORD_TYPE_O6" in release_notes
     assert "uses_external_runner" in release_notes
-    assert project["project"]["version"] == "2.0.0"
+    assert project["project"]["version"] == "2.1.0"
     assert "wrapper.py の JVSetServiceKey 呼び出し箇所" not in constants
     for record_type in range(1, 7):
         assert f"DATA_SPEC_O{record_type} =" not in constants

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -75,7 +75,7 @@ class TestGetCurrentVersion:
         version = get_current_version()
         # Source metadata is the candidate version; a stale release tag must
         # not make a development checkout report the previous release.
-        assert version == "2.0.0"
+        assert version == "2.1.0"
 
     @patch("subprocess.run")
     def test_fallback_to_installed_distribution_metadata(

--- a/uv.lock
+++ b/uv.lock
@@ -325,7 +325,7 @@ wheels = [
 
 [[package]]
 name = "jltsql"
-version = "2.0.0"
+version = "2.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

Cuts `2.1.0` so the deployed collector can run the capture work merged in #260. Without a release, `jrvltsql-wine-runtime` cannot move its pinned wheel off `2.0.0.dev5`, so the post-time window flags and first-capture `CollectedAt` provenance never reach the JRA collector — and prospective strict decision-odds evidence cannot start accumulating on the next race day.

Version bump only; no behaviour change in this PR.

```
pyproject.toml   version = 2.0.0 -> 2.1.0
src/__init__.py  __version__   -> 2.1.0
uv.lock          jltsql        -> 2.1.0
CHANGELOG.md / RELEASE_NOTES.md  2.1.0 section (post-time window flags, first-capture CollectedAt, sokuho PK operator-only migration)
tests            version assertions follow the bump
```

Minor, not patch: #260 added CLI options and changed sokuho PK migration from implicit to an explicit operator command. No schema rebuild/reimport is required relative to `2.0.0`.

## Testing

Local (GitHub Actions is budget-blocked org-wide, so this is not CI evidence):

```
pytest -q  ->  4868 passed, 520 skipped, 21 subtests passed
```