### PR TITLE
feat(fetcher): store full failed records content-addressed and fail closed (supersedes #256)

### DIFF
--- a/src/fetcher/base.py
+++ b/src/fetcher/base.py
@@ -3,10 +3,15 @@
 This module provides the base class for fetching JV-Data from JV-Link.
 """
 
-import base64
 import gc
+import hashlib
+import ntpath
+import os
+import posixpath
+import tempfile
 import time
 from abc import ABC, abstractmethod
+from pathlib import Path
 from typing import Callable, Iterator, Optional
 
 from src.jvlink.constants import JV_READ_NO_MORE_DATA, JV_READ_SUCCESS
@@ -42,10 +47,7 @@ class BaseFetcher(ABC):
         parser_factory: Parser factory instance
     """
 
-    # An odds or mining buffer runs to ~100KB and would be written three times
-    # over (this log, and the caller's raw and masked streams), so cap what a
-    # single failure can add.
-    FAILED_RECORD_BYTES_LOGGED = 4096
+    FAILED_RECORD_DIR_ENV = "JLTSQL_FAILED_RECORD_DIR"
 
     def __init__(
         self,
@@ -213,34 +215,33 @@ class BaseFetcher(ABC):
                         continue
                     self._records_fetched += 1
 
-                    # Parse record
+                    # Parse record. Any rejection is fatal: continuing would
+                    # let callers consume an incomplete provider stream and
+                    # could emit an unbounded failure log on a corrupt feed.
                     try:
                         data = self.parser_factory.parse(buff)
-                        if data:
-                            # Full-struct parsers (H1, H6) return List[Dict]
-                            records_list = data if isinstance(data, list) else [data]
+                    except Exception as error:
+                        self._raise_failed_record(buff, filename, error=error)
+                    if not data:
+                        self._raise_failed_record(buff, filename, error=None)
 
-                            for record_item in records_list:
-                                # Filter by to_date if specified
-                                if to_date and not self._is_within_date_range(record_item, to_date):
-                                    logger.debug(
-                                        "Skipping record outside date range",
-                                        record_num=self._records_fetched,
-                                        to_date=to_date,
-                                    )
-                                    continue
+                    # Full-struct parsers (H1, H6) return List[Dict]
+                    records_list = data if isinstance(data, list) else [data]
 
-                                self._records_parsed += 1
-                                # Include raw buffer for callers that need it (e.g., RealtimeUpdater)
-                                record_item["_raw"] = buff
-                                yield record_item
-                        else:
-                            self._records_failed += 1
-                            self._log_failed_record(buff, filename, error=None)
+                    for record_item in records_list:
+                        # Filter by to_date if specified
+                        if to_date and not self._is_within_date_range(record_item, to_date):
+                            logger.debug(
+                                "Skipping record outside date range",
+                                record_num=self._records_fetched,
+                                to_date=to_date,
+                            )
+                            continue
 
-                    except Exception as e:
-                        self._records_failed += 1
-                        self._log_failed_record(buff, filename, error=e)
+                        self._records_parsed += 1
+                        # Include raw buffer for callers that need it (e.g., RealtimeUpdater)
+                        record_item["_raw"] = buff
+                        yield record_item
 
                     # Periodic GC to free COM buffer references (every 10s).
                     # kmy-keiba frees COM buffers with Array.Resize(ref buff, 0) after each read.
@@ -333,27 +334,96 @@ class BaseFetcher(ABC):
                 result=result,
             )
 
-    def _log_failed_record(self, buff, filename, *, error) -> None:
-        """Log one rejected record with enough context to find it again.
+    @classmethod
+    def _failed_record_directory(cls) -> Path:
+        configured = os.environ.get(cls.FAILED_RECORD_DIR_ENV)
+        if configured:
+            return Path(configured).expanduser()
+        if os.name == "nt":
+            state_root = Path(os.environ.get("LOCALAPPDATA") or Path.home())
+        else:
+            state_root = Path(
+                os.environ.get("XDG_STATE_HOME") or (Path.home() / ".local" / "state")
+            )
+        return state_root / "jltsql" / "failed-records"
 
-        A record number alone cannot identify a record: it counts this run, so a
-        re-run points it at a different record, and the buffer it came from is
-        gone by the time anyone reads the log (the download cache is purged on
-        failure). Name the file it arrived in and carry the bytes themselves, so
-        the record can be replayed through a parser afterwards.
-        """
+    @staticmethod
+    def _safe_jvd_filename(filename: object) -> str:
+        """Keep only a bounded provider filename, never a credential-bearing path."""
+
+        value = str(filename or "unknown")
+        value = posixpath.basename(ntpath.basename(value))
+        return value[:255] or "unknown"
+
+    def _write_failed_record_artifact(self, record: bytes) -> tuple[str, str]:
+        """Atomically preserve one complete record under its SHA-256 identity."""
+
+        digest = hashlib.sha256(record).hexdigest()
+        artifact_dir = self._failed_record_directory()
+        artifact_dir.mkdir(mode=0o700, parents=True, exist_ok=True)
+        target = artifact_dir / f"{digest}.jvd"
+        if target.exists():
+            if target.read_bytes() != record:
+                raise FetcherError("Existing failed-record artifact does not match its SHA-256")
+            return f"sha256:{digest}", digest
+
+        descriptor, temporary_name = tempfile.mkstemp(
+            prefix=f".{digest}.", suffix=".tmp", dir=artifact_dir
+        )
+        temporary = Path(temporary_name)
+        try:
+            if hasattr(os, "fchmod"):
+                os.fchmod(descriptor, 0o600)
+            with os.fdopen(descriptor, "wb") as artifact:
+                artifact.write(record)
+                artifact.flush()
+                os.fsync(artifact.fileno())
+            os.replace(temporary, target)
+        finally:
+            if temporary.exists():
+                temporary.unlink()
+        return f"sha256:{digest}", digest
+
+    def _log_failed_record(self, buff, filename, *, error) -> str:
+        """Persist the complete rejected record and emit only bounded metadata."""
+
         record = bytes(buff) if buff else b""
-        logged = record[: self.FAILED_RECORD_BYTES_LOGGED]
+        artifact_id, digest = self._write_failed_record_artifact(record)
+        record_spec = record[:2].decode("ascii", errors="replace")
+        if not record_spec.isprintable():
+            record_spec = record[:2].hex()
         logger.error(
             "Failed to parse record",
-            jvd_file=filename,
+            jvd_file=self._safe_jvd_filename(filename),
             record_num=self._records_fetched,
-            record_spec=record[:2].decode("ascii", errors="replace"),
-            error=str(error) if error is not None else None,
+            record_spec=record_spec,
+            error_type=type(error).__name__[:128] if error is not None else None,
             record_len=len(record),
-            record_b64=base64.b64encode(logged).decode("ascii"),
-            record_b64_truncated=len(record) > len(logged),
+            record_sha256=digest,
+            artifact_id=artifact_id,
         )
+        return artifact_id
+
+    def _raise_failed_record(self, buff, filename, *, error) -> None:
+        """Record one bounded diagnostic and stop the provider stream."""
+
+        self._records_failed += 1
+        try:
+            artifact_id = self._log_failed_record(buff, filename, error=error)
+        except Exception as artifact_error:
+            logger.error(
+                "Failed to preserve rejected record artifact",
+                jvd_file=self._safe_jvd_filename(filename),
+                record_num=self._records_fetched,
+                record_len=len(bytes(buff)) if buff else 0,
+                error_type=type(artifact_error).__name__[:128],
+            )
+            raise FetcherError(
+                "Parser rejected a record and artifact preservation failed"
+            ) from artifact_error
+        raise FetcherError(
+            f"Parser rejected record {self._records_fetched}; artifact {artifact_id}"
+        ) from error
 
     def get_statistics(self) -> dict:
         """Get fetching statistics.

--- a/src/fetcher/base.py
+++ b/src/fetcher/base.py
@@ -3,6 +3,7 @@
 This module provides the base class for fetching JV-Data from JV-Link.
 """
 
+import base64
 import gc
 import time
 from abc import ABC, abstractmethod
@@ -40,6 +41,11 @@ class BaseFetcher(ABC):
         jvlink: JV-Link wrapper instance
         parser_factory: Parser factory instance
     """
+
+    # An odds or mining buffer runs to ~100KB and would be written three times
+    # over (this log, and the caller's raw and masked streams), so cap what a
+    # single failure can add.
+    FAILED_RECORD_BYTES_LOGGED = 4096
 
     def __init__(
         self,
@@ -230,18 +236,11 @@ class BaseFetcher(ABC):
                                 yield record_item
                         else:
                             self._records_failed += 1
-                            logger.warning(
-                                "Failed to parse record",
-                                record_num=self._records_fetched,
-                            )
+                            self._log_failed_record(buff, filename, error=None)
 
                     except Exception as e:
                         self._records_failed += 1
-                        logger.error(
-                            "Error parsing record",
-                            record_num=self._records_fetched,
-                            error=str(e),
-                        )
+                        self._log_failed_record(buff, filename, error=e)
 
                     # Periodic GC to free COM buffer references (every 10s).
                     # kmy-keiba frees COM buffers with Array.Resize(ref buff, 0) after each read.
@@ -333,6 +332,28 @@ class BaseFetcher(ABC):
                 filename=filename,
                 result=result,
             )
+
+    def _log_failed_record(self, buff, filename, *, error) -> None:
+        """Log one rejected record with enough context to find it again.
+
+        A record number alone cannot identify a record: it counts this run, so a
+        re-run points it at a different record, and the buffer it came from is
+        gone by the time anyone reads the log (the download cache is purged on
+        failure). Name the file it arrived in and carry the bytes themselves, so
+        the record can be replayed through a parser afterwards.
+        """
+        record = bytes(buff) if buff else b""
+        logged = record[: self.FAILED_RECORD_BYTES_LOGGED]
+        logger.error(
+            "Failed to parse record",
+            jvd_file=filename,
+            record_num=self._records_fetched,
+            record_spec=record[:2].decode("ascii", errors="replace"),
+            error=str(error) if error is not None else None,
+            record_len=len(record),
+            record_b64=base64.b64encode(logged).decode("ascii"),
+            record_b64_truncated=len(record) > len(logged),
+        )
 
     def get_statistics(self) -> dict:
         """Get fetching statistics.

--- a/src/fetcher/historical.py
+++ b/src/fetcher/historical.py
@@ -716,18 +716,17 @@ class HistoricalFetcher(BaseFetcher):
                 try:
                     parsed = self.parser_factory.parse(raw)
                     if not parsed:
-                        self._records_failed += 1
-                        self._log_failed_record(raw, f"cache:{data_spec}", error=None)
-                        continue
+                        self._raise_failed_record(raw, f"cache:{data_spec}", error=None)
 
                     records = parsed if isinstance(parsed, list) else [parsed]
                     for record in records:
                         self._records_parsed += 1
                         record["_raw"] = raw
                         yield record
+                except FetcherError:
+                    raise
                 except Exception as error:
-                    self._records_failed += 1
-                    self._log_failed_record(raw, f"cache:{data_spec}", error=error)
+                    self._raise_failed_record(raw, f"cache:{data_spec}", error=error)
         else:
             # Cache miss: fetch from JV-Link, write to cache
             self.cache_manager = cache_manager

--- a/src/fetcher/historical.py
+++ b/src/fetcher/historical.py
@@ -717,11 +717,7 @@ class HistoricalFetcher(BaseFetcher):
                     parsed = self.parser_factory.parse(raw)
                     if not parsed:
                         self._records_failed += 1
-                        logger.warning(
-                            "Failed to parse cached record",
-                            record_num=self._records_fetched,
-                            data_spec=data_spec,
-                        )
+                        self._log_failed_record(raw, f"cache:{data_spec}", error=None)
                         continue
 
                     records = parsed if isinstance(parsed, list) else [parsed]
@@ -731,12 +727,7 @@ class HistoricalFetcher(BaseFetcher):
                         yield record
                 except Exception as error:
                     self._records_failed += 1
-                    logger.error(
-                        "Error parsing cached record",
-                        record_num=self._records_fetched,
-                        data_spec=data_spec,
-                        error=str(error),
-                    )
+                    self._log_failed_record(raw, f"cache:{data_spec}", error=error)
         else:
             # Cache miss: fetch from JV-Link, write to cache
             self.cache_manager = cache_manager

--- a/tests/test_failed_record_artifact.py
+++ b/tests/test_failed_record_artifact.py
@@ -10,14 +10,17 @@
 
 from __future__ import annotations
 
-import base64
-from unittest.mock import MagicMock
+import os
+from unittest.mock import MagicMock, patch
 
+import pytest
 import structlog
 
+from src.fetcher.base import FetcherError
 from src.fetcher.historical import HistoricalFetcher
 from src.parser.factory import ParserFactory
 from tests.fixtures.record_factory import make_se_record
+from tests.test_h1_official_contract import h1_raw
 
 JV_READ_COMPLETE = 0
 FAILED_RECORD_EVENT = "Failed to parse record"
@@ -45,19 +48,26 @@ def _fetcher(jv_read_results) -> HistoricalFetcher:
     return f
 
 
-def _failures(records: list[tuple[bytes, str]]) -> list[dict]:
+def _failures(
+    records: list[tuple[bytes, str]], artifact_dir
+) -> tuple[list[dict], HistoricalFetcher]:
     reads = [(len(buff), buff, filename) for buff, filename in records]
     reads.append((JV_READ_COMPLETE, None, None))
     fetcher = _fetcher(reads)
-    with structlog.testing.capture_logs() as logs:
+    with (
+        patch.dict(os.environ, {"JLTSQL_FAILED_RECORD_DIR": str(artifact_dir)}),
+        structlog.testing.capture_logs() as logs,
+        pytest.raises(FetcherError),
+    ):
         list(fetcher.fetch("RACE", "20220101", "20221231", option=4))
-    return [entry for entry in logs if entry.get("event") == FAILED_RECORD_EVENT]
+    failures = [entry for entry in logs if entry.get("event") == FAILED_RECORD_EVENT]
+    return failures, fetcher
 
 
-def test_a_failed_record_names_the_file_it_arrived_in() -> None:
+def test_a_failed_record_names_the_file_it_arrived_in(tmp_path) -> None:
     record = make_se_record(month_day="0231")
 
-    failure = _failures([(record, "SEVM2003129920230808162730.jvd")])[0]
+    failure = _failures([(record, "SEVM2003129920230808162730.jvd")], tmp_path)[0][0]
 
     assert failure["jvd_file"] == "SEVM2003129920230808162730.jvd"
     assert failure["record_num"] == 1
@@ -65,35 +75,28 @@ def test_a_failed_record_names_the_file_it_arrived_in() -> None:
     assert failure["log_level"] == "error"
 
 
-def test_a_failed_record_carries_its_own_bytes() -> None:
+def test_a_failed_record_carries_its_own_bytes(tmp_path) -> None:
     record = make_se_record(month_day="0231")
 
-    failure = _failures([(record, "f1.jvd")])[0]
+    failure = _failures([(record, "f1.jvd")], tmp_path)[0][0]
 
     assert failure["record_len"] == len(record)
-    assert failure["record_b64_truncated"] is False
-    assert base64.b64decode(failure["record_b64"]) == record
+    assert failure["artifact_id"] == f"sha256:{failure['record_sha256']}"
+    assert (tmp_path / f"{failure['record_sha256']}.jvd").read_bytes() == record
+    assert "record_b64" not in failure
+    assert "artifact_path" not in failure
 
 
-def test_long_records_are_truncated_visibly() -> None:
-    record = make_se_record(month_day="0231") + b"X" * 8192
-
-    failure = _failures([(record, "f1.jvd")])[0]
-
-    assert failure["record_len"] == len(record)
-    assert failure["record_b64_truncated"] is True
-    assert base64.b64decode(failure["record_b64"]) == record[:4096]
-
-
-def test_every_failed_record_is_logged_separately() -> None:
+def test_a_bad_feed_stops_after_one_bounded_failure_log(tmp_path) -> None:
     records = [(make_se_record(month_day="0231", umaban=f"{n:02d}"), "f1.jvd") for n in (1, 2)]
 
-    failures = _failures(records)
+    failures, fetcher = _failures(records, tmp_path)
 
-    assert [f["record_num"] for f in failures] == [1, 2]
+    assert [failure["record_num"] for failure in failures] == [1]
+    assert fetcher.jvlink.jv_read.call_count == 1
 
 
-def test_cached_records_are_logged_the_same_way() -> None:
+def test_cached_records_are_logged_the_same_way(tmp_path, monkeypatch) -> None:
     """キャッシュ再生経路も同じ失敗で、同じ困り方をする."""
     record = make_se_record(month_day="0231")
     cache = MagicMock()
@@ -101,23 +104,67 @@ def test_cached_records_are_logged_the_same_way() -> None:
     cache.read_nl.return_value = iter([record])
     fetcher = _fetcher([(JV_READ_COMPLETE, None, None)])
 
-    with structlog.testing.capture_logs() as logs:
+    monkeypatch.setenv("JLTSQL_FAILED_RECORD_DIR", str(tmp_path))
+    with structlog.testing.capture_logs() as logs, pytest.raises(FetcherError):
         list(fetcher.fetch_with_cache(cache, "RACE", "20220101", "20221231", option=4))
 
     failure = [e for e in logs if e.get("event") == FAILED_RECORD_EVENT][0]
     assert failure["jvd_file"] == "cache:RACE"
-    assert base64.b64decode(failure["record_b64"]) == record
+    assert (tmp_path / f"{failure['record_sha256']}.jvd").read_bytes() == record
 
 
-def test_an_unexpected_error_keeps_the_record_too() -> None:
+def test_an_unexpected_error_keeps_the_record_without_logging_its_message(
+    tmp_path, monkeypatch
+) -> None:
     record = make_se_record()
-    fetcher = _fetcher([(len(record), record, "f1.jvd"), (JV_READ_COMPLETE, None, None)])
+    fetcher = _fetcher(
+        [
+            (len(record), record, "/service-key-file-secret/f1.jvd"),
+            (JV_READ_COMPLETE, None, None),
+        ]
+    )
     fetcher.parser_factory = MagicMock()
-    fetcher.parser_factory.parse.side_effect = RuntimeError("boom")
+    fetcher.parser_factory.parse.side_effect = RuntimeError("service-key-top-secret")
 
-    with structlog.testing.capture_logs() as logs:
+    monkeypatch.setenv("JLTSQL_FAILED_RECORD_DIR", str(tmp_path))
+    with structlog.testing.capture_logs() as logs, pytest.raises(FetcherError):
         list(fetcher.fetch("RACE", "20220101", "20221231", option=4))
 
     failure = [e for e in logs if e.get("event") == FAILED_RECORD_EVENT][0]
-    assert failure["error"] == "boom"
-    assert base64.b64decode(failure["record_b64"]) == record
+    assert failure["error_type"] == "RuntimeError"
+    assert "service-key-top-secret" not in repr(logs)
+    assert "service-key-file-secret" not in repr(logs)
+    assert failure["jvd_file"] == "f1.jvd"
+    assert (tmp_path / f"{failure['record_sha256']}.jvd").read_bytes() == record
+
+
+def test_long_failures_with_the_same_prefix_are_fatal_and_fully_replayable(
+    monkeypatch, tmp_path
+) -> None:
+    """Tail corruption must yield distinct full artifacts, then stop the feed."""
+
+    monkeypatch.setenv("JLTSQL_FAILED_RECORD_DIR", str(tmp_path))
+    official = h1_raw()
+    assert len(official) == 28955
+    failures = []
+
+    for offset in (5000, 6000):
+        damaged = bytearray(official)
+        damaged[offset : offset + 2] = b"\x81\x30"
+        record = bytes(damaged)
+        fetcher = _fetcher(
+            [(len(record), record, "H1-official.jvd"), (JV_READ_COMPLETE, None, None)]
+        )
+        with structlog.testing.capture_logs() as logs:
+            with pytest.raises(FetcherError):
+                list(fetcher.fetch("RACE", "20220101", "20221231", option=4))
+        failures.append(
+            (record, [entry for entry in logs if entry.get("event") == FAILED_RECORD_EVENT][0])
+        )
+
+    assert failures[0][1]["artifact_id"] != failures[1][1]["artifact_id"]
+    for original, failure in failures:
+        artifact = tmp_path / f"{failure['record_sha256']}.jvd"
+        assert artifact.read_bytes() == original
+        assert failure["record_len"] == len(original)
+        assert "record_b64" not in failure

--- a/tests/test_failed_record_artifact.py
+++ b/tests/test_failed_record_artifact.py
@@ -1,0 +1,123 @@
+"""パースに失敗したレコードを、あとから同定して再生できる形でログに残すこと.
+
+見るのは fetch() が出すログ行そのもので、パーサの内部構造ではない。レコードは
+すべて合成（tests/fixtures/record_factory.py）で、実データの再取得を要求しない。
+
+このテストが確認しないこと:
+- どのフィールドのどの値で弾かれたか。それはパーサ自身が出す行に載る（この行が
+  持つのは、どのレコードだったかと、その中身）。
+"""
+
+from __future__ import annotations
+
+import base64
+from unittest.mock import MagicMock
+
+import structlog
+
+from src.fetcher.historical import HistoricalFetcher
+from src.parser.factory import ParserFactory
+from tests.fixtures.record_factory import make_se_record
+
+JV_READ_COMPLETE = 0
+FAILED_RECORD_EVENT = "Failed to parse record"
+
+
+def _fetcher(jv_read_results) -> HistoricalFetcher:
+    """JV-Link を持たない HistoricalFetcher（本物の ParserFactory を通す）."""
+    f = HistoricalFetcher.__new__(HistoricalFetcher)
+    f.parser_factory = ParserFactory()
+    f.cache_manager = None
+    f.show_progress = False
+    f.progress_display = None
+    f._service_key = None
+    f._records_fetched = f._records_parsed = f._records_failed = 0
+    f._files_processed = f._total_files = 0
+    f._start_time = 0.0
+    f._jvd_self_repair_attempts = f._jvd_replay_records_remaining = 0
+    f._recoverable_read_errors = 0
+    f._jv_open_context = f._jv_open_last_file_timestamp = f._fetch_task_id = None
+
+    f.jvlink = MagicMock()
+    f.jvlink.jv_init.return_value = None
+    f.jvlink.jv_open.return_value = (0, len(jv_read_results), 0, "20220110000000")
+    f.jvlink.jv_read.side_effect = jv_read_results
+    return f
+
+
+def _failures(records: list[tuple[bytes, str]]) -> list[dict]:
+    reads = [(len(buff), buff, filename) for buff, filename in records]
+    reads.append((JV_READ_COMPLETE, None, None))
+    fetcher = _fetcher(reads)
+    with structlog.testing.capture_logs() as logs:
+        list(fetcher.fetch("RACE", "20220101", "20221231", option=4))
+    return [entry for entry in logs if entry.get("event") == FAILED_RECORD_EVENT]
+
+
+def test_a_failed_record_names_the_file_it_arrived_in() -> None:
+    record = make_se_record(month_day="0231")
+
+    failure = _failures([(record, "SEVM2003129920230808162730.jvd")])[0]
+
+    assert failure["jvd_file"] == "SEVM2003129920230808162730.jvd"
+    assert failure["record_num"] == 1
+    assert failure["record_spec"] == "SE"
+    assert failure["log_level"] == "error"
+
+
+def test_a_failed_record_carries_its_own_bytes() -> None:
+    record = make_se_record(month_day="0231")
+
+    failure = _failures([(record, "f1.jvd")])[0]
+
+    assert failure["record_len"] == len(record)
+    assert failure["record_b64_truncated"] is False
+    assert base64.b64decode(failure["record_b64"]) == record
+
+
+def test_long_records_are_truncated_visibly() -> None:
+    record = make_se_record(month_day="0231") + b"X" * 8192
+
+    failure = _failures([(record, "f1.jvd")])[0]
+
+    assert failure["record_len"] == len(record)
+    assert failure["record_b64_truncated"] is True
+    assert base64.b64decode(failure["record_b64"]) == record[:4096]
+
+
+def test_every_failed_record_is_logged_separately() -> None:
+    records = [(make_se_record(month_day="0231", umaban=f"{n:02d}"), "f1.jvd") for n in (1, 2)]
+
+    failures = _failures(records)
+
+    assert [f["record_num"] for f in failures] == [1, 2]
+
+
+def test_cached_records_are_logged_the_same_way() -> None:
+    """キャッシュ再生経路も同じ失敗で、同じ困り方をする."""
+    record = make_se_record(month_day="0231")
+    cache = MagicMock()
+    cache.has_nl_range.return_value = True
+    cache.read_nl.return_value = iter([record])
+    fetcher = _fetcher([(JV_READ_COMPLETE, None, None)])
+
+    with structlog.testing.capture_logs() as logs:
+        list(fetcher.fetch_with_cache(cache, "RACE", "20220101", "20221231", option=4))
+
+    failure = [e for e in logs if e.get("event") == FAILED_RECORD_EVENT][0]
+    assert failure["jvd_file"] == "cache:RACE"
+    assert base64.b64decode(failure["record_b64"]) == record
+
+
+def test_an_unexpected_error_keeps_the_record_too() -> None:
+    record = make_se_record()
+    fetcher = _fetcher([(len(record), record, "f1.jvd"), (JV_READ_COMPLETE, None, None)])
+    fetcher.parser_factory = MagicMock()
+    fetcher.parser_factory.parse.side_effect = RuntimeError("boom")
+
+    with structlog.testing.capture_logs() as logs:
+        list(fetcher.fetch("RACE", "20220101", "20221231", option=4))
+
+    failure = [e for e in logs if e.get("event") == FAILED_RECORD_EVENT][0]
+    assert failure["error"] == "boom"
+    assert base64.b64decode(failure["record_b64"]) == record

--- a/tests/test_historical_cache_failures.py
+++ b/tests/test_historical_cache_failures.py
@@ -2,6 +2,9 @@
 
 from unittest.mock import MagicMock
 
+import pytest
+
+from src.fetcher.base import FetcherError
 from src.fetcher.historical import HistoricalFetcher
 
 
@@ -16,25 +19,29 @@ def _fetcher_without_jvlink() -> HistoricalFetcher:
     return fetcher
 
 
-def test_cache_replay_counts_parser_rejection_as_failure():
+def test_cache_replay_counts_parser_rejection_as_failure(tmp_path, monkeypatch):
     cache = MagicMock()
     cache.has_nl_range.return_value = True
     cache.read_nl.return_value = iter([b"invalid"])
     fetcher = _fetcher_without_jvlink()
     fetcher.parser_factory.parse.return_value = None
 
-    assert list(fetcher.fetch_with_cache(cache, "RACE", "20260714", "20260714")) == []
+    monkeypatch.setenv("JLTSQL_FAILED_RECORD_DIR", str(tmp_path))
+    with pytest.raises(FetcherError):
+        list(fetcher.fetch_with_cache(cache, "RACE", "20260714", "20260714"))
     assert fetcher.get_statistics()["records_failed"] == 1
 
 
-def test_cache_replay_counts_parser_exception_as_failure():
+def test_cache_replay_counts_parser_exception_as_failure(tmp_path, monkeypatch):
     cache = MagicMock()
     cache.has_nl_range.return_value = True
     cache.read_nl.return_value = iter([b"invalid"])
     fetcher = _fetcher_without_jvlink()
     fetcher.parser_factory.parse.side_effect = ValueError("broken cache record")
 
-    assert list(fetcher.fetch_with_cache(cache, "RACE", "20260714", "20260714")) == []
+    monkeypatch.setenv("JLTSQL_FAILED_RECORD_DIR", str(tmp_path))
+    with pytest.raises(FetcherError):
+        list(fetcher.fetch_with_cache(cache, "RACE", "20260714", "20260714"))
     stats = fetcher.get_statistics()
     assert stats["records_fetched"] == 1
     assert stats["records_parsed"] == 0


### PR DESCRIPTION
## Summary

Supersedes #256 (@hayato1980's branch, head commit included unchanged) and fixes the two properties that made it unmergeable.

Logging a rejected record is the right idea, but the original stored only a **4096-byte prefix** and then *continued reading*. Both break what the artifact is for:

```
two official 28,955-byte H1 records, corrupted at offset 5000 and 6000
  -> identical 4096-byte prefixes -> indistinguishable artifacts, unreplayable
parse failure -> log -> next JVRead     # ingestion silently continues past a bad record
```

Now every parser exception *and* falsey parser rejection is fatal before another `JVRead` or yield (same in cache replay), and the **complete** raw record is stored content-addressed as `<sha256>.jvd` written to a same-directory temp file, `fsync`, `os.replace`, dir 0700 / file 0600. A hash collision with mismatching content is fatal rather than silently overwritten.

The log line stays bounded metadata only — basename capped at 255 chars, record number, 2-byte spec, exception **type** (not its message), length, sha256, content-addressed id — so a bad feed cannot flood it (one log, one raise) and secrets cannot leak; a test injects secrets into both the exception and the directory path and asserts neither appears.

## Validation

Red-first on the #256 head: the 28,955-byte tail-corruption case did **not** raise, the two distinct corruptions produced the same stored prefix, and the bad-feed test read past the first rejected record.

- Focused: 10 passed
- Full suite (CI command): 4,819 passed, 507 skipped, 14 deselected, 21 subtests passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Record parsing failures now stop processing and raise a clear fetcher error instead of being silently skipped.
  * Failed records are preserved as securely stored artifacts for troubleshooting and replay.
  * Cached-record parsing failures now follow the same error behavior as regular fetches.
  * Failure logs include useful identifying metadata while limiting sensitive details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->