### PR TITLE
fix(realtime): overlay current race lifecycle for windows (2.1.2)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [ master, main, develop ]
   pull_request:
-    branches: [ master, main, develop ]
+    branches: [ master, main, develop, 'release/**' ]
 
 permissions:
   contents: read

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,16 +15,18 @@
 
 - 発走時刻window指定時の時系列オッズ対象選択で、同一フルキー（Year,
   MonthDay, JyoCD, Kaiji, Nichiji, RaceNum）のレースをライフサイクル
-  ソース優先で1系列に選ぶ。`RT_RA`行が存在するキーはDataKubunに関わらず
-  `RT_RA`が所有し、`NL_RA`は`RT_RA`に無いキーだけに使う（`RT_RA` table
-  不在時は`NL_RA`が全キーを所有）。古い`NL_RA`発走時刻と当日`RT_RA`改定
-  時刻の同居を曖昧性と誤検知してbatch全体を中断し、後続due raceの公式
-  O1/O2捕捉を失う障害（2026-09-05）を修正した。
+  ソース優先で1系列に選ぶ。保存済み`RT_RA`行が存在するキーはまず`RT_RA`
+  が所有し、`NL_RA`は`RT_RA`に無いキーだけに使う（`RT_RA` table不在時は
+  `NL_RA`が全キーを所有）。古い`NL_RA`発走時刻と当日`RT_RA`改定時刻の
+  同居を曖昧性と誤検知してbatch全体を中断し、後続due raceの公式O1/O2
+  捕捉を失う障害（2026-09-05）を修正した。
 - 選択された現行行のDataKubunを公式RA domain（`src/parser/status_domain.py`）
   で検証し、欠落・空白・domain外は対象レースキーを名指ししてfail closed
-  （何も開かない）。検証後、所有ソースを問わずDataKubun=9（中止）のキーは
-  収集対象から除外し、隠れた行へfallbackしない。選択ソース内で12桁キーの
-  発走時刻が衝突する真の曖昧性は従来どおりfail closedを維持する。
+  （何も開かない）。通常保存経路では物理削除されるDataKubun=0が残存して
+  いた場合も、activeとして扱わずfail closedする。検証後、所有ソースを問わず
+  DataKubun=9（中止）の12桁キーは収集対象から除外し、隠れた行へfallback
+  しない。同じ12桁キーがactiveと中止の両状態を持つ場合は行順に依存せず
+  fail closedし、発走時刻が衝突する真の曖昧性も従来どおりfail closedを維持する。
 - window統計に`omitted_canceled_keys`を常時追加し（中止なしでも0を報告）、
   `window_kept_keys`を中止除外後の実際に開く対象数と一致させた。
 - 下流runtimeが機械parseするCLI進捗を拡張した: `Window:`行に`canceled=`、
@@ -35,6 +37,10 @@
 - windowなしの対象選択query・schema・保存形式・provider書き込みは変更なし。
   windowなし出力の変更はキー処理時のCLI `Keys:`行に`nonempty=`が加わる
   ことのみ。
+- 既存の通常updaterはRTのDataKubun=0を物理削除するため、消えたRT tombstone
+  と「RT更新なし」をこのread pathだけでは区別できない。残存DK0のfail-closedは
+  本修正に含むが、RT erase後に古いNL行へfallbackしないことは本releaseでは
+  未証明であり、無条件の全DataKubunライフサイクル解決は主張しない。
 
 ## [2.1.1] - 2026-09-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,33 @@
 
 該当なし。
 
+## [2.1.2] - 2026-09-05
+
+### 2.1.2
+
+- 発走時刻window指定時の時系列オッズ対象選択で、同一フルキー（Year,
+  MonthDay, JyoCD, Kaiji, Nichiji, RaceNum）のレースをライフサイクル
+  ソース優先で1系列に選ぶ。`RT_RA`行が存在するキーはDataKubunに関わらず
+  `RT_RA`が所有し、`NL_RA`は`RT_RA`に無いキーだけに使う（`RT_RA` table
+  不在時は`NL_RA`が全キーを所有）。古い`NL_RA`発走時刻と当日`RT_RA`改定
+  時刻の同居を曖昧性と誤検知してbatch全体を中断し、後続due raceの公式
+  O1/O2捕捉を失う障害（2026-09-05）を修正した。
+- 選択された現行行のDataKubunを公式RA domain（`src/parser/status_domain.py`）
+  で検証し、欠落・空白・domain外は対象レースキーを名指ししてfail closed
+  （何も開かない）。検証後、所有ソースを問わずDataKubun=9（中止）のキーは
+  収集対象から除外し、隠れた行へfallbackしない。選択ソース内で12桁キーの
+  発走時刻が衝突する真の曖昧性は従来どおりfail closedを維持する。
+- window統計に`omitted_canceled_keys`を常時追加し（中止なしでも0を報告）、
+  `window_kept_keys`を中止除外後の実際に開く対象数と一致させた。
+- 下流runtimeが機械parseするCLI進捗を拡張した: `Window:`行に`canceled=`、
+  `Keys:`行に`nonempty=`（実レコードを1行以上返したキー数。ok=成功キーの
+  代用にしない）を追加し、window指定時は対象0件でも終端
+  `Keys: 0/0 ...`サマリを必ず1行出力する。`nonempty_keys`はfetcherの全
+  progress callbackと完了logにも常時含まれる（0でも省略しない）。
+- windowなしの対象選択query・schema・保存形式・provider書き込みは変更なし。
+  windowなし出力の変更はキー処理時のCLI `Keys:`行に`nonempty=`が加わる
+  ことのみ。
+
 ## [2.1.1] - 2026-09-02
 
 ### 2.1.1
@@ -608,7 +635,8 @@
 - quickstart.py 対話形式セットアップウィザード
 - CLI コマンド（fetch, status, monitor, init）
 
-[Unreleased]: https://github.com/miyamamoto/jrvltsql/compare/v2.1.1...HEAD
+[Unreleased]: https://github.com/miyamamoto/jrvltsql/compare/v2.1.2...HEAD
+[2.1.2]: https://github.com/miyamamoto/jrvltsql/compare/v2.1.1...v2.1.2
 [2.1.1]: https://github.com/miyamamoto/jrvltsql/compare/v2.1.0...v2.1.1
 [2.1.0]: https://github.com/miyamamoto/jrvltsql/compare/v2.0.0...v2.1.0
 [2.0.0]: https://github.com/miyamamoto/jrvltsql/compare/v1.6.10...v2.0.0

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,57 @@
+# jrvltsql v2.1.2 Release Notes
+
+`2.1.2` is an emergency correctness hotfix on top of `2.1.1` for prospective
+time-series odds capture; no parser, schema, storage, migration, or
+provider-registration contract changes.
+
+What `2.1.2` fixes over `2.1.1`:
+
+- when `--post-time-within-minutes` / `--post-time-not-past-minutes` are
+  requested, race targets are selected per full race key (Year, MonthDay,
+  JyoCD, Kaiji, Nichiji, RaceNum) with lifecycle-source precedence: a same-day
+  `RT_RA` row owns its key regardless of DataKubun, and `NL_RA` is used only
+  for keys absent from `RT_RA`; when the optional `RT_RA` table is absent,
+  `NL_RA` owns every key. A stale `NL_RA` post time coexisting with the
+  current `RT_RA` revision is no longer misread as ambiguity — on 2026-09-05
+  that misread aborted the whole batch and left later due races without
+  official O1/O2 capture
+- the selected current row's DataKubun is validated against the official RA
+  domain; missing, blank, or out-of-domain statuses fail closed naming the
+  12-digit race key, and nothing is opened. After validation, DataKubun=9
+  cancellations are omitted for whichever source owns the key, never falling
+  back to the shadowed row. Genuine same-source post-time conflicts on the
+  12-digit JVRTOpen key still fail closed
+- window statistics always report `omitted_canceled_keys` (0 when none), and
+  `window_kept_keys` equals the keys actually opened
+- machine-parsed CLI progress is extended for downstream verification: the
+  `Window:` line adds `canceled=`, the `Keys:` lines add `nonempty=` (keys
+  that returned at least one record — `ok=` success alone is not evidence of
+  nonempty capture), a window run that keeps zero keys still prints exactly
+  one terminal `Keys: 0/0 ...` summary, and `nonempty_keys` is always
+  present in fetcher progress callbacks and the completion log
+- target selection and queries without the post-time window options are
+  unchanged; the only no-window output change is that `Keys:` lines gain
+  `nonempty=` when a key is processed
+
+Verification limits:
+
+- regression coverage is database-backed: SQLite fixtures mirroring the real
+  `NL_RA`/`RT_RA` key shape, with the generated PostgreSQL window query
+  executed against an equivalent SQLite model (no live PostgreSQL in the
+  focused run). No live JV-Link race day has exercised this build yet: the
+  first complete prospective proof must come from a future real race day, and
+  this release does not backfill 2026-09-05
+
+Adoption / rollback:
+
+- no schema change; no migration or reimport is required from `2.1.1`
+- downstream `jrvltsql-wine-runtime` must explicitly re-pin this release's
+  tag/artifact before KPS JRA prospective capture is considered repaired;
+  merging or tagging alone adopts nothing
+- rollback: re-adopt immutable `v2.1.1`
+  (`0f3161d30de65f15795608e2a4bec9fc91e05349`); no database rollback is
+  required
+
 # jrvltsql v2.1.1 Release Notes
 
 `2.1.1` is a CLI compatibility hotfix on top of `2.1.0`; no parser, schema,

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -8,19 +8,21 @@ What `2.1.2` fixes over `2.1.1`:
 
 - when `--post-time-within-minutes` / `--post-time-not-past-minutes` are
   requested, race targets are selected per full race key (Year, MonthDay,
-  JyoCD, Kaiji, Nichiji, RaceNum) with lifecycle-source precedence: a same-day
-  `RT_RA` row owns its key regardless of DataKubun, and `NL_RA` is used only
-  for keys absent from `RT_RA`; when the optional `RT_RA` table is absent,
-  `NL_RA` owns every key. A stale `NL_RA` post time coexisting with the
-  current `RT_RA` revision is no longer misread as ambiguity — on 2026-09-05
-  that misread aborted the whole batch and left later due races without
-  official O1/O2 capture
+  JyoCD, Kaiji, Nichiji, RaceNum) with lifecycle-source precedence: a stored
+  same-day `RT_RA` row first owns its full key, and `NL_RA` is used only for
+  full keys absent from `RT_RA`; when the optional `RT_RA` table is absent,
+  `NL_RA` owns every key. A stale `NL_RA` post time coexisting with the current
+  `RT_RA` revision is no longer misread as ambiguity — on 2026-09-05 that
+  misread aborted the whole batch and left later due races without official
+  O1/O2 capture
 - the selected current row's DataKubun is validated against the official RA
   domain; missing, blank, or out-of-domain statuses fail closed naming the
-  12-digit race key, and nothing is opened. After validation, DataKubun=9
-  cancellations are omitted for whichever source owns the key, never falling
-  back to the shadowed row. Genuine same-source post-time conflicts on the
-  12-digit JVRTOpen key still fail closed
+  12-digit race key, and nothing is opened. A persisted DataKubun=0 erase
+  marker also fails closed instead of becoming an active target. After
+  validation, DataKubun=9 cancellations are omitted for whichever source owns
+  the key, never falling back to the shadowed row. A 12-digit JVRTOpen key
+  carrying both active and canceled selected rows fails closed independent of
+  row order; genuine post-time conflicts still fail closed
 - window statistics always report `omitted_canceled_keys` (0 when none), and
   `window_kept_keys` equals the keys actually opened
 - machine-parsed CLI progress is extended for downstream verification: the
@@ -41,6 +43,12 @@ Verification limits:
   focused run). No live JV-Link race day has exercised this build yet: the
   first complete prospective proof must come from a future real race day, and
   this release does not backfill 2026-09-05
+- the normal updater physically removes RT DataKubun=0 rows. This read path
+  therefore cannot distinguish an already-removed RT erase tombstone from a
+  key which never received an RT update; rejecting a tombstone that remains
+  stored is covered, but preventing stale-NL fallback after an already-removed
+  RT erase is not proven by this release. `2.1.2` does not claim unconditional
+  lifecycle resolution for every DataKubun state
 
 Adoption / rollback:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "jltsql"
-version = "2.1.1"
+version = "2.1.2"
 description = "JRA-VAN DataLab の競馬データをSQLite・PostgreSQLにインポートするツール"
 readme = "README.md"
 license = "Apache-2.0"

--- a/specs/operations/20260905_race_lifecycle_overlay_hotfix_worklog.md
+++ b/specs/operations/20260905_race_lifecycle_overlay_hotfix_worklog.md
@@ -441,14 +441,49 @@
   in 2.61s**; Black check, diff check, and fatal Flake8 remain green. Scoped
   Ruff has no new debt (57 candidate diagnostics versus 58 on exact v2.1.1),
   and scoped MyPy has no new diagnostic (11 candidate versus 12 baseline).
+- 2026-09-05 repaired candidate freeze and remote verification: committed the
+  two P1 repairs as `ea187ee586d16a65826b104bf00756bb87229918`
+  (`fix(realtime): reject ambiguous lifecycle states`), pushed only after a
+  successful dry-run, and verified the remote hotfix branch and PR 267 head
+  equal that full SHA. The obsolete `589a3c08...` candidate remains explicitly
+  non-releasable. PR 267 remained draft with `release:blocker` throughout.
+- 2026-09-05 repaired-candidate exact-head gates: the workflow-equivalent full
+  suite on `ea187ee586d16a65826b104bf00756bb87229918` completed with **4876
+  passed, 514 skipped, 14 deselected, 33 subtests passed in 119.90s**, total
+  coverage **80%**. `scripts/validate_test_gate.py` returned `TEST GATE PASS`;
+  isolated fatal Flake8 returned 0; Black check over every changed Python file
+  and `git diff --check` passed. Scoped comparisons remain no-new-debt: Ruff
+  57 candidate versus 58 exact-v2.1.1 baseline, MyPy 11 versus 12.
+- 2026-09-05 repaired-candidate provisional distribution gate: built outside
+  the repository at
+  `/home/keiba/scratch/20260905_jrvltsql_212_repaired_dist.Q4M5jl`.
+  Distribution-content and wheel-init smoke checks passed; METADATA is exactly
+  version `2.1.2`. Wheel copies of `src/fetcher/realtime.py` and
+  `src/cli/main.py` equal the candidate sources by SHA-256
+  (`fff3582543c7d15abf83bc47d6d655c6c93ce947f84ad94c745426aa67111127`
+  and `60924eeb0df12bbbfca2718deb68cb9f556add46fc1093b4449675876ab717df`).
+  Provisional artifact hashes are sdist
+  `8ba6081ba6bfde324908371cc30523db32540d86a904ed773ed8b6199512fe19`
+  and wheel
+  `a9a58f6963c2674f8198520ae0d2f8d13f234e6d83100476b06f514a9e0e27b6`.
+  They are not release artifacts and must not be published or pinned.
+- 2026-09-05 authoritative GitHub Actions for the repaired code candidate:
+  Tests run `33959854432` is `success` for exact head
+  `ea187ee586d16a65826b104bf00756bb87229918`; jobs `test`, `lint`, and
+  `windows-batch-syntax` all succeeded, while the PR-inapplicable performance
+  job was skipped by its declared condition. The test job executed the
+  fail-closed gate, full suite, distribution-content check, and wheel-init
+  smoke. The PR remains draft/blocking until the different independent
+  reviewer finishes and this final tracked handoff update receives exact-head
+  CI.
 
 ## Pending safe sequence and STOP conditions
 
