### PR TITLE
fix(realtime): expose spec and post-time options on odds-timeseries alias (2.1.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,20 @@
 
 該当なし。
 
+## [2.1.1] - 2026-09-02
+
+### 2.1.1
+
+- `realtime odds-timeseries`に公式長期時系列spec限定の`--spec`と
+  `--post-time-within-minutes` / `--post-time-not-past-minutes`を公開し、generic
+  `timeseries`へそのまま転送する。未指定時は従来どおり0B41/0B42・発走時刻filter
+  なしとし、0B30〜0B36を含む非対応specは全日取得へfallbackせずnonzeroで拒否する。
+
 ## [2.1.0] - 2026-09-02
 
 ### 2.1.0
 
-- `realtime odds-timeseries`に`--post-time-within-minutes` /
+- generic `realtime timeseries`に`--post-time-within-minutes` /
   `--post-time-not-past-minutes`を追加し、発走前のレースだけを対象に公式
   時系列オッズ（0B41/0B42）を取得できるようにした。発走時刻は`NL_RA`/`RT_RA`
   から解決し、欠損・不正・曖昧な発走時刻はfail closedする。
@@ -599,7 +608,9 @@
 - quickstart.py 対話形式セットアップウィザード
 - CLI コマンド（fetch, status, monitor, init）
 
-[Unreleased]: https://github.com/miyamamoto/jrvltsql/compare/v2.0.0...HEAD
+[Unreleased]: https://github.com/miyamamoto/jrvltsql/compare/v2.1.1...HEAD
+[2.1.1]: https://github.com/miyamamoto/jrvltsql/compare/v2.1.0...v2.1.1
+[2.1.0]: https://github.com/miyamamoto/jrvltsql/compare/v2.0.0...v2.1.0
 [2.0.0]: https://github.com/miyamamoto/jrvltsql/compare/v1.6.10...v2.0.0
 [1.6.10]: https://github.com/miyamamoto/jrvltsql/compare/v1.6.9...v1.6.10
 [1.6.9]: https://github.com/miyamamoto/jrvltsql/compare/v1.6.8...v1.6.9

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,19 @@
+# jrvltsql v2.1.1 Release Notes
+
+`2.1.1` is a CLI compatibility hotfix on top of `2.1.0`; no parser, schema,
+storage, provider-registration, or migration contract changes.
+
+What `2.1.1` fixes over `2.1.0`:
+
+- `realtime odds-timeseries` now exposes `--post-time-within-minutes` and
+  `--post-time-not-past-minutes` and forwards them to the generic `timeseries`
+  implementation, so requested filtering cannot silently fall back to
+  whole-day collection
+- the alias exposes `--spec`, defaulting to `0B41,0B42`, while rejecting
+  sokuho (`0B30`-`0B36`) and every other unsupported spec before collection
+- omitting the new options preserves the previous official-spec, unfiltered
+  behavior exactly
+
 # jrvltsql v2.1.0 Release Notes
 
 `2.1.0` is a minor release on top of `2.0.0`. It adds prospective capture of the
@@ -6,7 +22,7 @@ no schema rebuild or reimport is required relative to `2.0.0`.
 
 What `2.1.0` adds over `2.0.0`:
 
-- `realtime odds-timeseries` accepts `--post-time-within-minutes` and
+- generic `realtime timeseries` accepts `--post-time-within-minutes` and
   `--post-time-not-past-minutes`, so a scheduled run can fetch only the races
   whose post time is still ahead instead of the whole day. Post time is resolved
   from `NL_RA`/`RT_RA`; missing, malformed, or ambiguous post times fail closed

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -86,6 +86,8 @@ jltsql realtime odds-timeseries --from 20250425 --to 20260425 --db postgresql
 ```
 
 - `odds-timeseries` は `0B41/0B42` を取得し、`TS_O1/TS_O2` に保存します。
+- `--spec` で片方だけを指定できます。公式長期時系列ではない `0B30`〜`0B36` や
+  その他の spec は、この alias では nonzero で拒否します。
 - `0B41/0B42` は公式仕様上の保存期間が 1年間です。
 - 0B30〜0B36 は速報オッズで、公式仕様上の保存期間は 1週間です。
 - コマンドは `NL_RA` に登録済みのレースを対象にし、JVRTOpen に `YYYYMMDDJJRR` 形式のキーを渡します。
@@ -149,12 +151,12 @@ SQLite に同じコマンドを実行しても database connection を開かず�
 SQLite は先に database をバックアップし、現行 schema で対象 table を再構築して
 ください。公式1年時系列の `TS_O1` / `TS_O2` はこの移行の対象外です。
 
-当日ライブ収集で全レースを再取得しない場合は、`timeseries` にレースレコードの
+当日ライブ収集で全レースを再取得しない場合は、`odds-timeseries` にレースレコードの
 発走時刻ウィンドウを明示します。次の例は、現在時刻（JST）から30分以内に発走し、
 発走後2分を超えていないレースだけを対象にします。
 
 ```bat
-jltsql realtime timeseries --spec 0B41 --from 20260901 --to 20260901 --db postgresql --post-time-within-minutes 30 --post-time-not-past-minutes 2
+jltsql realtime odds-timeseries --spec 0B41 --from 20260901 --to 20260901 --db postgresql --post-time-within-minutes 30 --post-time-not-past-minutes 2
 ```
 
 両オプションの既定値は無効です。どちらかを指定した場合、`NL_RA` / `RT_RA` の

--- a/docs/timeseries_odds.md
+++ b/docs/timeseries_odds.md
@@ -57,11 +57,11 @@ PostgreSQL も同じ `quickstart_timeseries.bat --db postgresql --from <FROM> --
 公式長期時系列は `TS_O1` / `TS_O2`、開催週速報は
 `TS_SOKUHO_O1`〜`TS_SOKUHO_O6` に分けて保存します。
 
-当日の公式時系列をライブ判断用に小さく取得する場合は、`timeseries` の発走時刻
+当日の公式時系列をライブ判断用に小さく取得する場合は、`odds-timeseries` の発走時刻
 ウィンドウを明示します。
 
 ```bat
-jltsql realtime timeseries --spec 0B41 --from 20260901 --to 20260901 --db postgresql --post-time-within-minutes 30 --post-time-not-past-minutes 2
+jltsql realtime odds-timeseries --spec 0B41 --from 20260901 --to 20260901 --db postgresql --post-time-within-minutes 30 --post-time-not-past-minutes 2
 ```
 
 `--post-time-within-minutes` は現在時刻（JST）から指定分以内に発走するキーを残し、

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "jltsql"
-version = "2.1.0"
+version = "2.1.1"
 description = "JRA-VAN DataLab の競馬データをSQLite・PostgreSQLにインポートするツール"
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,3 +1,3 @@
 """jrvltsql - JRA-VAN データ取得・管理ツール"""
 
-__version__ = "2.1.0"
+__version__ = "2.1.1"

--- a/src/cli/main.py
+++ b/src/cli/main.py
@@ -1690,6 +1690,25 @@ def realtime():
 # source and is kept for current-week/future accumulation.
 HISTORICAL_TIMESERIES_ODDS_SPECS = "0B41,0B42"
 SOKUHO_TIMESERIES_ODDS_SPECS = "0B30"
+OFFICIAL_HISTORICAL_TIMESERIES_ODDS_SPECS = frozenset(HISTORICAL_TIMESERIES_ODDS_SPECS.split(","))
+
+
+def _validate_official_historical_timeseries_specs(ctx, param, value):
+    """Keep the historical alias on official one-year time-series specs."""
+    requested_specs = [spec.strip() for spec in value.split(",")]
+    unsupported_specs = [
+        spec or "<empty>"
+        for spec in requested_specs
+        if spec not in OFFICIAL_HISTORICAL_TIMESERIES_ODDS_SPECS
+    ]
+    if unsupported_specs:
+        raise click.BadParameter(
+            "supports only official historical time-series specs 0B41 and 0B42; "
+            f"unsupported: {', '.join(unsupported_specs)}",
+            ctx=ctx,
+            param=param,
+        )
+    return value
 
 
 @realtime.command()
@@ -2191,6 +2210,13 @@ def timeseries(
 
 @realtime.command("odds-timeseries")
 @click.option(
+    "--spec",
+    "-s",
+    default=HISTORICAL_TIMESERIES_ODDS_SPECS,
+    callback=_validate_official_historical_timeseries_specs,
+    help="Official historical time-series spec (0B41 and/or 0B42)",
+)
+@click.option(
     "--from-date",
     "--from",
     "-f",
@@ -2207,6 +2233,18 @@ def timeseries(
     help="End date in YYYYMMDD format (default: today)",
 )
 @click.option(
+    "--post-time-within-minutes",
+    type=click.IntRange(min=0),
+    default=None,
+    help="Keep races whose NL_RA/RT_RA post time is at most N minutes ahead",
+)
+@click.option(
+    "--post-time-not-past-minutes",
+    type=click.IntRange(min=0),
+    default=None,
+    help="Drop races whose NL_RA/RT_RA post time is more than M minutes past",
+)
+@click.option(
     "--db",
     type=click.Choice(["sqlite", "postgresql"]),
     default=None,
@@ -2219,7 +2257,16 @@ def timeseries(
     help="SQLite database path (overrides config)",
 )
 @click.pass_context
-def odds_timeseries(ctx, from_date, to_date, db, db_path):
+def odds_timeseries(
+    ctx,
+    spec,
+    from_date,
+    to_date,
+    post_time_within_minutes,
+    post_time_not_past_minutes,
+    db,
+    db_path,
+):
     """Fetch official one-year JRA-VAN historical odds time-series.
 
     Official historical time-series odds are available for single/place/bracket
@@ -2227,9 +2274,11 @@ def odds_timeseries(ctx, from_date, to_date, db, db_path):
     """
     ctx.invoke(
         timeseries,
-        spec=HISTORICAL_TIMESERIES_ODDS_SPECS,
+        spec=spec,
         from_date=from_date,
         to_date=to_date,
+        post_time_within_minutes=post_time_within_minutes,
+        post_time_not_past_minutes=post_time_not_past_minutes,
         db=db,
         db_path=db_path,
     )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -939,6 +939,108 @@ auto_update_check: false
         self.assertEqual(window_clock_calls[0].args[0].utcoffset(None).total_seconds(), 32400)
 
 
+class TestRealtimeOddsTimeseriesAlias(unittest.TestCase):
+    """The official alias must preserve and forward the generic CLI contract."""
+
+    def setUp(self):
+        self.runner = CliRunner()
+
+    def test_default_forwards_official_specs_without_post_time_filtering(self):
+        from src.cli.main import odds_timeseries, timeseries
+
+        with patch.object(timeseries, "callback") as timeseries_callback:
+            result = self.runner.invoke(odds_timeseries)
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        timeseries_callback.assert_called_once_with(
+            spec="0B41,0B42",
+            from_date=None,
+            to_date=None,
+            post_time_within_minutes=None,
+            post_time_not_past_minutes=None,
+            db=None,
+            db_path=None,
+        )
+
+    def test_forwards_spec_dates_database_and_post_time_options(self):
+        from src.cli.main import odds_timeseries, timeseries
+
+        with patch.object(timeseries, "callback") as timeseries_callback:
+            result = self.runner.invoke(
+                odds_timeseries,
+                [
+                    "--spec",
+                    "0B42",
+                    "--from",
+                    "20260901",
+                    "--to",
+                    "20260902",
+                    "--post-time-within-minutes",
+                    "30",
+                    "--post-time-not-past-minutes",
+                    "2",
+                    "--db",
+                    "sqlite",
+                    "--db-path",
+                    "capture.db",
+                ],
+            )
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        timeseries_callback.assert_called_once_with(
+            spec="0B42",
+            from_date="20260901",
+            to_date="20260902",
+            post_time_within_minutes=30,
+            post_time_not_past_minutes=2,
+            db="sqlite",
+            db_path="capture.db",
+        )
+
+    def test_rejects_sokuho_and_other_unsupported_specs(self):
+        from src.cli.main import odds_timeseries, timeseries
+
+        unsupported_specs = (
+            "0B30",
+            "0B31",
+            "0B32",
+            "0B33",
+            "0B34",
+            "0B35",
+            "0B36",
+            "RACE",
+            "0B99",
+            "0B41,0B30",
+        )
+        for unsupported_spec in unsupported_specs:
+            with self.subTest(spec=unsupported_spec):
+                with patch.object(timeseries, "callback") as timeseries_callback:
+                    result = self.runner.invoke(
+                        odds_timeseries,
+                        ["--spec", unsupported_spec],
+                    )
+
+                self.assertNotEqual(result.exit_code, 0, result.output)
+                self.assertIn("only official historical time-series specs", result.output)
+                self.assertIn("unsupported:", result.output)
+                timeseries_callback.assert_not_called()
+
+    def test_reuses_nonnegative_post_time_option_validation(self):
+        from src.cli.main import odds_timeseries, timeseries
+
+        for option in (
+            "--post-time-within-minutes",
+            "--post-time-not-past-minutes",
+        ):
+            with self.subTest(option=option):
+                with patch.object(timeseries, "callback") as timeseries_callback:
+                    result = self.runner.invoke(odds_timeseries, [option, "-1"])
+
+                self.assertNotEqual(result.exit_code, 0, result.output)
+                self.assertIn("x>=0", result.output)
+                timeseries_callback.assert_not_called()
+
+
 class TestExportCommand(unittest.TestCase):
     """Test export command."""
 

--- a/tests/test_public_setup_contract.py
+++ b/tests/test_public_setup_contract.py
@@ -121,7 +121,7 @@ def test_removed_public_setup_contract_is_recorded_for_2_0() -> None:
     assert "## [2.0.0] - 2026-08-27" in changelog
     assert (
         "[Unreleased]: https://github.com/miyamamoto/jrvltsql/compare/"
-        "v2.0.0...HEAD"
+        "v2.1.1...HEAD"
     ) in changelog
     assert (
         "[2.0.0]: https://github.com/miyamamoto/jrvltsql/compare/"
@@ -135,7 +135,7 @@ def test_removed_public_setup_contract_is_recorded_for_2_0() -> None:
     assert "RECORD_TYPE_O1" in release_notes
     assert "RECORD_TYPE_O6" in release_notes
     assert "uses_external_runner" in release_notes
-    assert project["project"]["version"] == "2.1.0"
+    assert project["project"]["version"] == "2.1.1"
     assert "wrapper.py の JVSetServiceKey 呼び出し箇所" not in constants
     for record_type in range(1, 7):
         assert f"DATA_SPEC_O{record_type} =" not in constants

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -75,7 +75,7 @@ class TestGetCurrentVersion:
         version = get_current_version()
         # Source metadata is the candidate version; a stale release tag must
         # not make a development checkout report the previous release.
-        assert version == "2.1.0"
+        assert version == "2.1.1"
 
     @patch("subprocess.run")
     def test_fallback_to_installed_distribution_metadata(

--- a/uv.lock
+++ b/uv.lock
@@ -325,7 +325,7 @@ wheels = [
 
 [[package]]
 name = "jltsql"
-version = "2.1.0"
+version = "2.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

v2.1.0 で追加した発走時刻フィルタが汎用 `realtime timeseries` にしか出ておらず、`realtime odds-timeseries` alias は from/to/db/db-path しか転送していなかった。alias 経由でしか呼べないダウンストリーム collector（JRA wine-runtime の `prospective_odds_timeseries` mode）は取得前に fail closed するため、prospective な strict decision-odds 証跡が1件も溜まらない。

```
realtime odds-timeseries
  + --spec                          # 既定 0B41,0B42。0B30-0B36(速報)と未対応specは exit 2
  + --post-time-within-minutes      # 汎用 timeseries と同一 semantics を ctx.invoke で再利用
  + --post-time-not-past-minutes
```

option 未指定時の挙動は従来どおり（フィルタなし・公式spec）。フィルタを要求されたのに下流が対応していない場合は fallback せず fail closed。パーサ/保存契約、provider登録、初回 `CollectedAt` 保持は不変。バージョンは 2.1.1。

## Testing

- focused regressions: 11 passed, 12 subtests
- full suite: 4,858 passed / 514 skipped / 14 deselected / 33 subtests, coverage 80%
- fail-closed test-gate validator passed、fatal flake8 0 findings、`uv lock --check` passed
- distribution check 2 artifacts passed、wheel init smoke passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added `--spec` support to `realtime odds-timeseries`, accepting official long-term specifications (`0B41` and `0B42`).
  - Added post-time filtering options: `--post-time-within-minutes` and `--post-time-not-past-minutes`.
- **Bug Fixes**
  - Unsupported specifications, including sokuho options, are now rejected with a clear error instead of triggering unintended full-date fetching.
  - Existing unfiltered behavior is preserved when new options are omitted.
- **Documentation**
  - Updated CLI examples and usage guidance for `odds-timeseries`.
- **Release**
  - Version updated to 2.1.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->