### PR TITLE
feat(cli): fetch の --to を省略可能にする

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@
 
 ## [Unreleased]
 
+### Changed
+
+- `fetch` の `--to` を省略可能にする。省くとclient-side dateフィルタをかけず、`JVOpen` へ
+  終了時刻も渡さず（暦年で刻まず開始のみ 1 回）、NL cacheも使わない
+- 再開cursorを起点に「そこから先を全部」と要求する経路には上端の概念が無く、終端を渡すと
+  作成日基準で正当に降ってくるレコードがfilterで落ちていた
+- `--to` を渡したときの振る舞いは変えない
+
 ### Fixed
 
 - 発走時刻windowの既定1年date rangeでは、まず所有ソースを選んだ後、live

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -42,6 +42,13 @@ start-onlyの場合の `--to` は取得後の client-side filterです。option 
 複数年setupは数時間かかり得るため、配備側では監視可能な有限の
 `JVLINK_OPEN_TIMEOUT_SECONDS`（1〜86,400秒、既定120秒）を指定できます。
 
+`--to` は省略できます。省くとclient-side filterはかからず、`JVOpen` へ終了時刻も渡しません
+（暦年で刻まず、開始のみ 1 回）。NL cacheも使いません。
+
+```bat
+jltsql fetch --from 20260101 --spec RACE --option 1
+```
+
 主な `spec`:
 
 | spec | 用途 |

--- a/src/cli/main.py
+++ b/src/cli/main.py
@@ -118,7 +118,7 @@ def _print_fetch_statistics(result: dict) -> None:
     console.print(f"  Batches:  {result.get('batches_processed', 0)}")
 
 
-def _print_fetch_guardrail_notes(jv_option: int, data_specs) -> None:
+def _print_fetch_guardrail_notes(jv_option: int, data_specs, to_date=None) -> None:
     """Emit option- and dataspec-dependent date-range caveats after validation.
 
     注記は実走に 1 回で、要求された dataspec 全体を見る。刻める dataspec と
@@ -129,6 +129,8 @@ def _print_fetch_guardrail_notes(jv_option: int, data_specs) -> None:
         err_console.print(f"[yellow]Note:[/yellow] {FETCH_NOTE_SETUP_MODE}")
     if jv_option == 2:
         err_console.print(f"[yellow]Note:[/yellow] {FETCH_NOTE_OPTION2_RANGE}")
+    if to_date is None:
+        return  # 以下はすべて --to の注記。渡されていないなら当てはまらない
 
     from src.jvlink.constants import uses_range_fromtime
 
@@ -440,9 +442,11 @@ def update(ctx, force):
 @click.option(
     "--to",
     "date_to",
-    required=True,
+    default=None,
     help=(
-        "End date (YYYYMMDD). Filters Year+MonthDay and HC/WC ChokyoDate "
+        "End date (YYYYMMDD). Omit it for no upper bound: no client-side "
+        "filter, no JVOpen end point, and no NL cache. Otherwise it "
+        "filters Year+MonthDay and HC/WC ChokyoDate "
         "client-side; records without either date are kept and prevent a "
         "complete-cache marker. For a dataspec that accepts a range fromtime "
         "(currently live-verified RACE, except option 2) it is also the "
@@ -528,7 +532,7 @@ def fetch(ctx, date_from, date_to, data_specs, jv_option, db, batch_size, progre
     option_names = {1: "通常データ", 2: "今週データ", 3: "セットアップ", 4: "分割セットアップ"}
     console.print(f"[bold cyan]Fetching historical data from JRA-VAN DataLab...[/bold cyan]\n")
     console.print(f"  Data source: JRA (中央競馬)")
-    console.print(f"  Date range: {date_from} -- {date_to}")
+    console.print(f"  Date range: {date_from} -- {date_to or '(なし)'}")
     # 単数形は「いま処理している dataspec」だけを指す。実走全体の一覧は複数形に
     # して、driver が見出し行を spec 名として読まないようにする。
     spec_label = "Data spec: " if len(data_specs) == 1 else "Data specs:"
@@ -548,7 +552,7 @@ def fetch(ctx, date_from, date_to, data_specs, jv_option, db, batch_size, progre
         console.print(f"[red]Error:[/red] {exc}")
         sys.exit(1)
 
-    _print_fetch_guardrail_notes(jv_option, data_specs)
+    _print_fetch_guardrail_notes(jv_option, data_specs, date_to)
     console.print()
 
     try:

--- a/src/fetcher/historical.py
+++ b/src/fetcher/historical.py
@@ -33,13 +33,16 @@ def _extract_record_date(record: dict) -> Optional[str]:
     return None
 
 
-def validate_date_range(from_date: str, to_date: str) -> None:
+def validate_date_range(from_date: str, to_date: Optional[str] = None) -> None:
     """Reject malformed, non-calendar, or inverted date ranges.
 
     JVOpen・キャッシュ・スキーマ作成のいずれに触れるよりも前に呼ぶこと。
     fromtime はここで検証済みの日付からしか組み立てない。
     """
-    for label, value in (("from_date", from_date), ("to_date", to_date)):
+    bounds = [("from_date", from_date)]
+    if to_date is not None:  # 上端なしの要求
+        bounds.append(("to_date", to_date))
+    for label, value in bounds:
         if not isinstance(value, str) or len(value) != 8 or not value.isdigit():
             raise ValueError(
                 f"{label} must be an 8-digit YYYYMMDD string, got {value!r}"
@@ -51,7 +54,7 @@ def validate_date_range(from_date: str, to_date: str) -> None:
                 f"{label} must be a real calendar date in YYYYMMDD format, "
                 f"got {value!r}"
             ) from None
-    if from_date > to_date:
+    if to_date is not None and from_date > to_date:
         raise ValueError(
             f"from_date must not be after to_date: {from_date} > {to_date}"
         )
@@ -75,13 +78,13 @@ def _jvopen_fromtime(from_date: str, option: int) -> str:
 def _jvopen_fromtimes(
     data_spec: str,
     from_date: str,
-    to_date: str,
+    to_date: Optional[str],
     option: int,
 ) -> list[str]:
     """Split one request into the fromtime of each JVOpen call.
 
     なぜ刻むかは RANGE_FROMTIME_DATA_SPECS のコメントを見ること。刻まない