-1. Commit/freeze the batched review repair, push the new exact PR head, run the
-   full workflow-equivalent suite/build on that SHA, and obtain critical review
-   from a different independent reviewer. Keep PR 267 draft/blocking until all
-   actionable findings are closed.
-2. Wait for authoritative CI/review on the repaired head, resolve every thread,
+1. Commit and push this documentation-only handoff update, then repeat the
+   required exact-head gates and obtain final confirmation from the different
+   independent reviewer. Keep PR 267 draft/blocking until all actionable
+   findings are closed.
+2. Verify authoritative CI and unresolved-thread count on the final head,
    remove `release:blocker`, mark ready, and merge only from authoritative state.
 3. Rebuild and hash the authoritative release artifacts from the immutable merge
    SHA, publish `v2.1.2`, advance `stable/2.1` to the same commit, and provide the

--- a/specs/operations/20260905_race_lifecycle_overlay_hotfix_worklog.md
+++ b/specs/operations/20260905_race_lifecycle_overlay_hotfix_worklog.md
@@ -350,18 +350,111 @@
   `67649f5de39ebedd7fbf13721962454ef9525cbfb3694434b3b49fe887f60ad7`;
   wheel `fc07d18555742e5e13dd4a76ec9ed84a0cad26614c5ae0357c895cef58a65336`.
   These are local pre-freeze evidence, not the authoritative release hashes.
+- 2026-09-05 independent review of frozen candidate
+  `589a3c08cf39f2a9065cfea965dfd49cc4df33b8` returned NEEDS_CHANGES on two
+  P1 fail-open lifecycle edges. The reviewer reproduced that two selected RT
+  full keys with different Kaiji/Nichiji but the same 12-digit JVRTOpen key,
+  same HassoTime, and active/canceled states were opened or omitted according
+  to row order; cancellation was tracked by full key after the post-time
+  filter had collapsed to `rows[0]`. The reviewer also reproduced that the
+  official RA `DataKubun=0` erase state passed domain validation and was
+  treated as an active target. The original Claude Fable implementer session
+  reached its session quota before this review response, so one Codex teammate
+  is applying the batched review repair; this does not change the recorded
+  Fable implementation provenance above.
+- 2026-09-05 RED (batched independent-review repair, before any src change):
+  added one two-order regression for the physically possible distinct-full-key
+  collision (RT DK6 and RT DK9, identical 12-digit key and HassoTime) and one
+  RT/NL ownership parameterization for an unexpectedly persisted RA DK0 erase
+  marker. Both require `FetcherError` naming the 12-digit key before JV init.
+  Command: `nice -n 15 uv run --frozen --extra dev --extra postgres pytest
+  tests/test_time_series.py -k 'mixed_state_fails_closed_before_init or
+  persisted_erase_fails_closed_before_init' -v --no-cov` -> **4 failed, 38
+  deselected in 0.19s**, all with `DID NOT RAISE`. Active-first opened
+  `202609050612` with `omitted_canceled_keys=0`; canceled-first omitted that
+  same key with `omitted_canceled_keys=1`, proving row-order dependence. Both
+  RT-owned and NL-owned DK0 rows opened `202609050610`. No production source
+  was changed in this RED step.
+- 2026-09-05 batched repair (Codex teammate; still uncommitted): lifecycle
+  source ownership remains exact-full-key-first, then every selected row is
+  validated against the official RA domain. A selected persisted DK0 erase
+  marker now raises `FetcherError` naming its normalized 12-digit key before
+  JV init. Selected rows are grouped by that 12-digit JVRTOpen key; any
+  active/canceled mixture now fails closed independent of input order. An
+  all-DK9 group remains in post-time validation and is removed/counts as one
+  normalized key only afterwards, preserving genuine HassoTime-conflict
+  failure and the established window statistics. The existing cancellation
+  test now covers two distinct canceled full keys collapsing to one 12-digit
+  key. Changed paths are `src/fetcher/realtime.py`,
+  `tests/test_time_series.py`, `CHANGELOG.md`, `RELEASE_NOTES.md`, and this
+  worklog.
+- 2026-09-05 documentation scope correction: the normal updater physically
+  removes RT DK0. Therefore, this read path cannot distinguish an already
+  removed tombstone from no RT update, and preventing stale-NL resurrection
+  after an erase is **not proven**. CHANGELOG and release notes now say so and
+  no longer claim unconditional lifecycle correctness regardless of
+  DataKubun. A persisted DK0 is rejected; an absent tombstone remains a
+  pre-existing storage-semantics limitation requiring separate work.
+- 2026-09-05 GREEN after the production repair and Black:
+  `nice -n 15 uv run --frozen --extra dev --extra postgres pytest
+  tests/test_time_series.py -k 'mixed_state_fails_closed_before_init or
+  persisted_erase_fails_closed_before_init' -v --no-cov` -> **4 passed, 38
+  deselected in 0.12s**. Full affected file with the existing active,
+  cancellation, invalid-domain, RT-table-absent, genuine HassoTime-conflict,
+  PostgreSQL parity, and no-window coverage: `nice -n 15 uv run --frozen
+  --extra dev --extra postgres pytest tests/test_time_series.py -v --no-cov`
+  -> **42 passed in 0.70s**. Release-document contract: `nice -n 15 uv run
+  --frozen --extra dev --extra postgres pytest
+  tests/test_public_setup_contract.py -v --no-cov` -> **10 passed in 0.13s**.
+- 2026-09-05 formatting/static/diff gates for this repair: `nice -n 15 uv run
+  --frozen --extra dev --extra postgres black src/fetcher/realtime.py
+  tests/test_time_series.py` and the matching `black --check` both reported
+  **2 files unchanged**; isolated fatal lint (`flake8 ... --select=E9,F63,F7,F82`)
+  reported **0**; `git diff --check` passed. The five intended files remain
+  dirty by explicit handoff instruction; no commit or push was made. Because
+  the independent reviewer implemented the repair, a newly frozen full SHA
+  still requires a different independent reviewer before release.
+- 2026-09-05 remote release-track setup (state-changing, verified): read-only
+  `git ls-remote` first proved `release/2.1.2`, `stable/2.1`, `v2.1.2`, and the
+  hotfix branch absent. `git push --dry-run origin 0f3161d...:refs/heads/
+  release/2.1.2` showed only one new branch; the matching apply succeeded.
+  Post-fetch verification proved remote `release/2.1.2` equals exact v2.1.1
+  `0f3161d30de65f15795608e2a4bec9fc91e05349` with zero commits beyond it.
+  The hotfix push also ran dry first, then applied, and remote verification
+  proved candidate `589a3c08cf39f2a9065cfea965dfd49cc4df33b8` exactly. Rollback handles before
+  merge are deletion of those two newly-created remote branches; immutable
+  v2.1.1 remains the code rollback. No tag or stable branch was created.
+- 2026-09-05 PR state (state-changing, verified): opened hotfix PR
+  `https://github.com/miyamamoto/jrvltsql/pull/267` from the hotfix branch into
+  exact-base `release/2.1.2`. The newly added release-branch trigger worked:
+  authoritative Tests run `33959351499` started for candidate `589a3c08...`.
+  As soon as independent review reported the first P1, the measured open/ready
+  PR was converted to draft and labeled `release:blocker`,
+  `release:hotfix-candidate`, `risk:data-integrity`, and `risk:provider`;
+  re-read verification confirmed draft=true and the exact labels. Candidate
+  `589a3c08...` must not be merged, tagged, released, or adopted.
+- 2026-09-05 parent independently confirmed the STOP state: keep PR 267 draft,
+  batch both P1 repairs red-first, disclose the tombstone limitation, and mark
+  ready only after new exact-head affected plus required workflow-equivalent
+  gates and final review. The repaired focused aggregate was independently
+  rerun in this agent: four affected files -> **122 passed, 22 subtests passed
+  in 2.61s**; Black check, diff check, and fatal Flake8 remain green. Scoped
+  Ruff has no new debt (57 candidate diagnostics versus 58 on exact v2.1.1),
+  and scoped MyPy has no new diagnostic (11 candidate versus 12 baseline).
 
 ## Pending safe sequence and STOP conditions
 
-1. Review the complete diff, commit/freeze a full candidate SHA, and obtain
-   independent critical review; batch any actionable corrections and repeat the
-   affected/full gates as risk requires.
-2. Push `release/2.1.2` at the exact tag base and this branch, open the hotfix PR,
-   wait for authoritative CI/review, resolve every thread, merge, tag/release only
-   after the immutable merge SHA passes the release gates, and forward-port.
+1. Commit/freeze the batched review repair, push the new exact PR head, run the
+   full workflow-equivalent suite/build on that SHA, and obtain critical review
+   from a different independent reviewer. Keep PR 267 draft/blocking until all
+   actionable findings are closed.
+2. Wait for authoritative CI/review on the repaired head, resolve every thread,
+   remove `release:blocker`, mark ready, and merge only from authoritative state.
 3. Rebuild and hash the authoritative release artifacts from the immutable merge
    SHA, publish `v2.1.2`, advance `stable/2.1` to the same commit, and provide the
    merged tag/source/wheel pins to downstream `jrvltsql-wine-runtime`.
+4. Forward-port the repair from the published hotfix into current `master` by a
+   separate PR, preserving dependency order and recording its merge SHA.
 
 STOP on any fail-open path, unexpected database/schema change, failing test,
 non-authoritative merge state, unresolved review thread, artifact/source mismatch,