-    dataspec と option 2 は、従来どおり開始のみの 1 回になる。
+    dataspec、option 2、上端の無い要求は、従来どおり開始のみの 1 回になる。
 
     境界は隣り合う chunk で同じ値を共有する。JVOpen の対象は「開始時刻より
     大きく、終了時刻まで」なので、その値のファイルは前の chunk に入り次の
@@ -92,7 +95,7 @@ def _jvopen_fromtimes(
         ``開始-終了``（14 桁 + "-" + 14 桁）。
     """
     start = _jvopen_fromtime(from_date, option)
-    if not uses_range_fromtime(data_spec, option):
+    if to_date is None or not uses_range_fromtime(data_spec, option):
         return [start]
 
     last_day = datetime.strptime(to_date, "%Y%m%d")
@@ -281,7 +284,7 @@ class HistoricalFetcher(BaseFetcher):
         data_spec: str,
         fromtime: str,
         option: int,
-        to_date: str,
+        to_date: Optional[str],
         chunk_label: str,
         cache: "_NlCacheWriteState",
     ) -> Iterator[dict]:
@@ -460,7 +463,7 @@ class HistoricalFetcher(BaseFetcher):
         self,
         data_spec: str,
         from_date: str,
-        to_date: str,
+        to_date: Optional[str] = None,
         option: int = 1,
     ) -> Iterator[dict]:
         """Fetch historical data.
@@ -468,7 +471,7 @@ class HistoricalFetcher(BaseFetcher):
         Args:
             data_spec: Data specification code (e.g., "RACE", "DIFN")
             from_date: Start date in YYYYMMDD format
-            to_date: End date in YYYYMMDD format (filters records up to this date)
+            to_date: End date in YYYYMMDD format, or None for no upper bound
             option: JVOpen option:
                     1=通常データ（差分データ取得、蓄積系メンテナンス用）
                     2=今週データ（直近のレースのみ、非蓄積系用）
@@ -523,8 +526,11 @@ class HistoricalFetcher(BaseFetcher):
         # option=2 uses fromtime only for continuity within current race-cycle
         # data; it cannot prove an arbitrary requested historical range
         # complete. Bypass both existing NL cache markers and write-through
-        # caching for that mode.
-        active_cache_manager = self.cache_manager if option != 2 else None
+        # caching for that mode. A request with no upper bound cannot
+        # enumerate the dates it covered, so it is bypassed for the same reason.
+        active_cache_manager = (
+            self.cache_manager if option != 2 and to_date is not None else None
+        )
         cache_write_committed = active_cache_manager is None
         cache = _NlCacheWriteState(manager=active_cache_manager)
 
@@ -682,14 +688,14 @@ class HistoricalFetcher(BaseFetcher):
 
         yield from self.fetch(data_spec, from_date, to_date, option)
 
-    def fetch_with_cache(self, cache_manager, data_spec: str, from_date: str, to_date: str, option: int = 1) -> Iterator[dict]:
+    def fetch_with_cache(self, cache_manager, data_spec: str, from_date: str, to_date: Optional[str] = None, option: int = 1) -> Iterator[dict]:
         """Fetch records: use cache if complete, else fetch from JV-Link and populate cache.
 
         Args:
             cache_manager: CacheManager instance
             data_spec: Data specification code (e.g., "RACE")
             from_date: Start date in YYYYMMDD format
-            to_date: End date in YYYYMMDD format
+            to_date: End date in YYYYMMDD format, or None for no upper bound
             option: JVOpen option (default: 1)
 
         Yields:
@@ -708,7 +714,7 @@ class HistoricalFetcher(BaseFetcher):
             # Do not trust old false-complete markers created by earlier
             # versions, and do not attach a manager that could create new ones.
             yield from self.fetch(data_spec, from_date, to_date, option)
-        elif cache_manager.has_nl_range(data_spec, from_date, to_date):
+        elif to_date is not None and cache_manager.has_nl_range(data_spec, from_date, to_date):
             # Full cache hit: yield from cache
             self.reset_statistics()
             for raw in cache_manager.read_nl(data_spec, from_date, to_date):

--- a/src/importer/batch.py
+++ b/src/importer/batch.py
@@ -5,7 +5,7 @@ This module provides utilities for batch processing of JV-Data.
 
 from datetime import datetime, timedelta
 from itertools import islice
-from typing import Iterator, List
+from typing import Iterator, List, Optional
 
 from src.database.base import BaseDatabase
 from src.database.schema import create_all_tables
@@ -118,7 +118,7 @@ class BatchProcessor:
         self,
         data_spec: str,
         from_date: str,
-        to_date: str,
+        to_date: Optional[str] = None,
         option: int = 1,
         auto_commit: bool = True,
         ensure_tables: bool = True,
@@ -128,7 +128,7 @@ class BatchProcessor:
         Args:
             data_spec: Data specification code
             from_date: Start date (YYYYMMDD)
-            to_date: End date (YYYYMMDD) - records are filtered to this date
+            to_date: End date (YYYYMMDD), or None for no upper bound
             option: JVOpen option:
                     1=通常データ（差分データ取得）
                     2=今週データ（直近のレースのみ）

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -483,7 +483,8 @@ class TestFetchCommand(unittest.TestCase):
         """Test fetch command with missing arguments."""
         result = self.runner.invoke(cli, ["fetch"])
 
-        # Should fail due to missing required arguments (--from, --to, --spec)
+        # Should fail due to missing required arguments (--from, --spec).
+        # --to is optional: omitting it requests everything from --from on.
         self.assertNotEqual(result.exit_code, 0)
         # Check if error message contains missing required option
         self.assertTrue(

--- a/tests/test_fetch_without_upper_bound.py
+++ b/tests/test_fetch_without_upper_bound.py
@@ -1,0 +1,211 @@
+"""``fetch --to`` を省いた要求（開始点から先を全部）.
+
+``--to`` は 1 つの値で 2 つの仕事をしている。JVOpen の読み出し終了時刻が見るのは
+ファイルの作成日で、``_is_within_date_range`` が見るのはレコードの開催日。option=1/2 は
+作成日基準で配信するので、開催日が要求時点より先のレコードが正当に降ってくる。
+
+省いたときの 3 つと、省かなかったときに何も変わらないことを対で固定する。
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from src.fetcher.historical import (
+    HistoricalFetcher,
+    _jvopen_fromtimes,
+    validate_date_range,
+)
+from tests.cli_test_support import CliRunner
+
+DONE = (0, None, None)
+
+
+class _Wrapper:
+    def __init__(self):
+        self.open_fromtimes = []
+        self._reads = [(4, b"aaaa", "f1"), DONE]
+
+    def jv_open(self, data_spec, fromtime, option):
+        self.open_fromtimes.append(fromtime)
+        return (0, 1, 0, "20220110000000")
+
+    def jv_read(self):
+        return self._reads.pop(0)
+
+    def jv_close(self):
+        return 0
+
+
+def _fetcher(year="2026"):
+    """開催日 ``{year}/01/10`` のレコードを 1 件返す fetcher."""
+    f = HistoricalFetcher.__new__(HistoricalFetcher)
+    f.parser_factory = MagicMock()
+    f.parser_factory.parse.side_effect = lambda buff: [{"Year": year, "MonthDay": "0110"}]
+    f.cache_manager = None
+    f.show_progress = False
+    f.progress_display = None
+    f._service_key = None
+    f._records_fetched = f._records_parsed = f._records_failed = 0
+    f._files_processed = f._total_files = 0
+    f._repaired_read_errors = 0
+    f._start_time = 0.0
+    f._jvd_self_repair_attempts = f._jvd_replay_records_remaining = 0
+    f._open_records_baseline = 0
+    f._recoverable_read_errors = 0
+    f._jv_open_context = f._jv_open_last_file_timestamp = f._fetch_task_id = None
+    f.jvlink = _Wrapper()
+    return f
+
+
+class TestValidation:
+    def test_a_start_date_alone_is_accepted(self):
+        validate_date_range("20260101")
+
+    def test_the_start_date_is_still_validated(self):
+        with pytest.raises(ValueError, match="real calendar date"):
+            validate_date_range("20260230")
+
+    def test_an_inverted_range_is_still_rejected(self):
+        with pytest.raises(ValueError, match="must not be after"):
+            validate_date_range("20260301", "20260101")
+
+
+class TestJvopenGetsNoEndPoint:
+    def test_no_upper_bound_opens_once_from_the_start_point(self):
+        assert _jvopen_fromtimes("RACE", "20260101", None, 1) == ["20260101000000"]
+
+    def test_an_upper_bound_still_chunks_by_calendar_year(self):
+        assert len(_jvopen_fromtimes("RACE", "20240101", "20261231", 4)) == 3
+
+
+class TestClientSideFilter:
+    def test_no_upper_bound_keeps_a_record_dated_ahead_of_the_request(self):
+        f = _fetcher(year="2027")
+
+        assert len(list(f.fetch("RACE", "20260101", None, option=1))) == 1
+
+    def test_an_upper_bound_still_drops_it(self):
+        f = _fetcher(year="2027")
+
+        assert list(f.fetch("RACE", "20260101", "20260131", option=1)) == []
+
+    def test_the_drop_shows_only_as_the_fetched_parsed_gap(self):
+        f = _fetcher(year="2027")
+
+        list(f.fetch("RACE", "20260101", "20260131", option=1))
+
+        stats = f.get_statistics()
+        assert (stats["records_fetched"], stats["records_parsed"]) == (1, 0)
+        assert stats["records_failed"] == 0
+
+
+class TestNlCache:
+    def _run(self, to_date):
+        f = _fetcher()
+        f.cache_manager = MagicMock()
+        f.cache_manager.checkpoint_nl.return_value = 0
+        list(f.fetch("RACE", "20260101", to_date, option=1))
+        return f.cache_manager
+
+    def test_no_upper_bound_never_marks_a_range_complete(self):
+        """付けると has_nl_range が以後その範囲を提供側へ問い合わせなくなる."""
+        manager = self._run(None)
+
+        manager.mark_nl_range_complete.assert_not_called()
+        manager.write_nl_record.assert_not_called()
+
+    def test_an_upper_bound_still_marks_it(self):
+        manager = self._run("20260131")
+
+        manager.mark_nl_range_complete.assert_called_once()
+
+    def test_no_upper_bound_never_asks_has_nl_range(self):
+        """has_nl_range は範囲の全日付を走査する。上端が無ければ問えない."""
+        f = _fetcher()
+        manager = MagicMock()
+
+        list(f.fetch_with_cache(manager, "RACE", "20260101", None, option=1))
+
+        manager.has_nl_range.assert_not_called()
+        assert f.jvlink.open_fromtimes == ["20260101000000"]
+
+
+class TestBatchProcessor:
+    """CLI と fetcher の間の層が上端を埋めないこと."""
+
+    def _processor(self):
+        from src.importer.batch import BatchProcessor
+
+        fetcher = MagicMock()
+        fetcher.fetch.return_value = iter([])
+        fetcher.get_statistics.return_value = {"records_fetched": 0, "records_failed": 0}
+        with patch("src.importer.batch.HistoricalFetcher", return_value=fetcher):
+            processor = BatchProcessor(database=MagicMock(), show_progress=False)
+        processor.importer = MagicMock()
+        processor.importer.import_records.return_value = {"records_failed": 0}
+        return processor, fetcher
+
+    @pytest.mark.parametrize("to_date", [None, "20260821"])
+    def test_the_upper_bound_reaches_the_fetcher_unchanged(self, to_date):
+        processor, fetcher = self._processor()
+
+        processor.process_date_range(
+            data_spec="RACE", from_date="20260820", to_date=to_date, ensure_tables=False
+        )
+
+        assert fetcher.fetch.call_args.args == ("RACE", "20260820", to_date, 1)
+
+
+class TestCli:
+    ARGS = ["fetch", "--from", "20260820", "--spec", "RACE", "--db", "sqlite",
+            "--no-cache", "--no-progress"]
+
+    def _invoke(self, args):
+        from pathlib import Path
+
+        from src.cli.main import cli
+
+        processor = MagicMock()
+        processor.process_date_range.return_value = {
+            "records_fetched": 0, "records_parsed": 0,
+            "records_imported": 0, "records_failed": 0, "batches_processed": 0,
+        }
+        example = Path(__file__).resolve().parents[1] / "config" / "config.yaml.example"
+        runner = CliRunner(env={"COLUMNS": "200", "TERM": "dumb"})
+        with runner.isolated_filesystem():
+            Path("config.yaml").write_text(example.read_text(encoding="utf-8"), encoding="utf-8")
+            with (
+                patch("src.importer.batch.BatchProcessor", MagicMock(return_value=processor)),
+                patch("src.database.create_database_from_config", MagicMock()),
+                patch("src.database.schema.create_all_tables"),
+            ):
+                result = runner.invoke(cli, ["--config", "config.yaml", *args])
+        return result, processor
+
+    def test_fetch_runs_without_an_upper_bound(self):
+        result, processor = self._invoke(self.ARGS)
+
+        assert result.exit_code == 0, result.output
+        assert processor.process_date_range.call_args.kwargs["to_date"] is None
+
+    def test_an_upper_bound_still_reaches_the_processor(self):
+        _, processor = self._invoke(self.ARGS + ["--to", "20260821"])
+
+        assert processor.process_date_range.call_args.kwargs["to_date"] == "20260821"
+
+    def test_the_to_caveats_are_not_printed_without_an_upper_bound(self):
+        from src.cli.main import FETCH_NOTE_TO_CLIENT_FILTER
+
+        result, _ = self._invoke(self.ARGS)
+
+        # rich は 1 行が幅を超えると折り返すので、改行を畳んでから見る。
+        assert FETCH_NOTE_TO_CLIENT_FILTER not in result.output.replace("\n", "")
+
+    def test_a_malformed_start_date_is_still_rejected(self):
+        args = [a if a != "20260820" else "20260230" for a in self.ARGS]
+
+        result, processor = self._invoke(args)
+
+        assert result.exit_code == 1, result.output
+        processor.process_date_range.assert_not_called()


### PR DESCRIPTION
## 何を変えるか

`jltsql fetch` の `--to` を `required=True` から省略可能にする。

省いたとき:

- client filter をかけない
- JVOpen へ終了時刻を渡さない（暦年で刻まず開始のみ 1 回）
- NL キャッシュを使わない（日付を列挙できず完了マークを付けられないため）

`--to` を渡したときの振る舞いは変えない。

## なぜ

再開点を起点に「そこから先を全部」と要求することができない

`--to` は 1 つの値で 2 つの仕事をしている。

| | 何を見るか | どこで効くか |
|---|---|---|
| JVOpen の読み出し終了時刻 | ファイルの**作成日** | 範囲形式 fromtime を使う dataspec のみ |
| client filter | レコードの**開催日** | 常に・全 dataspec |

`option=1` / `option=2` が配信の基準にするのは作成日なので、**開催日が要求時点より先のレコードが正当に降ってくる**。そこへ上端を渡さなければならないのは、不自然に大きな日付を渡すことになり、直感的なインタフェースではない



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The `fetch` command now allows omitting the `--to` date for open-ended retrieval from a specified start date.
  * Open-ended fetches return subsequent records without applying an end-date filter or calendar-year splitting.
  * Added documentation and usage examples for open-ended fetching.

* **Bug Fixes**
  * Preserved existing behavior when an explicit `--to` date is provided.
  * Improved handling of open-ended fetches to avoid inappropriate cache assumptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->