--- a/specs/operations/20260905_race_lifecycle_overlay_hotfix_worklog.md
+++ b/specs/operations/20260905_race_lifecycle_overlay_hotfix_worklog.md
@@ -1,0 +1,368 @@
+# 2026-09-05 race lifecycle overlay hotfix worklog
+
+## Scope and provenance
+
+- Objective: repair `fetch_time_series_batch_from_db` prospective post-time target
+  selection so a same-day `RT_RA` lifecycle row supersedes the matching historical
+  `NL_RA` row before fail-closed post-time validation. Preserve rejection of true
+  same-source ambiguity and honor a current realtime cancellation without falling
+  back to the stale historical row.
+- Minimum scope: `src/fetcher/realtime.py`, the smallest regression coverage in
+  `tests/test_time_series.py`, version/release metadata for patch `2.1.2`, and this
+  tracked worklog. No schema, storage, migration, or provider-write change.
+- Repository: `miyamamoto/jrvltsql`.
+- Worktree:
+  `/home/keiba/worktrees/jrvltsql-hotfix-2.1.2-race-lifecycle-overlay-20260905`.
+- Branch: `hotfix/2.1.2-race-lifecycle-overlay`.
+- Hotfix base / production release: tag `v2.1.1`, full SHA
+  `0f3161d30de65f15795608e2a4bec9fc91e05349`.
+- Development branch observed after `git fetch origin master --tags --prune`:
+  `origin/master` at `2e58b17f6177eb0e0bc5bd097fa0b181ed2d7ba4`.
+- Intended integration order: create `release/2.1.2` from the exact `v2.1.1`
+  commit; merge this hotfix there; publish immutable `v2.1.2`; then forward-port
+  the same repair to `master` in a separate PR.
+- Downstream dependency: `miyamamoto/jrvltsql-wine-runtime` must pin the resulting
+  merged `jltsql` source/artifact before KPS JRA prospective capture can be
+  considered repaired. The first complete prospective proof must come from a
+  future real race day; this hotfix does not backfill 2026-09-05.
+- Release classification: emergency correctness hotfix. On 2026-09-05 a stale
+  `NL_RA` post time and a revised `RT_RA` post time for the same full race key were
+  UNIONed and interpreted as ambiguity before window filtering, aborting later
+  due races and leaving JRA race 06-12 without official O1/O2 capture.
+- Rollback: reinstall/re-pin immutable `v2.1.1` at
+  `0f3161d30de65f15795608e2a4bec9fc91e05349`; no database rollback is required.
+
+## Guardrails
+
+- Add the failing regression first and record its exact failure before modifying
+  production code.
+- Missing, malformed, or truly ambiguous current lifecycle data remains a hard
+  failure. A current `RT_RA` row, including cancellation status, owns the full
+  race key; an older `NL_RA` row is used only when that key is absent from
+  `RT_RA`.
+- All tests run at `nice -n 15`. Do not inspect, open, signal, reprioritize, or
+  otherwise interact with the concurrent NAR P8 DuckDB workload.
+- No credentials or connection strings are recorded.
+
+## Chronology
+
+- 2026-09-05: read the complete release-readiness skill and its release/host
+  references. Read `docs/release_policy.md`; no repository or ancestor
+  `AGENTS.md` exists in this checkout. Ran the JRA readiness scan: 58 PASS,
+  2 pre-existing KPS WARN, 0 FAIL.
+- 2026-09-05: fetched `origin/master` and tags, verified the exact base and
+  development SHAs above, created this dedicated worktree from `v2.1.1`, and
+  confirmed the worktree was initially clean.
+- 2026-09-05: selected Claude Code `--model fable` for the implementation
+  (`claude-fable-5`, CLI 2.1.233), because this is a fail-closed lifecycle
+  selector whose source precedence and cancellation boundaries directly alter
+  collection decisions. Session ID for same-worktree continuation:
+  `26f1d160-d2a4-41b4-994a-c95fe270a934`.
+- 2026-09-05 RED: added four focused lifecycle tests without changing
+  production code. After tightening the incident fixture to the actual Nakayama
+  key shape (`20260905-06-08`, stale `NL_RA` 14:00 versus current `RT_RA`
+  `DataKubun=6` 14:01, with 06-12 at 16:30), ran:
+  `nice -n 15 python3 -m pytest tests/test_time_series.py -k 'rt_lifecycle' -v`.
+  Result: **3 failed, 1 passed, 26 deselected**. The primary red was
+  `FetcherError: ... 202609050608: ambiguous HassoTime values [1400, 1401]`;
+  cancellation red opened both `202609050611` and `202609050612` instead of
+  only race 12; PostgreSQL-query parity reproduced the same ambiguity. The
+  paired selected-source conflict test remained green, proving the existing
+  fail-closed boundary that the repair must preserve.
+- 2026-09-05 GREEN: implemented the minimal repair in `src/fetcher/realtime.py`
+  only. When a post-time window is requested and `RT_RA`/`rt_ra` exists, the
+  SQLite and PostgreSQL target queries tag each row with its lifecycle source
+  and `DataKubun` and use `UNION ALL`; the new `_overlay_current_lifecycle_rows`
+  helper then selects by the exact full key (Year, MonthDay, JyoCD, Kaiji,
+  Nichiji, RaceNum): any `RT_RA` row owns its full key regardless of
+  `DataKubun` (including 9), `NL_RA` is used only for full keys absent from
+  `RT_RA`, and duplicates within the selected source are preserved. Selected
+  rows still pass the unchanged fail-closed `_filter_race_rows_by_post_time`
+  validation; only after validation are full keys canceled by RT `DataKubun=9`
+  omitted, with no NL fallback. The no-window queries (both engines) and the
+  NL-only window path are untouched; no schema, storage, migration, or
+  provider-write change.
+- 2026-09-05 GREEN evidence: the PATH `pytest` shim runs Python 3.10 and fails
+  one unrelated parser-import test (`StrEnum`; project requires >=3.12), so the
+  gates ran on the uv-managed venv (CPython 3.13.5) with pinned lock:
+  `nice -n 15 uv run --frozen --extra dev pytest tests/test_time_series.py -k
+  'rt_lifecycle' -v --no-cov` -> **4 passed, 26 deselected in 0.30s**;
+  `nice -n 15 uv run --frozen --extra dev --extra postgres pytest
+  tests/test_time_series.py --no-cov` -> **30 passed in 0.52s**. Version
+  metadata and release docs intentionally not yet touched.
+- 2026-09-05 RED (refinement before candidate freeze): critical review of the
+  implemented overlay found three fail-closed gaps; added the smallest failing
+  coverage without touching production code. (a) A selected lifecycle row with
+  missing/blank/officially-invalid RA `DataKubun` (official domain:
+  `src/parser/status_domain.py`) is silently treated as active — the new
+  parameterized `test_sqlite_race_window_rt_lifecycle_rejects_undecidable_datakubun`
+  ((RT, None), (RT, ""), (RT, "8"), (NL, " "), (NL, "９")) expects a
+  `FetcherError` naming `202609050610` and got **DID NOT RAISE** in all five
+  cases. (b) A canceled row owned by NL (06-10 `DataKubun=9`, absent from
+  RT_RA) is opened — the extended cancellation test failed with
+  `('0B41', '202609050610')` opened before race 12; RT-9-blocks-NL-fallback
+  is asserted in the same test. (c) Window statistics keep omitted
+  cancellations — PG-parity red `assert 2 == 1` on `window_kept_keys` (the
+  run log even printed `omitted_canceled_keys=1` while stats did not carry
+  it), and the exact-progress test is red for the missing
+  `omitted_canceled_keys: 0` key in the no-cancellation shape. Command:
+  `nice -n 15 uv run --frozen --extra dev --extra postgres pytest
+  tests/test_time_series.py -k 'rt_lifecycle or keeps_near_post' -v --no-cov`
+  -> **8 failed, 2 passed, 25 deselected in 0.43s**; the overlay and
+  selected-source conflict tests stayed green. No src/, version-metadata, or
+  release-doc change in this step.
+- 2026-09-05 GREEN (refinement): minimal production changes in
+  `src/fetcher/realtime.py` only. Every selected lifecycle row's DataKubun is
+  now validated with the official
+  `src.parser.status_domain.validate_data_kubun` for record type `RA`
+  (REALTIME context for RT rows, ACCUMULATED for NL rows; no ad-hoc accepted
+  set); a validation failure is converted to `FetcherError` naming the
+  12-digit race key and no key is opened. Cancellation (validated
+  `DataKubun=9`) is collected from whichever selected source owns the full
+  key, strictly after source selection, so RT 9 still never exposes the
+  shadowed NL row; HassoTime validation-before-cancellation and same-source
+  post-time conflict fail-closed ordering are unchanged. Window stats are now
+  truthful: `omitted_canceled_keys` is always exposed (0 when none) and
+  `window_kept_keys` is reduced by the omitted count so it equals
+  `total_keys` and the opened targets. The stat is documented on
+  `fetch_time_series_batch_from_db` and the overlay helper as counting
+  selected cancellations that passed validation and otherwise fell inside
+  the requested window. Evidence (uv-managed CPython 3.13.5, frozen lock):
+  `nice -n 15 uv run --frozen --extra dev --extra postgres pytest
+  tests/test_time_series.py -k 'rt_lifecycle or keeps_near_post' -v --no-cov`
+  -> **10 passed, 25 deselected in 0.35s**;
+  `nice -n 15 uv run --frozen --extra dev --extra postgres pytest
+  tests/test_time_series.py --no-cov` -> **35 passed in 0.60s**. Version
+  metadata and release docs still untouched.
+- 2026-09-05 RED (no-RT_RA boundary before candidate freeze): the refined
+  implementation gates lifecycle validation/cancellation on the presence of
+  the optional `RT_RA` table, but the selection contract makes NL own every
+  key when `RT_RA` is absent, so NL `DataKubun` must still be validated and
+  canceled instead of reverting to the unclassified 7-column path. Added two
+  minimal SQLite regressions with no `RT_RA` table (the fixture helper can
+  now create `NL_RA` alone):
+  `test_sqlite_race_window_rt_lifecycle_nl_owns_all_keys_when_rt_table_absent`
+  (NL 06-11 `DataKubun=9` in-window plus active 06-12; expects only race 12
+  opened with `omitted_canceled_keys=1`, `window_kept_keys=1`,
+  `total_keys=1`) is red: `('0B41', '202609050611')` was opened ahead of
+  race 12.
+  `test_sqlite_race_window_rt_lifecycle_rejects_undecidable_nl_datakubun_when_rt_table_absent`
+  (NL 06-10 `DataKubun='8'`) is red with **DID NOT RAISE**; the run log shows
+  both `202609050610` and `202609050612` were opened. Command:
+  `nice -n 15 uv run --frozen --extra dev --extra postgres pytest
+  tests/test_time_series.py -k 'rt_lifecycle or keeps_near_post' -v --no-cov`
+  -> **2 failed, 10 passed, 25 deselected in 0.43s**; all 10 previously
+  green lifecycle/stats tests stayed green. GREEN note: the real schema
+  already carries `DataKubun`, but the older synthetic NL-only window
+  fixtures (`keeps_near_post`, `skips_malformed`, `boundary_date`,
+  `candidate_fails_closed`, and the PostgreSQL no-rt fakes returning
+  7-column rows) do not; extending the no-RT window query to read NL
+  `DataKubun` will require adding that column to those fixtures. No src/,
+  version-metadata, or release-doc change in this step.
+- 2026-09-05 GREEN (no-RT_RA boundary): both engines' post-time-window target
+  queries now always emit source-tagged lifecycle rows with `DataKubun`;
+  when `RT_RA`/`rt_ra` is absent the query tags `NL` alone so NL owns every
+  full key, and validation/cancellation run through the same
+  `_overlay_current_lifecycle_rows` path (the conditional overlay flag was
+  removed; the window path is now unconditionally lifecycle-classified).
+  No-window queries are untouched on both engines and the exact no-window
+  PostgreSQL query contract test still passes. The legacy synthetic window
+  fixtures now model the real `NL_RA.DataKubun` column (`keeps_near_post`,
+  `skips_malformed`, `boundary_date`, `candidate_fails_closed` SQLite tables,
+  plus the PostgreSQL no-rt fake rows, now 9-column 'NL'-tagged) without
+  weakening any assertion; the PostgreSQL no-rt window test additionally
+  pins `datakubun` in the generated query. Evidence (uv-managed CPython
+  3.13.5, frozen lock): `nice -n 15 uv run --frozen --extra dev
+  --extra postgres pytest tests/test_time_series.py -k 'race_window' -v
+  --no-cov` -> **22 passed, 15 deselected in 0.51s** (every window-path
+  test, including both no-RT reds, now green);
+  `nice -n 15 uv run --frozen --extra dev --extra postgres pytest
+  tests/test_time_series.py --no-cov` -> **37 passed in 0.61s**. Version
+  metadata and release docs still untouched.
+- 2026-09-05 metadata: synchronized patch release metadata to `2.1.2` with
+  behavior green. Changed files: `pyproject.toml` and `src/__init__.py`
+  (2.1.1 -> 2.1.2); `uv.lock` project entry updated via `uv lock`
+  ("Updated jltsql v2.1.1 -> v2.1.2", diff confirmed to touch only that
+  version line); exact-version contract tests
+  (`tests/test_public_setup_contract.py`: Unreleased compare link now
+  `v2.1.2...HEAD` and project version pin; `tests/test_updater.py`:
+  pyproject-fallback version); `CHANGELOG.md` (new `[2.1.2] - 2026-09-05`
+  lifecycle-overlay/cancellation/fail-closed/stats entry, Unreleased link
+  moved to `v2.1.2...HEAD`, `[2.1.2]` compare link added);
+  `RELEASE_NOTES.md` (prepended v2.1.2 scope, verification limits — no live
+  JV-Link race day yet, PostgreSQL window query verified on an equivalent
+  SQLite model — no schema/migration requirement, downstream
+  `jrvltsql-wine-runtime` re-pin note, rollback; older notes preserved).
+  Focused gate: `nice -n 15 uv run --frozen --extra dev --extra postgres
+  pytest tests/test_public_setup_contract.py
+  "tests/test_updater.py::TestGetCurrentVersion" -v --no-cov` ->
+  **14 passed in 0.17s**, including source/lock/CLI version consistency.
+  Full suite, build, and distribution smoke intentionally not yet run; no
+  commit/push yet. Planned rollback: re-adopt immutable `v2.1.1` at
+  `0f3161d30de65f15795608e2a4bec9fc91e05349`; no database rollback required.
+- 2026-09-05 RED (CLI window stdout contract): the downstream
+  `jrvltsql-wine-runtime` parses the CLI `Window:` stdout line, but
+  `omitted_canceled_keys` exists only in the progress dict. Extended the
+  existing focused test
+  `tests/test_cli.py::TestRealtimeTimeseriesCommand::test_timeseries_passes_race_window_options_and_reports_selection`
+  with `omitted_canceled_keys: 2` in the fake window progress and one exact
+  token/order assertion:
+  `Window: considered=3 candidates=3 kept=1 canceled=2 future=1 past=1
+  date_excluded=0`. Command: `nice -n 15 uv run --frozen --extra dev
+  --extra postgres pytest "tests/test_cli.py::TestRealtimeTimeseriesCommand::
+  test_timeseries_passes_race_window_options_and_reports_selection" -v
+  --no-cov` -> **FAILED**: the token string was `not found in` the captured
+  output, whose actual line is `Window: considered=3 candidates=3 kept=1
+  future=1 past=1 date_excluded=0` — `canceled=` is absent from the
+  unchanged CLI. GREEN note: `console = Console(legacy_windows=True)` wraps
+  at width 80 in non-tty captures; the extended line is 85 characters, so
+  emitting `canceled=` must also guarantee the line stays unwrapped (e.g.
+  `soft_wrap=True`) or the exact-token contract will break in captures. No
+  production-code change in this step.
+- 2026-09-05 GREEN (CLI window stdout contract): `src/cli/main.py` window
+  progress line now emits `canceled={omitted_canceled_keys}` between `kept=`
+  and `future=` in the exact tested token order, defaulting to 0, and that
+  single machine-parsed `console.print` uses `soft_wrap=True` so the
+  85-character line stays unwrapped in captured/non-TTY output; no other
+  output changed. Evidence (uv-managed CPython 3.13.5, frozen lock,
+  dev+postgres, nice -n 15): the focused test
+  `tests/test_cli.py::TestRealtimeTimeseriesCommand::test_timeseries_passes_race_window_options_and_reports_selection`
+  -> **1 passed in 0.07s**; class `TestRealtimeTimeseriesCommand` ->
+  **4 passed in 1.23s**; full `tests/test_cli.py` -> **47 passed in 2.01s**.
+- 2026-09-05 RED (nonempty capture evidence): `success_keys` counts a key as
+  ok even when JVRTOpen succeeds but `_fetch_and_parse()` yields zero rows,
+  so downstream evidence cannot distinguish nonempty capture. Added the
+  smallest failing coverage without touching src. New
+  `test_fetch_time_series_batch_from_db_counts_nonempty_keys` (two keys:
+  open-success with 0 rows, then open-success with 1 row) is red with
+  `KeyError: 'nonempty_keys'` after proving the substitution — the empty key
+  passed `status == "success"`, `success_keys == 1`, `records_for_key == 0`.
+  Extended `test_fetch_time_series_batch_from_db_closes_no_data_stream`
+  (no_data per-key shape) -> red `KeyError: 'nonempty_keys'`. Extended the
+  exact window_filter progress dict in
+  `test_sqlite_race_window_keeps_near_post_and_reports_drop_reasons` with
+  `nonempty_keys: 0` -> red "Right contains 1 more item:
+  {'nonempty_keys': 0}". Extended the focused CLI progress test with a fake
+  final key progress carrying `nonempty_keys: 1` and the exact Keys token
+  order -> red: `'ok=1 nonempty=1 no_data=0' not found`, actual line is
+  `Keys: 1/1 ok=1 no_data=0 errors=0 records=3`. The structured completion
+  summary is a structlog line (not a callback contract); the CLI final Keys
+  line covers the user-facing summary instead. Commands:
+  `nice -n 15 uv run --frozen --extra dev --extra postgres pytest
+  tests/test_time_series.py -k 'counts_nonempty or closes_no_data_stream or
+  keeps_near_post' -v --no-cov` -> **3 failed, 1 passed, 34 deselected**
+  (the passing one is the unaffected range-scan close test);
+  same runner on the focused CLI test -> **1 failed**. No src/,
+  version-metadata, or release-doc change in this step.
+- 2026-09-05 RED (idle-window Keys summary): added the focused CLI test
+  `test_timeseries_window_idle_run_emits_zero_keys_summary` (same fixture
+  pattern as the window test): the fetcher emits only a `window_filter`
+  progress with `total_keys=0` (kept=0, canceled=1, past=1) and yields no
+  records. The contract requires exactly one terminal no-`last=` summary
+  line per spec containing
+  `Keys: 0/0 ok=0 nonempty=0 no_data=0 errors=0 records=0`, with the
+  Window line separate. Red as intended: the Window assertion passes but
+  the Keys count is **`AssertionError: 0 != 1`** — the final summary is
+  guarded by `if key_progress["processed_keys"]:` in the unchanged CLI, so
+  an idle window day emits no machine-checkable "nothing was opened"
+  evidence. Command: `nice -n 15 uv run --frozen --extra dev
+  --extra postgres pytest "tests/test_cli.py::TestRealtimeTimeseriesCommand::
+  test_timeseries_window_idle_run_emits_zero_keys_summary" -v --no-cov` ->
+  **1 failed in 0.09s**. No src/ change in this step.
+- 2026-09-05 GREEN (nonempty + idle batch): `fetch_time_series_batch_from_db`
+  now tracks `nonempty_keys` (initialized 0, incremented only after one
+  complete buffered key materializes >0 records) and includes it, always
+  present including zero, in every progress shape — `window_filter`,
+  `invalid_key`, the shared per-key status callback — and in the structured
+  "Batch time series fetch completed" log. The CLI initializes
+  `nonempty_keys: 0` in `key_progress`, emits `nonempty=` between `ok=` and
+  `no_data=` on both the intermediate and terminal `Keys:` lines, marks both
+  machine-parsed lines `soft_wrap=True`, and prints the terminal no-`last=`
+  summary whenever a post-time window was requested OR keys were processed,
+  so an idle 0/0 window day emits the summary exactly once while legacy
+  no-window/no-key output stays silent. `CHANGELOG.md`/`RELEASE_NOTES.md`
+  now describe the machine-readable canceled/nonempty/idle progress and
+  correct the earlier no-window claim: target selection/queries stay
+  unchanged without a window, but `Keys:` lines gain `nonempty=` whenever a
+  key is processed. Evidence (uv CPython 3.13.5, frozen, dev+postgres,
+  nice -n 15): previously red set
+  (`counts_nonempty or closes_no_data_stream or keeps_near_post`) ->
+  **4 passed, 34 deselected in 0.12s**; the two focused CLI window tests ->
+  **2 passed in 0.07s**; full `tests/test_time_series.py` -> **38 passed in
+  0.65s**; full `tests/test_cli.py` -> **48 passed in 1.71s**; doc-reading
+  `tests/test_public_setup_contract.py` -> **9 passed in 0.12s**. Full
+  repository suite and commit intentionally deferred.
+- 2026-09-05 release-path CI gate: `docs/release_policy.md` mandates merging
+  the hotfix PR into `release/X.Y.Z`, but `.github/workflows/test.yml`
+  limited the `pull_request` trigger to `[ master, main, develop ]`, so the
+  required release PR could never receive the authoritative Tests gate.
+  Decision: fail-closed contract first, then the minimal trigger change.
+  Added `test_tests_workflow_gates_release_hotfix_pull_requests` to
+  `tests/test_public_setup_contract.py` (parses the workflow YAML, tolerates
+  the YAML 1.1 `on`->True key, requires `release/**` in
+  `pull_request.branches`). Red against the unchanged workflow:
+  `nice -n 15 uv run --frozen --extra dev --extra postgres pytest
+  "tests/test_public_setup_contract.py::
+  test_tests_workflow_gates_release_hotfix_pull_requests" -v --no-cov` ->
+  **FAILED**, `AssertionError: assert 'release/**' in
+  ['master', 'main', 'develop']`. Then extended only the `pull_request`
+  trigger to `[ master, main, develop, 'release/**' ]` — push triggers
+  unchanged (policy publishes from PR-gated release branches; no push gate
+  is required for them). Green: the focused test -> **1 passed in 0.03s**;
+  full `tests/test_public_setup_contract.py` -> **10 passed in 0.13s**.
+  Not committed.
+- 2026-09-05 candidate hardening (still uncommitted): Black formatted the six
+  affected Python files and its scoped `--check` is green; `git diff --check`
+  is green. The workflow-equivalent fatal Flake8 gate (`--isolated --select=
+  E9,F63,F7,F82` over `src tests scripts tools`) reports **0**. A configured
+  scoped Ruff comparison over the six affected Python files reports the same
+  **58 pre-existing diagnostics** on the candidate as exact `v2.1.1` after
+  correcting one newly introduced local-import order (baseline 58; candidate
+  58; no new diagnostic). A direct-module scoped MyPy comparison with
+  `--follow-imports=skip --ignore-missing-imports --no-strict-optional` first
+  found one new `no-any-return` at `_race_key_label`; wrapping the external
+  key generator result in `str()` removed it. Candidate and exact-v2.1.1
+  baseline now carry the identical **12 pre-existing diagnostics** (11 in
+  existing realtime paths plus missing PyYAML stubs in CLI), with no new
+  diagnostic. Baseline worktree:
+  `/home/keiba/scratch/20260905_jrvltsql_211_lint_baseline`, detached at
+  `0f3161d30de65f15795608e2a4bec9fc91e05349`.
+- 2026-09-05 focused post-format gate: `nice -n 15 uv run --frozen --extra
+  dev --extra postgres pytest tests/test_time_series.py tests/test_cli.py
+  tests/test_public_setup_contract.py tests/test_updater.py -v --no-cov` ->
+  **118 passed, 22 subtests passed in 2.61s**.
+- 2026-09-05 full local Tests-workflow gate: `nice -n 15 uv run --frozen
+  --extra dev --extra postgres pytest tests --ignore=tests/integration
+  --ignore=tests/e2e -m "not slow" -v --cov=src --cov-report=xml
+  --cov-report=term` -> **4872 passed, 514 skipped, 14 deselected, 33
+  subtests passed in 118.20s**, total coverage **80%**. Skips are the suite's
+  environment-gated PostgreSQL/provider cases; no failure occurred.
+- 2026-09-05 provisional distribution gate (uncommitted tree; must be rebuilt
+  from the immutable merge SHA before publication): built `jltsql-2.1.2.tar.gz`
+  and `jltsql-2.1.2-py3-none-any.whl` outside the repository at
+  `/home/keiba/scratch/20260905_jrvltsql_212_dist.f7tmoa`. Distribution
+  contents check passed for both and wheel init smoke passed. Wheel METADATA
+  reports version `2.1.2`; embedded `src/fetcher/realtime.py` and
+  `src/cli/main.py` SHA-256 values exactly equal the working-tree sources
+  (`c3dc2f7caa15793d07e3b0e4a51956d7a409e6d291e0622fb632d92d400c46e5`
+  and `60924eeb0df12bbbfca2718deb68cb9f556add46fc1093b4449675876ab717df`).
+  Provisional artifact hashes: sdist
+  `67649f5de39ebedd7fbf13721962454ef9525cbfb3694434b3b49fe887f60ad7`;
+  wheel `fc07d18555742e5e13dd4a76ec9ed84a0cad26614c5ae0357c895cef58a65336`.
+  These are local pre-freeze evidence, not the authoritative release hashes.
+
+## Pending safe sequence and STOP conditions
+
+1. Review the complete diff, commit/freeze a full candidate SHA, and obtain
+   independent critical review; batch any actionable corrections and repeat the
+   affected/full gates as risk requires.
+2. Push `release/2.1.2` at the exact tag base and this branch, open the hotfix PR,
+   wait for authoritative CI/review, resolve every thread, merge, tag/release only
+   after the immutable merge SHA passes the release gates, and forward-port.
+3. Rebuild and hash the authoritative release artifacts from the immutable merge
+   SHA, publish `v2.1.2`, advance `stable/2.1` to the same commit, and provide the
+   merged tag/source/wheel pins to downstream `jrvltsql-wine-runtime`.
+
+STOP on any fail-open path, unexpected database/schema change, failing test,
+non-authoritative merge state, unresolved review thread, artifact/source mismatch,
+or a need to touch the NAR P8 process or its target database.

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,3 +1,3 @@
 """jrvltsql - JRA-VAN データ取得・管理ツール"""
 
-__version__ = "2.1.1"
+__version__ = "2.1.2"

--- a/src/cli/main.py
+++ b/src/cli/main.py
@@ -2108,6 +2108,7 @@ def timeseries(
                         "processed_keys": 0,
                         "total_keys": 0,
                         "success_keys": 0,
+                        "nonempty_keys": 0,
                         "no_data_keys": 0,
                         "error_keys": 0,
                         "total_records": 0,
@@ -2116,15 +2117,21 @@ def timeseries(
                     def report_key_progress(progress):
                         key_progress.update(progress)
                         if progress.get("status") == "window_filter":
+                            # 下流のwine runtimeがこの行をparseする。tokenと
+                            # 順序は契約であり、canceled= は検証済み中止の
+                            # 除外数（中止なしでも0）。soft_wrapで非TTY
+                            # 捕捉時も1行のまま折り返さない。
                             console.print(
                                 "  Window: "
                                 f"considered={progress.get('considered_keys', 0):,} "
                                 f"candidates={progress.get('window_candidate_keys', 0):,} "
                                 f"kept={progress.get('window_kept_keys', 0):,} "
+                                f"canceled={progress.get('omitted_canceled_keys', 0):,} "
                                 f"future={progress.get('dropped_too_far_future', 0):,} "
                                 f"past={progress.get('dropped_too_far_past', 0):,} "
                                 "date_excluded="
-                                f"{progress.get('skipped_out_of_window_by_date', 0):,}"
+                                f"{progress.get('skipped_out_of_window_by_date', 0):,}",
+                                soft_wrap=True,
                             )
                             return
                         processed = int(progress.get("processed_keys", 0))
@@ -2135,15 +2142,20 @@ def timeseries(
                         )
                         if not should_print:
                             return
+                        # Keys行も下流がparseする契約行: nonempty= は実レコード
+                        # を返したキー数で、ok(成功)とは区別する。soft_wrapで
+                        # 折り返さない。
                         console.print(
                             "\r  Keys: "
                             f"{processed:,}/{total:,} "
                             f"ok={progress.get('success_keys', 0):,} "
+                            f"nonempty={progress.get('nonempty_keys', 0):,} "
                             f"no_data={progress.get('no_data_keys', 0):,} "
                             f"errors={progress.get('error_keys', 0):,} "
                             f"records={progress.get('total_records', 0):,} "
                             f"last={progress.get('key') or '-'}:{status}",
                             end="",
+                            soft_wrap=True,
                         )
 
                     pg_config = (
@@ -2178,14 +2190,24 @@ def timeseries(
                             console.print(f"\r  Processed: {record_count:,} records", end="")
 
                     flush_batch(records_batch)
-                    if key_progress["processed_keys"]:
+                    window_requested = (
+                        post_time_within_minutes is not None
+                        or post_time_not_past_minutes is not None
+                    )
+                    if window_requested or key_progress["processed_keys"]:
+                        # window指定時は対象0件(0/0)でも終端サマリを必ず1行
+                        # 出し、下流が「何も開かなかった」ことを機械検証
+                        # できるようにする。window無しの0キー時は従来どおり
+                        # 出力しない。
                         console.print(
                             "\r  Keys: "
                             f"{key_progress['processed_keys']:,}/{key_progress['total_keys']:,} "
                             f"ok={key_progress['success_keys']:,} "
+                            f"nonempty={key_progress['nonempty_keys']:,} "
                             f"no_data={key_progress['no_data_keys']:,} "
                             f"errors={key_progress['error_keys']:,} "
-                            f"records={key_progress['total_records']:,}"
+                            f"records={key_progress['total_records']:,}",
+                            soft_wrap=True,
                         )
                     console.print(
                         f"  [green][OK][/green] {spec_code}: {record_count:,} records processed"

--- a/src/fetcher/realtime.py
+++ b/src/fetcher/realtime.py
@@ -163,24 +163,30 @@ def _race_key_label(key_fields: tuple) -> str:
 
 def _overlay_current_lifecycle_rows(
     race_rows: list[tuple],
-) -> tuple[list[tuple], set[tuple]]:
+) -> tuple[list[tuple], set[str]]:
     """Select the current lifecycle source for each exact full race key.
 
     Rows carry (LifecycleSource, DataKubun, Year, MonthDay, JyoCD, Kaiji,
     Nichiji, RaceNum, HassoTime). A same-day RT_RA row supersedes the
-    historical NL_RA row for the identical full key regardless of DataKubun,
-    including cancellation status 9; NL_RA rows are used only for full keys
-    absent from RT_RA. Duplicates from the selected source are preserved so a
-    genuine 12-digit-key post-time conflict still fails closed downstream.
+    historical NL_RA row for the identical full key before lifecycle-state
+    validation, including cancellation status 9; NL_RA rows are used only for
+    full keys absent from RT_RA. Duplicates from the selected source are
+    preserved so a genuine 12-digit-key post-time conflict still fails closed
+    downstream.
 
     Because DataKubun decides whether a selected row is active or canceled,
     every selected row must carry an officially valid current RA DataKubun
     (``src.parser.status_domain``); an undecidable status fails closed with
-    the 12-digit race key named, and nothing is opened.
+    the 12-digit race key named, and nothing is opened. DataKubun 0 is an
+    erase instruction which the normal updater physically removes, so finding
+    one persisted here is an inconsistent state and also fails closed.
 
-    Returns the selected 7-column rows and the full keys whose selected
-    source reports cancellation (DataKubun 9) — from RT or NL alike, since
-    selection already happened and RT 9 never exposes the NL row.
+    The selected full keys are also grouped by their normalized 12-digit
+    JVRTOpen key. If one such key is both active and canceled, its state cannot
+    be represented by JVRTOpen and the batch fails closed independent of row
+    order. Returns the selected 7-column rows and the 12-digit keys whose
+    selected rows all report cancellation (DataKubun 9) — from RT or NL alike,
+    since selection already happened and RT 9 never exposes the NL row.
     Cancellations are not removed here: their rows stay subject to
     fail-closed post-time validation first.
     """
@@ -197,7 +203,8 @@ def _overlay_current_lifecycle_rows(
             raise FetcherError(f"Race lifecycle overlay cannot classify source {row[0]!r}")
 
     selected: list[tuple] = []
-    canceled_full_keys: set[tuple] = set()
+    lifecycle_states: dict[str, set[str]] = {}
+    canceled_race_keys: set[str] = set()
     for row in race_rows:
         source, data_kubun = row[0], row[1]
         full_key = tuple(row[2:8])
@@ -215,10 +222,25 @@ def _overlay_current_lifecycle_rows(
             raise FetcherError(
                 f"Race lifecycle selection rejected {_race_key_label(row[2:8])}: {exc}"
             ) from exc
+        race_key = _race_key_label(row[2:8])
+        if validated_kubun == "0":
+            raise FetcherError(
+                f"Race lifecycle selection rejected {race_key}: "
+                "persisted RA DataKubun '0' erase marker"
+            )
         selected.append(tuple(row[2:]))
+        lifecycle_state = "canceled" if validated_kubun == "9" else "active"
+        lifecycle_states.setdefault(race_key, set()).add(lifecycle_state)
         if validated_kubun == "9":
-            canceled_full_keys.add(full_key)
-    return selected, canceled_full_keys
+            canceled_race_keys.add(race_key)
+
+    mixed_state_keys = [key for key, states in lifecycle_states.items() if len(states) > 1]
+    if mixed_state_keys:
+        problems = "; ".join(
+            f"{key}: ambiguous active/canceled lifecycle states" for key in mixed_state_keys
+        )
+        raise FetcherError("Race lifecycle selection rejected keys: " + problems)
+    return selected, canceled_race_keys
 
 
 def materialize_complete_records(
@@ -614,11 +636,11 @@ class RealtimeFetcher(BaseFetcher):
                                initial ``window_filter`` entry carries the
                                window statistics, including
                                ``omitted_canceled_keys``: the number of
-                               selected cancellations (DataKubun 9 reported
-                               by the lifecycle source that owns the full
-                               race key) that passed validation and otherwise
-                               fell inside the requested window. It is always
-                               present (0 when none), and
+                               normalized JVRTOpen keys whose selected
+                               lifecycle rows all report DataKubun 9, passed
+                               validation, and otherwise fell inside the
+                               requested window. It is always present (0 when
+                               none), and
                                ``window_kept_keys`` is reduced by the same
                                amount so it equals total_keys and the keys
                                actually opened.
@@ -892,14 +914,20 @@ class RealtimeFetcher(BaseFetcher):
                 post_time_not_past_minutes=post_time_not_past_minutes,
             )
             if canceled_race_keys:
-                # A validated cancellation owns its full key in whichever
-                # source was selected: omit it without opening and without
-                # falling back to the shadowed row.
-                race_rows = [row for row in race_rows if tuple(row[:6]) not in canceled_race_keys]
-            # omitted_canceled_keys counts selected cancellations that passed
-            # validation and otherwise fell inside the requested window. It is
-            # always reported (0 when none), and window_kept_keys shrinks by
-            # the same amount so it equals total_keys/opened targets.
+                # A validated cancellation owns its normalized JVRTOpen key in
+                # whichever source was selected: omit it without opening and
+                # without falling back to the shadowed row. Mixed active and
+                # canceled state for one 12-digit key was rejected above.
+                race_rows = [
+                    row
+                    for row in race_rows
+                    if _race_key_label(tuple(row[:6])) not in canceled_race_keys
+                ]
+            # omitted_canceled_keys counts normalized JVRTOpen keys whose
+            # selected rows all report cancellation, passed validation, and
+            # otherwise fell inside the requested window. It is always
+            # reported (0 when none), and window_kept_keys shrinks by the same
+            # amount so it equals total_keys/opened targets.
             omitted_canceled_keys = window_stats["window_kept_keys"] - len(race_rows)
             window_stats["window_kept_keys"] = len(race_rows)
             window_stats["omitted_canceled_keys"] = omitted_canceled_keys

--- a/src/fetcher/realtime.py
+++ b/src/fetcher/realtime.py
@@ -16,6 +16,7 @@ from src.jvlink.constants import (
     generate_time_series_key,
     is_time_series_spec,
 )
+from src.parser.status_domain import DataKubunContext, validate_data_kubun
 from src.utils.logger import get_logger
 
 logger = get_logger(__name__)
@@ -148,6 +149,76 @@ def _filter_race_rows_by_post_time(
         "skipped_out_of_window_by_date": skipped_out_of_window_by_date,
     }
     return kept, stats
+
+
+def _race_key_label(key_fields: tuple) -> str:
+    """Name a race by its 12-digit JVRTOpen key, or raw fields when malformed."""
+    year, monthday, jyo_cd, _kaiji, _nichiji, race_num = key_fields
+    try:
+        date_str = f"{int(year):04d}{int(monthday):04d}"
+        return str(generate_time_series_key(date_str, str(jyo_cd).strip().zfill(2), int(race_num)))
+    except (TypeError, ValueError):
+        return repr(key_fields)
+
+
+def _overlay_current_lifecycle_rows(
+    race_rows: list[tuple],
+) -> tuple[list[tuple], set[tuple]]:
+    """Select the current lifecycle source for each exact full race key.
+
+    Rows carry (LifecycleSource, DataKubun, Year, MonthDay, JyoCD, Kaiji,
+    Nichiji, RaceNum, HassoTime). A same-day RT_RA row supersedes the
+    historical NL_RA row for the identical full key regardless of DataKubun,
+    including cancellation status 9; NL_RA rows are used only for full keys
+    absent from RT_RA. Duplicates from the selected source are preserved so a
+    genuine 12-digit-key post-time conflict still fails closed downstream.
+
+    Because DataKubun decides whether a selected row is active or canceled,
+    every selected row must carry an officially valid current RA DataKubun
+    (``src.parser.status_domain``); an undecidable status fails closed with
+    the 12-digit race key named, and nothing is opened.
+
+    Returns the selected 7-column rows and the full keys whose selected
+    source reports cancellation (DataKubun 9) — from RT or NL alike, since
+    selection already happened and RT 9 never exposes the NL row.
+    Cancellations are not removed here: their rows stay subject to
+    fail-closed post-time validation first.
+    """
+    rt_full_keys: set[tuple] = set()
+    for row in race_rows:
+        if len(row) != 9:
+            raise FetcherError(
+                "Race lifecycle overlay requires LifecycleSource, DataKubun, "
+                "Year, MonthDay, JyoCD, Kaiji, Nichiji, RaceNum, and HassoTime"
+            )
+        if row[0] == "RT":
+            rt_full_keys.add(tuple(row[2:8]))
+        elif row[0] != "NL":
+            raise FetcherError(f"Race lifecycle overlay cannot classify source {row[0]!r}")
+
+    selected: list[tuple] = []
+    canceled_full_keys: set[tuple] = set()
+    for row in race_rows:
+        source, data_kubun = row[0], row[1]
+        full_key = tuple(row[2:8])
+        if source == "NL" and full_key in rt_full_keys:
+            continue
+        try:
+            validated_kubun = validate_data_kubun(
+                "RA",
+                data_kubun,
+                context=(
+                    DataKubunContext.REALTIME if source == "RT" else DataKubunContext.ACCUMULATED
+                ),
+            )
+        except ValueError as exc:
+            raise FetcherError(
+                f"Race lifecycle selection rejected {_race_key_label(row[2:8])}: {exc}"
+            ) from exc
+        selected.append(tuple(row[2:]))
+        if validated_kubun == "9":
+            canceled_full_keys.add(full_key)
+    return selected, canceled_full_keys
 
 
 def materialize_complete_records(
@@ -539,6 +610,18 @@ class RealtimeFetcher(BaseFetcher):
                        of SQLite.
             progress_callback: Optional callback called after each race key is
                                attempted. Receives counters and key status.
+                               When a post-time window is requested, the
+                               initial ``window_filter`` entry carries the
+                               window statistics, including
+                               ``omitted_canceled_keys``: the number of
+                               selected cancellations (DataKubun 9 reported
+                               by the lifecycle source that owns the full
+                               race key) that passed validation and otherwise
+                               fell inside the requested window. It is always
+                               present (0 when none), and
+                               ``window_kept_keys`` is reduced by the same
+                               amount so it equals total_keys and the keys
+                               actually opened.
             post_time_within_minutes: Keep keys no more than this many minutes
                                       before their race-record post time.
             post_time_not_past_minutes: Drop keys more than this many minutes
@@ -584,32 +667,49 @@ class RealtimeFetcher(BaseFetcher):
         )
 
         # Forward-only 0B15 cards are stored in RT_RA, while historical RACE
-        # records are stored in NL_RA. Use both sources and de-duplicate the
-        # key-bearing columns. This exposes no result fields: only the race
-        # identity is used to construct the JVRTOpen request key.
+        # records are stored in NL_RA. Without a post-time window both sources
+        # are merged and de-duplicated on the key-bearing columns. With a
+        # window, rows always keep their source and DataKubun so the selected
+        # current lifecycle row is validated and can cancel its key: a current
+        # RT_RA row supersedes the stale NL_RA row for the same full race key,
+        # and when RT_RA is absent NL_RA owns every full key. This exposes no
+        # result fields: only the race identity is used to construct the
+        # JVRTOpen request key.
         if pg_config:
             if window_filter_requested:
-                rt_union = (
+                if self._postgres_table_exists(pg_config, "rt_ra"):
+                    # UNION ALL: duplicates inside the selected source must
+                    # survive the overlay so a genuine 12-digit-key post-time
+                    # conflict still fails closed.
+                    query = """
+                        WITH race_targets AS (
+                            SELECT 'RT' AS lifecycle_source, datakubun,
+                                   year, monthday, jyocd, kaiji, nichiji, racenum, hassotime
+                            FROM rt_ra
+                            UNION ALL
+                            SELECT 'NL', datakubun,
+                                   year, monthday, jyocd, kaiji, nichiji, racenum, hassotime
+                            FROM nl_ra
+                        )
+                        SELECT
+                            lifecycle_source, datakubun,
+                            year, monthday, jyocd, kaiji, nichiji, racenum, hassotime
+                        FROM race_targets
+                        WHERE 1=1
                     """
-                        UNION
-                        SELECT year, monthday, jyocd, kaiji, nichiji, racenum, hassotime
-                        FROM rt_ra
+                else:
+                    query = """
+                        WITH race_targets AS (
+                            SELECT 'NL' AS lifecycle_source, datakubun,
+                                   year, monthday, jyocd, kaiji, nichiji, racenum, hassotime
+                            FROM nl_ra
+                        )
+                        SELECT
+                            lifecycle_source, datakubun,
+                            year, monthday, jyocd, kaiji, nichiji, racenum, hassotime
+                        FROM race_targets
+                        WHERE 1=1
                     """
-                    if self._postgres_table_exists(pg_config, "rt_ra")
-                    else ""
-                )
-                distinct = "" if rt_union else " DISTINCT"
-                query = f"""
-                    WITH race_targets AS (
-                        SELECT year, monthday, jyocd, kaiji, nichiji, racenum, hassotime
-                        FROM nl_ra
-                        {rt_union}
-                    )
-                    SELECT{distinct}
-                        year, monthday, jyocd, kaiji, nichiji, racenum, hassotime
-                    FROM race_targets
-                    WHERE 1=1
-                """
             else:
                 rt_union = (
                     """
@@ -649,27 +749,39 @@ class RealtimeFetcher(BaseFetcher):
                         WHERE type = 'table' AND lower(name) = lower('RT_RA')
                         """).fetchone() is not None
             if window_filter_requested:
-                rt_union = (
+                if has_rt_ra:
+                    # UNION ALL: duplicates inside the selected source must
+                    # survive the overlay so a genuine 12-digit-key post-time
+                    # conflict still fails closed.
+                    query = """
+                        WITH race_targets AS (
+                            SELECT 'RT' AS LifecycleSource, DataKubun,
+                                   Year, MonthDay, JyoCD, Kaiji, Nichiji, RaceNum, HassoTime
+                            FROM RT_RA
+                            UNION ALL
+                            SELECT 'NL', DataKubun,
+                                   Year, MonthDay, JyoCD, Kaiji, Nichiji, RaceNum, HassoTime
+                            FROM NL_RA
+                        )
+                        SELECT
+                            LifecycleSource, DataKubun,
+                            Year, MonthDay, JyoCD, Kaiji, Nichiji, RaceNum, HassoTime
+                        FROM race_targets
+                        WHERE 1=1
                     """
-                        UNION
-                        SELECT Year, MonthDay, JyoCD, Kaiji, Nichiji, RaceNum, HassoTime
-                        FROM RT_RA
+                else:
+                    query = """
+                        WITH race_targets AS (
+                            SELECT 'NL' AS LifecycleSource, DataKubun,
+                                   Year, MonthDay, JyoCD, Kaiji, Nichiji, RaceNum, HassoTime
+                            FROM NL_RA
+                        )
+                        SELECT
+                            LifecycleSource, DataKubun,
+                            Year, MonthDay, JyoCD, Kaiji, Nichiji, RaceNum, HassoTime
+                        FROM race_targets
+                        WHERE 1=1
                     """
-                    if has_rt_ra
-                    else ""
-                )
-                distinct = "" if rt_union else " DISTINCT"
-                query = f"""
-                    WITH race_targets AS (
-                        SELECT Year, MonthDay, JyoCD, Kaiji, Nichiji, RaceNum, HassoTime
-                        FROM NL_RA
-                        {rt_union}
-                    )
-                    SELECT{distinct}
-                        Year, MonthDay, JyoCD, Kaiji, Nichiji, RaceNum, HassoTime
-                    FROM race_targets
-                    WHERE 1=1
-                """
             else:
                 rt_union = (
                     """
@@ -773,11 +885,29 @@ class RealtimeFetcher(BaseFetcher):
 
         window_stats: Optional[dict[str, int]] = None
         if window_filter_requested:
+            race_rows, canceled_race_keys = _overlay_current_lifecycle_rows(race_rows)
             race_rows, window_stats = _filter_race_rows_by_post_time(
                 race_rows,
                 post_time_within_minutes=post_time_within_minutes,
                 post_time_not_past_minutes=post_time_not_past_minutes,
             )
+            if canceled_race_keys:
+                # A validated cancellation owns its full key in whichever
+                # source was selected: omit it without opening and without
+                # falling back to the shadowed row.
+                race_rows = [row for row in race_rows if tuple(row[:6]) not in canceled_race_keys]
+            # omitted_canceled_keys counts selected cancellations that passed
+            # validation and otherwise fell inside the requested window. It is
+            # always reported (0 when none), and window_kept_keys shrinks by
+            # the same amount so it equals total_keys/opened targets.
+            omitted_canceled_keys = window_stats["window_kept_keys"] - len(race_rows)
+            window_stats["window_kept_keys"] = len(race_rows)
+            window_stats["omitted_canceled_keys"] = omitted_canceled_keys
+            if omitted_canceled_keys:
+                logger.info(
+                    "Omitted canceled races after post-time validation",
+                    omitted_canceled_keys=omitted_canceled_keys,
+                )
             logger.info("Applied race post-time window", **window_stats)
             if progress_callback:
                 progress_callback(
@@ -788,6 +918,7 @@ class RealtimeFetcher(BaseFetcher):
                         "total_keys": len(race_rows),
                         **window_stats,
                         "success_keys": 0,
+                        "nonempty_keys": 0,
                         "no_data_keys": 0,
                         "error_keys": 0,
                         "total_records": 0,
@@ -805,9 +936,12 @@ class RealtimeFetcher(BaseFetcher):
         if ret != JV_RT_SUCCESS:
             raise FetcherError(f"JV-Link initialization failed: {ret}")
 
-        # Statistics
+        # Statistics. nonempty_keys counts only keys whose complete buffered
+        # response materialized at least one record: success_keys alone is not
+        # evidence of nonempty capture.
         total_keys = len(race_rows)
         success_keys = 0
+        nonempty_keys = 0
         no_data_keys = 0
         error_keys = 0
         total_records = 0
@@ -841,6 +975,7 @@ class RealtimeFetcher(BaseFetcher):
                             "processed_keys": processed_keys,
                             "total_keys": total_keys,
                             "success_keys": success_keys,
+                            "nonempty_keys": nonempty_keys,
                             "no_data_keys": no_data_keys,
                             "error_keys": error_keys,
                             "records_for_key": 0,
@@ -883,6 +1018,8 @@ class RealtimeFetcher(BaseFetcher):
                     key_records = list(self._fetch_and_parse())
                     records_for_key = len(key_records)
                     success_keys += 1
+                    if records_for_key:
+                        nonempty_keys += 1
                     key_status = "success"
                     total_records += records_for_key
                     yield from key_records
@@ -914,6 +1051,7 @@ class RealtimeFetcher(BaseFetcher):
                             "processed_keys": processed_keys,
                             "total_keys": total_keys,
                             "success_keys": success_keys,
+                            "nonempty_keys": nonempty_keys,
                             "no_data_keys": no_data_keys,
                             "error_keys": error_keys,
                             "records_for_key": records_for_key,
@@ -935,6 +1073,7 @@ class RealtimeFetcher(BaseFetcher):
             data_spec=data_spec,
             total_keys=total_keys,
             success_keys=success_keys,
+            nonempty_keys=nonempty_keys,
             no_data_keys=no_data_keys,
             error_keys=error_keys,
             total_records=total_records,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -817,6 +817,7 @@ auto_update_check: false
                     "considered_keys": 3,
                     "window_candidate_keys": 3,
                     "window_kept_keys": 1,
+                    "omitted_canceled_keys": 2,
                     "dropped_too_far_future": 1,
                     "dropped_too_far_past": 1,
                     "skipped_out_of_window_by_date": 0,
@@ -824,6 +825,20 @@ auto_update_check: false
                     "no_data_keys": 0,
                     "error_keys": 0,
                     "total_records": 0,
+                }
+            )
+            callback(
+                {
+                    "status": "success",
+                    "key": "202609010501",
+                    "processed_keys": 1,
+                    "total_keys": 1,
+                    "success_keys": 1,
+                    "nonempty_keys": 1,
+                    "no_data_keys": 0,
+                    "error_keys": 0,
+                    "records_for_key": 3,
+                    "total_records": 3,
                 }
             )
             return iter(())
@@ -874,12 +889,106 @@ auto_update_check: false
         call_kwargs = fetcher.fetch_time_series_batch_from_db.call_args.kwargs
         self.assertEqual(call_kwargs["post_time_within_minutes"], 30)
         self.assertEqual(call_kwargs["post_time_not_past_minutes"], 2)
-        self.assertIn("considered=3", result.output)
-        self.assertIn("candidates=3", result.output)
-        self.assertIn("kept=1", result.output)
-        self.assertIn("future=1", result.output)
-        self.assertIn("past=1", result.output)
-        self.assertIn("date_excluded=0", result.output)
+        # 下流のwine runtimeがこの行をparseするため、tokenと順序を固定する。
+        # canceled= は検証済み中止の除外数で、中止なしでも0が出力される。
+        self.assertIn(
+            "Window: considered=3 candidates=3 kept=1 canceled=2 "
+            "future=1 past=1 date_excluded=0",
+            result.output,
+        )
+        # Keys行も同様にparseされる: ok(成功キー)と実レコードを返した
+        # nonemptyキーを区別し、token順を固定する。
+        self.assertIn("ok=1 nonempty=1 no_data=0", result.output)
+
+    def test_timeseries_window_idle_run_emits_zero_keys_summary(self):
+        """対象0件のidle実行でもspecごとに終端Keysサマリを1行だけ出す。
+
+        窓フィルタで全キーが落ちた(total_keys=0)日でも、下流のwine runtime
+        は「何も開かなかった」ことをKeys行で機械的に確認する。last=を含ま
+        ない終端形1行のみで、Window行は別行のまま。
+        """
+        database = MagicMock()
+        database.__enter__.return_value = database
+        database.__exit__.return_value = None
+        fetcher = MagicMock()
+
+        def fetch_rows(**kwargs):
+            callback = kwargs["progress_callback"]
+            callback(
+                {
+                    "status": "window_filter",
+                    "key": None,
+                    "processed_keys": 0,
+                    "total_keys": 0,
+                    "considered_keys": 2,
+                    "window_candidate_keys": 2,
+                    "window_kept_keys": 0,
+                    "omitted_canceled_keys": 1,
+                    "dropped_too_far_future": 0,
+                    "dropped_too_far_past": 1,
+                    "skipped_out_of_window_by_date": 0,
+                    "success_keys": 0,
+                    "nonempty_keys": 0,
+                    "no_data_keys": 0,
+                    "error_keys": 0,
+                    "total_records": 0,
+                }
+            )
+            return iter(())
+
+        fetcher.fetch_time_series_batch_from_db.side_effect = fetch_rows
+        updater = MagicMock()
+
+        with self.runner.isolated_filesystem():
+            config_path = Path("config.yaml")
+            config_path.write_text("""
+database:
+  type: postgresql
+databases:
+  postgresql:
+    enabled: true
+jvlink:
+  sid: TEST
+auto_update_check: false
+""")
+            with (
+                patch("src.database.create_database_from_config", return_value=database),
+                patch("src.fetcher.realtime.RealtimeFetcher", return_value=fetcher),
+                patch("src.realtime.updater.RealtimeUpdater", return_value=updater),
+            ):
+                result = self.runner.invoke(
+                    cli,
+                    [
+                        "--config",
+                        str(config_path),
+                        "realtime",
+                        "timeseries",
+                        "--spec",
+                        "0B41",
+                        "--from",
+                        "20260901",
+                        "--to",
+                        "20260901",
+                        "--db",
+                        "postgresql",
+                        "--post-time-within-minutes",
+                        "30",
+                        "--post-time-not-past-minutes",
+                        "2",
+                    ],
+                )
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertIn(
+            "Window: considered=2 candidates=2 kept=0 canceled=1 "
+            "future=0 past=1 date_excluded=0",
+            result.output,
+        )
+        self.assertEqual(
+            result.output.count("Keys: 0/0 ok=0 nonempty=0 no_data=0 errors=0 records=0"),
+            1,
+        )
+        self.assertNotIn("last=", result.output)
 
     def test_timeseries_window_implicit_dates_use_jst(self):
         from datetime import datetime as real_datetime

--- a/tests/test_public_setup_contract.py
+++ b/tests/test_public_setup_contract.py
@@ -33,9 +33,7 @@ def test_public_setup_uses_supported_registration_and_dataspecs() -> None:
         assert not any(guidance in text for guidance in stale_guidance), path
 
     config = yaml.safe_load(
-        (REPOSITORY_ROOT / "config/config.yaml.example").read_text(
-            encoding="utf-8"
-        )
+        (REPOSITORY_ROOT / "config/config.yaml.example").read_text(encoding="utf-8")
     )
     data_specs = config["data_fetch"]["initial"]["data_specs"]
     assert data_specs
@@ -82,8 +80,7 @@ def test_tracked_public_markdown_omits_the_retired_infrastructure_token() -> Non
             path.read_text(encoding="utf-8"),
         )
         assert all(
-            hashlib.sha256(token.lower().encode("ascii")).hexdigest()
-            != blocked_hash
+            hashlib.sha256(token.lower().encode("ascii")).hexdigest() != blocked_hash
             for token in tokens
         ), path
 
@@ -107,25 +104,17 @@ def test_sqlite_bootstrap_does_not_import_an_optional_postgresql_driver() -> Non
 
 def test_removed_public_setup_contract_is_recorded_for_2_0() -> None:
     changelog = (REPOSITORY_ROOT / "CHANGELOG.md").read_text(encoding="utf-8")
-    release_notes = (REPOSITORY_ROOT / "RELEASE_NOTES.md").read_text(
-        encoding="utf-8"
-    )
-    constants = (REPOSITORY_ROOT / "src/jvlink/constants.py").read_text(
-        encoding="utf-8"
-    )
-    project = tomllib.loads(
-        (REPOSITORY_ROOT / "pyproject.toml").read_text(encoding="utf-8")
-    )
+    release_notes = (REPOSITORY_ROOT / "RELEASE_NOTES.md").read_text(encoding="utf-8")
+    constants = (REPOSITORY_ROOT / "src/jvlink/constants.py").read_text(encoding="utf-8")
+    project = tomllib.loads((REPOSITORY_ROOT / "pyproject.toml").read_text(encoding="utf-8"))
 
     assert "2.0.0" in changelog
     assert "## [2.0.0] - 2026-08-27" in changelog
     assert (
-        "[Unreleased]: https://github.com/miyamamoto/jrvltsql/compare/"
-        "v2.1.1...HEAD"
+        "[Unreleased]: https://github.com/miyamamoto/jrvltsql/compare/" "v2.1.2...HEAD"
     ) in changelog
     assert (
-        "[2.0.0]: https://github.com/miyamamoto/jrvltsql/compare/"
-        "v1.6.10...v2.0.0"
+        "[2.0.0]: https://github.com/miyamamoto/jrvltsql/compare/" "v1.6.10...v2.0.0"
     ) in changelog
     assert "final candidate" not in release_notes.lower()
     assert "not released yet" not in release_notes.lower()
@@ -135,7 +124,7 @@ def test_removed_public_setup_contract_is_recorded_for_2_0() -> None:
     assert "RECORD_TYPE_O1" in release_notes
     assert "RECORD_TYPE_O6" in release_notes
     assert "uses_external_runner" in release_notes
-    assert project["project"]["version"] == "2.1.1"
+    assert project["project"]["version"] == "2.1.2"
     assert "wrapper.py の JVSetServiceKey 呼び出し箇所" not in constants
     for record_type in range(1, 7):
         assert f"DATA_SPEC_O{record_type} =" not in constants
@@ -146,15 +135,9 @@ def test_version_and_lock_metadata_are_consistent() -> None:
     from src import __version__
     from src.cli import main as cli_main
 
-    project = tomllib.loads(
-        (REPOSITORY_ROOT / "pyproject.toml").read_text(encoding="utf-8")
-    )
-    lock = tomllib.loads(
-        (REPOSITORY_ROOT / "uv.lock").read_text(encoding="utf-8")
-    )
-    locked_project = next(
-        package for package in lock["package"] if package["name"] == "jltsql"
-    )
+    project = tomllib.loads((REPOSITORY_ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+    lock = tomllib.loads((REPOSITORY_ROOT / "uv.lock").read_text(encoding="utf-8"))
+    locked_project = next(package for package in lock["package"] if package["name"] == "jltsql")
 
     assert __version__ == project["project"]["version"]
     assert cli_main.__version__ == __version__
@@ -162,27 +145,19 @@ def test_version_and_lock_metadata_are_consistent() -> None:
 
     build_requires = project["build-system"]["requires"]
     setuptools_requirement = next(
-        requirement
-        for requirement in build_requires
-        if requirement.startswith("setuptools>=")
+        requirement for requirement in build_requires if requirement.startswith("setuptools>=")
     )
-    assert Version(setuptools_requirement.removeprefix("setuptools>=")) >= Version(
-        "77.0.3"
-    )
+    assert Version(setuptools_requirement.removeprefix("setuptools>=")) >= Version("77.0.3")
 
     manifest = (REPOSITORY_ROOT / "MANIFEST.in").read_text(encoding="utf-8")
     assert "prune specs" in manifest.splitlines()
 
-    workflow = (
-        REPOSITORY_ROOT / ".github/workflows/test.yml"
-    ).read_text(encoding="utf-8")
+    workflow = (REPOSITORY_ROOT / ".github/workflows/test.yml").read_text(encoding="utf-8")
     assert "pip install uv==" in workflow
 
 
 def test_architecture_documents_the_generic_non_windows_runner_contract() -> None:
-    architecture = (REPOSITORY_ROOT / "docs/architecture.md").read_text(
-        encoding="utf-8"
-    )
+    architecture = (REPOSITORY_ROOT / "docs/architecture.md").read_text(encoding="utf-8")
 
     assert "JVLINK_BRIDGE_RUNNER" in architecture
 
@@ -203,3 +178,20 @@ def test_2_0_notes_define_the_data_and_rollback_migration_boundary() -> None:
         assert term in notes
     assert "reimport" in changelog
     assert "rollback" in changelog
+
+
+def test_tests_workflow_gates_release_hotfix_pull_requests() -> None:
+    """Hotfix PRs target release/X.Y.Z; the Tests workflow must gate them.
+
+    docs/release_policy.md routes an emergency hotfix into a pull request
+    against ``release/X.Y.Z``. If the ``pull_request`` trigger omits release
+    branches, the mandatory Tests gate silently never runs on the only PR
+    that publishes a hotfix, so the release-path CI evidence cannot exist.
+    """
+    workflow = yaml.safe_load(
+        (REPOSITORY_ROOT / ".github/workflows/test.yml").read_text(encoding="utf-8")
+    )
+    # YAML 1.1 parses the bare `on` key as boolean True.
+    triggers = workflow.get("on", workflow.get(True))
+    branches = triggers["pull_request"]["branches"]
+    assert "release/**" in branches

--- a/tests/test_time_series.py
+++ b/tests/test_time_series.py
@@ -939,9 +939,14 @@ def test_sqlite_race_window_rt_lifecycle_cancellation_does_not_fall_back_to_nl(
                 ("2", 2026, 905, "06", 4, 8, 12, "1630"),
             ],
         )
-        conn.execute(
+        conn.executemany(
             "INSERT INTO RT_RA VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
-            ("9", 2026, 905, "06", 4, 8, 11, "1615"),
+            [
+                ("9", 2026, 905, "06", 4, 8, 11, "1615"),
+                # A second canceled full key collapses to the same JVRTOpen
+                # key deterministically; it is still one omitted key.
+                ("9", 2026, 905, "06", 5, 1, 11, "1615"),
+            ],
         )
         conn.commit()
 
@@ -1175,6 +1180,107 @@ def test_sqlite_race_window_rt_lifecycle_source_conflict_fails_closed(tmp_path, 
     fetcher.jvlink = _window_jvlink()
 
     with pytest.raises(FetcherError, match=r"202609050612.*ambiguous"):
+        list(
+            fetcher.fetch_time_series_batch_from_db(
+                data_spec="0B41",
+                db_path=str(db_path),
+                from_date="20260905",
+                to_date="20260905",
+                post_time_within_minutes=20,
+                post_time_not_past_minutes=1,
+            )
+        )
+    assert fetcher.jvlink.init_calls == 0
+
+
+@pytest.mark.parametrize(
+    "race_rows",
+    [
+        pytest.param(
+            [
+                ("RT", "6", 2026, 905, "06", 4, 8, 12, "1630"),
+                ("RT", "9", 2026, 905, "06", 5, 1, 12, "1630"),
+            ],
+            id="active-first",
+        ),
+        pytest.param(
+            [
+                ("RT", "9", 2026, 905, "06", 5, 1, 12, "1630"),
+                ("RT", "6", 2026, 905, "06", 4, 8, 12, "1630"),
+            ],
+            id="canceled-first",
+        ),
+    ],
+)
+def test_postgresql_race_window_rt_lifecycle_mixed_state_fails_closed_before_init(
+    monkeypatch, race_rows
+):
+    """One JVRTOpen key cannot be both active and canceled based on row order."""
+    from src.fetcher.base import FetcherError
+    from src.fetcher.realtime import RealtimeFetcher
+
+    _fixed_lifecycle_incident_now(monkeypatch)
+    monkeypatch.setattr(
+        RealtimeFetcher,
+        "_fetch_time_series_race_rows_from_postgres",
+        staticmethod(lambda _query, _params, _config: race_rows),
+    )
+    monkeypatch.setattr(
+        RealtimeFetcher,
+        "_postgres_table_exists",
+        staticmethod(lambda _config, table_name: table_name == "rt_ra"),
+    )
+    fetcher = object.__new__(RealtimeFetcher)
+    fetcher.jvlink = _window_jvlink()
+
+    with pytest.raises(FetcherError, match=r"202609050612.*ambiguous.*lifecycle"):
+        list(
+            fetcher.fetch_time_series_batch_from_db(
+                data_spec="0B41",
+                db_path="ignored.sqlite",
+                from_date="20260905",
+                to_date="20260905",
+                pg_config={"host": "localhost", "database": "keiba"},
+                post_time_within_minutes=20,
+                post_time_not_past_minutes=1,
+            )
+        )
+    assert fetcher.jvlink.init_calls == 0
+
+
+@pytest.mark.parametrize("owning_source", ["RT", "NL"])
+def test_sqlite_race_window_rt_lifecycle_persisted_erase_fails_closed_before_init(
+    tmp_path, monkeypatch, owning_source
+):
+    """A stored RA DataKubun 0 erase marker is not an active race target."""
+    import sqlite3
+    from contextlib import closing
+
+    from src.fetcher.base import FetcherError
+    from src.fetcher.realtime import RealtimeFetcher
+
+    _fixed_lifecycle_incident_now(monkeypatch)
+    db_path = tmp_path / f"lifecycle-{owning_source.lower()}-erase.db"
+    with closing(sqlite3.connect(db_path)) as conn:
+        _create_lifecycle_race_tables(conn)
+        if owning_source == "RT":
+            conn.execute(
+                "INSERT INTO NL_RA VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+                ("2", 2026, 905, "06", 4, 8, 10, "1620"),
+            )
+            table = "RT_RA"
+        else:
+            table = "NL_RA"
+        conn.execute(
+            f"INSERT INTO {table} VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+            ("0", 2026, 905, "06", 4, 8, 10, "1620"),
+        )
+        conn.commit()
+
+    fetcher = object.__new__(RealtimeFetcher)
+    fetcher.jvlink = _window_jvlink()
+
+    with pytest.raises(FetcherError, match=r"202609050610.*DataKubun.*0.*erase"):
         list(
             fetcher.fetch_time_series_batch_from_db(
                 data_spec="0B41",

--- a/tests/test_time_series.py
+++ b/tests/test_time_series.py
@@ -71,10 +71,10 @@ def test_key_generation():
 
 def test_fetch_time_series_batch_from_db_uses_simple_key():
     """DB登録済みレースからの時系列取得が12桁キーを使うことを確認する。"""
-    from contextlib import closing
     import sqlite3
     import tempfile
     import types
+    from contextlib import closing
     from pathlib import Path
 
     from src.fetcher.realtime import RealtimeFetcher
@@ -193,6 +193,84 @@ def test_fetch_time_series_batch_from_db_closes_no_data_stream():
         assert progress[-1]["status"] == "no_data"
         assert progress[-1]["processed_keys"] == 1
         assert progress[-1]["no_data_keys"] == 1
+        assert progress[-1]["nonempty_keys"] == 0
+
+
+def test_fetch_time_series_batch_from_db_counts_nonempty_keys():
+    """success_keysは実レコードの証拠にならない: 空成功キーを区別して数える。
+
+    JVRTOpenが成功してもJVReadが0行のキーはnonempty_keysを増やさず、
+    実レコードを返したキーだけが増やす。下流の収集証跡はok(success)では
+    なくnonemptyを非空捕捉の根拠に使う。
+    """
+    import sqlite3
+    import tempfile
+    import types
+    from contextlib import closing
+    from pathlib import Path
+
+    from src.fetcher.realtime import RealtimeFetcher
+
+    with tempfile.TemporaryDirectory(dir="/tmp") as temp_dir:
+        db_path = Path(temp_dir) / "keiba.db"
+        with closing(sqlite3.connect(db_path)) as conn:
+            conn.execute("""
+                CREATE TABLE NL_RA (
+                    Year INTEGER,
+                    MonthDay INTEGER,
+                    JyoCD TEXT,
+                    Kaiji INTEGER,
+                    Nichiji INTEGER,
+                    RaceNum INTEGER
+                )
+                """)
+            conn.execute("INSERT INTO NL_RA VALUES (2025, 1201, '05', 5, 8, 11)")
+            conn.execute("INSERT INTO NL_RA VALUES (2025, 1201, '05', 5, 8, 12)")
+            conn.commit()
+
+        class FakeJVLink:
+            def jv_init(self):
+                return 0
+
+            def jv_rt_open(self, data_spec, key):
+                return 0, 1
+
+            def jv_close(self):
+                return 0
+
+        fetcher = object.__new__(RealtimeFetcher)
+        fetcher.jvlink = FakeJVLink()
+        calls = {"count": 0}
+
+        def fake_fetch_and_parse(self):
+            calls["count"] += 1
+            if calls["count"] > 1:
+                yield {"RecordSpec": "O1", "_raw": b"O1"}
+
+        fetcher._fetch_and_parse = types.MethodType(fake_fetch_and_parse, fetcher)
+        progress = []
+
+        records = list(
+            fetcher.fetch_time_series_batch_from_db(
+                data_spec="0B30",
+                db_path=str(db_path),
+                from_date="20251201",
+                to_date="20251201",
+                progress_callback=progress.append,
+            )
+        )
+
+        assert records == [{"RecordSpec": "O1", "_raw": b"O1"}]
+        # 1キー目: openは成功したがJVReadは0行 -> ok=1 でも非空は0。
+        assert progress[0]["status"] == "success"
+        assert progress[0]["success_keys"] == 1
+        assert progress[0]["records_for_key"] == 0
+        assert progress[0]["nonempty_keys"] == 0
+        # 2キー目: 実レコード1行で初めて非空キーが増える。
+        assert progress[1]["status"] == "success"
+        assert progress[1]["success_keys"] == 2
+        assert progress[1]["records_for_key"] == 1
+        assert progress[1]["nonempty_keys"] == 1
 
 
 def test_fetch_time_series_batch_from_db_discards_partial_key():
@@ -457,16 +535,17 @@ def test_sqlite_race_window_keeps_near_post_and_reports_drop_reasons(tmp_path, m
     with closing(sqlite3.connect(db_path)) as conn:
         conn.execute("""
             CREATE TABLE NL_RA (
+                DataKubun TEXT,
                 Year INTEGER, MonthDay INTEGER, JyoCD TEXT, Kaiji INTEGER,
                 Nichiji INTEGER, RaceNum INTEGER, HassoTime TEXT
             )
             """)
         conn.executemany(
-            "INSERT INTO NL_RA VALUES (?, ?, ?, ?, ?, ?, ?)",
+            "INSERT INTO NL_RA VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
             [
-                (2026, 901, "05", 3, 4, 1, "1230"),
-                (2026, 901, "05", 3, 4, 2, "1231"),
-                (2026, 901, "05", 3, 4, 3, "1157"),
+                ("2", 2026, 901, "05", 3, 4, 1, "1230"),
+                ("2", 2026, 901, "05", 3, 4, 2, "1231"),
+                ("2", 2026, 901, "05", 3, 4, 3, "1157"),
             ],
         )
         conn.commit()
@@ -502,7 +581,9 @@ def test_sqlite_race_window_keeps_near_post_and_reports_drop_reasons(tmp_path, m
         "dropped_too_far_future": 1,
         "dropped_too_far_past": 1,
         "skipped_out_of_window_by_date": 0,
+        "omitted_canceled_keys": 0,
         "success_keys": 0,
+        "nonempty_keys": 0,
         "no_data_keys": 0,
         "error_keys": 0,
         "total_records": 0,
@@ -520,15 +601,16 @@ def test_race_window_skips_malformed_post_time_on_out_of_window_date(tmp_path, m
     with closing(sqlite3.connect(db_path)) as conn:
         conn.execute("""
             CREATE TABLE NL_RA (
+                DataKubun TEXT,
                 Year INTEGER, MonthDay INTEGER, JyoCD TEXT, Kaiji INTEGER,
                 Nichiji INTEGER, RaceNum INTEGER, HassoTime TEXT
             )
             """)
         conn.executemany(
-            "INSERT INTO NL_RA VALUES (?, ?, ?, ?, ?, ?, ?)",
+            "INSERT INTO NL_RA VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
             [
-                (2026, 901, "05", 3, 4, 1, "1230"),
-                (2026, 902, "05", 3, 4, 1, "not-a-time"),
+                ("2", 2026, 901, "05", 3, 4, 1, "1230"),
+                ("2", 2026, 902, "05", 3, 4, 1, "not-a-time"),
             ],
         )
         conn.commit()
@@ -578,15 +660,16 @@ def test_race_window_boundary_date_is_evaluated_by_post_time(tmp_path, monkeypat
     with closing(sqlite3.connect(db_path)) as conn:
         conn.execute("""
             CREATE TABLE NL_RA (
+                DataKubun TEXT,
                 Year INTEGER, MonthDay INTEGER, JyoCD TEXT, Kaiji INTEGER,
                 Nichiji INTEGER, RaceNum INTEGER, HassoTime TEXT
             )
             """)
         conn.executemany(
-            "INSERT INTO NL_RA VALUES (?, ?, ?, ?, ?, ?, ?)",
+            "INSERT INTO NL_RA VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
             [
-                (2026, 831, "05", 3, 4, 1, "1200"),
-                (2026, 831, "05", 3, 4, 2, "2359"),
+                ("2", 2026, 831, "05", 3, 4, 1, "1200"),
+                ("2", 2026, 831, "05", 3, 4, 2, "2359"),
             ],
         )
         conn.commit()
@@ -650,10 +733,12 @@ def test_postgresql_race_window_filters_rows_from_pg_source(monkeypatch):
 
     def fake_pg_rows(query, params, pg_config):
         captured["query"] = query
+        # 実スキーマどおり nl_ra は datakubun を持ち、rt_ra 不在時は
+        # 'NL' タグ付きの9列ライフサイクル行が返る。
         return [
-            (2026, 901, "05", 3, 4, 1, "1230"),
-            (2026, 901, "05", 3, 4, 2, "1231"),
-            (2026, 901, "05", 3, 4, 3, "1157"),
+            ("NL", "2", 2026, 901, "05", 3, 4, 1, "1230"),
+            ("NL", "2", 2026, 901, "05", 3, 4, 2, "1231"),
+            ("NL", "2", 2026, 901, "05", 3, 4, 3, "1157"),
         ]
 
     monkeypatch.setattr(
@@ -685,6 +770,7 @@ def test_postgresql_race_window_filters_rows_from_pg_source(monkeypatch):
     )
 
     assert "hassotime" in captured["query"].lower()
+    assert "datakubun" in captured["query"].lower()
     assert fetcher.jvlink.opened == [("0B42", "202609010501")]
 
 
@@ -713,12 +799,13 @@ def test_race_window_candidate_fails_closed_and_names_bad_race_key(
     with closing(sqlite3.connect(db_path)) as conn:
         conn.execute("""
             CREATE TABLE NL_RA (
+                DataKubun TEXT,
                 Year INTEGER, MonthDay INTEGER, JyoCD TEXT, Kaiji INTEGER,
                 Nichiji INTEGER, RaceNum INTEGER, HassoTime TEXT
             )
             """)
         conn.executemany(
-            "INSERT INTO NL_RA VALUES (2026, 901, '05', 3, 4, 1, ?)",
+            "INSERT INTO NL_RA VALUES ('2', 2026, 901, '05', 3, 4, 1, ?)",
             [(post_time,) for post_time in post_times],
         )
         conn.commit()
@@ -737,6 +824,463 @@ def test_race_window_candidate_fails_closed_and_names_bad_race_key(
             )
         )
     assert fetcher.jvlink.init_calls == 0
+
+
+def _fixed_lifecycle_incident_now(monkeypatch):
+    from datetime import datetime
+
+    import src.fetcher.realtime as realtime_module
+    from src.fetcher.realtime import JST
+
+    # 2026-09-05 16:16 JST: レース12(16:30)が20分窓の対象になった瞬間。
+    now = datetime(2026, 9, 5, 16, 16, tzinfo=JST)
+    monkeypatch.setattr(realtime_module, "_now_jst", lambda: now, raising=False)
+
+
+def _create_lifecycle_race_tables(conn, tables=("NL_RA", "RT_RA")):
+    # SCHEMAS["NL_RA"]/["RT_RA"] のうち選択に関与する形状を再現する:
+    # DataKubun と PRIMARY KEY (Year, MonthDay, JyoCD, Kaiji, Nichiji,
+    # RaceNum)。保存は INSERT OR REPLACE なので、フルキーごとに現在の
+    # ライフサイクル行は1件だけ物理的に存在できる。RT_RAは任意テーブルで、
+    # 不在のDBではNL_RAだけを作る。
+    for table in tables:
+        conn.execute(f"""
+            CREATE TABLE {table} (
+                DataKubun TEXT,
+                Year INTEGER, MonthDay INTEGER, JyoCD TEXT, Kaiji INTEGER,
+                Nichiji INTEGER, RaceNum INTEGER, HassoTime TEXT,
+                PRIMARY KEY (Year, MonthDay, JyoCD, Kaiji, Nichiji, RaceNum)
+            )
+            """)
+
+
+def test_sqlite_race_window_rt_lifecycle_overlay_supersedes_stale_nl_row(tmp_path, monkeypatch):
+    """同一フルキーではRT_RAの現行行がNL_RAの古い発走時刻を上書きする。
+
+    2026-09-05障害の再現: NL_RA 1400 と RT_RA(DataKubun 6) 1401 の同居を
+    曖昧性として扱うと窓判定前に一括中断し、窓内のレース12(16:30)まで
+    取得できなくなる。RT系列がキーを所有すれば 1401 は過去側で落ち、
+    レース12だけが開く。
+    """
+    import sqlite3
+    from contextlib import closing
+
+    from src.fetcher.realtime import RealtimeFetcher
+
+    _fixed_lifecycle_incident_now(monkeypatch)
+    db_path = tmp_path / "lifecycle-overlay.db"
+    with closing(sqlite3.connect(db_path)) as conn:
+        _create_lifecycle_race_tables(conn)
+        conn.executemany(
+            "INSERT INTO NL_RA VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+            [
+                ("2", 2026, 905, "06", 4, 8, 8, "1400"),
+                ("2", 2026, 905, "06", 4, 8, 12, "1630"),
+            ],
+        )
+        conn.executemany(
+            "INSERT INTO RT_RA VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+            [
+                ("6", 2026, 905, "06", 4, 8, 8, "1401"),
+                ("2", 2026, 905, "06", 4, 8, 12, "1630"),
+            ],
+        )
+        conn.commit()
+
+    progress = []
+    fetcher = object.__new__(RealtimeFetcher)
+    fetcher.jvlink = _window_jvlink()
+
+    assert (
+        list(
+            fetcher.fetch_time_series_batch_from_db(
+                data_spec="0B41",
+                db_path=str(db_path),
+                from_date="20260905",
+                to_date="20260905",
+                post_time_within_minutes=20,
+                post_time_not_past_minutes=1,
+                progress_callback=progress.append,
+            )
+        )
+        == []
+    )
+
+    assert fetcher.jvlink.opened == [("0B41", "202609050612")]
+    assert progress[0]["window_kept_keys"] == 1
+    assert progress[0]["dropped_too_far_past"] == 1
+    assert progress[0]["dropped_too_far_future"] == 0
+
+
+def test_sqlite_race_window_rt_lifecycle_cancellation_does_not_fall_back_to_nl(
+    tmp_path, monkeypatch
+):
+    """選択された現行行の中止(DataKubun 9)は所有ソースを問わず開いてはならない。
+
+    レース11はNL_RAの発走時刻では窓内だが、RT_RAが中止を報じている
+    (RT中止はNLへのフォールバックを防ぐ)。レース10はRT_RAに無く、
+    選択されたNL_RA行自身が中止を報じている。どちらの中止キーも開かず、
+    残るレース12だけを開く。
+    """
+    import sqlite3
+    from contextlib import closing
+
+    from src.fetcher.realtime import RealtimeFetcher
+
+    _fixed_lifecycle_incident_now(monkeypatch)
+    db_path = tmp_path / "lifecycle-cancel.db"
+    with closing(sqlite3.connect(db_path)) as conn:
+        _create_lifecycle_race_tables(conn)
+        conn.executemany(
+            "INSERT INTO NL_RA VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+            [
+                ("9", 2026, 905, "06", 4, 8, 10, "1620"),
+                ("2", 2026, 905, "06", 4, 8, 11, "1615"),
+                ("2", 2026, 905, "06", 4, 8, 12, "1630"),
+            ],
+        )
+        conn.execute(
+            "INSERT INTO RT_RA VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+            ("9", 2026, 905, "06", 4, 8, 11, "1615"),
+        )
+        conn.commit()
+
+    fetcher = object.__new__(RealtimeFetcher)
+    fetcher.jvlink = _window_jvlink()
+
+    progress = []
+    assert (
+        list(
+            fetcher.fetch_time_series_batch_from_db(
+                data_spec="0B41",
+                db_path=str(db_path),
+                from_date="20260905",
+                to_date="20260905",
+                post_time_within_minutes=20,
+                post_time_not_past_minutes=1,
+                progress_callback=progress.append,
+            )
+        )
+        == []
+    )
+
+    assert fetcher.jvlink.opened == [("0B41", "202609050612")]
+    # NL所有・RT所有の両方の中止が数えられ、開く対象と統計が一致する。
+    assert progress[0]["window_kept_keys"] == 1
+    assert progress[0]["omitted_canceled_keys"] == 2
+    assert progress[0]["total_keys"] == 1
+
+
+@pytest.mark.parametrize(
+    ("owning_source", "bad_data_kubun"),
+    [
+        ("RT", None),
+        ("RT", ""),
+        ("RT", "8"),
+        ("NL", " "),
+        ("NL", "９"),
+    ],
+)
+def test_sqlite_race_window_rt_lifecycle_rejects_undecidable_datakubun(
+    tmp_path, monkeypatch, owning_source, bad_data_kubun
+):
+    """選択行のDataKubunが欠落/空白/公式RAドメイン外ならfail-closedする。
+
+    DataKubunが選択行のactive/中止を決める以上、判定不能な値をactiveとして
+    暗黙に扱ってはならない。公式RA DataKubunドメイン
+    (src/parser/status_domain.py) の域外値はレースキーを名指しして
+    FetcherErrorで停止し、何も開かない。
+    """
+    import sqlite3
+    from contextlib import closing
+
+    from src.fetcher.base import FetcherError
+    from src.fetcher.realtime import RealtimeFetcher
+    from src.parser.status_domain import CURRENT_REALTIME_DATA_KUBUN
+
+    if isinstance(bad_data_kubun, str):
+        assert bad_data_kubun not in CURRENT_REALTIME_DATA_KUBUN["RA"]
+
+    _fixed_lifecycle_incident_now(monkeypatch)
+    db_path = tmp_path / "lifecycle-bad-datakubun.db"
+    with closing(sqlite3.connect(db_path)) as conn:
+        _create_lifecycle_race_tables(conn)
+        # 有効なレース12を同居させ、選択行の検証失敗が個別スキップではなく
+        # バッチ全体の停止(fail-closed)になることを確認する。
+        conn.execute(
+            "INSERT INTO NL_RA VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+            ("2", 2026, 905, "06", 4, 8, 12, "1630"),
+        )
+        if owning_source == "RT":
+            # 隠される側のNL行は有効: RTが所有した上で検証に失敗すること。
+            conn.execute(
+                "INSERT INTO NL_RA VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+                ("2", 2026, 905, "06", 4, 8, 10, "1620"),
+            )
+            conn.execute(
+                "INSERT INTO RT_RA VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+                (bad_data_kubun, 2026, 905, "06", 4, 8, 10, "1620"),
+            )
+        else:
+            conn.execute(
+                "INSERT INTO NL_RA VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+                (bad_data_kubun, 2026, 905, "06", 4, 8, 10, "1620"),
+            )
+        conn.commit()
+
+    fetcher = object.__new__(RealtimeFetcher)
+    fetcher.jvlink = _window_jvlink()
+
+    with pytest.raises(FetcherError, match=r"202609050610.*DataKubun"):
+        list(
+            fetcher.fetch_time_series_batch_from_db(
+                data_spec="0B41",
+                db_path=str(db_path),
+                from_date="20260905",
+                to_date="20260905",
+                post_time_within_minutes=20,
+                post_time_not_past_minutes=1,
+            )
+        )
+    assert fetcher.jvlink.init_calls == 0
+
+
+def test_sqlite_race_window_rt_lifecycle_nl_owns_all_keys_when_rt_table_absent(
+    tmp_path, monkeypatch
+):
+    """任意テーブルRT_RAが無いDBでも、NL_RAが全キーを所有し中止を除外する。
+
+    選択契約は「RT_RAに無いフルキーはNL_RAが所有する」。RT_RAテーブル自体の
+    不在は"NLが全キーを所有する"の意味であり、DataKubunを見ない旧7列経路へ
+    退行してはならない。中止レース11(DataKubun 9、窓内)は開かず、レース12
+    だけを開き、統計は除外1・保持1・total 1で開く対象と一致する。
+    """
+    import sqlite3
+    from contextlib import closing
+
+    from src.fetcher.realtime import RealtimeFetcher
+
+    _fixed_lifecycle_incident_now(monkeypatch)
+    db_path = tmp_path / "lifecycle-no-rt-table.db"
+    with closing(sqlite3.connect(db_path)) as conn:
+        _create_lifecycle_race_tables(conn, tables=("NL_RA",))
+        conn.executemany(
+            "INSERT INTO NL_RA VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+            [
+                ("9", 2026, 905, "06", 4, 8, 11, "1615"),
+                ("2", 2026, 905, "06", 4, 8, 12, "1630"),
+            ],
+        )
+        conn.commit()
+
+    progress = []
+    fetcher = object.__new__(RealtimeFetcher)
+    fetcher.jvlink = _window_jvlink()
+
+    assert (
+        list(
+            fetcher.fetch_time_series_batch_from_db(
+                data_spec="0B41",
+                db_path=str(db_path),
+                from_date="20260905",
+                to_date="20260905",
+                post_time_within_minutes=20,
+                post_time_not_past_minutes=1,
+                progress_callback=progress.append,
+            )
+        )
+        == []
+    )
+
+    assert fetcher.jvlink.opened == [("0B41", "202609050612")]
+    assert progress[0]["considered_keys"] == 2
+    assert progress[0]["window_kept_keys"] == 1
+    assert progress[0]["omitted_canceled_keys"] == 1
+    assert progress[0]["total_keys"] == 1
+
+
+def test_sqlite_race_window_rt_lifecycle_rejects_undecidable_nl_datakubun_when_rt_table_absent(
+    tmp_path, monkeypatch
+):
+    """RT_RA不在でも、選択されたNL行の判定不能DataKubunはfail-closed。"""
+    import sqlite3
+    from contextlib import closing
+
+    from src.fetcher.base import FetcherError
+    from src.fetcher.realtime import RealtimeFetcher
+
+    _fixed_lifecycle_incident_now(monkeypatch)
+    db_path = tmp_path / "lifecycle-no-rt-bad-datakubun.db"
+    with closing(sqlite3.connect(db_path)) as conn:
+        _create_lifecycle_race_tables(conn, tables=("NL_RA",))
+        conn.executemany(
+            "INSERT INTO NL_RA VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+            [
+                ("8", 2026, 905, "06", 4, 8, 10, "1620"),
+                ("2", 2026, 905, "06", 4, 8, 12, "1630"),
+            ],
+        )
+        conn.commit()
+
+    fetcher = object.__new__(RealtimeFetcher)
+    fetcher.jvlink = _window_jvlink()
+
+    with pytest.raises(FetcherError, match=r"202609050610.*DataKubun"):
+        list(
+            fetcher.fetch_time_series_batch_from_db(
+                data_spec="0B41",
+                db_path=str(db_path),
+                from_date="20260905",
+                to_date="20260905",
+                post_time_within_minutes=20,
+                post_time_not_past_minutes=1,
+            )
+        )
+    assert fetcher.jvlink.init_calls == 0
+
+
+def test_sqlite_race_window_rt_lifecycle_source_conflict_fails_closed(tmp_path, monkeypatch):
+    """選択されたRTソース内で12桁キーが衝突する行は従来どおりfail-closed。
+
+    PRIMARY KEY (Year, MonthDay, JyoCD, Kaiji, Nichiji, RaceNum) と
+    INSERT OR REPLACE 保存のため、同一フルキーの同一ソース内重複は物理的に
+    作れない。物理的に到達可能な同一ソース内曖昧性は、Kaiji/Nichijiが異なる
+    行が同じ12桁JVRTOpenキーへ畳まれる形状であり、その形状で検証する。
+    NL_RA側に一致行があってもRTソース内の衝突を隠してはならない。
+    """
+    import sqlite3
+    from contextlib import closing
+
+    from src.fetcher.base import FetcherError
+    from src.fetcher.realtime import RealtimeFetcher
+
+    _fixed_lifecycle_incident_now(monkeypatch)
+    db_path = tmp_path / "lifecycle-conflict.db"
+    with closing(sqlite3.connect(db_path)) as conn:
+        _create_lifecycle_race_tables(conn)
+        conn.execute(
+            "INSERT INTO NL_RA VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+            ("2", 2026, 905, "06", 4, 8, 12, "1630"),
+        )
+        conn.executemany(
+            "INSERT INTO RT_RA VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+            [
+                ("6", 2026, 905, "06", 4, 8, 12, "1630"),
+                ("6", 2026, 905, "06", 5, 1, 12, "1633"),
+            ],
+        )
+        conn.commit()
+
+    fetcher = object.__new__(RealtimeFetcher)
+    fetcher.jvlink = _window_jvlink()
+
+    with pytest.raises(FetcherError, match=r"202609050612.*ambiguous"):
+        list(
+            fetcher.fetch_time_series_batch_from_db(
+                data_spec="0B41",
+                db_path=str(db_path),
+                from_date="20260905",
+                to_date="20260905",
+                post_time_within_minutes=20,
+                post_time_not_past_minutes=1,
+            )
+        )
+    assert fetcher.jvlink.init_calls == 0
+
+
+def test_postgresql_race_window_rt_lifecycle_overlay_parity(tmp_path, monkeypatch):
+    """PostgreSQL経路の生成クエリ/ロジックがRTライフサイクル上書きを表現する。
+
+    ライブPostgreSQLを使わず、生成されたSQLをそのままSQLite上で実行して
+    (%s→?、LPADシムのみ翻訳) クエリ自体の選択結果を検証する。nl_ra/rt_raは
+    本番と同じ6列PRIMARY KEYを持つ。レース8は上書き後に過去側で落ち、
+    レース11はRT中止が所有し、rt_raに無いレース12だけがnl_raから開く。
+    """
+    import sqlite3
+    from contextlib import closing
+
+    from src.fetcher.realtime import RealtimeFetcher
+
+    _fixed_lifecycle_incident_now(monkeypatch)
+    db_path = tmp_path / "pg-parity.db"
+    with closing(sqlite3.connect(db_path)) as conn:
+        for table in ("nl_ra", "rt_ra"):
+            conn.execute(f"""
+                CREATE TABLE {table} (
+                    datakubun TEXT,
+                    year INTEGER, monthday INTEGER, jyocd TEXT, kaiji INTEGER,
+                    nichiji INTEGER, racenum INTEGER, hassotime TEXT,
+                    PRIMARY KEY (year, monthday, jyocd, kaiji, nichiji, racenum)
+                )
+                """)
+        conn.executemany(
+            "INSERT INTO nl_ra VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+            [
+                ("2", 2026, 905, "06", 4, 8, 8, "1400"),
+                ("2", 2026, 905, "06", 4, 8, 11, "1615"),
+                ("2", 2026, 905, "06", 4, 8, 12, "1630"),
+            ],
+        )
+        conn.executemany(
+            "INSERT INTO rt_ra VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+            [
+                ("6", 2026, 905, "06", 4, 8, 8, "1401"),
+                ("9", 2026, 905, "06", 4, 8, 11, "1615"),
+            ],
+        )
+        conn.commit()
+
+    captured = {}
+
+    def run_pg_query_on_sqlite(query, params, pg_config):
+        captured["query"] = query
+        with closing(sqlite3.connect(db_path)) as conn:
+            conn.create_function(
+                "LPAD",
+                3,
+                lambda value, length, fill: str(value).rjust(int(length), str(fill)),
+            )
+            return conn.execute(query.replace("%s", "?"), params).fetchall()
+
+    monkeypatch.setattr(
+        RealtimeFetcher,
+        "_fetch_time_series_race_rows_from_postgres",
+        staticmethod(run_pg_query_on_sqlite),
+    )
+    monkeypatch.setattr(
+        RealtimeFetcher,
+        "_postgres_table_exists",
+        staticmethod(lambda _config, table_name: table_name == "rt_ra"),
+    )
+    fetcher = object.__new__(RealtimeFetcher)
+    fetcher.jvlink = _window_jvlink()
+
+    progress = []
+    assert (
+        list(
+            fetcher.fetch_time_series_batch_from_db(
+                data_spec="0B42",
+                db_path="ignored.sqlite",
+                from_date="20260905",
+                to_date="20260905",
+                pg_config={"host": "localhost", "database": "keiba"},
+                post_time_within_minutes=20,
+                post_time_not_past_minutes=1,
+                progress_callback=progress.append,
+            )
+        )
+        == []
+    )
+
+    assert "datakubun" in captured["query"].lower()
+    assert fetcher.jvlink.opened == [("0B42", "202609050612")]
+    # 中止除外後の統計は開く対象と一致しなければならない: 除外済みキーを
+    # window_kept_keys に残さず、除外数を明示的に数える。
+    assert progress[0]["window_kept_keys"] == 1
+    assert progress[0]["omitted_canceled_keys"] == 1
+    assert progress[0]["total_keys"] == 1
+    assert progress[0]["dropped_too_far_past"] == 1
+    assert progress[0]["dropped_too_far_future"] == 0
 
 
 def test_race_window_off_leaves_legacy_postgresql_query_and_rows_untouched(monkeypatch):

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -75,7 +75,7 @@ class TestGetCurrentVersion:
         version = get_current_version()
         # Source metadata is the candidate version; a stale release tag must
         # not make a development checkout report the previous release.
-        assert version == "2.1.1"
+        assert version == "2.1.2"
 
     @patch("subprocess.run")
     def test_fallback_to_installed_distribution_metadata(
@@ -163,10 +163,12 @@ class TestCheckForUpdates:
         from src.utils.updater import check_for_updates
 
         mock_response = MagicMock()
-        mock_response.read.return_value = json.dumps({
-            "tag_name": "v99.0.0",
-            "html_url": "https://github.com/miyamamoto/jrvltsql/releases/v99.0.0",
-        }).encode()
+        mock_response.read.return_value = json.dumps(
+            {
+                "tag_name": "v99.0.0",
+                "html_url": "https://github.com/miyamamoto/jrvltsql/releases/v99.0.0",
+            }
+        ).encode()
         mock_response.__enter__ = lambda s: s
         mock_response.__exit__ = MagicMock(return_value=False)
         mock_urlopen.return_value = mock_response

--- a/uv.lock
+++ b/uv.lock
@@ -325,7 +325,7 @@ wheels = [
 
 [[package]]
 name = "jltsql"
-version = "2.1.1"
+version = "2.1.2"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

- Fix the 2026-09-05 prospective O1/O2 collection abort in v2.1.1: a current RT_RA revised post time now owns the matching full race key before post-time validation, instead of conflicting with stale NL_RA.
- Validate selected RA lifecycle fail closed: reject invalid/missing DataKubun and persisted DK0, reject mixed active/DK9 state for one normalized JVRTOpen key independent of row order, omit all-canceled keys once, and preserve true selected-source post-time ambiguity failures.
- Expose stable machine evidence: Window canceled, Keys nonempty, and an unconditional terminal Keys 0/0 line for idle window runs.
- Allow the mandated release/X.Y.Z hotfix PR path to trigger the Tests workflow.

## Release track and risk

- Emergency correctness hotfix from immutable v2.1.1 SHA `0f3161d30de65f15795608e2a4bec9fc91e05349`.
- Base `release/2.1.2` was created at that exact SHA; this branch has no master-only commits.
- Provider/read-selection and data-integrity risk. No schema, storage, migration, destructive write, or provider-registration change.
- Known limitation: the normal updater physically deletes an RT row for DataKubun=0. Once deleted, this read path cannot distinguish that erase from no RT update and can fall back to stale NL_RA. A physically present DK0 marker is rejected, but durable tombstone semantics are not part of this minimal hotfix and are not proven.
- Downstream adoption remains explicit. No live JV-Link race day has exercised 2.1.2; the first complete real prospective proof must be on a future race day, and nothing is backfilled.
- Rollback: re-adopt immutable v2.1.1 at `0f3161d30de65f15795608e2a4bec9fc91e05349`. No database rollback is required.

## Red-first evidence

- Exact incident fixture: `202609050608` stale NL_RA 1400 plus current RT_RA DataKubun 6 at 1401, with later due race `202609050612`. Old code failed with `FetcherError ... 202609050608: ambiguous HassoTime values [1400, 1401]` and never opened race 12.
- Cancellation red opened stale NL targets; invalid or missing selected DataKubun did not raise; RT-table-absent NL cancellation also opened.
- Review-repair reds proved both row orders of a normalized-key active/DK9 collision did not raise, and both RT-owned and NL-owned persisted DK0 rows were incorrectly opened. All four now fail closed before JV init.
- CLI reds proved missing `canceled=`, missing `nonempty=`, and no terminal Keys line for an idle 0/0 window.
- Release-path red proved `release/**` absent from the workflow pull_request branches.

Full command-by-command evidence is tracked in `specs/operations/20260905_race_lifecycle_overlay_hotfix_worklog.md`.

## Verification on final PR head

Exact head: `36646fbf935a71472df581b84c94717a03263947`; production code repair: `ea187ee586d16a65826b104bf00756bb87229918`; the final commit changes only the tracked worklog.

- Affected aggregate: 122 passed, 22 subtests passed.
- Workflow-equivalent full suite on exact head: 4876 passed, 514 environment-gated skips, 14 deselected, 33 subtests passed in 114.55 seconds; 80 percent coverage.
- Black scoped check, diff check, fail-closed test-gate validator, and fatal Flake8 workflow gate: green.
- Configured scoped Ruff: no new diagnostics versus exact v2.1.1 baseline, 57 versus 58.
- Scoped MyPy: no new diagnostics versus exact v2.1.1 baseline, 11 versus 12.
- Exact-head provisional build: wheel and sdist succeeded; distribution contents and wheel-init smoke passed; wheel METADATA is 2.1.2; embedded realtime and CLI sources equal the candidate sources. Provisional hashes only: wheel `82d931bfa19606807c58389f6cdc947abbf52a6e1a0823a89f35a653ff485fae`, sdist `27e57de68973a25308ea72e604e2faaee4e1ff560c28355e000aeaf31bd61c53`. These must not be published; release artifacts will be rebuilt from the merge SHA.
- Different independent reviewer: GREEN on exact head, with no P0/P1/P2 finding.
- Authoritative GitHub Actions: run `33960147906` on exact head; final result is recorded in the merge gate below.

## Verification limits

- SQLite fixtures mirror the real key/PK shape. The generated PostgreSQL query is exercised on an equivalent SQLite execution model; no live PostgreSQL mutation was performed.
- No live JV-Link race day has exercised 2.1.2. This is explicitly not presented as prospective capture proof.
- Physically removed updater tombstones remain the disclosed limitation above.

## Merge gate

- [x] Red-first negative paths recorded
- [x] Focused and full local gates green on exact head
- [x] Clean worktree and immutable rollback pin
- [x] Different independent review GREEN
- [x] Unresolved review threads zero
- [x] Authoritative exact-head GitHub Tests jobs green
- [ ] Rebuild artifacts from immutable merge SHA before tag and release
